### PR TITLE
fix: change 'a seller' to 'the seller' in checkout

### DIFF
--- a/src/components/checkout/OrderFinalizeComponent.tsx
+++ b/src/components/checkout/OrderFinalizeComponent.tsx
@@ -259,7 +259,7 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 			{/* Seller Contact Section - Show on summary or after payment */}
 			{sellerPubkeys.length > 0 && (
 				<div className="bg-gray-50 rounded-lg p-4">
-					<h3 className="font-medium text-gray-900 mb-3">Need to contact a seller?</h3>
+					<h3 className="font-medium text-gray-900 mb-3">Need to contact the seller?</h3>
 					<div className="space-y-2">
 						{invoices
 							.filter((invoice) => invoice.type === 'merchant')


### PR DESCRIPTION
## Summary

Changes "Need to contact a seller?" to "Need to contact the seller?" in the checkout order finalize component.

Fixes #353

## Test plan

- [ ] Go through checkout flow to the order finalize/summary page
- [ ] Verify text now says "Need to contact the seller?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)