### PR TITLE
fix: improved loading indicator for sales page

### DIFF
--- a/src/components/orders/OrderDataTable.tsx
+++ b/src/components/orders/OrderDataTable.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { ArrowDownNarrowWide, ArrowUpNarrowWide, CheckCircle, Circle, Clock, Filter, Loader, XCircle } from 'lucide-react'
+import { ArrowDownNarrowWide, ArrowUpNarrowWide, CheckCircle, Circle, Clock, Filter, Loader, Loader2, XCircle } from 'lucide-react'
 import type { OrderWithRelatedEvents } from '@/queries/orders'
 import type { ColumnDef, ColumnFiltersState, FilterFn, SortingState } from '@tanstack/react-table'
 import { flexRender, getCoreRowModel, getFilteredRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table'
@@ -165,10 +165,9 @@ export function OrderDataTable<TData>({
 
 			<div className="flex-1 overflow-y-auto pb-4">
 				{isLoading ? (
-					<div className="space-y-4 pt-4 px-4 xl:px-6">
-						<div className="p-6 text-center">
-							Loading...
-						</div>
+					<div className="flex justify-center items-center h-full mt-8">
+						<Loader2 className="w-8 h-8 animate-spin text-primary" />
+						<p className="ml-2">Loading sales...</p>
 					</div>
 				) : table.getRowModel().rows?.length ? (
 					<div className="space-y-4 pt-4 px-4 xl:px-6">

--- a/src/components/orders/OrderDataTable.tsx
+++ b/src/components/orders/OrderDataTable.tsx
@@ -166,13 +166,9 @@ export function OrderDataTable<TData>({
 			<div className="flex-1 overflow-y-auto pb-4">
 				{isLoading ? (
 					<div className="space-y-4 pt-4 px-4 xl:px-6">
-						{Array(7)
-							.fill(0)
-							.map((_, i) => (
-								<div key={i} className="rounded-md border border-gray-200 p-6 text-center">
-									Loading...
-								</div>
-							))}
+						<div className="p-6 text-center">
+							Loading...
+						</div>
 					</div>
 				) : table.getRowModel().rows?.length ? (
 					<div className="space-y-4 pt-4 px-4 xl:px-6">


### PR DESCRIPTION
Fix [BUG: Sales page stuck at loading](https://github.com/PlebeianApp/market/issues/688) #688

The main issue is an inconsistent UI that looks like individual sales are loading. The simple fix is to replace it with page-content loading, which better represents the actual state.

Improved UI:

<img width="829" height="963" src="https://github.com/user-attachments/assets/f2da42be-d8bc-43dd-b4c3-52ca0bb51e25" alt="Screenshot 2026-03-12 at 11 05 27">

An improvement that I'm currently looking into (as I'm still getting familiar with the NDK) is to ensure the loading does not stall. This seems to be causing the loading indicator not going away when there are no events that match the filter.