### PR TITLE
fix(seed): publish replaceable products with current timestamps

### DIFF
--- a/scripts/gen_nip15_products.ts
+++ b/scripts/gen_nip15_products.ts
@@ -1,4 +1,5 @@
 import { faker } from '@faker-js/faker'
+import { ndkActions } from '@/lib/stores/ndk'
 import NDK, { NDKEvent, type NDKPrivateKeySigner, type NDKTag } from '@nostr-dev-kit/ndk'
 
 /**
@@ -94,12 +95,9 @@ export async function createNip15ProductEvent(
 
 	event.tags = tags
 
-	// Set created_at to be in the past (older than NIP-99 products)
-	event.created_at = Math.floor(Date.now() / 1000) - faker.number.int({ min: 86400, max: 2592000 }) // 1-30 days ago
-
 	try {
 		await event.sign(signer)
-		await event.publish()
+		await ndkActions.publishEvent(event)
 		console.log(`Published NIP-15 product: ${productData.name}`)
 		return true
 	} catch (error) {


### PR DESCRIPTION
## Summary

This fixes local seed behavior for replaceable product events.

## Problem

Seeded replaceable product events were being published with stale `created_at` timestamps, which triggered NDK guardrails for old replaceable events.

## Change

- remove manual backdating for seeded replaceable product events
- publish seeded replaceable product events through the repo’s standard publish path

## Why this is correct

Replaceable current-state events should publish with current timestamps rather than historical ones. This keeps the seed path aligned with relay/NDK expectations without suppressing guardrails.

## Validation

- ran local startup/seed flow
- confirmed seeded replaceable product events no longer hit the stale replaceable timestamp guardrail
- confirmed seeding still completes successfully