### PR TITLE
feat(deploy): add explicit APP_STAGE and improve rollback safety

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -121,9 +121,19 @@ jobs:
             set -e
             chmod +x /tmp/relay-deploy/install-relay.sh
             /tmp/relay-deploy/install-relay.sh staging /tmp/relay-deploy
-            sudo cp /tmp/relay-deploy/Caddyfile.staging /etc/caddy/Caddyfile
-            sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
-              sudo caddy start --config /etc/caddy/Caddyfile --adapter caddyfile
+            CADDY_BACKUP="$(mktemp)"
+            sudo cp /etc/caddy/Caddyfile "$CADDY_BACKUP" 2>/dev/null || true
+            if ! { sudo cp /tmp/relay-deploy/Caddyfile.staging /etc/caddy/Caddyfile && \
+              (sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
+               sudo caddy start --config /etc/caddy/Caddyfile --adapter caddyfile); }; then
+              echo "Caddy reload failed, restoring previous config"
+              if [[ -f "$CADDY_BACKUP" ]]; then
+                sudo cp "$CADDY_BACKUP" /etc/caddy/Caddyfile || true
+                sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || true
+              fi
+              exit 1
+            fi
+            rm -f "$CADDY_BACKUP"
 
       - name: Verify staging relay
         env:
@@ -177,9 +187,19 @@ jobs:
             set -e
             chmod +x /tmp/relay-deploy/install-relay.sh
             /tmp/relay-deploy/install-relay.sh production /tmp/relay-deploy
-            sudo cp /tmp/relay-deploy/Caddyfile.production /etc/caddy/Caddyfile
-            sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
-              sudo caddy start --config /etc/caddy/Caddyfile --adapter caddyfile
+            CADDY_BACKUP="$(mktemp)"
+            sudo cp /etc/caddy/Caddyfile "$CADDY_BACKUP" 2>/dev/null || true
+            if ! { sudo cp /tmp/relay-deploy/Caddyfile.production /etc/caddy/Caddyfile && \
+              (sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
+               sudo caddy start --config /etc/caddy/Caddyfile --adapter caddyfile); }; then
+              echo "Caddy reload failed, restoring previous config"
+              if [[ -f "$CADDY_BACKUP" ]]; then
+                sudo cp "$CADDY_BACKUP" /etc/caddy/Caddyfile || true
+                sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || true
+              fi
+              exit 1
+            fi
+            rm -f "$CADDY_BACKUP"
 
       - name: Verify production relay
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,24 @@
 name: Deploy to Staging
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows:
+      - E2E Tests
+    types:
+      - completed
   workflow_dispatch:
 
 env:
   BUN_VERSION: 'latest'
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     outputs:
       release_name: ${{ steps.release.outputs.name }}
@@ -19,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -54,12 +63,15 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     needs: build
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.event == 'push')
     runs-on: ubuntu-latest
     environment: staging
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -98,6 +110,7 @@ jobs:
       - name: Create environment file
         run: |
           cat > deploy-package/.env << EOF
+          APP_STAGE=staging
           NODE_ENV=production
           PORT=3000
           APP_RELAY_URL=${{ secrets.STAGING_RELAY_URL }}
@@ -152,9 +165,28 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           password: ${{ secrets.STAGING_PASSWORD }}
           script: |
-            set -e
+            set -euo pipefail
             RELEASE_DIR="/home/deployer/releases/${{ needs.build.outputs.release_name }}"
             APP_DIR="/home/deployer/market-staging"
