### PR TITLE
fix: silence ndk errrors for no-cache configuration

### DIFF
--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -166,7 +166,9 @@ export const ndkActions = {
 		const ndk = new NDK({
 			explicitRelayUrls: explicitRelays,
 			enableOutboxModel: !localRelayOnly,
-			aiGuardrails: true,
+			aiGuardrails: {
+				skip: new Set(['ndk-no-cache']),
+			},
 		})
 
 		const zapNdk = new NDK({


### PR DESCRIPTION
<img width="1409" height="220" src="https://github.com/user-attachments/assets/0d8730b5-9d7e-4a94-b46d-f86ea75cb2f8" alt="silence-no-cache-errors">

closes #495