### PR TITLE
feat(profile): add product button to empty state

### DIFF
--- a/src/routes/profile.$profileId.tsx
+++ b/src/routes/profile.$profileId.tsx
@@ -11,6 +11,7 @@ import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { useEntityPermissions } from '@/hooks/useEntityPermissions'
 import { getHexColorFingerprintFromHexPubkey, truncateText, checkImageLoadable } from '@/lib/utils'
 import { ndkActions } from '@/lib/stores/ndk'
+import { productFormActions } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { addToBlacklist, removeFromBlacklist } from '@/publish/blacklist'
 import { addToFeaturedUsers, removeFromFeaturedUsers } from '@/publish/featured'
@@ -70,6 +71,13 @@ function RouteComponent() {
 	// Handle edit profile
 	const handleEdit = () => {
 		navigate({ to: '/dashboard/account/profile' })
+	}
+
+	// Handle add product
+	const handleAddProduct = () => {
+		productFormActions.reset()
+		productFormActions.setEditingProductId(null)
+		navigate({ to: '/dashboard/products/products/new' })
 	}
 
 	// Handle message button
@@ -255,8 +263,14 @@ function RouteComponent() {
 							))}
 						</ItemGrid>
 					) : (
-						<div className="flex flex-col items-center justify-center flex-1">
+						<div className="flex flex-col items-center justify-center flex-1 gap-4">
 							<span className="text-2xl font-heading">No products found</span>
+							{permissions.canEdit && (
+								<Button onClick={handleAddProduct} className="flex items-center gap-2">
+									<Plus className="h-5 w-5" />
+									Add Your First Product
+								</Button>
+							)}
 						</div>
 					)}
 				</div>


### PR DESCRIPTION
## Summary

- Adds "Add Your First Product" button to profile page empty state
- Only visible to profile owner (uses existing `permissions.canEdit` check)
- Navigates to product creation page (`/dashboard/products/products/new`)

Closes #389

## Test plan

- [x] Log in and navigate to your profile page
- [x] Verify "Add Your First Product" button appears when you have no products
- [x] Click button and confirm it navigates to product creation
- [x] Verify button does NOT appear when viewing another user's profile

## Screenshots

<img width="1459" height="907" src="https://github.com/user-attachments/assets/099d5047-cd6b-4fdd-92d2-360691b9ced1" alt="image">

<img width="1797" height="826" src="https://github.com/user-attachments/assets/db037e36-878d-4155-b6ab-d34be569867a" alt="image">

<img width="1334" height="906" src="https://github.com/user-attachments/assets/55e0050f-db3f-4bc5-bfcb-e0cafa57425f" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)