### PR TITLE
fix: move ndk init to queryclient creation step

### DIFF
--- a/src/frontend.tsx
+++ b/src/frontend.tsx
@@ -1,44 +1,90 @@
-import { QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { RouterProvider, createRouter } from '@tanstack/react-router'
-import { StrictMode } from 'react'
+import { StrictMode, useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import '../styles/index.css'
-import { queryClient } from './lib/queryClient'
+import { createQueryClient } from './lib/queryClient'
 import { routeTree } from './routeTree.gen'
 
-declare global {
-	interface ImportMeta {
-		hot?: {
-			data: Record<string, any>
-		}
-	}
+// Function to create a router once we have a queryClient
+function createAppRouter(queryClient: QueryClient) {
+	return createRouter({
+		routeTree,
+		context: {
+			queryClient,
+		},
+		defaultPreload: 'intent',
+		defaultPreloadStaleTime: 0,
+	})
 }
 
-// Create a new router instance
-const router = createRouter({
-	routeTree,
-	context: {
-		queryClient,
-	},
-	defaultPreload: 'intent',
-	defaultPreloadStaleTime: 0,
-})
-
-declare module '@tanstack/react-router' {
-	interface Register {
-		router: typeof router
-	}
-}
-
-function AppContent() {
-	return <RouterProvider router={router} />
-}
-
+// Main app initialization and rendering
 function App() {
+	const [queryClient, setQueryClient] = useState<QueryClient | null>(null)
+	const [router, setRouter] = useState<any | null>(null)
+	const [isLoading, setIsLoading] = useState(true)
+	const [error, setError] = useState<string | null>(null)
+
+	useEffect(() => {
+		const initialize = async () => {
+			try {
+				setIsLoading(true)
+				
+				// First fetch the config
+				const response = await fetch('/api/config')
+				if (!response.ok) {
+					throw new Error(`Failed to fetch config: ${response.status} ${response.statusText}`)
+				}
+				const config = await response.json()
+				console.log('Fetched config:', config)
+				
+				// Create queryClient with NDK initialization
+				const client = await createQueryClient(config.appRelay)
+				setQueryClient(client)
+				
+				// Create router with the queryClient
+				const appRouter = createAppRouter(client)
+				setRouter(appRouter)
+				
+			} catch (err) {
+				console.error('Initialization error:', err)
+				setError(err instanceof Error ? err.message : 'Unknown error during initialization')
+			} finally {
+				setIsLoading(false)
+			}
+		}
+
+		initialize()
+	}, [])
+
+	if (isLoading) {
+		return <div className="flex justify-center items-center h-screen">
+			Initializing application...
+		</div>
+	}
+
+	if (error) {
+		return <div className="flex justify-center items-center h-screen flex-col gap-2">
+			<div className="text-red-500">Error: {error}</div>
+			<button 
+				className="px-4 py-2 bg-blue-500 text-white rounded"
+				onClick={() => window.location.reload()}
+			>
+				Retry
+			</button>
+		</div>
+	}
+
+	if (!queryClient || !router) {
+		return <div className="flex justify-center items-center h-screen">
+			Failed to initialize application
+		</div>
+	}
+
 	return (
 		<StrictMode>
 			<QueryClientProvider client={queryClient}>
-				<AppContent />
+				<RouterProvider router={router} />
 			</QueryClientProvider>
 		</StrictMode>
 	)
@@ -54,3 +100,4 @@ if (import.meta.hot) {
 	// The hot module reloading API is not available in production.
 	createRoot(elem).render(<App />)
 }
+

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,3 +1,18 @@
 import { QueryClient } from '@tanstack/react-query'
+import { ndkActions } from './stores/ndk'
+import { authActions } from './stores/auth'
+import { defaulRelaysUrls } from './constants'
 
-export const queryClient = new QueryClient()
+// Initialize NDK and create a queryClient only after initialization
+export async function createQueryClient(relayUrl?: string): Promise<QueryClient> {
+  if (relayUrl) {
+    console.log(`Initializing NDK with relay: ${relayUrl}`)
+    ndkActions.initialize([relayUrl, ...defaulRelaysUrls])
+    await ndkActions.connect()
+    await authActions.getAuthFromLocalStorageAndLogin()
+    console.log('NDK initialized successfully')
+  }
+  
+  // Create and return a new QueryClient only after NDK is initialized
+  return new QueryClient()
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,9 +3,6 @@ import { LoginDialog } from '@/components/auth/LoginDialog'
 import { Footer } from '@/components/layout/Footer'
 import { Header } from '@/components/layout/Header'
 import { Pattern } from '@/components/pattern'
-import { defaulRelaysUrls } from '@/lib/constants'
-import { authActions } from '@/lib/stores/auth'
-import { ndkActions } from '@/lib/stores/ndk'
 import { useConfigQuery } from '@/queries/config'
 import { createRootRoute, Outlet, useNavigate } from '@tanstack/react-router'
 import { useEffect, useState } from 'react'
@@ -21,7 +18,6 @@ function RootComponent() {
 function RootLayout() {
 	const { data: config, isLoading, isError } = useConfigQuery()
 	const [showLoginDialog, setShowLoginDialog] = useState(false)
-	const [ndkInitialized, setNdkInitialized] = useState(false)
 	const navigate = useNavigate()
 	const isSetupPage = window.location.pathname === '/setup'
 
@@ -34,25 +30,8 @@ function RootLayout() {
 		}
 	}, [config, navigate, isLoading, isError, isSetupPage])
 
-	useEffect(() => {
-		const initializeNDK = async () => {
-			if (config?.appRelay) {
-				console.log(`Adding relay from config: ${config.appRelay}`)
-				ndkActions.initialize([config.appRelay, ...defaulRelaysUrls])
-				await ndkActions.connect()
-				await authActions.getAuthFromLocalStorageAndLogin()
-				console.log('NDK initialized')
-				setNdkInitialized(true)
-			}
-		}
-
-		if (config && !ndkInitialized) {
-			initializeNDK().catch(console.error)
-		}
-	}, [config, ndkInitialized])
-
-	// If loading or NDK not yet initialized, don't render routes
-	if (isLoading || (config?.appRelay && !ndkInitialized)) {
+	// If loading, don't render routes
+	if (isLoading) {
 		return <div className="flex justify-center items-center h-screen">Loading...</div>
 	}
 


### PR DESCRIPTION
I don't know if this is the solution, this is just one potential way to fix the problem where we aren't initializing NDK before we start routing, so the routes try to load without an NDK