### PR TITLE
fix: change Currency label to 'Choose your local currency'

### DIFF
--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -220,7 +220,7 @@ export function DetailTab() {
 			{/* Currency Dropdown */}
 			<div className="space-y-2">
 				<Label htmlFor="currency" className="text-sm font-medium">
-					Currency <span className="text-red-500">*</span>
+					Choose your local currency <span className="text-red-500">*</span>
 				</Label>
 				<Select value={currency} onValueChange={handleCurrencyChange}>
 					<SelectTrigger>


### PR DESCRIPTION
## Summary

- Changes the "Currency" label to "Choose your local currency" on the Add a Product page
- Clarifies the purpose of the field for new users

Fixes #374

## Test plan

- [x] Navigate to Dashboard > Products > Add A Product
- [x] Go to the DETAIL tab
- [x] Verify the label now says "Choose your local currency *" instead of "Currency *"

## Screenshot

<img width="1341" height="843" src="https://github.com/user-attachments/assets/d9e1dd12-9a01-4485-aee5-6fccc16540b7" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)