+            PREVIOUS_RELEASE="$(readlink -f "$APP_DIR" || true)"
+            CADDY_BACKUP="$(mktemp)"
+            sudo cp /etc/caddy/Caddyfile "$CADDY_BACKUP" 2>/dev/null || true
+
+            rollback() {
+              echo "Deployment failed, restoring previous release"
+              if [[ -f "$CADDY_BACKUP" ]]; then
+                sudo cp "$CADDY_BACKUP" /etc/caddy/Caddyfile || true
+                sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || true
+              fi
+              if [[ -n "$PREVIOUS_RELEASE" && -d "$PREVIOUS_RELEASE" ]]; then
+                ln -sfn "$PREVIOUS_RELEASE" "$APP_DIR"
+                cd "$APP_DIR"
+                pm2 startOrReload ecosystem.config.cjs --only market-staging || true
+                pm2 save --force || true
+              fi
+            }
+
+            trap rollback ERR
 
             # Install dependencies
             cd "$RELEASE_DIR"
@@ -181,6 +213,9 @@ jobs:
             # Cleanup old releases (keep last 3)
             cd /home/deployer/releases
             ls -t | grep '^market-staging' | tail -n +4 | xargs -r rm -rf
+
+            rm -f "$CADDY_BACKUP"
+            trap - ERR
 
             echo "✅ Staging deployment complete"
 

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,0 +1,75 @@
+name: Promote to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Which semantic version component to increment
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag-release:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Create next release tag
+        env:
+          BUMP: ${{ github.event.inputs.bump }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+
+          LATEST_TAG="$(git tag --list '*-release' --sort=-version:refname | head -n 1)"
+          VERSION="${LATEST_TAG%-release}"
+          VERSION="${VERSION#v}"
+
+          if [[ -z "$VERSION" ]]; then
+            VERSION="0.0.0"
+          fi
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "::error::Unsupported bump: $BUMP"
+              exit 1
+              ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}-release"
+          echo "Creating tag ${NEW_TAG}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+          echo "✅ Created ${NEW_TAG}. Production deploy will start from release.yml."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ on:
 env:
   BUN_VERSION: 'latest'
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build
@@ -25,12 +29,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
 
-      - name: Extract version from tag
+      - name: Resolve release tag
         id: version
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          git fetch --tags --force
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+            if [[ -z "$TAG" ]]; then
+              TAG="$(git tag --list '*-release' --sort=-version:refname | head -n 1)"
+            fi
+
+            if [[ -z "$TAG" ]]; then
+              echo "::error::No release tag found"
+              exit 1
+            fi
+
+            git checkout "refs/tags/$TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Deploying version: $TAG"
 
@@ -74,6 +95,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ needs.build.outputs.version }}
 
       - name: Download artifact
         uses: actions/download-artifact@v4
@@ -112,6 +135,7 @@ jobs:
       - name: Create environment file
         run: |
           cat > deploy-package/.env << EOF
+          APP_STAGE=production
           NODE_ENV=production
           PORT=3001
           APP_RELAY_URL=${{ secrets.PROD_RELAY_URL }}
@@ -170,9 +194,29 @@ jobs:
           username: ${{ secrets.PROD_USER }}
           password: ${{ secrets.PROD_PASSWORD }}
           script: |
-            set -e
+            set -euo pipefail
             RELEASE_DIR="/opt/releases/${{ needs.build.outputs.release_name }}"
             APP_DIR="/opt/market-production"
+            PREVIOUS_RELEASE="$(readlink -f "$APP_DIR" || true)"
+            CADDY_BACKUP="$(mktemp)"
+            sudo cp /etc/caddy/Caddyfile "$CADDY_BACKUP" 2>/dev/null || true
+
+            rollback() {
+              echo "Deployment failed, restoring previous release"
+              if [[ -f "$CADDY_BACKUP" ]]; then
+                sudo cp "$CADDY_BACKUP" /etc/caddy/Caddyfile || true
+                sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || true
+              fi
+              if [[ -n "$PREVIOUS_RELEASE" && -d "$PREVIOUS_RELEASE" ]]; then
+                sudo ln -sfn "$PREVIOUS_RELEASE" "$APP_DIR"
+                sudo chown -h $USER:$USER "$APP_DIR"
+                cd "$APP_DIR"
+                pm2 startOrReload ecosystem.config.cjs --only market-production || true
+                pm2 save --force || true
+              fi
+            }
+
+            trap rollback ERR
 
             # Install dependencies
             cd "$RELEASE_DIR"
