### PR TITLE
fix: improve product deletion feedback and products dashboard UI

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -34,6 +34,14 @@ import { createUserNwcWallets } from './gen_wallets'
 
 config()
 
+// Force local relay only mode to prevent connecting to public relays during seeding
+// This must be set before ndkActions.initialize() is called
+// @ts-ignore - Bun.env is available in Bun runtime
+if (typeof Bun !== 'undefined') {
+	Bun.env.LOCAL_RELAY_ONLY = 'true'
+}
+process.env.LOCAL_RELAY_ONLY = 'true'
+
 const RELAY_URL = process.env.APP_RELAY_URL
 const APP_PRIVATE_KEY = process.env.APP_PRIVATE_KEY
 

--- a/scripts/startup.ts
+++ b/scripts/startup.ts
@@ -7,6 +7,14 @@ import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 
 config()
 
+// Force local relay only mode to prevent connecting to public relays during startup
+// This must be set before ndkActions.initialize() is called
+// @ts-ignore - Bun.env is available in Bun runtime
+if (typeof Bun !== 'undefined') {
+	Bun.env.LOCAL_RELAY_ONLY = 'true'
+}
+process.env.LOCAL_RELAY_ONLY = 'true'
+
 const RELAY_URL = process.env.APP_RELAY_URL
 const APP_PRIVATE_KEY = process.env.APP_PRIVATE_KEY
 

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -249,9 +249,12 @@ export const ndkActions = {
 			},
 		})
 
-		const zapNdk = new NDK({
-			explicitRelayUrls: ZAP_RELAYS,
-		})
+		// Skip Zap NDK in local-relay-only mode (seeding, testing) to prevent publishing to public relays
+		const zapNdk = localRelayOnly
+			? null
+			: new NDK({
+					explicitRelayUrls: ZAP_RELAYS,
+				})
 
 		// Determine write relays - staging only writes to main relay, others write to all
 		const mainRelay = getMainRelay()
