### PR TITLE
feat(orders): add stock update dialog after shipping

### DIFF
--- a/src/components/orders/OrderActions.tsx
+++ b/src/components/orders/OrderActions.tsx
@@ -21,6 +21,7 @@ import { toast } from 'sonner'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Textarea } from '../ui/textarea'
+import { StockUpdateDialog } from './StockUpdateDialog'
 
 interface OrderActionsProps {
 	order: OrderWithRelatedEvents
@@ -35,6 +36,8 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 
 	const [trackingNumber, setTrackingNumber] = useState('')
 	const [isShippingOpen, setIsShippingOpen] = useState(false)
+
+	const [isStockUpdateOpen, setIsStockUpdateOpen] = useState(false)
 
 	const updateOrderStatus = useUpdateOrderStatusMutation()
 	const updateShippingStatus = useUpdateShippingStatusMutation()
@@ -100,10 +103,18 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 
 		setIsShippingOpen(false)
 		setTrackingNumber('')
+
+		// After marking as shipped, open the stock update dialog
+		setIsStockUpdateOpen(true)
 	}
 
 	if (!isBuyer && !isSeller) {
 		return null // Don't show actions if user is neither buyer nor seller
+	}
+
+	const handleStockUpdateComplete = () => {
+		// Stock has been updated, dialog can close
+		// No need to update order status - shipping status is already set
 	}
 
 	// Check if there are any available actions
@@ -175,8 +186,6 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 								Mark as Shipped
 							</DropdownMenuItem>
 						)}
-
-						{/* Seller can no longer complete orders; completion is buyer-only after shipped */}
 
 						{/* Cancel action - open dialog */}
 						{canCancel && (
@@ -251,6 +260,14 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
+
+			{/* Stock Update Dialog */}
+			<StockUpdateDialog
+				open={isStockUpdateOpen}
+				onOpenChange={setIsStockUpdateOpen}
+				order={order}
+				onComplete={handleStockUpdateComplete}
+			/>
 		</div>
 	)
 }

