### PR TITLE
fix: require all mandatory fields before saving product

### DIFF
--- a/src/components/sheet-contents/collections/ShippingTab.tsx
+++ b/src/components/sheet-contents/collections/ShippingTab.tsx
@@ -129,8 +129,9 @@ export function ShippingTab() {
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
 											placeholder="Extra cost"
-											className="w-24 text-sm"
+											className="w-36 text-sm"
 										/>
+										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
 										<Button type="button" variant="ghost" size="sm" onClick={() => removeShippingOption(index)}>
 											<span className="i-delete w-4 h-4" />
 										</Button>

--- a/src/components/sheet-contents/collections/ShippingTab.tsx
+++ b/src/components/sheet-contents/collections/ShippingTab.tsx
@@ -123,15 +123,17 @@ export function ShippingTab() {
 									</div>
 									<div className="flex items-center gap-2">
 										<span className="text-sm text-gray-500">Extra cost</span>
-										<Input
-											type="number"
-											step="0.01"
-											min="0"
-											value={shipping.extraCost}
-											onChange={(e) => updateExtraCost(index, e.target.value)}
-											className="w-32 text-sm"
-										/>
-										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
+										<div className="flex items-center gap-1 mr-2">
+											<Input
+												type="number"
+												step="0.01"
+												min="0"
+												value={shipping.extraCost}
+												onChange={(e) => updateExtraCost(index, e.target.value)}
+												className="w-32 text-sm"
+											/>
+											{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
+										</div>
 										<Button type="button" variant="ghost" size="sm" onClick={() => removeShippingOption(index)}>
 											<span className="i-delete w-4 h-4" />
 										</Button>

--- a/src/components/sheet-contents/collections/ShippingTab.tsx
+++ b/src/components/sheet-contents/collections/ShippingTab.tsx
@@ -122,14 +122,14 @@ export function ShippingTab() {
 										)}
 									</div>
 									<div className="flex items-center gap-2">
+										<span className="text-sm text-gray-500">Extra cost</span>
 										<Input
 											type="number"
 											step="0.01"
 											min="0"
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
-											placeholder="Extra cost"
-											className="w-36 text-sm"
+											className="w-32 text-sm"
 										/>
 										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
 										<Button type="button" variant="ghost" size="sm" onClick={() => removeShippingOption(index)}>

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -568,6 +568,7 @@ export function ImagesTab() {
 			<div className="flex flex-col gap-4">
 				<Label>
 					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Image Upload</span>
+					<span className="sr-only">required</span>
 					<span className="text-xs text-gray-500 ml-2">(at least 1 required)</span>
 				</Label>
 
@@ -688,6 +689,7 @@ export function ShippingTab() {
 			<div className="space-y-2">
 				<Label>
 					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Shipping Options</span>
+					<span className="sr-only">required</span>
 					<span className="text-xs text-gray-500 ml-2">(at least 1 required)</span>
 				</Label>
 				<p className="text-gray-600">Select shipping options that will be available for this product</p>

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -719,15 +719,17 @@ export function ShippingTab() {
 									</div>
 									<div className="flex items-center gap-2">
 										<span className="text-sm text-gray-500">Extra cost</span>
-										<Input
-											type="number"
-											step="0.01"
-											min="0"
-											value={shipping.extraCost}
-											onChange={(e) => updateExtraCost(index, e.target.value)}
-											className="w-32 text-sm"
-										/>
-										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
+										<div className="flex items-center gap-1 mr-2">
+											<Input
+												type="number"
+												step="0.01"
+												min="0"
+												value={shipping.extraCost}
+												onChange={(e) => updateExtraCost(index, e.target.value)}
+												className="w-32 text-sm"
+											/>
+											{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
+										</div>
 										<Button
 											type="button"
 											variant="outline"

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -566,7 +566,10 @@ export function ImagesTab() {
 			<p className="text-gray-600">We recommend using square images of 1600x1600 and under 2mb.</p>
 
 			<div className="flex flex-col gap-4">
-				<Label>Image Upload</Label>
+				<Label>
+					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Image Upload</span>
+					<span className="text-xs text-gray-500 ml-2">(at least 1 required)</span>
+				</Label>
 
 				{images.map((image, i) => (
 					<ImageUploader
@@ -683,6 +686,10 @@ export function ShippingTab() {
 	return (
 		<div className="space-y-6">
 			<div className="space-y-2">
+				<Label>
+					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Shipping Options</span>
+					<span className="text-xs text-gray-500 ml-2">(at least 1 required)</span>
+				</Label>
 				<p className="text-gray-600">Select shipping options that will be available for this product</p>
 			</div>
 
@@ -716,8 +723,9 @@ export function ShippingTab() {
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
 											placeholder="Extra cost"
-											className="w-24 text-sm"
+											className="w-28 text-sm"
 										/>
+										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
 										<Button
 											type="button"
 											variant="outline"

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -718,14 +718,14 @@ export function ShippingTab() {
 										)}
 									</div>
 									<div className="flex items-center gap-2">
+										<span className="text-sm text-gray-500">Extra cost</span>
 										<Input
 											type="number"
 											step="0.01"
 											min="0"
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
-											placeholder="Extra cost"
-											className="w-36 text-sm"
+											className="w-32 text-sm"
 										/>
 										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
 										<Button

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -725,7 +725,7 @@ export function ShippingTab() {
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
 											placeholder="Extra cost"
-											className="w-28 text-sm"
+											className="w-36 text-sm"
 										/>
 										{option?.currency && <span className="text-sm text-gray-500">{option.currency}</span>}
 										<Button


### PR DESCRIPTION
## Summary

- Disable Save button when missing required fields
- Show error message below Save button listing what's missing
- Add required field indicators on Images and Shipping tabs
- Fix Extra cost input width and show currency

## Required Fields Validated

- Name
- Price (checks fiatPrice or sats price based on currency mode)
- Quantity
- Category
- At least 1 image
- At least 1 shipping option

## Changes

- `ProductFormContent.tsx`: Added validation logic to disable Save button and show missing fields message
- `tabs.tsx`: Added required field labels, widened Extra cost input, added currency display

## Test Plan

- [ ] Create new product - Save button should be disabled until all fields are filled
- [ ] Error message shows all missing fields (e.g., "Missing: name, price, quantity, category, image, shipping option")
- [ ] Fill each required field - error message updates to show remaining missing fields
- [ ] Fill all fields - Save button becomes enabled, error message disappears
- [ ] Extra cost input shows full placeholder text and currency to the right
- [ ] Test with fiat currency mode - validates fiatPrice field
- [ ] Test with sats currency mode - validates price field

## Closes

- Closes #411
- Closes #421
- Closes #422
- Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)