### PR TITLE
fix: add base href to resolve relative path issues

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<base href="/" />
 		<meta name="theme-color" content="#0A0A0A" />
 		<link rel="icon" type="image/svg+xml" href="../public/images/logo.svg" />
 		<link rel="icon" type="image/x-icon" href="../public/favicon.ico" />


### PR DESCRIPTION
Set base URL to root to ensure correct resolution of relative paths for assets and navigation links.