### PR TITLE
feat(wallet): harden auth and wallet secret persistence

### DIFF
--- a/src/components/auth/PrivateKeyLogin.tsx
+++ b/src/components/auth/PrivateKeyLogin.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { authActions, NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY } from '@/lib/stores/auth'
+import { authActions, NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, parseLegacyStoredPrivateKey } from '@/lib/stores/auth'
+import { parsePasswordSecretEnvelope } from '@/lib/security/clientSecretStorage'
 import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools'
 import { useEffect, useRef, useState } from 'react'
 import { Copy, Eye, EyeOff, Loader2 } from 'lucide-react'
@@ -30,12 +31,9 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		const storedKey = localStorage.getItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
 		if (storedKey) {
 			setHasStoredKey(true)
-			try {
-				const [pubkey] = storedKey.split(':')
-				setStoredPubkey(pubkey)
-			} catch (e) {
-				console.error('Failed to parse stored key:', e)
-			}
+			const parsedEnvelope = parsePasswordSecretEnvelope(storedKey)
+			const legacyStoredKey = parseLegacyStoredPrivateKey(storedKey)
+			setStoredPubkey(parsedEnvelope?.pubkey || legacyStoredKey?.pubkey || null)
 		}
 	}, [])
 
@@ -78,8 +76,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 			const normalizedKey = normalizePrivateKey(key)
 			const secretKeyBytes = nip19.decode(normalizedKey).data as Uint8Array
 			const pubkey = getPublicKey(secretKeyBytes)
