### PR TITLE
Add support for NIP-15 shop profiles

### DIFF
--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -27,10 +27,34 @@ import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { Edit, MapPin, MessageCircle, Minus, Plus, Share2 } from 'lucide-react'
 import { useState, useEffect, useMemo } from 'react'
+import { useAllShopProfiles, mergeShopWithProfile, groupProductsByStall, type ShopProfile } from '@/queries/shopProfile'
+import { Store } from 'lucide-react'
 import { toast } from 'sonner'
 
 interface ProfilePageProps {
 	profileId: string
+}
+
+function StallHeader({ stall }: { stall: ShopProfile }) {
+	return (
+		<div className="flex items-center gap-3 mb-4 px-6">
+			{stall.picture ? (
+				<img src={stall.picture} alt={stall.name} className="w-8 h-8 rounded-full object-cover border border-zinc-200" />
+			) : (
+				<div className="w-8 h-8 rounded-full bg-zinc-100 flex items-center justify-center">
+					<Store className="w-4 h-4 text-zinc-400" />
+				</div>
+			)}
+			<h3 className="text-base font-heading font-semibold text-zinc-700">{stall.name}</h3>
+			{stall.location && (
+				<span className="text-xs text-zinc-400 flex items-center gap-1">
+					<MapPin className="w-3 h-3" />
+					{stall.location}
+				</span>
+			)}
+			{stall.currency && <span className="text-xs text-zinc-400">{stall.currency}</span>}
+		</div>
+	)
 }
 
 export function ProfilePage({ profileId }: ProfilePageProps) {
@@ -41,6 +65,13 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	const { profile, user } = profileData || {}
 
 	const { data: sellerProducts } = useSuspenseQuery(productsByPubkeyQueryOptions(user?.pubkey || ''))
+	const { data: allStalls = [], isLoading: isLoadingStalls } = useAllShopProfiles(user?.pubkey)
+	const primaryStall = allStalls[0] ?? null
+	const displayName = mergeShopWithProfile(primaryStall?.name, profile?.name) ?? 'Unnamed user'
+	const displayAbout = mergeShopWithProfile(primaryStall?.description, profile?.about)
+	const displayBanner = mergeShopWithProfile(primaryStall?.banner, profile?.banner)
+	const displayPicture = mergeShopWithProfile(primaryStall?.picture, profile?.image ?? (profile as any)?.picture)
+	const displayLocation = primaryStall?.location ?? null
 
 	const [showFullAbout, setShowFullAbout] = useState(false)
 	const [bannerIsLoadable, setBannerIsLoadable] = useState<boolean | null>(null)
@@ -49,7 +80,7 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	const breakpoint = useBreakpoint()
 	const isSmallScreen = breakpoint === 'sm'
 	const queryClient = useQueryClient()
-	const aboutText = profile?.about?.trim() ?? ''
+	const aboutText = displayAbout?.trim() ?? ''
 	const hasAbout = aboutText.length > 0
 	const truncationLength = isSmallScreen ? 70 : 250
 	const aboutTruncated = truncateText(aboutText, truncationLength)
@@ -101,6 +132,11 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		}
 		return locations
 	}, [shippingOptions])
