### PR TITLE
fix: cart animation-out on close

### DIFF
--- a/src/components/sheet-contents/cart/CartContent.tsx
+++ b/src/components/sheet-contents/cart/CartContent.tsx
@@ -2,17 +2,15 @@ import CartItem from '@/components/CartItem'
 import { ShippingSelector } from '@/components/ShippingSelector'
 import { UserWithAvatar } from '@/components/UserWithAvatar'
 import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import type { RichShippingInfo } from '@/lib/stores/cart'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { uiActions } from '@/lib/stores/ui'
-import { useStore } from '@tanstack/react-store'
+import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useNavigate } from '@tanstack/react-router'
-import { ChevronDown } from 'lucide-react'
+import { useStore } from '@tanstack/react-store'
 import { useEffect, useMemo, useState } from 'react'
 import { EmptyCartScreen } from './EmptyCartScreen'
-import { useAutoAnimate } from '@formkit/auto-animate/react'
 
 export function CartContent({ className = '' }: { className?: string }) {
 	const {
@@ -28,7 +26,6 @@ export function CartContent({ className = '' }: { className?: string }) {
 
 	const [parent, enableAnimations] = useAutoAnimate()
 	const [selectedShippingByUser, setSelectedShippingByUser] = useState<Record<string, string>>({})
-	const [detailsExpanded, setDetailsExpanded] = useState(false)
 	const navigate = useNavigate()
 
 	const totalItems = useMemo(() => {

--- a/src/components/sheet-contents/cart/index.tsx
+++ b/src/components/sheet-contents/cart/index.tsx
@@ -1,8 +1,6 @@
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { cartStore } from '@/lib/stores/cart'
-import { uiStore, uiActions } from '@/lib/stores/ui'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useState } from 'react'
 import { CartContent } from './CartContent'
 import { EmptyCartScreen } from './EmptyCartScreen'
 
@@ -14,44 +12,24 @@ export default function CartSheetContent({
 	description?: string
 }) {
 	const { cart } = useStore(cartStore)
-	const { drawers } = useStore(uiStore)
 	const isCartEmpty = Object.keys(cart.products).length === 0
-	const [open, setOpen] = useState(drawers.cart)
-
-	useEffect(() => {
-		setOpen(drawers.cart)
-	}, [drawers.cart])
-
-	const handleOpenChange = (nextOpen: boolean) => {
-		setOpen(nextOpen)
-		if (!nextOpen) {
-			// Delay closing in store until after animation
-			setTimeout(() => {
-				uiActions.closeDrawer('cart')
-			}, 300) // matches slide-out duration
-		}
-	}
 
 	if (isCartEmpty) {
 		return (
-			<Sheet open={open} onOpenChange={handleOpenChange}>
-				<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
-					<EmptyCartScreen />
-				</SheetContent>
-			</Sheet>
+			<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
+				<EmptyCartScreen />
+			</SheetContent>
 		)
 	}
 
 	return (
-		<Sheet open={open} onOpenChange={handleOpenChange}>
-			<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
-				<SheetHeader>
-					<SheetTitle>{title}</SheetTitle>
-					<SheetDescription className="hidden">{description}</SheetDescription>
-				</SheetHeader>
-				<CartContent />
-			</SheetContent>
-		</Sheet>
+		<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
+			<SheetHeader>
+				<SheetTitle>{title}</SheetTitle>
+				<SheetDescription className="hidden">{description}</SheetDescription>
+			</SheetHeader>
+			<CartContent />
+		</SheetContent>
 	)
 }
 


### PR DESCRIPTION
[Screencast from 2025-09-27 17-50-04.webm](https://github.com/user-attachments/assets/dada0c8d-5419-4069-a6f0-bfccc560329f)

Drawer cart was being set to false immediately before the animation runs, making animation to fail to run causing #89 