--- a/src/components/orders/StockUpdateDialog.tsx
+++ b/src/components/orders/StockUpdateDialog.tsx
@@ -1,0 +1,250 @@
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { fetchProductByATag, getProductId, getProductStock } from '@/queries/products'
+import { useUpdateProductMutation, type ProductFormData } from '@/publish/products'
+import type { OrderWithRelatedEvents } from '@/queries/orders'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { ndkActions } from '@/lib/stores/ndk'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import {
+	getProductTitle,
+	getProductDescription,
+	getProductPrice,
+	getProductImages,
+	getProductSpecs,
+	getProductType,
+	getProductVisibility,
+	getProductWeight,
+	getProductDimensions,
+	getProductCategories,
+	getProductCollection,
+	getProductShippingOptions,
+} from '@/queries/products'
+
+interface ProductStockUpdate {
+	productRef: string // Format: 30402:pubkey:dtag
+	productName: string
+	quantityOrdered: number
+	currentStock: number
+	newStock: number
+	productEvent: NDKEvent | null
+}
+
+interface StockUpdateDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	order: OrderWithRelatedEvents
+	onComplete: () => void
+}
+
+export function StockUpdateDialog({ open, onOpenChange, order, onComplete }: StockUpdateDialogProps) {
+	const [products, setProducts] = useState<ProductStockUpdate[]>([])
+	const [loading, setLoading] = useState(false)
+	const updateProductMutation = useUpdateProductMutation()
+	const ndk = ndkActions.getNDK()
+
+	// Extract products from order and fetch their current stock
+	useEffect(() => {
+		if (!open || !ndk) return
+
+		const fetchProductsData = async () => {
+			setLoading(true)
+			try {
+				// Get all item tags from the order
+				const itemTags = order.order.tags.filter((tag) => tag[0] === 'item')
+
+				const productUpdates: ProductStockUpdate[] = []
+
+				for (const itemTag of itemTags) {
+					const productRef = itemTag[1] // Format: 30402:pubkey:dtag
+					const quantity = parseInt(itemTag[2] || '1')
+
+					// Parse the product reference
+					const [kind, pubkey, dTag] = productRef.split(':')
+
+					if (kind !== '30402' || !pubkey || !dTag) {
+						console.warn('Invalid product reference:', productRef)
+						continue
+					}
+
+					// Fetch the product event
+					const productEvent = await fetchProductByATag(pubkey, dTag)
+
+					if (!productEvent) {
+						console.warn('Product not found:', productRef)
+						continue
+					}
+
+					const productName = getProductTitle(productEvent)
+					const stockTag = getProductStock(productEvent)
+					const currentStock = stockTag ? parseInt(stockTag[1]) : 0
+					const newStock = Math.max(0, currentStock - quantity)
+
+					productUpdates.push({
+						productRef,
+						productName,
+						quantityOrdered: quantity,
+						currentStock,
+						newStock,
+						productEvent,
+					})
+				}
+
+				setProducts(productUpdates)
+			} catch (error) {
+				console.error('Error fetching product data:', error)
+				toast.error('Failed to load product information')
+			} finally {
+				setLoading(false)
+			}
+		}
+
+		fetchProductsData()
+	}, [open, order, ndk])
+
+	const handleStockChange = (productRef: string, value: string) => {
+		const newStock = parseInt(value) || 0
+		setProducts((prev) => prev.map((p) => (p.productRef === productRef ? { ...p, newStock: Math.max(0, newStock) } : p)))
+	}
+
+	const handleUpdateStock = async () => {
+		setLoading(true)
+		try {
+			const signer = ndkActions.getSigner()
+			if (!signer) {
+				toast.error('No signer available')
+				return
+			}
+
+			// Update each product with new stock
+			for (const product of products) {
+				if (!product.productEvent) continue
+
+				const [, , dTag] = product.productRef.split(':')
+
+				// Build form data from existing product event
+				const priceTag = getProductPrice(product.productEvent)
+				const typeTag = getProductType(product.productEvent)
+				const visibilityTag = getProductVisibility(product.productEvent)
+				const weightTag = getProductWeight(product.productEvent)
+				const dimensionsTag = getProductDimensions(product.productEvent)
+				const images = getProductImages(product.productEvent)
+				const specs = getProductSpecs(product.productEvent)
+				const categories = getProductCategories(product.productEvent)
+				const shippingOptions = getProductShippingOptions(product.productEvent)
+				const collectionTag = getProductCollection(product.productEvent)
+
+				const formData: ProductFormData = {
+					name: product.productName,
+					description: getProductDescription(product.productEvent),
+					price: priceTag?.[1] || '0',
+					quantity: product.newStock.toString(),
+					currency: priceTag?.[2] || 'USD',
+					status: (visibilityTag?.[1] || 'on-sale') as 'hidden' | 'on-sale' | 'pre-order',
+					productType: typeTag?.[1] === 'simple' ? 'single' : 'variable',
+					mainCategory: categories[0]?.[1] || '',
+					selectedCollection: collectionTag,
+					categories: categories.slice(1).map((cat) => ({
+						key: cat[1],
+						name: cat[1],
+						checked: true,
+					})),
+					images: images.map((img, index) => ({
+						imageUrl: img[1],
+						imageOrder: parseInt(img[3] || index.toString()),
+					})),
+					specs: specs.map((spec) => ({
+						key: spec[1],
+						value: spec[2],
+					})),
+					shippings: shippingOptions.map((opt) => ({
+						shipping: { id: opt[1], name: opt[1] },
+						extraCost: opt[2] || '0',
+					})),
+					weight: weightTag
+						? {
+								value: weightTag[1],
+								unit: weightTag[2],
+							}
+						: null,
+					dimensions: dimensionsTag
+						? {
+								value: dimensionsTag[1],
+								unit: dimensionsTag[2],
+							}
+						: null,
+				}
+
+				await updateProductMutation.mutateAsync({
+					productDTag: dTag,
+					formData,
+				})
+			}
+
+			toast.success('All product stock levels updated successfully')
+			onComplete()
+			onOpenChange(false)
+		} catch (error) {
+			console.error('Error updating stock:', error)
+			toast.error('Failed to update stock levels')
+		} finally {
+			setLoading(false)
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>Update Product Stock</DialogTitle>
+					<DialogDescription>The order has been completed. Update the stock levels for the products in this order.</DialogDescription>
+				</DialogHeader>
+
+				{loading && products.length === 0 ? (
+					<div className="py-8 text-center text-muted-foreground">Loading product information...</div>
+				) : (
+					<div className="space-y-4 py-4">
+						{products.map((product) => (
+							<div key={product.productRef} className="border rounded-lg p-4 space-y-3">
+								<div className="font-medium">{product.productName}</div>
+								<div className="grid grid-cols-3 gap-4 text-sm">
+									<div>
+										<Label className="text-muted-foreground">Ordered</Label>
+										<div className="font-medium">{product.quantityOrdered}</div>
+									</div>
+									<div>
+										<Label className="text-muted-foreground">Current Stock</Label>
+										<div className="font-medium">{product.currentStock}</div>
+									</div>
+									<div>
+										<Label htmlFor={`stock-${product.productRef}`}>New Stock</Label>
+										<Input
+											id={`stock-${product.productRef}`}
+											type="number"
+											min="0"
+											value={product.newStock}
+											onChange={(e) => handleStockChange(product.productRef, e.target.value)}
+											className="mt-1"
+										/>
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+						Cancel
+					</Button>
+					<Button onClick={handleUpdateStock} disabled={loading || products.length === 0}>
+						{loading ? 'Updating...' : 'Update Stock'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/orders/orderColumns.tsx
+++ b/src/components/orders/orderColumns.tsx
@@ -50,7 +50,11 @@ const purchaseActionsColumn: ColumnDef<OrderWithRelatedEvents> = {
 
 		if (!currentUserPubkey) return null
 
-		return <OrderActions order={row.original} userPubkey={currentUserPubkey} />
+		return (
+			<div onClick={(e) => e.stopPropagation()}>
+				<OrderActions order={row.original} userPubkey={currentUserPubkey} />
+			</div>
+		)
 	},
 }
 
@@ -64,7 +68,11 @@ const salesActionsColumn: ColumnDef<OrderWithRelatedEvents> = {
 
 		if (!currentUserPubkey) return null
 
-		return <OrderActions order={row.original} userPubkey={currentUserPubkey} />
+		return (
+			<div onClick={(e) => e.stopPropagation()}>
+				<OrderActions order={row.original} userPubkey={currentUserPubkey} />
+			</div>
+		)
 	},
 }
 


### PR DESCRIPTION
Implement stock management feature that automatically opens a dialog to update product stock levels after marking an order as shipped. The dialog shows current stock and allows adjusting quantities for all products in the order.

- Create new StockUpdateDialog component
- Modify OrderActions to trigger dialog after shipping
- Wrap action buttons in div to prevent event propagation