+
+	const { grouped, ungroupedProducts } = useMemo(() => groupProductsByStall(allStalls, sellerProducts ?? []), [allStalls, sellerProducts])
+	const hasStalls = allStalls.length > 0
+	const totalProducts = (sellerProducts ?? []).length
+	const stallsSettled = !isLoadingStalls
 
 	// Handle edit profile
 	const handleEdit = () => {
@@ -175,22 +211,22 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	// Check if banner image is loadable
 	useEffect(() => {
 		const validateBanner = async () => {
-			if (profile?.banner) {
-				const isLoadable = await checkImageLoadable(profile.banner)
+			if (displayBanner) {
+				const isLoadable = await checkImageLoadable(displayBanner)
 				setBannerIsLoadable(isLoadable)
 			} else {
 				setBannerIsLoadable(null)
 			}
 		}
 		validateBanner()
-	}, [profile?.banner])
+	}, [displayBanner])
 
 	return (
 		<div className="relative min-h-screen flex flex-col">
 			<div className="absolute top-0 left-0 right-0 z-0 h-[40vh] sm:h-[40vh] md:h-[50vh] overflow-hidden">
-				{profile?.banner && bannerIsLoadable === true ? (
+				{displayBanner && bannerIsLoadable === true ? (
 					<div className="w-[150%] sm:w-full h-full -ml-[25%] sm:ml-0">
-						<img src={profile.banner} alt="profile-banner" className="w-full h-full object-cover" />
+						<img src={displayBanner} alt="shop-banner" className="w-full h-full object-cover" />
 					</div>
 				) : (
 					<div
@@ -205,17 +241,27 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 			<div className="flex flex-col relative z-10 pt-[18vh] sm:pt-[22vh] md:pt-[30vh] flex-1">
 				<div className="flex flex-row justify-between px-8 py-4 bg-black items-center">
 					<div className="flex flex-row items-center gap-4">
-						{profile?.picture && (
-							<img
-								src={profile.picture}
-								alt={profile.name || 'Profile picture'}
-								className="rounded-full w-10 h-10 sm:w-16 sm:h-16 border-2 border-black"
-							/>
+						{displayPicture && (
+							<img src={displayPicture} alt={displayName} className="rounded-full w-10 h-10 sm:w-16 sm:h-16 border-2 border-black" />
 						)}
 						<div className="flex items-center gap-2">
-							<h2 className="text-xl sm:text-2xl font-bold text-white">
-								{truncateText(profile?.name ?? 'Unnamed user', isSmallScreen ? 28 : 50)}
-							</h2>
+							<div>
+								<h2 className="text-xl sm:text-2xl font-bold text-white">{truncateText(displayName, isSmallScreen ? 28 : 50)}</h2>
+								<div className="flex items-center gap-3 mt-0.5">
+									{displayLocation && (
+										<p className="text-xs text-gray-400 flex items-center gap-1">
+											<MapPin className="w-3 h-3" />
+											{displayLocation}
+										</p>
+									)}
+									{allStalls.length > 1 && (
+										<span className="text-xs text-gray-400 flex items-center gap-1">
+											<Store className="w-3 h-3" />
+											{allStalls.length} stalls
+										</span>
+									)}
+								</div>
+							</div>
 							<Nip05Badge pubkey={user?.pubkey || ''} showAddress nip05={profile?.nip05} />
 						</div>
 					</div>
@@ -277,21 +323,8 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 					)}
 				</div>
 
-				<div className="p-4 flex-1 flex flex-col">
-					{sellerProducts && sellerProducts.length > 0 ? (
-						<ItemGrid
-							title={
-								<div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-center sm:text-left">
-									<span className="text-2xl font-heading">Products from</span>
-									<ProfileName pubkey={user?.pubkey || ''} className="text-2xl font-heading" />
-								</div>
-							}
-						>
-							{sellerProducts.map((product: NDKEvent) => (
-								<ProductCard key={product.id} product={product} />
-							))}
-						</ItemGrid>
-					) : (
+				<div className="relative z-10 flex-1 flex flex-col gap-8 bg-white border-t border-zinc-200 pt-4">
+					{totalProducts === 0 ? (
 						<div className="flex flex-col items-center justify-center flex-1 gap-4">
 							<span className="text-2xl font-heading">No products found</span>
 							{permissions.canEdit && (
@@ -301,23 +334,65 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 								</Button>
 							)}
 						</div>
+					) : !stallsSettled || !hasStalls ? (
+						<ItemGrid
+							title={
+								<div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-center sm:text-left">
+									<span className="text-2xl font-heading">Products from</span>
+									<ProfileName pubkey={user?.pubkey || ''} className="text-2xl font-heading" />
+								</div>
+							}
+						>
+							{(sellerProducts ?? []).map((product: NDKEvent) => (
+								<ProductCard key={product.id} product={product} />
+							))}
+						</ItemGrid>
+					) : (
+						<>
+							{grouped.map(({ stall, products }) => (
+								<div key={stall.id}>
+									<StallHeader stall={stall} />
+									{products.length > 0 ? (
+										<div className="px-6">
+											<ItemGrid>
+												{products.map((product: NDKEvent) => (
+													<ProductCard key={product.id} product={product} />
+												))}
+											</ItemGrid>
+										</div>
+									) : (
+										<p className="text-sm text-zinc-400 py-4 px-6">No products in this stall yet.</p>
+									)}
+								</div>
+							))}
+
+							{ungroupedProducts.length > 0 && (
+								<div>
+									<div className="pt-4 border-t border-zinc-100 px-6">
+										<h3 className="text-base font-heading font-semibold mb-4 text-zinc-400">Other products</h3>
+									</div>
+									<div className="p-6">
+										<ItemGrid>
+											{ungroupedProducts.map((product: NDKEvent) => (
+												<ProductCard key={product.id} product={product} />
+											))}
+										</ItemGrid>
+									</div>
+								</div>
+							)}
+						</>
 					)}
 				</div>
 			</div>
 
-			<ShareProfileDialog
-				open={shareDialogOpen}
-				onOpenChange={setShareDialogOpen}
-				pubkey={user?.pubkey || ''}
-				profileName={profile?.name}
-			/>
+			<ShareProfileDialog open={shareDialogOpen} onOpenChange={setShareDialogOpen} pubkey={user?.pubkey || ''} profileName={displayName} />
 
 			{pickupLocations.length > 0 && (
 				<PickupLocationDialog
 					open={pickupLocationDialogOpen}
 					onOpenChange={setPickupLocationDialogOpen}
 					locations={pickupLocations}
-					vendorName={profile?.name}
+					vendorName={displayName}
 				/>
 			)}
 		</div>

--- a/src/queries/shopProfile.tsx
+++ b/src/queries/shopProfile.tsx
@@ -1,0 +1,204 @@
+import { ndkActions } from '@/lib/stores/ndk'
+import { NDKEvent } from '@nostr-dev-kit/ndk'
+import { queryOptions, useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { v4 as uuidv4 } from 'uuid'
+
+export const STALL_KIND = 30017
+
+export interface StallShippingZone {
+	id: string
+	name?: string
+	cost: number
+	regions: string[]
+}
+
+export interface StallContent {
+	id: string
+	name: string
+	description?: string
+	currency: string
+	shipping: StallShippingZone[]
+}
+
+export interface ShopProfile {
+	id: string
+	name: string
+	description?: string
+	currency: string
+	shipping: StallShippingZone[]
+	banner?: string
+	picture?: string
+	location?: string
+}
+
+export interface StallWithProducts {
+	stall: ShopProfile
+	products: NDKEvent[]
+}
+
+// Event helpers
+function parseStallEvent(event: NDKEvent): ShopProfile | null {
+	try {
+		const content = JSON.parse(event.content) as StallContent
+		const getTag = (name: string) => event.tags.find((t) => t[0] === name)?.[1]
+		return {
+			id: content.id,
+			name: content.name,
+			description: content.description,
+			currency: content.currency,
+			shipping: content.shipping ?? [],
+			banner: getTag('banner'),
+			picture: getTag('picture'),
+			location: getTag('location'),
+		}
+	} catch (e) {
+		console.error('Failed to parse stall event:', e)
+		return null
+	}
+}
+
+function buildStallEvent(ndk: InstanceType<typeof import('@nostr-dev-kit/ndk').default>, shop: ShopProfile): NDKEvent {
+	const content: StallContent = {
+		id: shop.id,
+		name: shop.name,
+		description: shop.description,
+		currency: shop.currency,
+		shipping: shop.shipping,
+	}
+	const event = new NDKEvent(ndk)
+	event.kind = STALL_KIND as any
+	event.content = JSON.stringify(content)
+	event.tags = [['d', shop.id]]
+	if (shop.banner) event.tags.push(['banner', shop.banner])
+	if (shop.picture) event.tags.push(['picture', shop.picture])
+	if (shop.location) event.tags.push(['location', shop.location])
+	return event
+}
+
+export const fetchShopProfile = async (pubkey: string, stallId?: string): Promise<ShopProfile | null> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk || !pubkey) return null
+	try {
+		const filter: Record<string, any> = { kinds: [STALL_KIND], authors: [pubkey] }
+		if (stallId) filter['#d'] = [stallId]
+		const event = await ndk.fetchEvent(filter)
+		if (!event) return null
+		return parseStallEvent(event)
+	} catch (e) {
+		console.error('Failed to fetch shop profile:', e)
+		return null
+	}
+}
+
+export const fetchAllShopProfiles = async (pubkey: string): Promise<ShopProfile[]> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk || !pubkey) return []
+	try {
+		const events = await ndk.fetchEvents({ kinds: [STALL_KIND as any], authors: [pubkey] })
+		return Array.from(events)
+			.map(parseStallEvent)
+			.filter((s): s is ShopProfile => s !== null)
+	} catch (e) {
+		console.error('Failed to fetch all shop profiles:', e)
+		return []
+	}
+}
+
+export function getProductStallId(product: NDKEvent): string | null {
+	try {
+		const content = JSON.parse(product.content)
+		return content?.stall_id ?? null
+	} catch {
+		return null
+	}
+}
+
+export function groupProductsByStall(
+	stalls: ShopProfile[],
+	products: NDKEvent[],
+): { grouped: StallWithProducts[]; ungroupedProducts: NDKEvent[] } {
+	if (stalls.length === 0) {
+		// no stalls at all — return everything as ungrouped
+		return { grouped: [], ungroupedProducts: products }
+	}
+
+	const stallMap = new Map<string, ShopProfile>(stalls.map((s) => [s.id, s]))
+	const stallProductsMap = new Map<string, NDKEvent[]>()
+	const ungroupedProducts: NDKEvent[] = []
+
+	for (const product of products) {
+		const stallId = getProductStallId(product)
+		if (stallId && stallMap.has(stallId)) {
+			if (!stallProductsMap.has(stallId)) stallProductsMap.set(stallId, [])
+			stallProductsMap.get(stallId)!.push(product)
+		} else {
+			ungroupedProducts.push(product)
+		}
+	}
+
+	const grouped: StallWithProducts[] = stalls.map((stall) => ({
+		stall,
+		products: stallProductsMap.get(stall.id) ?? [],
+	}))
+
+	return { grouped, ungroupedProducts }
+}
+
+// Publish
+export const publishShopProfile = async (shop: ShopProfile): Promise<NDKEvent> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	if (!ndk.signer) throw new Error('No signer available — please connect your Nostr account')
+	const event = buildStallEvent(ndk, shop)
+	await event.publish()
+	return event
+}
+
+export function createEmptyShopProfile(): ShopProfile {
+	return { id: uuidv4(), name: '', description: '', currency: 'SATS', shipping: [] }
+}
+
+// Query options
+export const shopProfileQueryOptions = (pubkey: string, stallId?: string) =>
+	queryOptions({
+		queryKey: ['shopProfile', pubkey, stallId ?? 'primary'],
+		queryFn: () => fetchShopProfile(pubkey, stallId),
+		enabled: !!pubkey,
+		staleTime: 5 * 60 * 1000,
+	})
+
+export const allShopProfilesQueryOptions = (pubkey: string) =>
+	queryOptions({
+		queryKey: ['shopProfiles', pubkey],
+		queryFn: () => fetchAllShopProfiles(pubkey),
+		enabled: !!pubkey,
+		staleTime: 5 * 60 * 1000,
+	})
+
+// React hooks
+export const useShopProfile = (pubkey: string | undefined, stallId?: string) =>
+	useQuery({ ...shopProfileQueryOptions(pubkey ?? '', stallId), enabled: !!pubkey })
+
+export const useAllShopProfiles = (pubkey: string | undefined) =>
+	useQuery({ ...allShopProfilesQueryOptions(pubkey ?? ''), enabled: !!pubkey })
+
+export const usePublishShopProfileMutation = () => {
+	const queryClient = useQueryClient()
+	const ndk = ndkActions.getNDK()
+	const pubkey = ndk?.activeUser?.pubkey
+	return useMutation({
+		mutationFn: (shop: ShopProfile) => publishShopProfile(shop),
+		onSuccess: () => {
+			if (pubkey) {
+				queryClient.invalidateQueries({ queryKey: ['shopProfile', pubkey] })
+				queryClient.invalidateQueries({ queryKey: ['shopProfiles', pubkey] })
+			}
+		},
+	})
+}
+
+// Merge helper
+export function mergeShopWithProfile<T>(shopValue: T | undefined | null, profileValue: T | undefined | null): T | undefined {
+	if (shopValue !== undefined && shopValue !== null && shopValue !== ('' as any)) return shopValue as T
+	return profileValue as T | undefined
+}

--- a/src/routes/_dashboard-layout/dashboard/account/profile.tsx
+++ b/src/routes/_dashboard-layout/dashboard/account/profile.tsx
@@ -13,10 +13,50 @@ import { useQuery } from '@tanstack/react-query'
 import { profileByIdentifierQueryOptions } from '@/queries/profiles'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
+import { Store, User, ChevronDown, ChevronUp, Info } from 'lucide-react'
+import { v4 as uuidv4 } from 'uuid'
+import { useAllShopProfiles, usePublishShopProfileMutation, type ShopProfile, createEmptyShopProfile } from '@/queries/shopProfile'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/account/profile')({
 	component: ProfileComponent,
 })
+
+// Collapsible Section
+function SectionHeader({
+	icon: Icon,
+	title,
+	subtitle,
+	open,
+	onToggle,
+	accent,
+}: {
+	icon: React.ElementType
+	title: string
+	subtitle: string
+	open: boolean
+	onToggle: () => void
+	accent: 'pink' | 'purple'
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onToggle}
+			className={`w-full flex items-center justify-between px-4 py-3 rounded-lg border transition-colors text-left
+				${accent === 'pink' ? 'border-pink-200 bg-pink-50 hover:bg-pink-100' : 'border-purple-200 bg-purple-50 hover:bg-purple-100'}`}
+		>
+			<div className="flex items-center gap-3">
+				<div className={`p-1.5 rounded-md ${accent === 'pink' ? 'bg-pink-500 text-white' : 'bg-purple-500 text-white'}`}>
+					<Icon className="w-4 h-4" />
+				</div>
+				<div>
+					<p className="font-semibold text-sm text-gray-900">{title}</p>
+					<p className="text-xs text-gray-500">{subtitle}</p>
+				</div>
+			</div>
+			{open ? <ChevronUp className="w-4 h-4 text-gray-400" /> : <ChevronDown className="w-4 h-4 text-gray-400" />}
+		</button>
+	)
+}
 
 function ProfileComponent() {
 	useDashboardTitle('Profile')
@@ -30,6 +70,18 @@ function ProfileComponent() {
 		...profileByIdentifierQueryOptions(pubkey || ''),
 		enabled: !!pubkey,
 	})
