### PR TITLE
ui: product shipping cost placeholder

### DIFF
--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -912,8 +912,8 @@ export function ShippingTab() {
 											min="0"
 											value={shipping.extraCost}
 											onChange={(e) => updateExtraCost(index, e.target.value)}
-											placeholder="Extra cost"
-											className="w-24 text-sm"
+											placeholder="Add cost specific to this product"
+											className="w-40 sm:w-56 md:w-76 text-sm"
 										/>
 										<Button
 											type="button"


### PR DESCRIPTION
closes #376
<img width="2560" height="1440" src="https://github.com/user-attachments/assets/147cbba3-5cd1-42a7-8b6c-9cba8e254866" alt="product-shipping-cost-placeholder">