@@ -205,12 +249,15 @@ jobs:
             cd /opt/releases
             ls -t | grep '^market-production' | tail -n +6 | xargs -r rm -rf
 
+            rm -f "$CADDY_BACKUP"
+            trap - ERR
+
             echo "✅ Production deployment of ${{ needs.build.outputs.version }} complete"
 
       - name: Health check
         run: |
           sleep 15
-          curl -sf https://plebeian.market/api/config || echo "⚠️ Health check pending"
+          curl -sf https://plebeian.market/api/config
           echo "✅ Production deployment complete"
 
       - name: Verify relay is still running

--- a/README.md
+++ b/README.md
@@ -169,7 +169,10 @@ Without running this command, changes to route files or creating new routes won'
 
 ## Releasing
 
-Production releases are triggered by pushing a tag with the `-release` suffix. The GitHub Actions workflow listens for these tags.
+Staging deploys automatically after the `E2E Tests` workflow succeeds on `master`.
+Production deploys require the `production` environment approval and can be triggered
+either by pushing a `*-release` tag or by running the `Promote to Production`
+workflow, which creates the next release tag for you.
 
 ### One-liner
 
@@ -180,9 +183,11 @@ git tag v0.2.9-release && git push origin v0.2.9-release
 ### Steps
 
 1. Ensure all changes are merged to `master`
-2. Check the latest release tag: `git tag --sort=-version:refname | head -1`
-3. Create and push a new tag with incremented version:
+2. Wait for staging deployment to finish successfully
+3. Either:
+   Create and push a new tag with incremented version:
    ```bash
    git tag vX.Y.Z-release && git push origin vX.Y.Z-release
    ```
-4. The GitHub Action will automatically build and deploy to production
+4. Or run `Promote to Production` in GitHub Actions and choose `patch`, `minor`, or `major`
+5. The `Deploy to Production` workflow will build and deploy the selected tag after approval

--- a/deploy-simple/README.md
+++ b/deploy-simple/README.md
@@ -124,6 +124,10 @@ bun run dev
 
 ## Setting Up GitHub Actions
 
+GitHub Actions are the canonical deployment path for `staging` and `production`.
+The shell scripts in this directory are now best treated as manual fallback or
+development helpers.
+
 ### Step 1: Create GitHub Environments
 
 1. Go to your repo → Settings → Environments
@@ -169,12 +173,14 @@ nak key generate
 ### Step 4: Deploy
 
 ```bash
-# Staging: Push to master
+# Staging: merge to master, then wait for E2E Tests to finish and trigger staging deploy
 git push origin master
 
-# Production: Create a release tag
+# Production option 1: Create a release tag manually
 git tag v1.0.0-release
 git push origin v1.0.0-release
+
+# Production option 2: Run the "Promote to Production" workflow in GitHub Actions
 ```
 
 ---
@@ -282,6 +288,7 @@ deploy-simple/
 
 | Variable          | Description                                              |
 | ----------------- | -------------------------------------------------------- |
+| `APP_STAGE`       | Explicit stage override (`staging`, `production`, etc.)  |
 | `NODE_ENV`        | `development`, `staging`, or `production`                |
 | `PORT`            | Application port (3000 for staging, 3001 for production) |
 | `APP_RELAY_URL`   | Nostr relay WebSocket URL                                |
@@ -450,15 +457,21 @@ The project includes GitHub Actions workflows for automated deployments:
 
 ### Staging (`.github/workflows/deploy.yml`)
 
-- **Trigger:** Push to `master` branch
+- **Trigger:** Successful completion of `E2E Tests` on `master`, or manual dispatch
 - **Environment:** `staging`
 - **URL:** https://staging.plebeian.market
 
 ### Production (`.github/workflows/release.yml`)
 