-			const encryptedKey = `${pubkey}:${normalizedKey}`
-			localStorage.setItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, encryptedKey)
+			await authActions.storeEncryptedPrivateKey(normalizedKey, password, pubkey)
 			setHasStoredKey(true)
 			setStoredPubkey(pubkey)
 		} catch (error) {
@@ -148,13 +145,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 
 		try {
 			setIsLoading(true)
-			const storedKey = localStorage.getItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
-			if (!storedKey) {
-				throw new Error('No stored key found')
-			}
-
-			const [, key] = storedKey.split(':')
-			await authActions.loginWithPrivateKey(key)
+			await authActions.decryptAndLogin(encryptionPassword)
 			onSuccess?.()
 		} catch (error) {
 			setPasswordError(error instanceof Error ? error.message : 'Failed to decrypt key')

--- a/src/lib/security/clientSecretStorage.ts
+++ b/src/lib/security/clientSecretStorage.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod'
+
+const SECRET_STORAGE_VERSION = 1
+const PBKDF2_ITERATIONS = 250_000
+const AES_GCM_KEY_LENGTH = 256
+const AES_GCM_IV_BYTES = 12
+const PBKDF2_SALT_BYTES = 16
+
+const passwordEnvelopeSchema = z.object({
+	version: z.literal(SECRET_STORAGE_VERSION),
+	mode: z.literal('password'),
+	kdf: z.literal('PBKDF2-SHA256'),
+	iterations: z.number().int().positive(),
+	salt: z.string().min(1),
+	iv: z.string().min(1),
+	ciphertext: z.string().min(1),
+	pubkey: z.string().min(1).optional(),
+})
+
+export type PasswordSecretEnvelope = z.infer<typeof passwordEnvelopeSchema>
+
+const memorySessionSecrets = new Map<string, string>()
+
+function getCrypto(): Crypto {
+	if (!globalThis.crypto?.subtle) {
+		throw new Error('Web Crypto is unavailable')
+	}
+
+	return globalThis.crypto
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let binary = ''
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte)
+	}
+	return btoa(binary)
+}
+
+function base64ToBytes(value: string): Uint8Array {
+	const binary = atob(value)
+	const bytes = new Uint8Array(binary.length)
+	for (let i = 0; i < binary.length; i++) {
+		bytes[i] = binary.charCodeAt(i)
+	}
+	return bytes
+}
+
+function utf8Encode(value: string): Uint8Array {
+	return new TextEncoder().encode(value)
+}
+
+function utf8Decode(bytes: BufferSource): string {
+	return new TextDecoder().decode(bytes)
+}
+
+function randomBytes(length: number): Uint8Array {
+	return getCrypto().getRandomValues(new Uint8Array(length))
+}
+
+async function derivePasswordKey(password: string, salt: Uint8Array, usages: KeyUsage[]): Promise<CryptoKey> {
+	const cryptoApi = getCrypto()
+	const passwordKey = await cryptoApi.subtle.importKey('raw', utf8Encode(password), 'PBKDF2', false, ['deriveKey'])
+
+	return cryptoApi.subtle.deriveKey(
+		{
+			name: 'PBKDF2',
+			hash: 'SHA-256',
+			salt,
+			iterations: PBKDF2_ITERATIONS,
+		},
+		passwordKey,
+		{
+			name: 'AES-GCM',
+			length: AES_GCM_KEY_LENGTH,
+		},
+		false,
+		usages,
+	)
+}
+
+export function parsePasswordSecretEnvelope(rawValue: string | null | undefined): PasswordSecretEnvelope | null {
+	if (!rawValue) return null
+
+	try {
+		return passwordEnvelopeSchema.parse(JSON.parse(rawValue))
+	} catch {
+		return null
+	}
+}
+
+export async function encryptSecretWithPassword(
+	plaintext: string,
+	password: string,
+	options?: { pubkey?: string },
+): Promise<PasswordSecretEnvelope> {
+	const cryptoApi = getCrypto()
+	const salt = randomBytes(PBKDF2_SALT_BYTES)
+	const iv = randomBytes(AES_GCM_IV_BYTES)
+	const key = await derivePasswordKey(password, salt, ['encrypt'])
+	const ciphertext = await cryptoApi.subtle.encrypt({ name: 'AES-GCM', iv }, key, utf8Encode(plaintext))
+
+	return {
+		version: SECRET_STORAGE_VERSION,
+		mode: 'password',
+		kdf: 'PBKDF2-SHA256',
+		iterations: PBKDF2_ITERATIONS,
+		salt: bytesToBase64(salt),
+		iv: bytesToBase64(iv),
+		ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+		...(options?.pubkey ? { pubkey: options.pubkey } : {}),
+	}
+}
+
+export async function decryptSecretWithPassword(envelope: PasswordSecretEnvelope, password: string): Promise<string> {
+	const cryptoApi = getCrypto()
+
+	try {
+		const key = await derivePasswordKey(password, base64ToBytes(envelope.salt), ['decrypt'])
+		const plaintext = await cryptoApi.subtle.decrypt(
+			{
+				name: 'AES-GCM',
+				iv: base64ToBytes(envelope.iv),
+			},
+			key,
+			base64ToBytes(envelope.ciphertext),
+		)
+
+		return utf8Decode(plaintext)
+	} catch {
+		throw new Error('Incorrect password or corrupted key material')
+	}
+}
+
+export async function savePasswordProtectedSecret(
+	storage: Storage,
+	storageKey: string,
+	plaintext: string,
+	password: string,
+	options?: { pubkey?: string },
+): Promise<void> {
+	const envelope = await encryptSecretWithPassword(plaintext, password, options)
+	storage.setItem(storageKey, JSON.stringify(envelope))
+}
+
+export async function loadPasswordProtectedSecret(storage: Storage, storageKey: string, password: string): Promise<string | null> {
+	const envelope = parsePasswordSecretEnvelope(storage.getItem(storageKey))
+	if (!envelope) return null
+
+	return decryptSecretWithPassword(envelope, password)
+}
+
+export function storeMemorySessionSecret(slot: string, secret: string): void {
+	memorySessionSecrets.set(slot, secret)
+}
+
+export function loadMemorySessionSecret(slot: string): string | null {
+	return memorySessionSecrets.get(slot) ?? null
+}
+
+export function clearMemorySessionSecret(slot: string): void {
+	memorySessionSecrets.delete(slot)
+}
+
+export function clearAllMemorySessionSecrets(): void {
+	memorySessionSecrets.clear()
+}

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -5,6 +5,7 @@ import { cartActions } from './cart'
 import { fetchProductsByPubkey } from '@/queries/products'
 import { hasAcceptedTerms, TERMS_ACCEPTED_KEY } from '@/components/dialogs/TermsConditionsDialog'
 import { uiActions } from './ui'
