### PR TITLE
fix: remove description duplication in product & collection summaries

### DIFF
--- a/src/publish/collections.tsx
+++ b/src/publish/collections.tsx
@@ -39,7 +39,7 @@ export const createCollectionEvent = (
 	event.tags = [
 		['d', id], // Collection identifier
 		['title', formData.name],
-		['summary', formData.description], // Collection summary
+		['summary', ''], // Collection summary
 	]
 
 	// Optional header image

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -86,7 +86,7 @@ export const createProductEvent = (
 		['type', formData.productType === 'single' ? 'simple' : 'variable', 'physical'],
 		['visibility', formData.status],
 		['stock', formData.quantity],
-		['summary', formData.description],
+		['summary', ''],
 		...imagesTags,
 		...categoryTags,
 		...specTags,


### PR DESCRIPTION
Fix for duplication of product and collection descriptions in summaries messing up product listings in other Nostr clients  until added support for summaries with #465

Closes #301 