### PR TITLE
fix: add cursor-pointer to Button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-black box hover:translated',
+	'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-black box hover:translated cursor-pointer',
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## Summary

- Added `cursor-pointer` class to the base Button component styles
- All buttons now show pointer cursor on hover, including the Add Relay button

Fixes #361

## Test plan

- [x] Navigate to Dashboard > Account > Network
- [x] Hover over the "+ ADD" button - cursor should change to pointer
- [ ] Test other buttons throughout the app to confirm pointer cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)