### PR TITLE
docs: add nak tooling documentation and local dev template

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,4 @@
+NODE_ENV=development
+APP_RELAY_URL=ws://localhost:10547
+APP_PRIVATE_KEY=<your_private_key_in_hex>
+LOCAL_RELAY_ONLY=true

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
 		"nostrbook": {
 			"command": "npx",
 			"args": ["-y", "@nostrbook/mcp@latest"]
+		},
+		"nak": {
+			"command": "nak",
+			"args": ["mcp"]
 		}
 	}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**Note**: This file is shared in the repo. Do not add developer-specific paths or local configuration here.
+
 ## Project Overview
 
 Plebeian Market is a decentralized marketplace built on the Nostr protocol. All data is stored on Nostr relays - there is no traditional database. Browser storage (localStorage, sessionStorage, IndexedDB) is only used for user preferences, auth keys, and temporary state like shopping carts.
@@ -24,6 +26,24 @@ bun test:e2e:chrome      # Run e2e tests in Chrome only
 ```
 
 For local development, run a Nostr relay (e.g., `nak serve` at ws://localhost:10547) and configure `.env` from `.env.example`.
+
+## Local Development Tools
+
+**nak** (Nostr Army Knife) - Install from [github.com/fiatjaf/nak](https://github.com/fiatjaf/nak). Key commands:
+
+```bash
+nak serve          # Start local relay at ws://localhost:10547
+nak key generate   # Generate new Nostr keypair
+nak decode <nip19> # Decode nip19/nip05 entities
+nak fetch <nip19>  # Fetch events by identifier
+nak mcp            # Start MCP server for AI integration
+```
+
+**Environment files**:
+
+- `.env.example` - Template for production environment variables
+- `.env.dev.example` - Template for local development (uses `nak serve` at ws://localhost:10547)
+- Copy the appropriate template to `.env` and configure
 
 **Important**: Always run `bun run format` before committing or pushing changes.
 


### PR DESCRIPTION
## Summary

- Add `nak` CLI documentation to CLAUDE.md (serve, key generate, decode, fetch, mcp commands)
- Add `.env.dev.example` template for local development with nak relay
- Add nak MCP server to `.mcp.json` for AI integration
- Note that CLAUDE.md is shared and shouldn't contain developer-specific paths

## Files changed

- `CLAUDE.md` - Added Local Development Tools section with nak docs
- `.env.dev.example` - New template for local dev environment
- `.mcp.json` - Added nak MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)