### PR TITLE
fix: add consistent tooltips and hover styling to header buttons

### DIFF
--- a/src/components/CartButton.tsx
+++ b/src/components/CartButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cartStore } from '@/lib/stores/cart'
 import { uiActions } from '@/lib/stores/ui'
 import { useStore } from '@tanstack/react-store'
@@ -15,13 +16,18 @@ export function CartButton() {
 	}
 
 	return (
-		<Button variant="primary" className="p-2 relative" onClick={handleClick}>
-			<span className="i-basket w-6 h-6" />
-			{totalItems > 0 && (
-				<span className="absolute -top-1 -right-1 bg-secondary text-black text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
-					{totalItems > 99 ? '99+' : totalItems}
-				</span>
-			)}
-		</Button>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<Button variant="primary" className="p-2 relative hover:[&>span]:text-secondary" onClick={handleClick}>
+					<span className="i-basket w-6 h-6" />
+					{totalItems > 0 && (
+						<span className="absolute -top-1 -right-1 bg-secondary text-black text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
+							{totalItems > 99 ? '99+' : totalItems}
+						</span>
+					)}
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent side="bottom">View cart</TooltipContent>
+		</Tooltip>
 	)
 }

--- a/src/components/CurrencyDropdown.tsx
+++ b/src/components/CurrencyDropdown.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { CURRENCIES } from '@/lib/constants'
 import { uiActions, uiStore, type SupportedCurrency } from '@/lib/stores/ui'
 import { useStore } from '@tanstack/react-store'
@@ -20,15 +21,20 @@ export function CurrencyDropdown() {
 
 	return (
 		<div className="relative">
-			<Button
-				variant="primary"
-				className="p-2 px-3 relative hover:bg-secondary/20 flex items-center gap-1"
-				onClick={toggleDropdown}
-				data-testid="currency-dropdown-button"
-			>
-				<span className="text-sm font-medium">{selectedCurrency}</span>
-				<ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
-			</Button>
+			<Tooltip open={isOpen ? false : undefined}>
+				<TooltipTrigger asChild>
+					<Button
+						variant="primary"
+						className="p-2 px-3 relative flex items-center gap-1 hover:[&>span]:text-secondary hover:[&>svg]:text-secondary"
+						onClick={toggleDropdown}
+						data-testid="currency-dropdown-button"
+					>
+						<span className="text-sm font-medium">{selectedCurrency}</span>
+						<ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent side="bottom">Select currency</TooltipContent>
+			</Tooltip>
 
 			{isOpen && (
 				<>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { MobileMenu } from '@/components/layout/MobileMenu'
 import { ProductSearch } from '@/components/ProductSearch'
 import { Profile } from '@/components/Profile'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { authActions, authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
@@ -236,30 +237,40 @@ export function Header() {
 								) : isAuthenticated ? (
 									<>
 										<CartButton />
-										<Link to="/dashboard" data-testid="dashboard-link" className="relative">
-											<Button
-												variant="primary"
-												className={`p-2 relative hover:[&>span]:text-secondary ${
-													location.pathname.startsWith('/dashboard') ? 'bg-secondary text-black [&>span]:text-black' : ''
-												}`}
-												icon={<span className="i-dashboard w-6 h-6" />}
-												data-testid="dashboard-button"
-											/>
-											{totalNotifications > 0 && (
-												<span className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-white bg-pink-500 rounded-full">
-													{totalNotifications > 99 ? '99+' : totalNotifications}
-												</span>
-											)}
-										</Link>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Link to="/dashboard" data-testid="dashboard-link" className="relative">
+													<Button
+														variant="primary"
+														className={`p-2 relative hover:[&>span]:text-secondary ${
+															location.pathname.startsWith('/dashboard') ? 'bg-secondary text-black [&>span]:text-black' : ''
+														}`}
+														icon={<span className="i-dashboard w-6 h-6" />}
+														data-testid="dashboard-button"
+													/>
+													{totalNotifications > 0 && (
+														<span className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 text-[10px] font-bold text-white bg-pink-500 rounded-full">
+															{totalNotifications > 99 ? '99+' : totalNotifications}
+														</span>
+													)}
+												</Link>
+											</TooltipTrigger>
+											<TooltipContent side="bottom">Dashboard</TooltipContent>
+										</Tooltip>
 										<Profile compact />
-										<Button
-											variant="primary"
-											className="p-2 relative hover:[&>span]:text-secondary"
-											onClick={() => authActions.logout()}
-											data-testid="logout-button"
-										>
-											<LogOut className="w-6 h-6" />
-										</Button>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<Button
+													variant="primary"
+													className="p-2 relative hover:[&>span]:text-secondary"
+													onClick={() => authActions.logout()}
+													data-testid="logout-button"
+												>
+													<LogOut className="w-6 h-6" />
+												</Button>
+											</TooltipTrigger>
+											<TooltipContent side="bottom">Logout</TooltipContent>
+										</Tooltip>
 									</>
 								) : (
 									<Button

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -262,7 +262,7 @@ export function Header() {
 											<TooltipTrigger asChild>
 												<Button
 													variant="primary"
-													className="p-2 relative hover:[&>span]:text-secondary"
+													className="p-2 relative hover:[&>svg]:text-secondary"
 													onClick={() => authActions.logout()}
 													data-testid="logout-button"
 												>


### PR DESCRIPTION
## Summary

- Add tooltips to Cart, Currency selector, Dashboard, and Logout buttons for better accessibility
- Fix CurrencyDropdown hover styling to match other header buttons (using `hover:[&>span]:text-secondary` pattern)
- Add hover effect to CartButton icon

## Test plan

- [x] Hover over Currency selector - should show "Select currency" tooltip and text/icon should change to secondary color
- [x] Hover over Cart button - should show "View cart" tooltip and icon should change to secondary color
- [x] Hover over Dashboard button - should show "Dashboard" tooltip
- [x] Hover over Logout button - should show "Logout" tooltip

Fixes #444, fixes #288

## Screenshots

<img width="1213" height="735" src="https://github.com/user-attachments/assets/c5ffe897-3241-4283-a653-6da499ce2a0a" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)