### PR TITLE
Styling: bottom padding for finalized order details

### DIFF
--- a/src/components/checkout/OrderFinalizeComponent.tsx
+++ b/src/components/checkout/OrderFinalizeComponent.tsx
@@ -100,7 +100,7 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 	}
 
 	return (
-		<div className="space-y-6">
+		<div className="space-y-6 pb-8">
 			{/* Payment Status - only show if invoices exist */}
 			{isPostPayment && (
 				<div className="space-y-3">


### PR DESCRIPTION
<img width="2560" height="1440" src="https://github.com/user-attachments/assets/801992ee-0793-4212-8ad7-f4152d2fd7fa" alt="finalized_order_details_bottom padding">

closes #354