### PR TITLE
feat: flatten product form tabs to single level

### DIFF
--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -182,9 +182,7 @@ export function ProductFormContent({
 				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
 				<Tabs
 					value={activeTab}
-					onValueChange={(value) =>
-						productFormActions.updateValues({ activeTab: value as ProductFormTab })
-					}
+					onValueChange={(value) => productFormActions.updateValues({ activeTab: value as ProductFormTab })}
 					className="w-full"
 				>
 					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -3,7 +3,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
-import { productFormActions, productFormStore } from '@/lib/stores/product'
+import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
 import { useV4VShares } from '@/queries/v4v'
@@ -183,7 +183,7 @@ export function ProductFormContent({
 				<Tabs
 					value={activeTab}
 					onValueChange={(value) =>
-						productFormActions.updateValues({ activeTab: value as 'name' | 'detail' | 'spec' | 'category' | 'images' | 'shipping' })
+						productFormActions.updateValues({ activeTab: value as ProductFormTab })
 					}
 					className="w-full"
 				>

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -34,7 +34,7 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { mainTab, productSubTab, editingProductId, isDirty } = formState
+	const { activeTab, editingProductId, isDirty } = formState
 
 	// Get user pubkey from auth store directly to avoid timing issues
 	const authState = useStore(authStore)
@@ -73,8 +73,7 @@ export function ProductFormContent({
 			if (!draftKey) return
 
 			// Preserve current tab state before reset
-			const currentMainTab = formState.mainTab
-			const currentProductSubTab = formState.productSubTab
+			const currentActiveTab = formState.activeTab
 
 			await productFormActions.clearDraftForProduct(draftKey)
 
@@ -83,18 +82,18 @@ export function ProductFormContent({
 			if (productEventId && productDTag) {
 				productFormActions.setEditingProductId(productDTag)
 				await productFormActions.loadProductForEdit(productEventId, {
-					preserveTabState: { mainTab: currentMainTab, productSubTab: currentProductSubTab },
+					preserveTabState: { activeTab: currentActiveTab },
 				})
 			} else {
 				// No product to reload, just reset but restore tabs
 				productFormActions.reset()
-				productFormActions.setTabState(currentMainTab, currentProductSubTab)
+				productFormActions.setTabState(currentActiveTab)
 			}
 
 			setHasDraft(false)
 			uiActions.clearDashboardHeaderAction()
 		}
-	}, [productDTag, editingProductId, productEventId, formState.mainTab, formState.productSubTab])
+	}, [productDTag, editingProductId, productEventId, formState.activeTab])
 
 	// Stable callback that reads from the ref
 	const handleDiscardEdits = useCallback(() => {
@@ -180,100 +179,79 @@ export function ProductFormContent({
 			className={`flex flex-col ${className}`}
 		>
 			<div>
-				{/* Main Tabs: Product and Shipping */}
+				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
 				<Tabs
-					value={mainTab}
-					onValueChange={(value) => productFormActions.updateValues({ mainTab: value as 'product' | 'shipping' })}
+					value={activeTab}
+					onValueChange={(value) =>
+						productFormActions.updateValues({ activeTab: value as 'name' | 'detail' | 'spec' | 'category' | 'images' | 'shipping' })
+					}
 					className="w-full"
 				>
-					<TabsList className="w-full rounded-none bg-transparent h-auto p-0 flex">
+					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
 						<TabsTrigger
-							value="product"
-							className="flex-1 px-4 py-2 font-medium data-[state=active]:text-secondary border-b-1 data-[state=active]:border-secondary data-[state=inactive]:text-black rounded-none"
-							data-testid="main-tab-product"
+							value="name"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-name"
 						>
-							Product
+							Name
+						</TabsTrigger>
+						<TabsTrigger
+							value="detail"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-detail"
+						>
+							Detail
+						</TabsTrigger>
+						<TabsTrigger
+							value="spec"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-spec"
+						>
+							Spec
+						</TabsTrigger>
+						<TabsTrigger
+							value="category"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-category"
+						>
+							Category
+						</TabsTrigger>
+						<TabsTrigger
+							value="images"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-images"
+						>
+							Images
 						</TabsTrigger>
 						<TabsTrigger
 							value="shipping"
-							className="flex-1 px-4 py-2 font-medium data-[state=active]:text-secondary border-b-1 data-[state=active]:border-secondary data-[state=inactive]:text-black rounded-none"
-							data-testid="main-tab-shipping"
+							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+							data-testid="product-tab-shipping"
 						>
 							Shipping
 						</TabsTrigger>
 					</TabsList>
 
-					{/* Product Tab Content */}
-					<TabsContent value="product" className="mt-2">
-						{/* Product Sub-Tabs */}
-						<Tabs
-							value={productSubTab}
-							onValueChange={(value) =>
-								productFormActions.updateValues({ productSubTab: value as 'name' | 'detail' | 'spec' | 'category' | 'images' })
-							}
-							className="w-full"
-						>
-							<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
-								<TabsTrigger
-									value="name"
-									className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									data-testid="product-tab-name"
-								>
-									Name
-								</TabsTrigger>
-								<TabsTrigger
-									value="detail"
-									className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									data-testid="product-tab-detail"
-								>
-									Detail
-								</TabsTrigger>
-								<TabsTrigger
-									value="spec"
-									className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									data-testid="product-tab-spec"
-								>
-									Spec
-								</TabsTrigger>
-								<TabsTrigger
-									value="category"
-									className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									data-testid="product-tab-category"
-								>
-									Category
-								</TabsTrigger>
-								<TabsTrigger
-									value="images"
-									className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									data-testid="product-tab-images"
-								>
-									Images
-								</TabsTrigger>
-							</TabsList>
-
-							<TabsContent value="name" className="mt-4">
-								<NameTab />
-							</TabsContent>
-
-							<TabsContent value="detail" className="mt-4">
-								<DetailTab />
-							</TabsContent>
-
-							<TabsContent value="spec" className="mt-4">
-								<SpecTab />
-							</TabsContent>
-
-							<TabsContent value="category" className="mt-4">
-								<CategoryTab />
-							</TabsContent>
-
-							<TabsContent value="images" className="mt-4">
-								<ImagesTab />
-							</TabsContent>
-						</Tabs>
+					<TabsContent value="name" className="mt-4">
+						<NameTab />
 					</TabsContent>
 
-					{/* Shipping Tab Content */}
+					<TabsContent value="detail" className="mt-4">
+						<DetailTab />
+					</TabsContent>
+
+					<TabsContent value="spec" className="mt-4">
+						<SpecTab />
+					</TabsContent>
+
+					<TabsContent value="category" className="mt-4">
+						<CategoryTab />
+					</TabsContent>
+
+					<TabsContent value="images" className="mt-4">
+						<ImagesTab />
+					</TabsContent>
+
 					<TabsContent value="shipping" className="mt-4">
 						<ShippingTab />
 					</TabsContent>
@@ -283,7 +261,7 @@ export function ProductFormContent({
 			{showFooter && (
 				<div className="bg-white border-t pt-4 pb-4 mt-4">
 					<div className="flex gap-2 w-full">
-						{(productSubTab !== 'name' || mainTab === 'shipping') && (
+						{activeTab !== 'name' && (
 							<Button
 								type="button"
 								variant="outline"
@@ -296,7 +274,7 @@ export function ProductFormContent({
 							</Button>
 						)}
 
-						{mainTab === 'shipping' || editingProductId ? (
+						{activeTab === 'shipping' || editingProductId ? (
 							<form.Subscribe
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
 								children={([canSubmit, isSubmitting]) => {

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -56,6 +56,9 @@ export type ProductDimensions = {
 
 export type ProductFormTab = 'name' | 'detail' | 'spec' | 'category' | 'images' | 'shipping'
 
+// Tab navigation order
+const PRODUCT_FORM_TABS: ProductFormTab[] = ['name', 'detail', 'spec', 'category', 'images', 'shipping']
+
 export interface ProductFormState {
 	editingProductId: string | null
 	isDirty: boolean // Track if form has been modified from saved state
@@ -247,13 +250,12 @@ export const productFormActions = {
 
 	nextTab: () => {
 		productFormStore.setState((state) => {
-			const tabs: ProductFormTab[] = ['name', 'detail', 'spec', 'category', 'images', 'shipping']
-			const currentIndex = tabs.indexOf(state.activeTab)
+			const currentIndex = PRODUCT_FORM_TABS.indexOf(state.activeTab)
 
-			if (currentIndex < tabs.length - 1) {
+			if (currentIndex < PRODUCT_FORM_TABS.length - 1) {
 				return {
 					...state,
-					activeTab: tabs[currentIndex + 1],
+					activeTab: PRODUCT_FORM_TABS[currentIndex + 1],
 				}
 			}
 
@@ -263,13 +265,12 @@ export const productFormActions = {
 
 	previousTab: () => {
 		productFormStore.setState((state) => {
-			const tabs: ProductFormTab[] = ['name', 'detail', 'spec', 'category', 'images', 'shipping']
-			const currentIndex = tabs.indexOf(state.activeTab)
+			const currentIndex = PRODUCT_FORM_TABS.indexOf(state.activeTab)
 
 			if (currentIndex > 0) {
 				return {
 					...state,
-					activeTab: tabs[currentIndex - 1],
+					activeTab: PRODUCT_FORM_TABS[currentIndex - 1],
 				}
 			}
 


### PR DESCRIPTION
## Summary

Replaces the two-level tab structure with a single row of 6 tabs:

**Before:** Product | Shipping → (under Product) Name | Detail | Spec | Category | Images

**After:** Name | Detail | Spec | Category | Images | Shipping

## Benefits

- Simpler navigation - all sections visible at once
- Fewer clicks to reach any section
- Clearer overview of form progress
- Consistent styling maintained

## Changes

- Updated `ProductFormState` to use single `activeTab` instead of `mainTab` + `productSubTab`
- Simplified `nextTab` and `previousTab` navigation logic
- Flattened the Tabs component structure in `ProductFormContent.tsx`

## Test plan

- [ ] Create new product - verify all 6 tabs are visible in a single row
- [ ] Navigate using tab clicks - each tab should work
- [ ] Navigate using Back/Next buttons - should move through tabs correctly
- [ ] Edit existing product - tabs should preserve state correctly
- [ ] Responsive behavior on mobile - tabs should wrap or scroll as needed

Fixes #425

## Screenshot

<img width="1216" height="827" src="https://github.com/user-attachments/assets/0562f078-4727-4778-9c6c-f090f5b81c7b" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)