### PR TITLE
fix: set converted fiat price to 0 for 0 fiatPrice

### DIFF
--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -115,7 +115,7 @@ export function DetailTab() {
 			productFormActions.updateValues({ price: satsValue.toString(), fiatPrice: value })
 		} else if (value === '' || value === '0') {
 			// Clear the price if input is empty or zero
-			productFormActions.updateValues({ price: '0', fiatPrice: '' })
+			productFormActions.updateValues({ price: '0', fiatPrice: '0' })
 		}
 	}
 


### PR DESCRIPTION
[set-0-fiat-price-for-0-price-in product-tabs.webm](https://github.com/user-attachments/assets/eada5c3d-378e-4d4b-8bb7-97d8e0e7cb2f)

closes #427