-- **Trigger:** Push tag matching `*-release` (e.g., `v1.0.0-release`)
+- **Trigger:** Push tag matching `*-release` (e.g., `v1.0.0-release`), or manual dispatch to redeploy an existing release tag
 - **Environment:** `production` (requires approval)
 - **URL:** https://plebeian.market
+
+### Production Promotion (`.github/workflows/promote-production.yml`)
+
+- **Trigger:** Manual dispatch
+- **Purpose:** Create and push the next `*-release` tag automatically (`patch`, `minor`, or `major`)
+- **Follow-up:** The production deploy workflow starts from the created tag
 
 ### Required GitHub Secrets
 

--- a/deploy-simple/RELAY_DEPLOY.md
+++ b/deploy-simple/RELAY_DEPLOY.md
@@ -77,4 +77,5 @@ bun run scripts/migrate-relay.ts
 ## Rollback
 
 If a deploy fails, `install-relay.sh` restores the previous binary, env file,
-and service unit before exiting non-zero.
+and service unit before exiting non-zero. The workflow also restores the
+previous Caddy config if the new relay Caddyfile fails to reload.

--- a/deploy-simple/caddyfiles/Caddyfile.production
+++ b/deploy-simple/caddyfiles/Caddyfile.production
@@ -27,7 +27,7 @@ plebeian.market {
 	}
 }
 
-# Nostr relay (managed separately)
+# Nostr relay
 relay.plebeian.market {
 	reverse_proxy localhost:3334
 }

--- a/deploy-simple/caddyfiles/Caddyfile.staging
+++ b/deploy-simple/caddyfiles/Caddyfile.staging
@@ -2,7 +2,7 @@
 #
 # Services:
 #   staging.plebeian.market       → Market app (port 3000)
-#   relay.staging.plebeian.market → Nostr relay (port 10547)
+#   relay.staging.plebeian.market → Nostr relay (port 10549)
 
 staging.plebeian.market {
 	root * /home/deployer/market-staging/dist

--- a/deploy-simple/env/.env.production.example
+++ b/deploy-simple/env/.env.production.example
@@ -6,6 +6,7 @@
 # Copy to: deploy-simple/env/.env.production
 # Usage:   ./deploy.sh production user@plebeian.market
 
+APP_STAGE=production
 NODE_ENV=production
 PORT=3001
 

--- a/deploy-simple/env/.env.staging.example
+++ b/deploy-simple/env/.env.staging.example
@@ -6,6 +6,7 @@
 # Copy to: deploy-simple/env/.env.staging
 # Usage:   ./deploy.sh staging user@staging.plebeian.market
 
+APP_STAGE=staging
 NODE_ENV=production
 PORT=3000
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -224,6 +224,11 @@ const serveStatic = async (path: string) => {
  * Determine the deployment stage from NODE_ENV
  */
 function determineStage(): 'production' | 'staging' | 'development' {
+	const explicitStage = process.env.APP_STAGE
+	if (explicitStage === 'staging' || explicitStage === 'production' || explicitStage === 'development') {
+		return explicitStage
+	}
+
 	const env = process.env.NODE_ENV
 	if (env === 'staging') return 'staging'
 	if (env === 'production') return 'production'


### PR DESCRIPTION
Introduce APP_STAGE environment variable to explicitly define deployment stage (staging/production/development) instead of inferring from NODE_ENV alone.

Add comprehensive rollback mechanisms for both app and relay deployments:

- Backup and restore Caddy configurations on reload failures
- Restore previous app release if deployment fails
- Update relay deployment to handle Caddy reload failures

Create "Promote to Production" workflow for automated semantic version tagging. Update staging deployment to trigger after successful E2E tests on master. Improve documentation to reflect new deployment workflows and safety features.