### PR TITLE
fix(profile): change 'More products from' to 'Products from'

### DIFF
--- a/src/routes/profile.$profileId.tsx
+++ b/src/routes/profile.$profileId.tsx
@@ -245,7 +245,7 @@ function RouteComponent() {
 						<ItemGrid
 							title={
 								<div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-center sm:text-left">
-									<span className="text-2xl font-heading">More products from</span>
+									<span className="text-2xl font-heading">Products from</span>
 									<ProfileName pubkey={user?.pubkey || ''} className="text-2xl font-heading" />
 								</div>
 							}


### PR DESCRIPTION
## Summary

- Changes heading from "More products from [Username]" to "Products from [Username]"
- The "More" prefix was incorrect since this is the primary view of a seller's products on their profile page

Closes #394

## Test plan

- [x] Navigate to any user's profile page
- [x] Verify heading says "Products from [Username]" (not "More products from")

## Screenshot

<img width="1920" height="1080" src="https://github.com/user-attachments/assets/7b05cb60-d09a-4524-a2ee-254e86ab9e75" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)