### PR TITLE
docs: add Claude Code configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
-  "mcpServers": {
-    "nostrbook": {
-      "command": "npx",
-      "args": ["-y", "@nostrbook/mcp@latest"]
-    }
-  }
+	"mcpServers": {
+		"nostrbook": {
+			"command": "npx",
+			"args": ["-y", "@nostrbook/mcp@latest"]
+		}
+	}
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "nostrbook": {
+      "command": "npx",
+      "args": ["-y", "@nostrbook/mcp@latest"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10
 
 **Important**: Always run `bun run format` before committing or pushing changes.
 
+**After pushing**: Check GitHub Actions/workflows to confirm there are no failures.
+
 ## Architecture
 
 ### Data Flow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,3 +105,7 @@ Supports NIP-07 (browser extension), NIP-46 (bunker/remote signing), and local p
 ## UI Components
 
 Always use [Radix UI primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) for UI components. Radix provides accessible, unstyled components that handle focus management, keyboard navigation, and ARIA attributes. See `src/components/` for existing patterns using Radix with Tailwind styling.
+
+## Design
+
+Figma designs: https://www.figma.com/design/re69Ae2WVk5yKdaGxCbnb5/Plebeian

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ bun test:e2e:chrome      # Run e2e tests in Chrome only
 
 For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10547) and configure `.env` from `.env.example`.
 
+**Important**: Always run `bun run format` before committing or pushing changes.
+
 ## Architecture
 
 ### Data Flow
@@ -45,11 +47,38 @@ For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10
 ### Nostr Event Kinds
 
 - 30402: Products
-- 30403: Orders
+- 30403: Orders (legacy)
 - 30405: Collections
 - 30406: Shipping options
 - 1063: Comments (NIP-22)
 - 31990/30078: App settings
+- 31555: Product reviews
+- 14, 16, 17: Order communication (NIP-17 encrypted DMs)
+
+## Gamma Markets Specification
+
+This project implements the [Gamma Markets e-commerce spec](https://github.com/GammaMarkets/market-spec), an extension of NIP-99 developed collaboratively by Nostr marketplace developers (Shopstr, Cypher, Plebeian, Conduit).
+
+### Order Flow
+
+1. Buyer creates order (Kind 16, type 1) with items and shipping
+2. Merchant sends payment request (Kind 16, type 2) or buyer pays automatically
+3. Buyer submits payment receipt (Kind 17) with proof
+4. Merchant confirms and updates status (Kind 16, type 3)
+5. Merchant provides shipping updates (Kind 16, type 4)
+
+### Payment Methods
+
+- Lightning Network via `lud16` addresses
+- eCash tokens (locked to merchant pubkey)
+- Manual processing (merchant-initiated requests)
+- Generic payment proof for fiat gateways
+
+### Key Design Decisions
+
+- No cascading inheritance: products explicitly reference collection attributes
+- All sensitive order communication uses NIP-17 encrypted DMs
+- Merchants recommend preferred apps via NIP-89
 
 ### Authentication
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Plebeian Market is a decentralized marketplace built on the Nostr protocol. All data is stored on Nostr relays - there is no traditional database. Browser storage (localStorage, sessionStorage, IndexedDB) is only used for user preferences, auth keys, and temporary state like shopping carts.
+
+## Commands
+
+```bash
+bun install              # Install dependencies
+bun dev                  # Start dev server (requires relay running)
+bun dev:seed             # Start with seeded test data
+bun run watch-routes     # Watch for route changes (run in separate terminal during development)
+bun seed                 # Seed relay with test data
+bun run format           # Format code with Prettier
+bun run format:check     # Check formatting
+bun test:e2e             # Run Playwright e2e tests (headless)
+bun test:e2e:headed      # Run e2e tests with visible browser
+bun test:e2e:chrome      # Run e2e tests in Chrome only
+```
+
+For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10547) and configure `.env` from `.env.example`.
+
+## Architecture
+
+### Data Flow
+
+1. **Server** (`src/index.tsx`): Bun server that serves the SPA and provides `/api/config` endpoint. Handles WebSocket connections for admin event signing.
+
+2. **Client initialization** (`src/frontend.tsx`): Fetches config from server, initializes NDK (Nostr Development Kit), creates TanStack Query client and router.
+
+3. **State management**: TanStack Store for local state (`src/lib/stores/`), TanStack React Query for server state from Nostr relays.
+
+### Key Directories
+
+- `src/routes/` - File-based routing (TanStack Router). Route files export `Route` with optional `loader` for data prefetching.
+- `src/lib/stores/` - TanStack Store state: `ndk.ts` (relay connections), `auth.ts` (user auth), `cart.ts` (shopping cart), `wallet.ts` (NWC wallets)
+- `src/lib/schemas/` - Zod schemas for validating Nostr events
+- `src/queries/queryKeyFactory.ts` - Query key factories for TanStack Query cache management
+- `src/publish/` - Functions for publishing Nostr events
+- `src/components/` - React components organized by feature
+
+### Nostr Event Kinds
+
+- 30402: Products
+- 30403: Orders
+- 30405: Collections
+- 30406: Shipping options
+- 1063: Comments (NIP-22)
+- 31990/30078: App settings
+
+### Authentication
+
+Supports NIP-07 (browser extension), NIP-46 (bunker/remote signing), and local private key storage. Auth state managed in `src/lib/stores/auth.ts`.
+
+## Tech Stack
+
+- Runtime: Bun
+- Framework: React 19
+- Routing: TanStack Router (file-based)
+- State: TanStack Store + TanStack React Query v5
+- Styling: Tailwind CSS v4
+- UI: Radix UI primitives
+- Forms: TanStack Form + Zod
+- Nostr: NDK (Nostr Development Kit)
+- Testing: Playwright

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Plebeian Market is a decentralized marketplace built on the Nostr protocol. All data is stored on Nostr relays - there is no traditional database. Browser storage (localStorage, sessionStorage, IndexedDB) is only used for user preferences, auth keys, and temporary state like shopping carts.
 
+Plebeian Market originally ran on NIP-15, but the current version uses NIP-99 with a migration path for existing users (see `src/routes/_dashboard-layout/dashboard/products/migration-tool.tsx`).
+
 ## Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,3 +97,7 @@ Supports NIP-07 (browser extension), NIP-46 (bunker/remote signing), and local p
 - Forms: TanStack Form + Zod
 - Nostr: NDK (Nostr Development Kit)
 - Testing: Playwright
+
+## UI Components
+
+Always use [Radix UI primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) for UI components. Radix provides accessible, unstyled components that handle focus management, keyboard navigation, and ARIA attributes. See `src/components/` for existing patterns using Radix with Tailwind styling.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10
 
 **After pushing**: Check GitHub Actions/workflows to confirm there are no failures.
 
+**Creating issues**: Check `.github/ISSUE_TEMPLATE/` for bug report and feature request templates before creating issues.
+
 ## Architecture
 
 ### Data Flow


### PR DESCRIPTION
## Summary

Add Claude Code configuration to improve developer productivity and ensure consistency across the team.

## Why Add Claude Config?

Several developers on this project use Claude Code for development. Without shared configuration, each developer's Claude instance starts from scratch - needing to rediscover the tech stack, coding patterns, and project conventions every session.

**Benefits of shared config:**

- **Faster onboarding** - New developers (and new Claude sessions) immediately understand the architecture, commands, and patterns
- **Consistency** - All developers get the same guidance on using Radix UI, running formatters, checking CI, and following issue templates
- **Nostr context** - The nostrbook MCP server gives Claude instant access to NIP documentation, so it understands the protocol without needing to search
- **Reduced errors** - Reminders to run `bun run format` and check GitHub Actions catch issues before they become PR review comments
- **Living documentation** - CLAUDE.md serves as lightweight, actionable docs that stay current because developers use it daily

## What's Included

- **CLAUDE.md** - Project overview, commands, architecture, Gamma Markets spec reference
- **.mcp.json** - Configures nostrbook MCP server for all developers (NIP lookups)

## Future Enhancements

We can add custom commands, skills, and agents over time. For example, adding these agents would improve context handling):

- **Teddie the Tester** - Creates Playwright test scripts for features that have been developed
- **Pennie the Prepper** - Documents issues in the repo with proper formatting and context
- **Archie the Architect** - Reviews PRs to ensure they follow architectural principles the team want to follow

## Test plan

- [x] CLAUDE.md created with accurate project information
- [x] Commands verified against package.json
- [x] MCP server configuration added
- [x] Formatting and CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)