### PR TITLE
fix: add instructional text to shipping options cost field

### DIFF
--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -463,8 +463,9 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 							{formData.service !== 'digital' && (
 								<div className="space-y-2">
 									<Label htmlFor="price" className="font-medium">
-										Price *
+										Base Cost *
 									</Label>
+									<p className="text-sm text-muted-foreground">Can be adjusted per product</p>
 									<div className="flex gap-2">
 										<Input
 											id="price"


### PR DESCRIPTION
## Summary

- Changes "Price" label to "Base Cost" on the shipping options form
- Adds helper text "Can be adjusted per product" to clarify this is a default that can be modified

Fixes #375

## Test plan

- [x] Navigate to Dashboard > Products > Shipping Options
- [x] Click "Add Shipping Option" or edit an existing one
- [x] Verify the price field now shows "Base Cost *" with helper text below

## Screenshot

<img width="1346" height="796" src="https://github.com/user-attachments/assets/22f0a2a4-3cee-425d-a7e4-ee92008199e5" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)