### PR TITLE
fix: improve dashboard UX with better empty states and step order

### DIFF
--- a/src/components/orders/OrderDataTable.tsx
+++ b/src/components/orders/OrderDataTable.tsx
@@ -42,6 +42,7 @@ interface OrderDataTableProps<TData> {
 	showOrderBy?: boolean
 	onOrderByChange?: (value: string) => void
 	orderBy?: string
+	emptyMessage?: string
 }
 
 export function OrderDataTable<TData>({
@@ -57,6 +58,7 @@ export function OrderDataTable<TData>({
 	showOrderBy = false,
 	onOrderByChange,
 	orderBy = 'newest',
+	emptyMessage = 'No orders found.',
 }: OrderDataTableProps<TData>) {
 	const [sorting, setSorting] = useState<SortingState>([])
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -234,7 +236,7 @@ export function OrderDataTable<TData>({
 					</div>
 				) : (
 					<div className="px-4 xl:px-6">
-						<Card className="rounded-md border p-6 text-center mt-4">No orders found.</Card>
+						<Card className="rounded-md border p-6 text-center mt-4">{emptyMessage}</Card>
 					</div>
 				)}
 			</div>

--- a/src/routes/_dashboard-layout/dashboard/account/your-purchases.tsx
+++ b/src/routes/_dashboard-layout/dashboard/account/your-purchases.tsx
@@ -90,6 +90,7 @@ function YourPurchasesComponent() {
 				showOrderBy={true}
 				onOrderByChange={setOrderBy}
 				orderBy={orderBy}
+				emptyMessage="You haven't purchased anything yet."
 			/>
 		</div>
 	)

--- a/src/routes/_dashboard-layout/dashboard/index.tsx
+++ b/src/routes/_dashboard-layout/dashboard/index.tsx
@@ -236,11 +236,7 @@ function DashboardInnerComponent() {
 						</div>
 					) : recentOrders.length === 0 ? (
 						<div className="text-center py-8">
-							<p className="text-muted-foreground mb-4">No orders yet</p>
-							<p className="text-sm text-muted-foreground mb-4">Start by creating a product listing or browsing the marketplace</p>
-							<Link to="/dashboard/products/products/new">
-								<Button>Create Your First Product</Button>
-							</Link>
+							<p className="text-muted-foreground">No orders yet</p>
 						</div>
 					) : (
 						<div className="space-y-4">
@@ -299,11 +295,11 @@ function DashboardInnerComponent() {
 									3
 								</span>
 								<div>
-									<div className="font-semibold">Create your first product</div>
-									<p className="text-sm text-muted-foreground">List an item with photos, description, and pricing</p>
-									<Link to="/dashboard/products/products/new">
+									<div className="font-semibold">Set up shipping options</div>
+									<p className="text-sm text-muted-foreground">Define how you'll deliver products to customers</p>
+									<Link to="/dashboard/products/shipping-options">
 										<Button variant="link" className="p-0 h-auto">
-											Create Product →
+											Configure Shipping →
 										</Button>
 									</Link>
 								</div>
@@ -313,11 +309,11 @@ function DashboardInnerComponent() {
 									4
 								</span>
 								<div>
-									<div className="font-semibold">Set up shipping options</div>
-									<p className="text-sm text-muted-foreground">Define how you'll deliver products to customers</p>
-									<Link to="/dashboard/products/shipping-options">
+									<div className="font-semibold">Create your first product</div>
+									<p className="text-sm text-muted-foreground">List an item with photos, description, and pricing</p>
+									<Link to="/dashboard/products/products/new">
 										<Button variant="link" className="p-0 h-auto">
-											Configure Shipping →
+											Create Product →
 										</Button>
 									</Link>
 								</div>

--- a/src/routes/_dashboard-layout/dashboard/index.tsx
+++ b/src/routes/_dashboard-layout/dashboard/index.tsx
@@ -218,8 +218,8 @@ function DashboardInnerComponent() {
 			{/* Recent Activity */}
 			<Card>
 				<CardHeader>
-					<CardTitle>Recent Orders</CardTitle>
-					<CardDescription>Your latest marketplace activity</CardDescription>
+					<CardTitle>Recent Activity</CardTitle>
+					<CardDescription>Your latest sales and purchases</CardDescription>
 				</CardHeader>
 				<CardContent>
 					{isLoading ? (

--- a/src/routes/_dashboard-layout/dashboard/sales/sales.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/sales.tsx
@@ -90,6 +90,7 @@ function SalesComponent() {
 				showOrderBy={true}
 				onOrderByChange={setOrderBy}
 				orderBy={orderBy}
+				emptyMessage="You haven't sold anything yet."
 			/>
 		</div>
 	)


### PR DESCRIPTION
## Summary

- Swap Getting Started steps 3 and 4 so shipping options are set up before creating a product (required dependency)
- Change Sales page empty state from "No orders found." to "You haven't sold anything yet."
- Change Purchases page empty state from "No orders found." to "You haven't purchased anything yet."
- Remove misplaced "Create Your First Product" button from Recent Orders section on dashboard

## Test plan

- [x] Visit Dashboard with no products - Getting Started shows shipping before product creation
- [x] Visit Sales page with no sales - shows "You haven't sold anything yet."
- [x] Visit Your Purchases page with no purchases - shows "You haven't purchased anything yet."
- [x] Visit Dashboard with no orders - Recent Orders section shows simple "No orders yet" without product button

Fixes #446, fixes #447, fixes #448, fixes #449

## Screenshots

<img width="1338" height="1034" src="https://github.com/user-attachments/assets/7de2b8cb-f6a8-40e2-af5b-4351675830d0" alt="image">

<img width="1338" height="1034" src="https://github.com/user-attachments/assets/8082f859-3b61-428f-bfec-8e8270a2f2a8" alt="image">

<img width="1338" height="1034" src="https://github.com/user-attachments/assets/b834d18b-5b18-4b50-993f-1a70ffc21953" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)