+	const { data: allStalls = [], isLoading: isLoadingShop } = useAllShopProfiles(pubkey)
+	const [activeStallId, setActiveStallId] = useState<string | null>(null)
+	const fetchedShopProfile = activeStallId ? (allStalls.find((s) => s.id === activeStallId) ?? null) : null
+
+	const [shopForm, setShopForm] = useState({ name: '', description: '', currency: 'SATS', location: '' })
+	const [shopImages, setShopImages] = useState<{ banner?: string; picture?: string }>({})
+	const [originalShopForm, setOriginalShopForm] = useState<typeof shopForm | null>(null)
+	const [originalShopImages, setOriginalShopImages] = useState<typeof shopImages>({})
+	const [personalOpen, setPersonalOpen] = useState(false)
+	const [shopOpen, setShopOpen] = useState(false)
+	const [isCreatingNew, setIsCreatingNew] = useState(false)
+	const publishShopMutation = usePublishShopProfileMutation()
 
 	// Extract profile from the query result
 	const fetchedProfile = fetchedData?.profile
@@ -52,6 +104,12 @@ function ProfileComponent() {
 	// Update profile mutation
 	const updateProfileMutation = useUpdateProfileMutation()
 	const isLoading = isLoadingProfile || updateProfileMutation.isPending
+
+	useEffect(() => {
+		if (allStalls.length > 0 && !activeStallId && !isCreatingNew) {
+			setActiveStallId(allStalls[0].id)
+		}
+	}, [allStalls, activeStallId, isCreatingNew])
 
 	// Update local state when fetched profile changes
 	useEffect(() => {
@@ -82,8 +140,23 @@ function ProfileComponent() {
 		}
 	}, [fetchedProfile])
 
+	useEffect(() => {
+		if (fetchedShopProfile && fetchedShopProfile.id === activeStallId) {
+			const form = {
+				name: fetchedShopProfile.name || '',
+				description: fetchedShopProfile.description || '',
+				currency: fetchedShopProfile.currency || 'SATS',
+				location: fetchedShopProfile.location || '',
+			}
+			setShopForm(form)
+			setShopImages({ banner: fetchedShopProfile.banner, picture: fetchedShopProfile.picture })
+			setOriginalShopForm(form)
+			setOriginalShopImages({ banner: fetchedShopProfile.banner, picture: fetchedShopProfile.picture })
+		}
+	}, [fetchedShopProfile, activeStallId])
+
 	// Handle form submission
-	const handleSave = async () => {
+	const handleSavePersonal = async () => {
 		if (!pubkey) {
 			toast.error('No active user')
 			return
@@ -104,6 +177,30 @@ function ProfileComponent() {
 			setProfile(updatedProfile)
 		} catch (error) {
 			// Error handling is done in the mutation
+		}
+	}
+
+	const handleSaveShop = async () => {
+		if (!shopForm.name.trim()) return toast.error('Shop name is required')
+		const shopProfile: ShopProfile = {
+			id: fetchedShopProfile?.id ?? uuidv4(),
+			name: shopForm.name.trim(),
+			description: shopForm.description.trim(),
+			currency: shopForm.currency || 'SATS',
+			location: shopForm.location.trim() || undefined,
+			banner: shopImages.banner,
+			picture: shopImages.picture,
+			shipping: fetchedShopProfile?.shipping ?? [],
+		}
+		try {
+			await publishShopMutation.mutateAsync(shopProfile)
+			toast.success('Shop profile saved!')
+			setOriginalShopForm({ ...shopForm })
+			setOriginalShopImages({ ...shopImages })
+			setIsCreatingNew(false)
+			setActiveStallId(shopProfile.id)
+		} catch (e: any) {
+			toast.error(e?.message || 'Failed to publish shop profile')
 		}
 	}
 
@@ -139,12 +236,25 @@ function ProfileComponent() {
 		return formFieldsChanged || imageChanges
 	}
 
+	const shopHasChanges = () => {
+		if (!originalShopForm) return shopForm.name.trim() !== ''
+		return (
+			shopForm.name !== originalShopForm.name ||
+			shopForm.description !== originalShopForm.description ||
+			shopForm.location !== originalShopForm.location ||
+			shopForm.currency !== originalShopForm.currency ||
+			shopImages.banner !== originalShopImages.banner ||
+			shopImages.picture !== originalShopImages.picture
+		)
+	}
+	const canSaveShop = shopHasChanges() && shopForm.name.trim() !== ''
+
 	const changesExist = hasChanges()
 	const mandatoryFieldsFilled = areMandatoryFieldsFilled()
 
 	// Allow saving if mandatory fields are filled, even if no original profile exists yet
 	// This handles the case where user is creating a new profile
-	const canSave = mandatoryFieldsFilled && (changesExist || Object.keys(originalProfile).length === 0)
+	const canSavePersonal = mandatoryFieldsFilled && (changesExist || Object.keys(originalProfile).length === 0)
 
 	const handleHeaderImageSave = (data: { url: string; index: number }) => {
 		setProfile((prev) => ({ ...prev, banner: data.url }))
@@ -173,197 +283,378 @@ function ProfileComponent() {
 		<div>
 			<div className="hidden lg:flex sticky top-0 z-10 bg-white border-b py-4 px-4 lg:px-6 items-center justify-between">
 				<h1 className="text-2xl font-bold">Profile</h1>
-				<Button
-					type="button"
-					disabled={isLoading || !canSave}
-					onClick={handleSave}
-					className="btn-black flex items-center gap-2 px-4 py-2 text-sm font-semibold"
-					data-testid="profile-save-button-desktop"
-				>
-					{isLoading ? 'Saving...' : canSave ? (Object.keys(originalProfile).length === 0 ? 'Create Profile' : 'Save Changes') : 'Saved'}
-				</Button>
+				<div className="flex gap-2">
+					<Button
+						type="button"
+						variant="outline"
+						disabled={isLoading || !canSavePersonal}
+						onClick={handleSavePersonal}
+						className="flex items-center gap-2 text-sm font-semibold"
+						data-testid="personal-save-button-desktop"
+					>
+						<User className="w-4 h-4" />
+						{updateProfileMutation.isPending ? 'Saving...' : canSavePersonal ? 'Save Personal' : 'Personal Saved'}
+					</Button>
+					<Button
+						type="button"
+						disabled={isLoading || !canSaveShop}
+						onClick={handleSaveShop}
+						className="btn-black flex items-center gap-2 text-sm font-semibold"
+						data-testid="shop-save-button-desktop"
+					>
+						<Store className="w-4 h-4" />
+						{publishShopMutation.isPending ? 'Saving...' : canSaveShop ? 'Save Shop Profile' : 'Shop Saved'}
+					</Button>
+				</div>
 			</div>
 			<div className="space-y-6 p-4 lg:p-8">
-				{isLoadingProfile ? (
+				{isLoadingProfile || isLoadingShop ? (
 					<div className="flex items-center justify-center p-8">
 						<div className="animate-spin h-8 w-8 border-4 border-primary border-t-transparent rounded-full"></div>
 					</div>
 				) : (
 					<div className="space-y-6">
+						<div className="flex gap-2 items-start p-3 rounded-lg bg-blue-50 border border-blue-200 text-blue-800 text-sm">
+							<Info className="w-4 h-4 mt-0.5 shrink-0" />
+							<span>
+								<strong>Personal Profile</strong> updates your Nostr identity (kind 0). <strong>Shop Profile</strong> creates a separate
+								marketplace identity (NIP-15 stall) — your shop visitors will see shop details instead of your personal profile.
+							</span>
+						</div>
 						<div className="space-y-4">
-							<div className="space-y-2">
-								<Label htmlFor="headerImage">
-									Header Image <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<ImageUploader
-									src={profile.banner || null}
-									index={-1}
-									imagesLength={1}
-									forSingle={true}
-									initialUrl={profile.banner}
-									onSave={handleHeaderImageSave}
-									onDelete={handleImageDelete}
-									imageDimensionText="dimensions: 2000px High x 400px Wide"
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="profileImage">
-									Profile Image <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<ImageUploader
-									src={profile.image || null}
-									index={-1}
-									imagesLength={1}
-									forSingle={true}
-									initialUrl={profile.image}
-									onSave={handleProfileImageSave}
-									onDelete={handleImageDelete}
-									imageDimensionText="dimensions: 200px High x 200px Wide"
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="name">
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Name</span>
-								</Label>
-								<Input
-									id="name"
-									name="name"
-									value={formData.name}
-									onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
-									placeholder="e.g John Doe"
-									required
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="displayName">
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Display Name</span>
-								</Label>
-								<Input
-									id="displayName"
-									name="displayName"
-									value={formData.displayName}
-									onChange={(e) => setFormData((prev) => ({ ...prev, displayName: e.target.value }))}
-									placeholder="e.g Bitcoin Merchant"
-									required
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="about">
-									About <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<Textarea
-									id="about"
-									name="about"
-									value={formData.about}
-									onChange={(e) => setFormData((prev) => ({ ...prev, about: e.target.value }))}
-									placeholder="Write a short bio"
-									rows={4}
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="nip05">
-									Nostr Address (NIP05) <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<Input
-									id="nip05"
-									name="nip05"
-									value={formData.nip05}
-									onChange={(e) => setFormData((prev) => ({ ...prev, nip05: e.target.value }))}
-									placeholder="you@example.com"
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="lud16">
-									Lightning Address (LUD16) <span className="text-muted-foreground font-normal">(optional)</span>
-									<div className="text-xs text-muted-foreground mt-1 font-normal">
-										Recommended wallets: (
-										<a href="https://coinos.io" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
-											CoinOS
-										</a>
-										,{' '}
-										<a href="https://primal.net" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
-											Primal
-										</a>
-										,{' '}
-										<a href="https://lnbits.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
-											LNBits
-										</a>
-										,{' '}
-										<a href="https://minibits.cash" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
-											Minibits
-										</a>
-										,{' '}
-										<a
-											href="https://app.mutinywallet.com/setup"
-											target="_blank"
-											rel="noopener noreferrer"
-											className="underline hover:text-pink-500"
-										>
-											Mutiny
-										</a>
-										,{' '}
-										<a href="https://getalby.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
-											Alby
-										</a>
-										)
+							<SectionHeader
+								icon={User}
+								title="Personal Profile"
+								subtitle="Your Nostr identity, synced across all Nostr apps"
+								open={personalOpen}
+								onToggle={() => setPersonalOpen((v) => !v)}
+								accent="pink"
+							/>
+							{personalOpen && (
+								<div className="space-y-4 pl-1">
+									<div className="space-y-2">
+										<Label htmlFor="headerImage">
+											Header Image <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<ImageUploader
+											src={profile.banner || null}
+											index={-1}
+											imagesLength={1}
+											forSingle={true}
+											initialUrl={profile.banner}
+											onSave={handleHeaderImageSave}
+											onDelete={handleImageDelete}
+											imageDimensionText="dimensions: 2000px High x 400px Wide"
+										/>
 									</div>
-								</Label>
-								<Input
-									id="lud16"
-									name="lud16"
-									value={formData.lud16}
-									onChange={(e) => setFormData((prev) => ({ ...prev, lud16: e.target.value }))}
-									placeholder="you@walletprovider.com"
-								/>
-							</div>
 
-							<div className="space-y-2">
-								<Label htmlFor="lud06">
-									LNURL (LUD06) <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<Input
-									id="lud06"
-									name="lud06"
-									value={formData.lud06}
-									onChange={(e) => setFormData((prev) => ({ ...prev, lud06: e.target.value }))}
-									placeholder="LNURL..."
-								/>
-							</div>
+									<div className="space-y-2">
+										<Label htmlFor="profileImage">
+											Profile Image <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<ImageUploader
+											src={profile.image || null}
+											index={-1}
+											imagesLength={1}
+											forSingle={true}
+											initialUrl={profile.image}
+											onSave={handleProfileImageSave}
+											onDelete={handleImageDelete}
+											imageDimensionText="dimensions: 200px High x 200px Wide"
+										/>
+									</div>
 
-							<div className="space-y-2">
-								<Label htmlFor="website">
-									Website <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<Input
-									id="website"
-									name="website"
-									value={formData.website}
-									onChange={(e) => setFormData((prev) => ({ ...prev, website: e.target.value }))}
-									placeholder="https://yourwebsite.com"
-								/>
-							</div>
+									<div className="space-y-2">
+										<Label htmlFor="name">
+											<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Name</span>
+										</Label>
+										<Input
+											id="name"
+											name="name"
+											value={formData.name}
+											onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+											placeholder="e.g John Doe"
+											required
+										/>
+									</div>
 
-							<Button
-								type="button"
-								disabled={isLoading || !canSave}
-								className="btn-black w-full lg:hidden"
-								onClick={handleSave}
-								data-testid="profile-save-button"
-							>
-								{isLoading
-									? 'Saving...'
-									: canSave
-										? Object.keys(originalProfile).length === 0
-											? 'Create Profile'
-											: 'Save Changes'
-										: 'Saved'}
-							</Button>
+									<div className="space-y-2">
+										<Label htmlFor="displayName">
+											<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Display Name</span>
+										</Label>
+										<Input
+											id="displayName"
+											name="displayName"
+											value={formData.displayName}
+											onChange={(e) => setFormData((prev) => ({ ...prev, displayName: e.target.value }))}
+											placeholder="e.g Bitcoin Merchant"
+											required
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="about">
+											About <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<Textarea
+											id="about"
+											name="about"
+											value={formData.about}
+											onChange={(e) => setFormData((prev) => ({ ...prev, about: e.target.value }))}
+											placeholder="Write a short bio"
+											rows={4}
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="nip05">
+											Nostr Address (NIP05) <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<Input
+											id="nip05"
+											name="nip05"
+											value={formData.nip05}
+											onChange={(e) => setFormData((prev) => ({ ...prev, nip05: e.target.value }))}
+											placeholder="you@example.com"
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="lud16">
+											Lightning Address (LUD16) <span className="text-muted-foreground font-normal">(optional)</span>
+											<div className="text-xs text-muted-foreground mt-1 font-normal">
+												Recommended wallets: (
+												<a href="https://coinos.io" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
+													CoinOS
+												</a>
+												,{' '}
+												<a href="https://primal.net" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
+													Primal
+												</a>
+												,{' '}
+												<a href="https://lnbits.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
+													LNBits
+												</a>
+												,{' '}
+												<a href="https://minibits.cash" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
+													Minibits
+												</a>
+												,{' '}
+												<a
+													href="https://app.mutinywallet.com/setup"
+													target="_blank"
+													rel="noopener noreferrer"
+													className="underline hover:text-pink-500"
+												>
+													Mutiny
+												</a>
+												,{' '}
+												<a href="https://getalby.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-pink-500">
+													Alby
+												</a>
+												)
+											</div>
+										</Label>
+										<Input
+											id="lud16"
+											name="lud16"
+											value={formData.lud16}
+											onChange={(e) => setFormData((prev) => ({ ...prev, lud16: e.target.value }))}
+											placeholder="you@walletprovider.com"
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="lud06">
+											LNURL (LUD06) <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<Input
+											id="lud06"
+											name="lud06"
+											value={formData.lud06}
+											onChange={(e) => setFormData((prev) => ({ ...prev, lud06: e.target.value }))}
+											placeholder="LNURL..."
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="website">
+											Website <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<Input
+											id="website"
+											name="website"
+											value={formData.website}
+											onChange={(e) => setFormData((prev) => ({ ...prev, website: e.target.value }))}
+											placeholder="https://yourwebsite.com"
+										/>
+									</div>
+
+									<Button
+										type="button"
+										disabled={isLoading || !canSavePersonal}
+										className="btn-black w-full lg:hidden"
+										onClick={handleSavePersonal}
+										data-testid="profile-save-button"
+									>
+										{isLoading
+											? 'Saving...'
+											: canSavePersonal
+												? Object.keys(originalProfile).length === 0
+													? 'Create Profile'
+													: 'Save Changes'
+												: 'Saved'}
+									</Button>
+								</div>
+							)}
+						</div>
+						<div className="space-y-4">
+							{allStalls.length > 0 && (
+								<div className="flex flex-wrap gap-2">
+									{allStalls.map((stall) => (
+										<button
+											key={stall.id}
+											type="button"
+											onClick={() => {
+												setActiveStallId(stall.id)
+												setIsCreatingNew(false)
+											}}
+											className={`px-3 py-1.5 rounded-full text-sm border transition-colors
+                     ${
+												activeStallId === stall.id
+													? 'bg-purple-500 text-white border-purple-500'
+													: 'border-gray-300 hover:border-purple-400 text-gray-700'
+											}`}
+										>
+											{stall.name || 'Unnamed stall'}
+										</button>
+									))}
+									<button
+										type="button"
+										onClick={() => {
+											setActiveStallId(null)
+											setIsCreatingNew(true)
+											setShopForm({ name: '', description: '', currency: 'SATS', location: '' })
+											setShopImages({})
+											setOriginalShopForm(null)
+											setOriginalShopImages({})
+											setShopOpen(true)
+										}}
+										className="px-3 py-1.5 rounded-full text-sm border border-dashed border-gray-400 hover:border-purple-400 text-gray-500"
+									>
+										+ New stall
+									</button>
+								</div>
+							)}
+							<SectionHeader
+								icon={Store}
+								title={activeStallId ? 'Shop Profile' : 'New Shop Profile'}
+								subtitle={activeStallId ? "Edit this stall's marketplace identity" : 'Create a new stall — fill in the details below'}
+								open={shopOpen}
+								onToggle={() => setShopOpen((v) => !v)}
+								accent="purple"
+							/>
+							{shopOpen && (
+								<div className="space-y-4 pl-1">
+									<div className="space-y-2">
+										<Label>
+											Shop Banner <span className="text-muted-foreground font-normal">(optional — overrides personal banner)</span>
+										</Label>
+										<ImageUploader
+											src={shopImages.banner || null}
+											index={-1}
+											imagesLength={1}
+											forSingle
+											initialUrl={shopImages.banner}
+											onSave={({ url }) => setShopImages((p) => ({ ...p, banner: url }))}
+											onDelete={() => setShopImages((p) => ({ ...p, banner: undefined }))}
+											imageDimensionText="dimensions: 2000px Wide x 400px High"
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label>
+											Shop Logo / Avatar <span className="text-muted-foreground font-normal">(optional — overrides personal avatar)</span>
+										</Label>
+										<ImageUploader
+											src={shopImages.picture || null}
+											index={-1}
+											imagesLength={1}
+											forSingle
+											initialUrl={shopImages.picture}
+											onSave={({ url }) => setShopImages((p) => ({ ...p, picture: url }))}
+											onDelete={() => setShopImages((p) => ({ ...p, picture: undefined }))}
+											imageDimensionText="dimensions: 200px x 200px"
+										/>
+									</div>
+
+									<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+										<div className="space-y-2">
+											<Label htmlFor="shopName">
+												<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Shop Name</span>
+											</Label>
+											<Input
+												id="shopName"
+												value={shopForm.name}
+												onChange={(e) => setShopForm((p) => ({ ...p, name: e.target.value }))}
+												placeholder="e.g. My Bitcoin Store"
+											/>
+										</div>
+										<div className="space-y-2">
+											<Label htmlFor="shopCurrency">
+												Currency <span className="text-muted-foreground font-normal">(optional)</span>
+											</Label>
+											<Input
+												id="shopCurrency"
+												value={shopForm.currency}
+												onChange={(e) => setShopForm((p) => ({ ...p, currency: e.target.value }))}
+												placeholder="SATS"
+											/>
+										</div>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="shopDescription">
+											Shop Description <span className="text-muted-foreground font-normal">(optional — overrides personal about)</span>
+										</Label>
+										<Textarea
+											id="shopDescription"
+											value={shopForm.description}
+											onChange={(e) => setShopForm((p) => ({ ...p, description: e.target.value }))}
+											placeholder="Describe your shop, what you sell, your policies..."
+											rows={3}
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="shopLocation">
+											Shop Location <span className="text-muted-foreground font-normal">(optional)</span>
+										</Label>
+										<Input
+											id="shopLocation"
+											value={shopForm.location}
+											onChange={(e) => setShopForm((p) => ({ ...p, location: e.target.value }))}
+											placeholder="e.g. New York, USA"
+										/>
+									</div>
+
+									<Button
+										type="button"
+										disabled={isLoading || !canSaveShop}
+										className="btn-black w-full lg:hidden flex items-center justify-center gap-2"
+										onClick={handleSaveShop}
+									>
+										<Store className="w-4 h-4" />
+										{publishShopMutation.isPending
+											? 'Publishing to Nostr...'
+											: canSaveShop
+												? fetchedShopProfile
+													? 'Update Shop Profile'
+													: 'Create Shop Profile'
+												: 'Shop Profile Saved'}
+									</Button>
+								</div>
+							)}
 						</div>
 					</div>
 				)}


### PR DESCRIPTION
fixes: #435 

I have added shopProfile.ts, a new query/publish utility that reads and writes NIP-15 kind 30017 stall events. The d tag ID matches content.id per spec. Extra UI fields (banner, picture, location) are stored as event tags.

Updated the Profile dashboard to split into two collapsible sections.  Personal Profile (kind 0) and Shop Profile (kind 30017). Merchants can create multiple stalls, switch between them with a pill picker, and create new ones with a blank form. Each stall saves independently via publishShopMutation.

Updated ProfilePage to fetch all stalls for a merchant via useAllShopProfiles.

Also, products currently have no stall_id in their kind 30018 content because the product creation form does not ask the merchant to assign a product to a stall. As a result, groupProductsByStall always returns all products as ungroupedProducts and the per-stall grouping on the profile page never activates, so products appear under "Other products" instead of under their stall header.