### PR TITLE
fix: LoginDialog close button

### DIFF
--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -26,7 +26,7 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
-				className="sm:max-w-[425px] p-0 [&>button]:text-white [&>button]:hover:text-gray-300 [&>button]:top-6 [&>button]:right-6"
+				className="sm:max-w-[425px] p-0 [&>button:not([data-dialog-close])]:text-white [&>button:not([data-dialog-close])]:hover:text-gray-300"
 				data-testid="login-dialog"
 			>
 				{/* Header Section */}


### PR DESCRIPTION
The close button on the dialog was not closing because it overrode some default styling from the main LoginDialog component.