### PR TITLE
fix: subcategories not loaded correctly in product edit form

### DIFF
--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -191,14 +191,14 @@ export const productFormActions = {
 			const dimensionsTag = getProductDimensions(event)
 			const shippingTags = getProductShippingOptions(event)
 
-			const mainCategoryFromTags = categories.find((tag) => tag.length === 2 && tag[0] === 't')?.[1]
-			const subCategoriesFromTags = categories
-				.filter((tag) => tag.length > 2 && tag[0] === 't')
-				.map((tag, index) => ({
-					key: `category-${Date.now()}-${index}`,
-					name: tag[1],
-					checked: true,
-				}))
+			// First category from NDKEvent is considered "Main" category.
+			// The next 3 are the "sub-categories".
+			const mainCategoryFromTags = categories.at(0)?.at(1)
+			const subCategoriesFromTags = categories.slice(1, 4).map((tag, index) => ({
+				key: `category-${Date.now()}-${index}`,
+				name: tag[1],
+				checked: true,
+			}))
 
 			// Parse shipping options
 			const shippingOptions: ProductShippingForm[] = shippingTags.map((tag) => {


### PR DESCRIPTION
This PR should fix [[BUG] Custom category not sticking](https://github.com/PlebeianApp/market/issues/681) #681

The issue was related to the loading of the subcategories on the Product Edit page. The fix was to respect the following format:

- First category (event tag with "t") is "Main Category"
- Following 3 categories are "Sub-categories"

I reasoned this based on looking through the rest of the codebase and documentation. If I somehow misinterpreted it, please let me know.

Saving & loading Product sub-categories now works in the app.