### PR TITLE
feat: add alphabetical sorting for products (default)

### DIFF
--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -158,7 +158,7 @@ function ProductsOverviewComponent() {
 	const navigate = useNavigate()
 	const matchRoute = useMatchRoute()
 	const [expandedProduct, setExpandedProduct] = useState<string | null>(null)
-	const [orderBy, setOrderBy] = useState<string>('newest')
+	const [orderBy, setOrderBy] = useState<string>('alphabetical')
 	useDashboardTitle('Products')
 
 	// Auto-animate for smooth list transitions
@@ -194,9 +194,20 @@ function ProductsOverviewComponent() {
 	const sortedProducts = useMemo(() => {
 		if (!products) return []
 		return [...products].sort((a, b) => {
+			// Alphabetical sorting
+			if (orderBy === 'alphabetical') {
+				const titleA = getProductTitle(a).toLowerCase()
+				const titleB = getProductTitle(b).toLowerCase()
+				return titleA.localeCompare(titleB)
+			}
+			if (orderBy === 'alphabetical-reverse') {
+				const titleA = getProductTitle(a).toLowerCase()
+				const titleB = getProductTitle(b).toLowerCase()
+				return titleB.localeCompare(titleA)
+			}
+			// Time-based sorting
 			const timeA = a.created_at || 0
 			const timeB = b.created_at || 0
-			// For replaceable events, created_at is both creation and update time
 			if (orderBy === 'oldest' || orderBy === 'least-updated') {
 				return timeA - timeB
 			} else {
@@ -255,10 +266,12 @@ function ProductsOverviewComponent() {
 				<h1 className="text-2xl font-bold">Products</h1>
 				<div className="flex items-center gap-4">
 					<Select value={orderBy} onValueChange={setOrderBy}>
-						<SelectTrigger className="w-48">
+						<SelectTrigger className="w-56">
 							<SelectValue placeholder="Order By" />
 						</SelectTrigger>
 						<SelectContent>
+							<SelectItem value="alphabetical">Alphabetically (A-Z)</SelectItem>
+							<SelectItem value="alphabetical-reverse">Alphabetically (Z-A)</SelectItem>
 							<SelectItem value="newest">Newest First</SelectItem>
 							<SelectItem value="oldest">Oldest First</SelectItem>
 							<SelectItem value="recently-updated">Recently Updated</SelectItem>
@@ -281,6 +294,8 @@ function ProductsOverviewComponent() {
 							<SelectValue placeholder="Order By" />
 						</SelectTrigger>
 						<SelectContent>
+							<SelectItem value="alphabetical">Alphabetically (A-Z)</SelectItem>
+							<SelectItem value="alphabetical-reverse">Alphabetically (Z-A)</SelectItem>
 							<SelectItem value="newest">Newest First</SelectItem>
 							<SelectItem value="oldest">Oldest First</SelectItem>
 							<SelectItem value="recently-updated">Recently Updated</SelectItem>

--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -158,7 +158,7 @@ function ProductsOverviewComponent() {
 	const navigate = useNavigate()
 	const matchRoute = useMatchRoute()
 	const [expandedProduct, setExpandedProduct] = useState<string | null>(null)
-	const [orderBy, setOrderBy] = useState<string>('alphabetical')
+	const [orderBy, setOrderBy] = useState<string>('newest')
 	useDashboardTitle('Products')
 
 	// Auto-animate for smooth list transitions


### PR DESCRIPTION
## Summary

- Add "Alphabetically (A-Z)" and "Alphabetically (Z-A)" sort options to the products list
- ~Make alphabetical (A-Z) the default sort order~
- Update both desktop and mobile sort dropdowns
- Widen dropdown to fit longer option text

## Test plan

- [x] Navigate to Dashboard > Products
- [x] Verify products are sorted alphabetically by default
- [x] Test switching between all sort options
- [ ] Verify mobile dropdown has same options

<img width="1209" height="998" src="https://github.com/user-attachments/assets/198a51a2-3f25-498a-9a8c-9c05551cf70d" alt="image">

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)