### PR TITLE
fix(zap): highlight selected amount button and add aria description

### DIFF
--- a/src/components/ZapDialog.tsx
+++ b/src/components/ZapDialog.tsx
@@ -162,6 +162,7 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 					<DialogTitle>
 						Zap {recipientName} {lightningAddress && <small>({lightningAddress})</small>}
 					</DialogTitle>
+					<DialogDescription className="sr-only">Send a lightning zap to {recipientName}</DialogDescription>
 				</DialogHeader>
 
 				{step === 'amount' && (
@@ -174,8 +175,8 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 									{DEFAULT_ZAP_AMOUNTS.map(({ displayText, amount: presetAmount }) => (
 										<Button
 											key={presetAmount}
-											variant={numericAmount === presetAmount ? 'tertiary' : 'outline'}
-											className="border-2 border-black"
+											variant={numericAmount === presetAmount ? 'focus' : 'outline'}
+											className={numericAmount === presetAmount ? 'border-2' : 'border-2 border-black'}
 											onClick={() => handleAmountButtonClick(presetAmount)}
 										>
 											{displayText}


### PR DESCRIPTION
## Summary

- Selected preset amount button now stays highlighted (uses 'focus' variant with yellow styling)
- Fixed border styling that was overriding variant colors
- Added visually hidden DialogDescription for accessibility (fixes console warning)

Closes #396

## Test plan

- [x] Open Zap dialog on any profile
- [x] Click different preset amounts (10, 21, 1000, etc.)
- [x] Verify clicked button stays highlighted (yellow)
- [x] Change manual amount field - button highlight should update accordingly
- [x] Check console - no more "Missing Description" warning

## Screenshot

<img width="1496" height="910" src="https://github.com/user-attachments/assets/8f69fb82-246a-4397-945f-73395abae375" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)