### PR TITLE
fix: only save n-connect to localstorage once login successful

### DIFF
--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -171,15 +171,17 @@ export const authActions = {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
 
-		localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, localSigner.privateKey || '')
-		localStorage.setItem(NOSTR_CONNECT_KEY, bunkerUrl)
-
 		try {
 			authStore.setState((state) => ({ ...state, isAuthenticating: true }))
 			const signer = new NDKNip46Signer(ndk, bunkerUrl, localSigner)
 			await signer.blockUntilReady()
 			ndkActions.setSigner(signer)
 			const user = await signer.user()
+
+			// Wait until user is logged in successfully before saving the bunkerURL/private key.
+
+			localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, localSigner.privateKey || '')
+			localStorage.setItem(NOSTR_CONNECT_KEY, bunkerUrl)
 
 			authStore.setState((state) => ({
 				...state,


### PR DESCRIPTION
Attempting to fix [[BUG]: Infinite spin on login button](https://github.com/PlebeianApp/market/issues/682) #682

The main issue here comes from connecting with n-connect or bunker. What happens if the user enables "auto-login" and begins an attempt at logging in with the above method, the sign-in method will be persisted even if it fails (i.e. unable to authenticate).

The fix I've implemented is simple: Only save n-connect/bunker login info to localstorage **after** successfully logging in. This appears to be the simplest way to resolve the issue.

I've tested the app and found the fix to work under the specific reproduction steps I documented in the issue. Unfortunately I have some failing tests on master so I can't guarantee I haven't broken anything. Please let me know if I have as this is my first PR :)