### PR TITLE
fix: correctly display sats price when editing fiat-priced products

### DIFF
--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -206,8 +206,7 @@ export function DetailTab() {
 			const fiatValue = parseFloat(fiatPrice) || 0
 			if (fiatValue > 0) {
 				const satsValue = convertCurrencyToSats(fiatValue, currency)
-				// Sats should always be an integer
-				productFormActions.updateValues({ price: Math.round(satsValue).toString() })
+				productFormActions.updateValues({ price: satsValue.toString() })
 			}
 		}
 	}, [storeCurrencyMode, fiatPrice, price, currency, exchangeRates])

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -90,15 +90,18 @@ export function DetailTab() {
 	const handleBitcoinPriceChange = (value: string) => {
 		const numValue = parseFloat(value) || 0
 
-		// Convert to SATS for storage
-		const satsValue = bitcoinUnit === 'SATS' ? numValue : convertBtcToSats(numValue)
-
-		productFormActions.updateValues({ price: satsValue.toString() })
+		// Convert to SATS for storage (sats should always be integers)
+		const satsValue = bitcoinUnit === 'SATS' ? Math.round(numValue) : convertBtcToSats(numValue)
 
 		// Update fiat field if a fiat currency is selected and visible
 		if (currency !== 'SATS' && currency !== 'BTC') {
 			const fiatValue = convertSatsToCurrency(satsValue, currency)
-			setFiatDisplayValue(fiatValue.toFixed(2))
+			const fiatValueStr = fiatValue.toFixed(2)
+			setFiatDisplayValue(fiatValueStr)
+			// Also update state.fiatPrice so it's used when publishing in fiat mode
+			productFormActions.updateValues({ price: satsValue.toString(), fiatPrice: fiatValueStr })
+		} else {
+			productFormActions.updateValues({ price: satsValue.toString() })
 		}
 	}
 
@@ -196,6 +199,18 @@ export function DetailTab() {
 			setFiatDisplayValue(fiatPrice)
 		}
 	}, [storeBitcoinUnit, storeCurrencyMode, fiatPrice])
+
+	// Calculate sats from fiat when loading a fiat-priced product (price is empty, fiatPrice has value)
+	useEffect(() => {
+		if (storeCurrencyMode === 'fiat' && fiatPrice && !price && exchangeRates) {
+			const fiatValue = parseFloat(fiatPrice) || 0
+			if (fiatValue > 0) {
+				const satsValue = convertCurrencyToSats(fiatValue, currency)
+				// Sats should always be an integer
+				productFormActions.updateValues({ price: Math.round(satsValue).toString() })
+			}
+		}
+	}, [storeCurrencyMode, fiatPrice, price, currency, exchangeRates])
 
 	// Update fiat display when currency or price changes (only for auto-conversion from sats)
 	useEffect(() => {

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -223,7 +223,9 @@ export const productFormActions = {
 				editingProductId: productDTag, // Use the d tag value, not the event ID!
 				name: title,
 				description: description,
-				price: priceValue,
+				// For fiat products, price (sats) will be calculated in the UI from fiatPrice
+				// For sats/BTC products, use the stored value directly
+				price: isFiatCurrency ? '' : priceValue,
 				fiatPrice: isFiatCurrency ? priceValue : '', // Set fiatPrice if currency is fiat
 				currency: priceCurrency,
 				currencyMode: isFiatCurrency ? 'fiat' : 'sats',


### PR DESCRIPTION
## Summary

- When editing a fiat-priced product (e.g., 60 GBP), the sats field now shows the correct converted value (~90,708 sats) instead of the raw fiat number (60)
- Also fixes the publishing bug where entering sats didn't update `state.fiatPrice`, causing sats to be saved as fiat
- Ensures sats values are always integers via `Math.round()`

Fixes #379

## Changes

- `src/lib/stores/product.ts`: Don't set `price` to fiat value when loading fiat-priced products
- `src/components/sheet-contents/products/tabs.tsx`:
  - Add useEffect to calculate sats from fiat when loading
  - Update `handleBitcoinPriceChange` to also update `state.fiatPrice`
  - Round sats to integers

## Test plan

- [x] Edit a product that was saved with a fiat price (e.g., 60 GBP)
- [x] Verify the sats field shows the correct converted value (not 60)
- [x] Create/edit a product, enter a sats value when fiat currency is selected
- [x] Save the product and verify the fiat price is correct (not the sats value)

## Note

There are follow-up issues with the draft/auto-save system documented in [issue comment](https://github.com/PlebeianApp/market/issues/379#issuecomment-3678018338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)