### PR TITLE
feat: add description text to collections empty state

### DIFF
--- a/src/routes/_dashboard-layout/dashboard/products/collections.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/collections.tsx
@@ -282,7 +282,7 @@ function CollectionsComponent() {
 									<span className="i-market w-5 h-5" />
 									<h3 className="mt-2 text-lg font-semibold text-gray-700">No collections yet</h3>
 									<p className="mt-1 text-sm">
-										Collections are optional. Use them as "Categories," "Favourites," or "Coming Soon," or leave them empty. Your shop, your
+										Collections are optional. Use them as "Categories," "Favorites," or "Coming Soon," or leave them empty. Your shop, your
 										way.
 									</p>
 									<p className="mt-1 text-sm">Click the "Create A Collection" button to create your first one.</p>

--- a/src/routes/_dashboard-layout/dashboard/products/collections.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/collections.tsx
@@ -281,6 +281,10 @@ function CollectionsComponent() {
 								<div className="text-center text-gray-500 py-10">
 									<span className="i-market w-5 h-5" />
 									<h3 className="mt-2 text-lg font-semibold text-gray-700">No collections yet</h3>
+									<p className="mt-1 text-sm">
+										Collections are optional. Use them as "Categories," "Favourites," or "Coming Soon," or leave them empty.
+										Your shop, your way.
+									</p>
 									<p className="mt-1 text-sm">Click the "Create A Collection" button to create your first one.</p>
 								</div>
 							)}

--- a/src/routes/_dashboard-layout/dashboard/products/collections.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/collections.tsx
@@ -282,8 +282,8 @@ function CollectionsComponent() {
 									<span className="i-market w-5 h-5" />
 									<h3 className="mt-2 text-lg font-semibold text-gray-700">No collections yet</h3>
 									<p className="mt-1 text-sm">
-										Collections are optional. Use them as "Categories," "Favourites," or "Coming Soon," or leave them empty.
-										Your shop, your way.
+										Collections are optional. Use them as "Categories," "Favourites," or "Coming Soon," or leave them empty. Your shop, your
+										way.
 									</p>
 									<p className="mt-1 text-sm">Click the "Create A Collection" button to create your first one.</p>
 								</div>


### PR DESCRIPTION
## Summary

- Added explanatory text to the Collections page empty state
- Text: "Collections are optional. Use them as 'Categories,' 'Favourites,' or 'Coming Soon,' or leave them empty. Your shop, your way."

Fixes #360

## Test plan

- [ ] Navigate to Dashboard > Products > Collections (with no collections)
- [ ] Verify the description text appears before "Click the 'Create A Collection' button..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)