### PR TITLE
fix: resolve race condition and filter current product in 'More from seller'

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -18,7 +18,7 @@ import { PriceDisplay } from './PriceDisplay'
 import { Button } from './ui/button'
 import { ZapButton } from './ZapButton'
 
-export function ProductCard({ product }: { product: NDKEvent }) {
+export function ProductCard({ product, currentUserPubkey: propUserPubkey }: { product: NDKEvent; currentUserPubkey?: string | null }) {
 	const title = getProductTitle(product)
 	const images = getProductImages(product)
 	const price = getProductPrice(product)
@@ -28,16 +28,24 @@ export function ProductCard({ product }: { product: NDKEvent }) {
 	const visibility = visibilityTag?.[1] || 'on-sale'
 	// Out of stock if stock is explicitly 0 or undefined (no stock tag), but not for pre-order items
 	const isOutOfStock = visibility !== 'pre-order' && (stockQuantity === undefined || stockQuantity === 0)
-	const [isOwnProduct, setIsOwnProduct] = useState(false)
-	const [currentUserPubkey, setCurrentUserPubkey] = useState<string | null>(null)
+	// Initialize ownership based on prop if provided (avoids race condition)
+	const [isOwnProduct, setIsOwnProduct] = useState(propUserPubkey ? propUserPubkey === product.pubkey : false)
+	const [currentUserPubkey, setCurrentUserPubkey] = useState<string | null>(propUserPubkey || null)
 	const [isAddingToCart, setIsAddingToCart] = useState(false)
 	const [showConfirmation, setShowConfirmation] = useState(false)
 	const location = useLocation()
 	const cart = useCart()
 	const queryClient = useQueryClient()
 
-	// Check if current user is the seller of this product
+	// Check if current user is the seller of this product (only if pubkey not provided via prop)
 	useEffect(() => {
+		// Skip async fetch if we already have the pubkey from props
+		if (propUserPubkey !== undefined) {
+			setCurrentUserPubkey(propUserPubkey)
+			setIsOwnProduct(propUserPubkey === product.pubkey)
+			return
+		}
+
 		const checkIfOwnProduct = async () => {
 			const user = await ndkActions.getUser()
 			if (user?.pubkey) {
@@ -46,7 +54,7 @@ export function ProductCard({ product }: { product: NDKEvent }) {
 			}
 		}
 		checkIfOwnProduct()
-	}, [product.pubkey])
+	}, [product.pubkey, propUserPubkey])
 
 	// Check if product is already in cart
 	const isInCart = !!cart.cart.products[product.id]

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -736,16 +736,18 @@ function RouteComponent() {
 			</div>
 
 			{/* More from this seller */}
-			<div className="flex flex-col gap-4 p-4">
-				<h2 className="font-heading text-2xl text-center lg:text-left">More from this seller</h2>
-				<ItemGrid className="gap-4 sm:gap-8">
-					{sellerProducts
-						.filter((p) => p.id !== productId)
-						.map((p) => (
-							<ProductCard key={p.id} product={p} currentUserPubkey={currentUserPubkey} />
-						))}
-				</ItemGrid>
-			</div>
+			{sellerProducts.filter((p) => p.id !== productId).length > 0 && (
+				<div className="flex flex-col gap-4 p-4">
+					<h2 className="font-heading text-2xl text-center lg:text-left">More from this seller</h2>
+					<ItemGrid className="gap-4 sm:gap-8">
+						{sellerProducts
+							.filter((p) => p.id !== productId)
+							.map((p) => (
+								<ProductCard key={p.id} product={p} currentUserPubkey={currentUserPubkey} />
+							))}
+					</ItemGrid>
+				</div>
+			)}
 
 			{/* Image Viewer Modal */}
 			<ImageViewerModal

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -141,6 +141,18 @@ function RouteComponent() {
 	const [imageViewerOpen, setImageViewerOpen] = useState(false)
 	const [selectedImageIndex, setSelectedImageIndex] = useState(0)
 	const [shareDialogOpen, setShareDialogOpen] = useState(false)
+	const [currentUserPubkey, setCurrentUserPubkey] = useState<string | null>(null)
+
+	// Fetch current user's pubkey for ProductCard ownership check
+	useEffect(() => {
+		const fetchUserPubkey = async () => {
+			const user = await ndkActions.getUser()
+			if (user?.pubkey) {
+				setCurrentUserPubkey(user.pubkey)
+			}
+		}
+		fetchUserPubkey()
+	}, [])
 
 	// Get app config
 	const { data: config } = useConfigQuery()
@@ -727,9 +739,11 @@ function RouteComponent() {
 			<div className="flex flex-col gap-4 p-4">
 				<h2 className="font-heading text-2xl text-center lg:text-left">More from this seller</h2>
 				<ItemGrid className="gap-4 sm:gap-8">
-					{sellerProducts.map((p) => (
-						<ProductCard key={p.id} product={p} />
-					))}
+					{sellerProducts
+						.filter((p) => p.id !== productId)
+						.map((p) => (
+							<ProductCard key={p.id} product={p} currentUserPubkey={currentUserPubkey} />
+						))}
 				</ItemGrid>
 			</div>
 


### PR DESCRIPTION
## Summary

- Fixes products not being recognized as "Your Product" due to async race condition in ProductCard (#403)
- Filters out the currently viewed product from "More from this seller" section (#404)

## Changes

- Added optional `currentUserPubkey` prop to `ProductCard` component that allows parent components to pass the user's pubkey synchronously
- When prop is provided, ownership check happens immediately without async delay
- Updated product detail page to fetch user pubkey and pass it to ProductCard components
- Added filter to exclude current product from seller's other products list

## Test plan

- [ ] Navigate to a product you own → should show "Your Product" immediately (not flash "Add to Cart" first)
- [ ] Navigate to a product page → current product should NOT appear in "More from this seller" section
- [ ] Other seller's products should still show correctly with "Add to Cart" button

Fixes #403
Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)