### PR TITLE
fix: update V4V button text and remove share icon

### DIFF
--- a/src/components/v4v/V4VManager.tsx
+++ b/src/components/v4v/V4VManager.tsx
@@ -215,7 +215,7 @@ export function V4VManager({
 							disabled={totalV4VPercentage === 0}
 							data-testid="add-v4v-recipient-form-button"
 						>
-							+ V4V Recipient
+							Add Recipient
 						</Button>
 						<Button
 							variant="outline"
@@ -223,7 +223,6 @@ export function V4VManager({
 							disabled={localShares.length === 0 || totalV4VPercentage === 0}
 							data-testid="equal-all-v4v-button"
 						>
-							<span className="i-sharing w-5 h-5 mr-2"></span>
 							Equal All
 						</Button>
 					</div>


### PR DESCRIPTION
## Summary

- Change "+ V4V Recipient" button text to "Add Recipient"
- Remove share icon from "Equal All" button

## Test plan

- [x] Visit V4V settings page
- [x] Verify left button shows "Add Recipient" (not "+ V4V Recipient")
- [x] Verify right button shows "Equal All" without a share icon

Fixes #377

## Screenshot

<img width="1399" height="967" src="https://github.com/user-attachments/assets/6b9917e5-ad34-468e-8d2a-653e922e8a27" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)