### PR TITLE
fix: shipping options UI improvements

### DIFF
--- a/src/components/layout/DashboardListItem.tsx
+++ b/src/components/layout/DashboardListItem.tsx
@@ -41,11 +41,11 @@ const DashboardListItem = React.forwardRef<HTMLDivElement, DashboardListItemProp
 				<Card ref={ref} className={cn(isDeleting && 'opacity-50 pointer-events-none', className)} {...props}>
 					<CollapsibleTrigger asChild>
 						<div className="p-4 flex flex-row items-center justify-between cursor-pointer group rounded-lg">
-							<div className="flex items-center gap-4">
-								<div className="p-2 bg-muted rounded-full">{icon ?? <WalletIcon className="h-6 w-6" />}</div>
-								<div className="min-w-0 flex-1">{triggerContent}</div>
+							<div className="flex items-center gap-4 min-w-0 flex-1 overflow-hidden">
+								<div className="p-2 bg-muted rounded-full shrink-0">{icon ?? <WalletIcon className="h-6 w-6" />}</div>
+								<div className="min-w-0 flex-1 overflow-hidden">{triggerContent}</div>
 							</div>
-							<div className="flex items-center gap-2">
+							<div className="flex items-center gap-2 shrink-0 ml-2">
 								{actions}
 								{useCloseIcon ? (
 									isOpen ? (

--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -328,10 +328,9 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 			icon={<ServiceIcon service={formData.service} />}
 			data-testid={isEditing ? `shipping-option-item-${getShippingId(shippingOption)}` : 'add-shipping-option-button'}
 			className="w-full max-w-full overflow-hidden"
-			useCloseIcon={true}
 		>
 			<div className="p-4 border-t">
-				<form onSubmit={handleSubmit} className="space-y-6 w-full max-w-2xl">
+				<form onSubmit={handleSubmit} className="space-y-6 w-full">
 					{/* Use a template */}
 					<div className="space-y-4">
 						<h3 className="text-lg font-semibold">Use a template</h3>


### PR DESCRIPTION
## Summary

Fixes UI issues in the Shipping Options dashboard page.

## Changes

### Issue #431 - Expand/collapse UX issues

- **Fixed expand icon visibility**: Added overflow handling to DashboardListItem so the chevron icon is always visible even when there are many countries listed
- **Changed X icon to chevron**: Removed `useCloseIcon={true}` to use consistent chevron icons like the Products list

### Issue #432 - Form not full width

- Removed `max-w-2xl` constraint so the form expands to use the full available width when editing a shipping option

## Files Changed

- `src/components/layout/DashboardListItem.tsx` - Added overflow handling for content wrapper
- `src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx` - Removed useCloseIcon and max-w-2xl

Closes #431
Closes #432

## Screenshot

Old:

<img width="1216" height="483" src="https://github.com/user-attachments/assets/6ac75fcb-f239-448f-9abf-34bc88f3bfa8" alt="image">

New:

<img width="1216" height="740" src="https://github.com/user-attachments/assets/847fb613-d00d-453e-aa38-b2495869b138" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)