### PR TITLE
fix(queries): guard browser localStorage in shared query modules

### DIFF
--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -33,9 +33,12 @@ export { productKeys }
 // Persisted to localStorage so deletions survive page reloads.
 
 const DELETED_PRODUCTS_STORAGE_KEY = 'plebeian_deleted_product_ids'
+const hasLocalStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
 // Map of d-tag -> deletion timestamp (unix seconds)
 const loadDeletedProductIds = (): Map<string, number> => {
+	if (!hasLocalStorage()) return new Map()
+
 	try {
 		const stored = localStorage.getItem(DELETED_PRODUCTS_STORAGE_KEY)
 		if (stored) {
@@ -57,6 +60,8 @@ const loadDeletedProductIds = (): Map<string, number> => {
 }
 
 const saveDeletedProductIds = (ids: Map<string, number>) => {
+	if (!hasLocalStorage()) return
+
 	try {
 		localStorage.setItem(DELETED_PRODUCTS_STORAGE_KEY, JSON.stringify(Object.fromEntries(ids)))
 	} catch (e) {

--- a/src/queries/shipping.tsx
+++ b/src/queries/shipping.tsx
@@ -18,9 +18,12 @@ export { shippingKeys }
 // Persisted to localStorage so deletions survive page reloads.
 
 const DELETED_SHIPPING_STORAGE_KEY = 'plebeian_deleted_shipping_ids'
+const hasLocalStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
 // Map of d-tag -> deletion timestamp (unix seconds)
 const loadDeletedShippingIds = (): Map<string, number> => {
+	if (!hasLocalStorage()) return new Map()
+
 	try {
 		const stored = localStorage.getItem(DELETED_SHIPPING_STORAGE_KEY)
 		if (stored) {
@@ -42,6 +45,8 @@ const loadDeletedShippingIds = (): Map<string, number> => {
 }
 
 const saveDeletedShippingIds = (ids: Map<string, number>) => {
+	if (!hasLocalStorage()) return
+
 	try {
 		localStorage.setItem(DELETED_SHIPPING_STORAGE_KEY, JSON.stringify(Object.fromEntries(ids)))
 	} catch (e) {


### PR DESCRIPTION
## Summary

This makes shared query modules safe to import in Bun/server contexts.

## Problem

`src/queries/products.tsx` and `src/queries/shipping.tsx` accessed browser-only `localStorage` during module load. That caused Bun/server-side startup and seed flows to throw `ReferenceError: localStorage is not defined`.

## Change

- add browser guards around `localStorage` access in the affected query modules
- return empty deletion maps outside the browser
- no-op local persistence writes outside the browser

## Why this is correct

These query modules are shared between browser and non-browser execution paths. Browser-only storage should not be touched at import time in Bun/server contexts.

## Validation

- validated that the affected query modules import cleanly in Bun
- reran local app startup flow successfully
- browser behavior remained unchanged