### PR TITLE
fix: change tracking number to tracking URL in shipping modal

### DIFF
--- a/src/components/orders/OrderActions.tsx
+++ b/src/components/orders/OrderActions.tsx
@@ -198,12 +198,12 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 					</DialogHeader>
 
 					<div className="space-y-2 py-4">
-						<Label htmlFor="tracking">Tracking Number (Optional)</Label>
+						<Label htmlFor="tracking">Add Tracking URL</Label>
 						<Input
 							id="tracking"
 							value={trackingNumber}
 							onChange={(e) => setTrackingNumber(e.target.value)}
-							placeholder="Enter tracking number"
+							placeholder="Enter tracking URL"
 						/>
 					</div>
 

--- a/src/components/orders/detail/TrackingInfoDisplay.tsx
+++ b/src/components/orders/detail/TrackingInfoDisplay.tsx
@@ -21,14 +21,14 @@ export function TrackingInfoDisplay({ trackingNumber, carrier, shippingStatus }:
 						{trackingNumber && (
 							<div className="flex items-center justify-between gap-2">
 								<div className="min-w-0 flex-1">
-									<p className="text-xs font-medium text-purple-700 uppercase tracking-wide">Tracking Number</p>
+									<p className="text-xs font-medium text-purple-700 uppercase tracking-wide">Tracking URL</p>
 									<p className="text-purple-900 font-mono text-sm break-all">{trackingNumber}</p>
 								</div>
 								<Button
 									variant="ghost"
 									size="sm"
 									className="h-8 px-2 text-purple-700 hover:text-purple-900 hover:bg-purple-100 flex-shrink-0"
-									onClick={() => copyToClipboard(trackingNumber, 'Tracking number copied to clipboard')}
+									onClick={() => copyToClipboard(trackingNumber, 'Tracking URL copied to clipboard')}
 								>
 									<Copy className="h-4 w-4" />
 								</Button>


### PR DESCRIPTION
## Summary

- Changed label from "Tracking Number (Optional)" to "Add Tracking URL" in the shipping dialog
- Updated placeholder from "Enter tracking number" to "Enter tracking URL"
- Updated display label from "Tracking Number" to "Tracking URL" in TrackingInfoDisplay
- Updated copy toast message to "Tracking URL copied to clipboard"

Fixes #384

## Test plan

- [ ] Open a seller order in Processing status
- [ ] Click "Ship" button
- [ ] Verify shipping dialog shows "Add Tracking URL" label
- [ ] Verify placeholder says "Enter tracking URL"
- [ ] Submit and verify tracking display shows "Tracking URL"

🤖 Generated with [Claude Code](https://claude.com/claude-code)