+import { clearAllMemorySessionSecrets, loadPasswordProtectedSecret, savePasswordProtectedSecret } from '@/lib/security/clientSecretStorage'
 
 export const NOSTR_CONNECT_KEY = 'nostr_connect_url'
 export const NOSTR_LOCAL_SIGNER_KEY = 'nostr_local_signer_key'
@@ -28,6 +29,20 @@ const initialState: AuthState = {
 
 export const authStore = new Store<AuthState>(initialState)
 
+export function parseLegacyStoredPrivateKey(value: string | null | undefined): { pubkey: string; privateKey: string } | null {
+	if (!value || value.trim().startsWith('{')) return null
+
+	const [pubkey, privateKey] = value.split(':')
+	if (!pubkey || !privateKey) return null
+
+	return { pubkey, privateKey }
+}
+
+function clearLegacyNip46Storage() {
+	localStorage.removeItem(NOSTR_LOCAL_SIGNER_KEY)
+	localStorage.removeItem(NOSTR_CONNECT_KEY)
+}
+
 export const authActions = {
 	getAuthFromLocalStorageAndLogin: async () => {
 		try {
@@ -35,10 +50,11 @@ export const authActions = {
 			if (autoLogin !== 'true') return
 
 			authStore.setState((state) => ({ ...state, isAuthenticating: true }))
-			const privateKey = localStorage.getItem(NOSTR_LOCAL_SIGNER_KEY)
-			const bunkerUrl = localStorage.getItem(NOSTR_CONNECT_KEY)
-			if (privateKey && bunkerUrl) {
-				await authActions.loginWithNip46(bunkerUrl, new NDKPrivateKeySigner(privateKey))
+			const legacyNip46PrivateKey = localStorage.getItem(NOSTR_LOCAL_SIGNER_KEY)
+			const legacyBunkerUrl = localStorage.getItem(NOSTR_CONNECT_KEY)
+			if (legacyNip46PrivateKey && legacyBunkerUrl) {
+				await authActions.loginWithNip46(legacyBunkerUrl, new NDKPrivateKeySigner(legacyNip46PrivateKey))
+				clearLegacyNip46Storage()
 				authActions.checkAndShowTermsDialog()
 				return
 			}
@@ -66,8 +82,16 @@ export const authActions = {
 				throw new Error('No encrypted key found')
 			}
 
-			const [, key] = encryptedPrivateKey.split(':')
+			const legacyStoredKey = parseLegacyStoredPrivateKey(encryptedPrivateKey)
+			const key = legacyStoredKey?.privateKey ?? (await loadPasswordProtectedSecret(localStorage, NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, password))
+			if (!key) {
+				throw new Error('Stored private key is invalid')
+			}
+
 			await authActions.loginWithPrivateKey(key)
+			if (legacyStoredKey) {
+				await authActions.storeEncryptedPrivateKey(key, password, legacyStoredKey.pubkey)
+			}
 			authStore.setState((state) => ({ ...state, needsDecryptionPassword: false }))
 			authActions.checkAndShowTermsDialog()
 		} catch (error) {
@@ -81,6 +105,10 @@ export const authActions = {
 		if (!hasAcceptedTerms()) {
 			uiActions.openDialog('terms')
 		}
+	},
+
+	storeEncryptedPrivateKey: async (privateKey: string, password: string, pubkey?: string) => {
+		await savePasswordProtectedSecret(localStorage, NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, privateKey, password, { pubkey })
 	},
 
 	loginWithPrivateKey: async (privateKey: string) => {
@@ -178,11 +206,6 @@ export const authActions = {
 			ndkActions.setSigner(signer)
 			const user = await signer.user()
 
-			// Wait until user is logged in successfully before saving the bunkerURL/private key.
-
-			localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, localSigner.privateKey || '')
-			localStorage.setItem(NOSTR_CONNECT_KEY, bunkerUrl)
-
 			authStore.setState((state) => ({
 				...state,
 				user,
@@ -205,10 +228,10 @@ export const authActions = {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) return
 		ndkActions.removeSigner()
-		localStorage.removeItem(NOSTR_LOCAL_SIGNER_KEY)
-		localStorage.removeItem(NOSTR_CONNECT_KEY)
+		clearLegacyNip46Storage()
 		localStorage.removeItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
 		localStorage.removeItem(NOSTR_AUTO_LOGIN)
+		clearAllMemorySessionSecrets()
 		// Clear cart when user logs out
 		cartActions.clear()
 		authStore.setState(() => initialState)

--- a/src/lib/stores/wallet.ts
+++ b/src/lib/stores/wallet.ts
@@ -4,6 +4,10 @@ import { v4 as uuidv4 } from 'uuid'
 import { useEffect, useState } from 'react'
 import NDK, { type NDKSigner } from '@nostr-dev-kit/ndk'
 import { NDKNWCWallet } from '@nostr-dev-kit/wallet'
+import { clearMemorySessionSecret, loadMemorySessionSecret, storeMemorySessionSecret } from '@/lib/security/clientSecretStorage'
+
+const LOCAL_WALLETS_STORAGE_KEY = 'nwc_wallets'
+const NWC_SESSION_SLOT_PREFIX = 'wallet_nwc_uri'
 
 // Wallet interface
 export interface Wallet {
@@ -35,6 +39,17 @@ const initialState: WalletState = {
 // Create the store
 export const walletStore = new Store<WalletState>(initialState)
 
+interface PersistedWalletRecord {
+	id: string
+	name: string
+	pubkey: string
+	relays: string[]
+	storedOnNostr?: boolean
+	createdAt: number
+	updatedAt: number
+	requiresReconnect?: boolean
+}
+
 // Define a type for the NWC URI parser function
 type NwcUriParser = (uri: string) => {
 	pubkey: string
@@ -65,6 +80,62 @@ export const parseNwcUri: NwcUriParser = (uri: string) => {
 		return null
 	} catch (e) {
 		console.error('Failed to parse NWC URI:', e)
+		return null
+	}
+}
+
+function getWalletSessionSlot(walletId: string): string {
+	return `${NWC_SESSION_SLOT_PREFIX}:${walletId}`
+}
+
+function toPersistedWalletRecord(wallet: Wallet): PersistedWalletRecord {
+	if (wallet.nwcUri) {
+		storeMemorySessionSecret(getWalletSessionSlot(wallet.id), wallet.nwcUri)
+	}
+
+	return {
+		id: wallet.id,
+		name: wallet.name,
+		pubkey: wallet.pubkey,
+		relays: wallet.relays,
+		storedOnNostr: wallet.storedOnNostr,
+		createdAt: wallet.createdAt,
+		updatedAt: wallet.updatedAt,
+		requiresReconnect: !wallet.storedOnNostr,
+	}
+}
+
+function hydratePersistedWallet(record: PersistedWalletRecord): Wallet | null {
+	const nwcUri = loadMemorySessionSecret(getWalletSessionSlot(record.id))
+
+	if (!nwcUri && record.requiresReconnect) {
+		console.warn(`[wallet] Dropping persisted local-only wallet ${record.id} after reload; secret material is no longer stored durably.`)
+		return null
+	}
+
+	return {
+		...record,
+		nwcUri: nwcUri || '',
+	}
+}
+
+function parseLegacyPersistedWallets(rawValue: string): Wallet[] | null {
+	try {
+		const parsed = JSON.parse(rawValue)
+		if (!Array.isArray(parsed)) return null
+		if (!parsed.every((wallet) => typeof wallet?.nwcUri === 'string')) return null
+
+		return parsed.map((wallet: any) => ({
+			id: wallet.id || uuidv4(),
+			name: wallet.name || `Wallet ${Math.floor(Math.random() * 1000)}`,
+			nwcUri: wallet.nwcUri,
+			pubkey: wallet.pubkey || parseNwcUri(wallet.nwcUri)?.pubkey || 'unknown',
+			relays: wallet.relays || [],
+			storedOnNostr: wallet.storedOnNostr || false,
+			createdAt: wallet.createdAt || Date.now(),
+			updatedAt: wallet.updatedAt || Date.now(),
+		}))
+	} catch {
 		return null
 	}
 }
@@ -168,20 +239,19 @@ export const walletActions = {
 	// Load wallets from localStorage
 	loadWalletsFromLocalStorage: async (): Promise<Wallet[]> => {
 		try {
-			const savedWallets = localStorage.getItem('nwc_wallets')
+			const savedWallets = localStorage.getItem(LOCAL_WALLETS_STORAGE_KEY)
 			if (savedWallets) {
-				const parsed = JSON.parse(savedWallets)
-				// Ensure all fields are present
-				return parsed.map((wallet: any) => ({
-					id: wallet.id || uuidv4(),
-					name: wallet.name || `Wallet ${Math.floor(Math.random() * 1000)}`,
-					nwcUri: wallet.nwcUri,
-					pubkey: wallet.pubkey || parseNwcUri(wallet.nwcUri)?.pubkey || 'unknown',
-					relays: wallet.relays || [],
-					storedOnNostr: wallet.storedOnNostr || false,
-					createdAt: wallet.createdAt || Date.now(),
-					updatedAt: wallet.updatedAt || Date.now(),
-				}))
+				const legacyWallets = parseLegacyPersistedWallets(savedWallets)
+				if (legacyWallets) {
+					legacyWallets.forEach((wallet) => {
+						storeMemorySessionSecret(getWalletSessionSlot(wallet.id), wallet.nwcUri)
+					})
+					walletActions.saveWalletsToLocalStorage(legacyWallets)
+					return legacyWallets
+				}
+
+				const parsed = JSON.parse(savedWallets) as PersistedWalletRecord[]
+				return parsed.map((wallet) => hydratePersistedWallet(wallet)).filter((wallet): wallet is Wallet => wallet !== null)
 			}
 		} catch (error) {
 			console.error('Failed to load wallets from localStorage:', error)
@@ -192,7 +262,7 @@ export const walletActions = {
 	// Save wallets to local storage
 	saveWalletsToLocalStorage: (wallets: Wallet[]): void => {
 		try {
-			localStorage.setItem('nwc_wallets', JSON.stringify(wallets))
+			localStorage.setItem(LOCAL_WALLETS_STORAGE_KEY, JSON.stringify(wallets.map((wallet) => toPersistedWalletRecord(wallet))))
 		} catch (error) {
 			console.error('Failed to save wallets to localStorage:', error)
 			toast.error('Failed to save wallets to local storage')
@@ -230,6 +300,7 @@ export const walletActions = {
 	removeWallet: (walletId: string): void => {
 		walletStore.setState((state) => {
 			const updatedWallets = state.wallets.filter((wallet) => wallet.id !== walletId)
+			clearMemorySessionSecret(getWalletSessionSlot(walletId))
 			walletActions.saveWalletsToLocalStorage(updatedWallets)
 
 			// Call the callback if it exists
@@ -260,6 +331,9 @@ export const walletActions = {
 				updatedAt: Date.now(),
 			}
 			updatedWallet = newWallets[walletIndex]
+			if (updatedWallet.nwcUri) {
+				storeMemorySessionSecret(getWalletSessionSlot(updatedWallet.id), updatedWallet.nwcUri)
+			}
 
 			walletActions.saveWalletsToLocalStorage(newWallets)
 

--- a/src/lib/tests/browserStorage.preload.ts
+++ b/src/lib/tests/browserStorage.preload.ts
@@ -1,0 +1,41 @@
+class MemoryStorage implements Storage {
+	private store = new Map<string, string>()
+
+	get length() {
+		return this.store.size
+	}
+
+	clear(): void {
+		this.store.clear()
+	}
+
+	getItem(key: string): string | null {
+		return this.store.get(key) ?? null
+	}
+
+	key(index: number): string | null {
+		return Array.from(this.store.keys())[index] ?? null
+	}
+
+	removeItem(key: string): void {
+		this.store.delete(key)
+	}
+
+	setItem(key: string, value: string): void {
+		this.store.set(key, value)
+	}
+}
+
+if (!globalThis.localStorage) {
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: new MemoryStorage(),
+		configurable: true,
+	})
+}
+
+if (!globalThis.sessionStorage) {
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		value: new MemoryStorage(),
+		configurable: true,
+	})
+}

--- a/src/lib/tests/clientSecretStorage.test.ts
+++ b/src/lib/tests/clientSecretStorage.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { decryptSecretWithPassword, encryptSecretWithPassword, parsePasswordSecretEnvelope } from '@/lib/security/clientSecretStorage'
+
+describe('clientSecretStorage', () => {
+	test('password mode round-trips without exposing raw private key material', async () => {
+		const envelope = await encryptSecretWithPassword('nsec1exampleprivatekey', 'correct horse battery staple', {
+			pubkey: 'f'.repeat(64),
+		})
+
+		expect(envelope.ciphertext).not.toContain('nsec1exampleprivatekey')
+		expect(await decryptSecretWithPassword(envelope, 'correct horse battery staple')).toBe('nsec1exampleprivatekey')
+	})
+
+	test('malformed envelope parse is rejected', () => {
+		expect(parsePasswordSecretEnvelope('{"mode":"password"}')).toBeNull()
+		expect(parsePasswordSecretEnvelope('not-json')).toBeNull()
+	})
+})

--- a/src/lib/tests/secretPersistence.test.ts
+++ b/src/lib/tests/secretPersistence.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+	authActions,
+	NOSTR_AUTO_LOGIN,
+	NOSTR_CONNECT_KEY,
+	NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY,
+	NOSTR_LOCAL_SIGNER_KEY,
+} from '@/lib/stores/auth'
+import { clearAllMemorySessionSecrets, parsePasswordSecretEnvelope } from '@/lib/security/clientSecretStorage'
+import { walletActions } from '@/lib/stores/wallet'
+
+describe('secret persistence hardening', () => {
+	beforeEach(() => {
+		localStorage.clear()
+		sessionStorage.clear()
+		clearAllMemorySessionSecrets()
+	})
+
+	afterEach(() => {
+		localStorage.clear()
+		sessionStorage.clear()
+		clearAllMemorySessionSecrets()
+	})
+
+	test('legacy private key storage is migrated to encrypted envelope and raw nsec does not remain in browser storage', async () => {
+		const legacyPrivateKey = 'nsec1legacyprivatekey'
+		localStorage.setItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, `${'a'.repeat(64)}:${legacyPrivateKey}`)
+
+		const originalLogin = authActions.loginWithPrivateKey
+		authActions.loginWithPrivateKey = async () => ({ pubkey: 'a'.repeat(64) } as any)
+
+		try {
+			await authActions.decryptAndLogin('test-password')
+		} finally {
+			authActions.loginWithPrivateKey = originalLogin
+		}
+
+		const storedValue = localStorage.getItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
+		expect(storedValue).toBeTruthy()
+		expect(storedValue).not.toContain(legacyPrivateKey)
+		expect(parsePasswordSecretEnvelope(storedValue)).not.toBeNull()
+	})
+
+	test('legacy NIP-46 plaintext storage is cleaned up only after successful login', async () => {
+		localStorage.setItem(NOSTR_AUTO_LOGIN, 'true')
+		localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, '1'.repeat(64))
+		localStorage.setItem(NOSTR_CONNECT_KEY, 'bunker://example?relay=wss%3A%2F%2Frelay.test&secret=test')
+
+		const originalLoginWithNip46 = authActions.loginWithNip46
+		const originalCheckTerms = authActions.checkAndShowTermsDialog
+		authActions.loginWithNip46 = async () => ({ pubkey: 'f'.repeat(64) } as any)
+		authActions.checkAndShowTermsDialog = () => {}
+
+		try {
+			await authActions.getAuthFromLocalStorageAndLogin()
+		} finally {
+			authActions.loginWithNip46 = originalLoginWithNip46
+			authActions.checkAndShowTermsDialog = originalCheckTerms
+		}
+
+		expect(localStorage.getItem(NOSTR_LOCAL_SIGNER_KEY)).toBeNull()
+		expect(localStorage.getItem(NOSTR_CONNECT_KEY)).toBeNull()
+	})
+
+	test('legacy NIP-46 plaintext storage is preserved when login fails', async () => {
+		localStorage.setItem(NOSTR_AUTO_LOGIN, 'true')
+		localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, '1'.repeat(64))
+		localStorage.setItem(NOSTR_CONNECT_KEY, 'bunker://example?relay=wss%3A%2F%2Frelay.test&secret=test')
+
+		const originalLoginWithNip46 = authActions.loginWithNip46
+		authActions.loginWithNip46 = async () => {
+			throw new Error('login failed')
+		}
+
+		try {
+			await authActions.getAuthFromLocalStorageAndLogin()
+		} finally {
+			authActions.loginWithNip46 = originalLoginWithNip46
+		}
+
+		expect(localStorage.getItem(NOSTR_LOCAL_SIGNER_KEY)).toBe('1'.repeat(64))
+		expect(localStorage.getItem(NOSTR_CONNECT_KEY)).toContain('bunker://')
+	})
+
+	test('legacy plaintext wallets are scrubbed from durable storage and dropped after simulated reload because local-only secrets are session-only', async () => {
+		const rawNwcUri = 'nostr+walletconnect://aaaa?relay=wss%3A%2F%2Frelay.test&secret=bbbb'
+		const wallet = {
+			id: 'wallet-1',
+			name: 'Wallet 1',
+			nwcUri: rawNwcUri,
+			pubkey: 'a'.repeat(64),
+			relays: ['wss://relay.test'],
+			storedOnNostr: false,
+			createdAt: Date.now(),
+			updatedAt: Date.now(),
+		}
+
+		localStorage.setItem('nwc_wallets', JSON.stringify([wallet]))
+		const firstLoadWallets = await walletActions.loadWalletsFromLocalStorage()
+
+		expect(firstLoadWallets[0]?.nwcUri).toBe(rawNwcUri)
+		expect(localStorage.getItem('nwc_wallets')).not.toContain('nostr+walletconnect://')
+
+		clearAllMemorySessionSecrets()
+		const secondLoadWallets = await walletActions.loadWalletsFromLocalStorage()
+		expect(secondLoadWallets).toEqual([])
+	})
+
+	test('saving wallets never leaves raw nostr wallet authority in durable browser storage', () => {
+		walletActions.saveWalletsToLocalStorage([
+			{
+				id: 'wallet-2',
+				name: 'Wallet 2',
+				nwcUri: 'nostr+walletconnect://cccc?relay=wss%3A%2F%2Frelay.test&secret=dddd',
+				pubkey: 'c'.repeat(64),
+				relays: ['wss://relay.test'],
+				storedOnNostr: false,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			},
+		])
+
+		expect(localStorage.getItem('nwc_wallets')).not.toContain('nostr+walletconnect://')
+	})
+})


### PR DESCRIPTION
## Why

This PR removes plaintext browser persistence for wallet authority and pseudo-encrypted private key storage.

The repo previously stored:

- raw `nostr+walletconnect://...` URIs in durable browser storage
- `${pubkey}:${nsec}` as a fake “encrypted” private-key format

This change closes those gaps as a security containment step.

## Invariant

Raw NWC authority and raw private key material must not persist in plaintext browser storage.

## Scope

- add password-protected secret envelope helper
- migrate private-key storage away from `${pubkey}:${nsec}`
- stop persisting raw NWC URIs durably
- move NIP-46/local wallet authority to memory-only/session behavior
- add migration and regression tests

## Explicit UX tradeoff

This PR intentionally makes local-only wallets session-only.

Behavior after this change:

- legacy plaintext local wallets are migrated to metadata-only durable storage
- raw `nwcUri` remains in memory only for the active session
- after full reload, local-only wallets are dropped and must be re-entered or stored on Nostr to be recoverable

This is a temporary security-first containment step, not the final wallet UX.

## Not Changed

- no checkout flow changes
- no order flow changes
- no payment settlement changes
- no encrypted durable local-wallet persistence yet

## Tests

Ran:
`bun test src/lib/tests/clientSecretStorage.test.ts src/lib/tests/secretPersistence.test.ts --preload ./src/lib/tests/browserStorage.preload.ts`

Coverage includes:

- password envelope round-trip
- malformed envelope rejection
- legacy private-key migration
- legacy NIP-46 cleanup only after successful login
- legacy NIP-46 preservation on failed login
- raw NWC not left in durable browser storage
- local-only wallets dropped after simulated reload because secrets are session-only

## Rollback

- revert this PR if the session-only local wallet tradeoff is not acceptable
- or follow quickly with encrypted durable local-wallet persistence

## Follow-up

Implement encrypted durable local-wallet persistence so saved local wallets survive reload without plaintext secret storage.