### PR TITLE
fix: edit collection throws 'Element type is invalid' error

### DIFF
--- a/src/routes/_dashboard-layout/dashboard/products/collections/$collectionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/collections/$collectionId.tsx
@@ -1,4 +1,4 @@
-import { CollectionFormContent } from '@/components/sheet-contents/NewCollectionContent'
+import { CollectionFormContent } from '@/components/sheet-contents/collections/CollectionFormContent'
 import { authStore } from '@/lib/stores/auth'
 import { collectionFormActions } from '@/lib/stores/collection'
 import { getCollectionId, getCollectionTitle, useCollectionsByPubkey } from '@/queries/collections'


### PR DESCRIPTION
## Summary

Fixed the error when clicking edit on a collection in Dashboard > Products > Collections.

## Problem

The re-export chain through `NewCollectionContent.tsx` was causing `CollectionFormContent` to be undefined at runtime, resulting in:

```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined.
```

## Solution

Import `CollectionFormContent` directly from its source file instead of through the re-export chain:

```diff
- import { CollectionFormContent } from '@/components/sheet-contents/NewCollectionContent'
+ import { CollectionFormContent } from '@/components/sheet-contents/collections/CollectionFormContent'
```

## Test plan

- [x] Navigate to Dashboard > Products > Collections
- [x] Click edit on any collection
- [x] Verify the edit form opens without error

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)