### PR TITLE
feat: add Open Graph meta tags for product social previews

### DIFF
--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -112,7 +112,10 @@ function useDocumentMeta(config: MetaTagsConfig) {
 		// Twitter Card tags
 		addMeta({ name: 'twitter:card', content: 'summary_large_image' })
 		addMeta({ name: 'twitter:title', content: title })
-		addMeta({ name: 'twitter:description', content: `${description} - ${price} ${currency}` })
+		addMeta({
+			name: 'twitter:description',
+			content: price !== undefined && currency ? `${description} - ${price} ${currency}` : description,
+		})
 		if (image) {
 			addMeta({ name: 'twitter:image', content: image })
 		}


### PR DESCRIPTION
## Summary

- Add `useDocumentMeta` hook that injects Open Graph and Twitter Card meta tags into the document head
- Meta tags include: og:title, og:description, og:image, og:url, og:type, og:site_name
- Twitter Card tags: twitter:card, twitter:title, twitter:description, twitter:image
- Product-specific: product:price:amount, product:price:currency
- Updates browser tab title to show product name

Uses native DOM APIs (same pattern as existing `useHeroBackground` hook) for React 19 compatibility.

**Note:** Full social media preview support requires SSR. This client-side implementation works for JS-executing crawlers (like Google) and improves SEO.

Fixes #454

## Test plan

- [x] Visit a product page
- [x] Check browser tab shows "Product Name | Plebeian Market"
- [x] Open DevTools → Elements → search for `og:title` in `<head>`
- [x] Verify all meta tags are present with correct product data
- [ ] Confirm social preview images are working correctly when merged into staging.plebeian.market.

## Screenshot

<img width="1480" height="984" src="https://github.com/user-attachments/assets/2365ba37-81c4-4bb4-ac0e-27c97d178544" alt="image">

🤖 Generated with [Claude Code](https://claude.com/claude-code)