### PR TITLE
fix: add cursor-pointer to vanity URL pricing tier buttons

### DIFF
--- a/src/routes/_dashboard-layout/dashboard/account/vanity-url.tsx
+++ b/src/routes/_dashboard-layout/dashboard/account/vanity-url.tsx
@@ -385,7 +385,7 @@ function VanityUrlComponent() {
 												key={key}
 												type="button"
 												disabled={!validationState.isValid || validationState.isAvailable === false}
-												className={`w-full flex items-center gap-4 p-4 border rounded-lg transition-all hover:border-yellow-500 hover:bg-yellow-500/5 disabled:opacity-50 disabled:cursor-not-allowed`}
+												className={`w-full flex items-center gap-4 p-4 border rounded-lg transition-all hover:border-yellow-500 hover:bg-yellow-500/5 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer`}
 												onClick={() => handleZap(tier)}
 											>
 												<div className="flex items-center justify-center w-10 h-10 rounded-full bg-yellow-500/10">


### PR DESCRIPTION
## Description

Fixes #713

Added `cursor-pointer` class to the pricing tier buttons on the Vanity URL screen. The buttons were missing the pointer cursor style, which is a common UX expectation for clickable elements.

### Changes

- Added `cursor-pointer` to the `<button>` element in the pricing tiers section of `vanity-url.tsx`

### Before

Buttons on the Vanity URL screen did not show the finger pointer on mouse over.

### After

Buttons now properly display the cursor pointer when hovered.

This is a minimal, safe fix that only adds the missing cursor style without affecting other functionality.