@@ -294,8 +297,10 @@ export const ndkActions = {
 				ndkStore.setState((s) => ({ ...s, isConnected: connected }))
 				if (connected) console.log('✅ NDK connected to relays')
 
-				// Also connect zap NDK in background
-				void ndkActions.connectZapNdk(5000)
+				// Also connect zap NDK in background (if available - skipped in local-relay-only mode)
+				if (state.zapNdk) {
+					void ndkActions.connectZapNdk(5000)
+				}
 			} finally {
 				ndkStore.setState((s) => ({ ...s, isConnecting: false }))
 				connectPromise = null

--- a/src/publish/collections.tsx
+++ b/src/publish/collections.tsx
@@ -1,6 +1,7 @@
 import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { collectionsKeys } from '@/queries/queryKeyFactory'
+import { markCollectionAsDeleted } from '@/queries/collections'
 import { toast } from 'sonner'
 import { ndkActions } from '@/lib/stores/ndk'
 import type { RichShippingInfo } from '@/lib/stores/cart'
@@ -240,6 +241,10 @@ export const useDeleteCollectionMutation = () => {
 		},
 
 		onSuccess: async (success, collectionId) => {
+			// Mark collection as deleted locally so it's filtered from queries
+			// even if relays still return it
+			markCollectionAsDeleted(collectionId)
+
 			// Get current user pubkey
 			let userPubkey = ''
 			if (signer) {

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -2,6 +2,7 @@ import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 import type { RichShippingInfo } from '@/lib/stores/cart'
 import { ndkActions } from '@/lib/stores/ndk'
 import { productKeys } from '@/queries/queryKeyFactory'
+import { markProductAsDeleted } from '@/queries/products'
 import NDK, { NDKEvent, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -328,6 +329,10 @@ export const useDeleteProductMutation = () => {
 		},
 
 		onSuccess: async (success, productDTag) => {
+			// Mark product as deleted locally so it's filtered from queries
+			// even if relays still return it
+			markProductAsDeleted(productDTag)
+
 			// Get current user pubkey
 			let userPubkey = ''
 			if (signer) {

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -24,6 +24,54 @@ import { naddrFromAddress } from '@/lib/nostr/naddr'
 // Re-export productKeys for use in other query files
 export { productKeys }
 
+// --- DELETED PRODUCTS TRACKING ---
+// Track deleted product IDs to filter them out from relay responses
+// (Relays may still return deleted events until they process the deletion)
+// Persisted to localStorage so deletions survive page reloads
+
+const DELETED_PRODUCTS_STORAGE_KEY = 'plebeian_deleted_product_ids'
+
+const loadDeletedProductIds = (): Set<string> => {
+	try {
+		const stored = localStorage.getItem(DELETED_PRODUCTS_STORAGE_KEY)
+		if (stored) {
+			const parsed = JSON.parse(stored)
+			if (Array.isArray(parsed)) {
+				return new Set(parsed)
+			}
+		}
+	} catch (e) {
+		console.error('Failed to load deleted product IDs from localStorage:', e)
+	}
+	return new Set()
+}
+
+const saveDeletedProductIds = (ids: Set<string>) => {
+	try {
+		localStorage.setItem(DELETED_PRODUCTS_STORAGE_KEY, JSON.stringify([...ids]))
+	} catch (e) {
+		console.error('Failed to save deleted product IDs to localStorage:', e)
+	}
+}
+
+const deletedProductIds = loadDeletedProductIds()
+
+export const markProductAsDeleted = (dTag: string) => {
+	deletedProductIds.add(dTag)
+	saveDeletedProductIds(deletedProductIds)
+}
+
+export const isProductDeleted = (dTag: string) => {
+	return deletedProductIds.has(dTag)
+}
+
+const filterDeletedProducts = (events: NDKEvent[]): NDKEvent[] => {
+	return events.filter((event) => {
+		const dTag = event.tags.find((t) => t[0] === 'd')?.[1]
+		return dTag ? !deletedProductIds.has(dTag) : true
+	})
+}
+
 // Helper to check if an ID looks like a Nostr event ID (64-hex characters)
 export const isEventId = (id: string): boolean => /^[a-f0-9]{64}$/i.test(id)
 
@@ -74,8 +122,8 @@ export const fetchProducts = async (limit: number = 500, tag?: string, includeHi
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	const allEvents = Array.from(events).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 
-	// Filter out blacklisted products and authors
-	const filteredEvents = filterBlacklistedEvents(allEvents)
+	// Filter out blacklisted products and authors, then filter out locally-deleted products
+	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
@@ -116,8 +164,8 @@ export const fetchProductsPaginated = async (limit: number = 20, until?: number,
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	const allEvents = Array.from(events).sort((a, b) => b.created_at! - a.created_at!)
 
-	// Filter out blacklisted products and authors
-	const filteredEvents = filterBlacklistedEvents(allEvents)
+	// Filter out blacklisted products and authors, then filter out locally-deleted products
+	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
@@ -185,7 +233,8 @@ export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boole
 	const allEvents = Array.from(events)
 
 	// Filter out blacklisted products (author check not needed since we're querying by author)
-	const filteredEvents = filterBlacklistedEvents(allEvents)
+	// Then filter out locally-deleted products
+	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
@@ -361,8 +410,8 @@ export const fetchProductsByCollection = async (collectionEvent: NDKEvent): Prom
 	const results = await Promise.all(productPromises)
 	const allProducts = results.filter((event) => event !== null) as NDKEvent[]
 
-	// Filter out blacklisted products and authors
-	const filteredProducts = filterBlacklistedEvents(allProducts)
+	// Filter out blacklisted products and authors, then filter out locally-deleted products
+	const filteredProducts = filterDeletedProducts(filterBlacklistedEvents(allProducts))
 
 	// Filter out out-of-stock products from collection views
 	return filteredProducts.filter(isProductInStock)
@@ -882,6 +931,7 @@ export const fetchProductsBySearch = async (query: string, limit: number = 20) =
 		const fetchPromise = ndk
 			.fetchEvents(filter)
 			.then((events) => filterBlacklistedEvents(Array.from(events)))
+			.then((events) => filterDeletedProducts(events)) // Filter out locally-deleted products
 			.then((events) => events.filter(isProductInStock)) // Filter out out-of-stock products
 			.catch((err) => {
 				console.error('Product search fetch failed:', err)

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -25,30 +25,38 @@ import { naddrFromAddress } from '@/lib/nostr/naddr'
 export { productKeys }
 
 // --- DELETED PRODUCTS TRACKING ---
-// Track deleted product IDs to filter them out from relay responses
-// (Relays may still return deleted events until they process the deletion)
-// Persisted to localStorage so deletions survive page reloads
+// Track deleted product d-tags with deletion timestamps to filter them from relay responses.
+// Per NIP-09, deletions only apply to events older than the deletion event.
+// If a new event with the same d-tag is published after the deletion, it should be visible.
+// Persisted to localStorage so deletions survive page reloads.
 
 const DELETED_PRODUCTS_STORAGE_KEY = 'plebeian_deleted_product_ids'
 
-const loadDeletedProductIds = (): Set<string> => {
+// Map of d-tag -> deletion timestamp (unix seconds)
+const loadDeletedProductIds = (): Map<string, number> => {
 	try {
 		const stored = localStorage.getItem(DELETED_PRODUCTS_STORAGE_KEY)
 		if (stored) {
 			const parsed = JSON.parse(stored)
+			// Handle legacy format (array of strings) - migrate to new format
 			if (Array.isArray(parsed)) {
-				return new Set(parsed)
+				const now = Math.floor(Date.now() / 1000)
+				return new Map(parsed.map((dTag: string) => [dTag, now]))
+			}
+			// New format: object with d-tag keys and timestamp values
+			if (typeof parsed === 'object' && parsed !== null) {
+				return new Map(Object.entries(parsed))
 			}
 		}
 	} catch (e) {
 		console.error('Failed to load deleted product IDs from localStorage:', e)
 	}
-	return new Set()
+	return new Map()
 }
 
-const saveDeletedProductIds = (ids: Set<string>) => {
+const saveDeletedProductIds = (ids: Map<string, number>) => {
 	try {
-		localStorage.setItem(DELETED_PRODUCTS_STORAGE_KEY, JSON.stringify([...ids]))
+		localStorage.setItem(DELETED_PRODUCTS_STORAGE_KEY, JSON.stringify(Object.fromEntries(ids)))
 	} catch (e) {
 		console.error('Failed to save deleted product IDs to localStorage:', e)
 	}
@@ -56,19 +64,27 @@ const saveDeletedProductIds = (ids: Set<string>) => {
 
 const deletedProductIds = loadDeletedProductIds()
 
-export const markProductAsDeleted = (dTag: string) => {
-	deletedProductIds.add(dTag)
+export const markProductAsDeleted = (dTag: string, deletionTimestamp?: number) => {
+	// Use provided timestamp or current time
+	const timestamp = deletionTimestamp ?? Math.floor(Date.now() / 1000)
+	deletedProductIds.set(dTag, timestamp)
 	saveDeletedProductIds(deletedProductIds)
 }
 
-export const isProductDeleted = (dTag: string) => {
-	return deletedProductIds.has(dTag)
+export const isProductDeleted = (dTag: string, eventCreatedAt?: number) => {
+	const deletionTimestamp = deletedProductIds.get(dTag)
+	if (deletionTimestamp === undefined) return false
+	// If no event timestamp provided, assume deleted
+	if (eventCreatedAt === undefined) return true
+	// Per NIP-09: deletion only applies to events older than the deletion
+	return eventCreatedAt < deletionTimestamp
 }
 
 const filterDeletedProducts = (events: NDKEvent[]): NDKEvent[] => {
 	return events.filter((event) => {
 		const dTag = event.tags.find((t) => t[0] === 'd')?.[1]
-		return dTag ? !deletedProductIds.has(dTag) : true
+		if (!dTag) return true
+		return !isProductDeleted(dTag, event.created_at)
 	})
 }
 


### PR DESCRIPTION
## Summary

- **Relay status display** - When expanding a product, shows which relays have the product with color-coded status (Published/Deletion pending/Deleted/Not found)
- **Set visibility to hidden before deletion** - Ensures products aren't visible to customers even if relays don't honor deletion events
- **Per-relay deletion tracking** - Tracks success/failure of deletion events per relay with colored toast feedback
- **Product thumbnails** - Added 40x40px thumbnails to product list items for quick visual identification
- **Improved expanded layout** - Image on left, details (description, price, stock, visibility) on right with proper aspect ratio
- **Fix seed scripts** - Prevent seed/startup scripts from connecting to public relays (Fixes #583)
  - Skip Zap NDK creation when LOCAL_RELAY_ONLY=true
  - Set LOCAL_RELAY_ONLY=true in seed.ts and startup.ts before NDK init
  - Use dynamic timestamps (last 30 days) instead of hardcoded dates

## Test plan

- [x] Delete a product and verify toast shows per-relay status
- [x] Expand a product and verify relay status shows correctly
- [x] Verify thumbnails appear in the product list
- [x] Verify expanded product shows image on left, details on right
- [x] Verify deleted product gets visibility set to "hidden" before deletion event
- [ ] Perform further testing that the relay statuses are correct - IMPORTANT
- [ ] Run `bun seed` and verify it only connects to local relay

Closes #413, closes #414, closes #415, closes #416, closes #412
Fixes #583

## Screenshot

<img width="1210" height="1007" src="https://github.com/user-attachments/assets/dbe4f4e7-62e0-43c2-a723-43a541ee5e6c" alt="image">

<img width="1210" height="1007" src="https://github.com/user-attachments/assets/b1dd0c99-9348-4b2a-b9b0-3a41c8685590" alt="image">

<img width="1210" height="899" src="https://github.com/user-attachments/assets/fe2e826e-b4f3-435e-8343-fdd8ec98ebdf" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)