### PR TITLE
feat(cart): persist cart intent across devices with app data snapshots

### DIFF
--- a/e2e-new/fixtures/index.ts
+++ b/e2e-new/fixtures/index.ts
@@ -64,6 +64,7 @@ export const test = base.extend<TestFixtures>({
 
 	newUserPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
+		await resetRemoteCartForUser(devUser3.sk)
 		const context = await browser.newContext()
 		await setupAuthContext(context, devUser3)
 		const page = await context.newPage()

--- a/e2e-new/fixtures/index.ts
+++ b/e2e-new/fixtures/index.ts
@@ -1,7 +1,7 @@
 import { test as base, expect, type Page } from '@playwright/test'
 import { RelayMonitor } from './relay-monitor'
 import { setupAuthContext, type TestUser } from './auth'
-import { ensureScenario, type ScenarioName } from '../scenarios'
+import { ensureScenario, resetRemoteCartForUser, type ScenarioName } from '../scenarios'
 import { devUser1, devUser2, devUser3 } from '../../src/lib/fixtures'
 
 type TestFixtures = {
@@ -49,6 +49,7 @@ export const test = base.extend<TestFixtures>({
 
 	buyerPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
+		await resetRemoteCartForUser(devUser2.sk)
 		const context = await browser.newContext()
 		await setupAuthContext(context, devUser2)
 		const page = await context.newPage()

--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -51,6 +51,25 @@ async function publish(relay: Relay, skHex: string, template: EventTemplate) {
 	return event
 }
 
+export async function resetRemoteCartForUser(skHex: string): Promise<void> {
+	const relay = await Relay.connect(RELAY_URL)
+
+	try {
+		await publish(relay, skHex, {
+			kind: 30078,
+			created_at: Math.floor(Date.now() / 1000),
+			content: JSON.stringify({
+				version: 1,
+				updatedAt: Math.floor(Date.now() / 1000),
+				items: [],
+			}),
+			tags: [['d', 'plebeian-market-cart']],
+		})
+	} finally {
+		relay.close()
+	}
+}
+
 // --- Seeding functions ---
 
 async function seedBase(relay: Relay) {

--- a/e2e-new/tests/cart.spec.ts
+++ b/e2e-new/tests/cart.spec.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
+import { devUser2 } from '../../src/lib/fixtures'
+import { waitForLatestCartSnapshotToBeEmpty } from '../utils/relay-query'
 
 test.use({ scenario: 'marketplace' })
 
@@ -295,9 +297,11 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 5_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// Only 1 shipping selector should remain (for the remaining seller)
-		const shippingTriggers = dialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(1, { timeout: 10_000 })
+		// Only 1 live shipping selector control should remain for the remaining seller.
+		// Count the actual select triggers rather than raw text so exiting animated nodes
+		// don't get mistaken for an active seller section.
+		const shippingSelectors = dialog.locator('[data-slot="select-trigger"]:visible')
+		await expect(shippingSelectors).toHaveCount(1, { timeout: 10_000 })
 	})
 })
 
@@ -382,7 +386,7 @@ test.describe('Cart - Persistence', () => {
 		await waitForProducts(buyerPage)
 
 		await addWalletToCart(buyerPage)
-		await addGuideToCart(buyerPage)
+		await addTShirtToCart(buyerPage)
 
 		// Open cart and clear it
 		await openCart(buyerPage)
@@ -395,8 +399,8 @@ test.describe('Cart - Persistence', () => {
 
 		// Cart should now show empty state
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 5_000 })
-		await expect(dialog.getByText('Lightning Node Setup Guide')).not.toBeVisible()
-		await buyerPage.waitForTimeout(750)
+		await expect(dialog.getByText('Nostr T-Shirt')).not.toBeVisible()
+		await waitForLatestCartSnapshotToBeEmpty({ pubkey: devUser2.pk })
 
 		// Close and reload to confirm persistence of the cleared state
 		await buyerPage.keyboard.press('Escape')

--- a/e2e-new/tests/cart.spec.ts
+++ b/e2e-new/tests/cart.spec.ts
@@ -396,6 +396,7 @@ test.describe('Cart - Persistence', () => {
 		// Cart should now show empty state
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 5_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).not.toBeVisible()
+		await buyerPage.waitForTimeout(750)
 
 		// Close and reload to confirm persistence of the cleared state
 		await buyerPage.keyboard.press('Escape')

--- a/e2e-new/tests/cart.spec.ts
+++ b/e2e-new/tests/cart.spec.ts
@@ -377,16 +377,16 @@ test.describe('Cart - Persistence', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 	})
 
-	test('clearing cart removes all items after reload', async ({ newUserPage }) => {
-		await safeGoto(newUserPage, '/products')
-		await waitForProducts(newUserPage)
+	test('clearing cart removes all items after reload', async ({ buyerPage }) => {
+		await safeGoto(buyerPage, '/products')
+		await waitForProducts(buyerPage)
 
-		await addWalletToCart(newUserPage)
-		await addGuideToCart(newUserPage)
+		await addWalletToCart(buyerPage)
+		await addGuideToCart(buyerPage)
 
 		// Open cart and clear it
-		await openCart(newUserPage)
-		const dialog = cartDialog(newUserPage)
+		await openCart(buyerPage)
+		const dialog = cartDialog(buyerPage)
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 
 		// Click the "Clear" button at the bottom of the cart
@@ -398,13 +398,13 @@ test.describe('Cart - Persistence', () => {
 		await expect(dialog.getByText('Lightning Node Setup Guide')).not.toBeVisible()
 
 		// Close and reload to confirm persistence of the cleared state
-		await newUserPage.keyboard.press('Escape')
-		await newUserPage.reload()
-		await newUserPage.waitForLoadState('networkidle')
+		await buyerPage.keyboard.press('Escape')
+		await buyerPage.reload()
+		await buyerPage.waitForLoadState('networkidle')
 
 		// Re-open cart — should still be empty (no phantom items)
-		await openCart(newUserPage)
-		const dialogAfter = cartDialog(newUserPage)
+		await openCart(buyerPage)
+		const dialogAfter = cartDialog(buyerPage)
 		// Cart should not contain these products
 		await expect(dialogAfter.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 3_000 })
 	})

--- a/e2e-new/utils/relay-query.ts
+++ b/e2e-new/utils/relay-query.ts
@@ -60,3 +60,45 @@ export function getTagValue(event: RelayEvent, tagName: string): string | undefi
 export function filterByTag(events: RelayEvent[], tagName: string, tagValue: string): RelayEvent[] {
 	return events.filter((e) => e.tags.some((t) => t[0] === tagName && t[1] === tagValue))
 }
+
+function compareRelayEventsDesc(a: RelayEvent, b: RelayEvent): number {
+	const byCreatedAt = (b.created_at || 0) - (a.created_at || 0)
+	if (byCreatedAt !== 0) return byCreatedAt
+	if (a.id < b.id) return 1
+	if (a.id > b.id) return -1
+	return 0
+}
+
+export async function waitForLatestCartSnapshotToBeEmpty(opts: {
+	pubkey: string
+	timeoutMs?: number
+	pollMs?: number
+}): Promise<RelayEvent> {
+	const { pubkey, timeoutMs = 10_000, pollMs = 200 } = opts
+	const startedAt = Date.now()
+
+	while (Date.now() - startedAt < timeoutMs) {
+		const events = await queryRelayEvents({
+			authors: [pubkey],
+			kinds: [30078],
+			'#d': ['plebeian-market-cart'],
+			limit: 20,
+		})
+
+		const latest = [...events].sort(compareRelayEventsDesc)[0]
+		if (latest) {
+			try {
+				const parsed = JSON.parse(latest.content) as { items?: unknown }
+				if (Array.isArray(parsed.items) && parsed.items.length === 0) {
+					return latest
+				}
+			} catch {
+				// Ignore malformed events and keep polling until timeout.
+			}
+		}
+
+		await new Promise((resolve) => setTimeout(resolve, pollMs))
+	}
+
+	throw new Error(`Timed out waiting for empty remote cart snapshot for pubkey ${pubkey}`)
+}

--- a/src/components/sheet-contents/cart/CartContent.tsx
+++ b/src/components/sheet-contents/cart/CartContent.tsx
@@ -226,7 +226,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 							<Button
 								variant="outline"
 								className="flex-1 text-red-500 hover:bg-red-50 hover:text-red-600 border-red-200"
-								onClick={() => cartActions.clear()}
+								onClick={() => cartActions.clearForUserIntent()}
 								disabled={totalItems === 0}
 							>
 								Clear

--- a/src/lib/cart-persistence.test.ts
+++ b/src/lib/cart-persistence.test.ts
@@ -161,10 +161,7 @@ describe('cart persistence helpers', () => {
 		const serialized = serializeCartIntent(cart)
 
 		expect(serialized.version).toBe(1)
-		expect(serialized.items.map((item) => item.productRef)).toEqual([
-			`30402:${sellerA}:product-a`,
-			`30402:${sellerB}:product-b`,
-		])
+		expect(serialized.items.map((item) => item.productRef)).toEqual([`30402:${sellerA}:product-a`, `30402:${sellerB}:product-b`])
 		expect(serialized.items[1]?.shippingRef).toBe(`30406:${sellerB}:ship-1`)
 	})
 })

--- a/src/lib/cart-persistence.test.ts
+++ b/src/lib/cart-persistence.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	chooseNewerCartSnapshot,
+	normalizePersistedCart,
+	normalizeShippingForRestore,
+	rehydrateCartFromLiveData,
+	serializeCartIntent,
+} from '@/lib/cart-persistence'
+import { CART_PERSISTENCE_D_TAG, CART_PERSISTENCE_KIND, type PersistedCartContent } from '@/lib/schemas/cartPersistence'
+import type { NormalizedCart } from '@/lib/stores/cart'
+
+const sellerA = 'a'.repeat(64)
+const sellerB = 'b'.repeat(64)
+
+describe('cart persistence helpers', () => {
+	test('duplicate productRefs collapse deterministically', () => {
+		const normalized = normalizePersistedCart({
+			version: 1,
+			updatedAt: 10,
+			items: [
+				{ productRef: `30402:${sellerB}:product-2`, quantity: 1 },
+				{ productRef: `30402:${sellerA}:product-1`, quantity: 2, shippingRef: `30406:${sellerA}:ship-1` },
+				{ productRef: `30402:${sellerA}:product-1`, quantity: 7 },
+			],
+		})
+
+		expect(normalized.items).toHaveLength(2)
+		expect(normalized.items[0]).toEqual({
+			productRef: `30402:${sellerA}:product-1`,
+			quantity: 7,
+			shippingRef: undefined,
+		})
+		expect(normalized.items[1]?.productRef).toBe(`30402:${sellerB}:product-2`)
+	})
+
+	test('chooseNewerCartSnapshot picks highest created_at valid event', () => {
+		const baseContent = JSON.stringify({
+			version: 1,
+			updatedAt: 1,
+			items: [],
+		})
+
+		const chosen = chooseNewerCartSnapshot([
+			{
+				id: 'older',
+				kind: CART_PERSISTENCE_KIND,
+				tags: [['d', CART_PERSISTENCE_D_TAG]],
+				content: baseContent,
+				created_at: 100,
+			} as any,
+			{
+				id: 'invalid',
+				kind: CART_PERSISTENCE_KIND,
+				tags: [['d', CART_PERSISTENCE_D_TAG]],
+				content: '{"bad":true}',
+				created_at: 999,
+			} as any,
+			{
+				id: 'newer',
+				kind: CART_PERSISTENCE_KIND,
+				tags: [['d', CART_PERSISTENCE_D_TAG]],
+				content: baseContent,
+				created_at: 200,
+			} as any,
+		])
+
+		expect(chosen?.id).toBe('newer')
+	})
+
+	test('invalid shipping clears while product remains', () => {
+		const items = normalizeShippingForRestore(
+			[
+				{
+					productRef: `30402:${sellerA}:product-1`,
+					quantity: 2,
+					shippingRef: `30406:${sellerB}:ship-1`,
+				},
+			],
+			{
+				[`30402:${sellerA}:product-1`]: {
+					productRef: `30402:${sellerA}:product-1`,
+					sellerPubkey: sellerA,
+					productId: 'product-1',
+					shippingRefs: [`30406:${sellerA}:ship-1`],
+				},
+			},
+			{
+				[`30406:${sellerB}:ship-1`]: {
+					shippingRef: `30406:${sellerB}:ship-1`,
+					sellerPubkey: sellerB,
+				},
+			},
+		)
+
+		expect(items[0]?.shippingRef).toBeUndefined()
+	})
+
+	test('missing products drop during rehydrate', () => {
+		const snapshot: PersistedCartContent = {
+			version: 1,
+			updatedAt: 50,
+			items: [
+				{ productRef: `30402:${sellerA}:product-1`, quantity: 1 },
+				{ productRef: `30402:${sellerB}:product-2`, quantity: 2 },
+			],
+		}
+
+		const rehydrated = rehydrateCartFromLiveData(
+			snapshot,
+			{
+				[`30402:${sellerA}:product-1`]: {
+					productRef: `30402:${sellerA}:product-1`,
+					sellerPubkey: sellerA,
+					productId: 'product-1',
+					shippingRefs: [],
+				},
+			},
+			{},
+		)
+
+		expect(Object.keys(rehydrated.cart.products)).toEqual(['product-1'])
+		expect(rehydrated.updatedAt).toBe(50)
+	})
+
+	test('serializeCartIntent sorts deterministically and excludes invalid products', () => {
+		const cart: NormalizedCart = {
+			sellers: {},
+			products: {
+				b: {
+					id: 'product-b',
+					amount: 2,
+					shippingMethodId: `30406:${sellerB}:ship-1`,
+					shippingMethodName: 'Ship B',
+					shippingCost: 12,
+					shippingCostCurrency: 'USD',
+					sellerPubkey: sellerB,
+				},
+				a: {
+					id: 'product-a',
+					amount: 1,
+					shippingMethodId: null,
+					shippingMethodName: null,
+					shippingCost: 0,
+					shippingCostCurrency: null,
+					sellerPubkey: sellerA,
+				},
+				invalid: {
+					id: 'missing-seller',
+					amount: 1,
+					shippingMethodId: null,
+					shippingMethodName: null,
+					shippingCost: 0,
+					shippingCostCurrency: null,
+					sellerPubkey: '',
+				},
+			},
+			orders: {},
+			invoices: {},
+		}
+
+		const serialized = serializeCartIntent(cart)
+
+		expect(serialized.version).toBe(1)
+		expect(serialized.items.map((item) => item.productRef)).toEqual([
+			`30402:${sellerA}:product-a`,
+			`30402:${sellerB}:product-b`,
+		])
+		expect(serialized.items[1]?.shippingRef).toBe(`30406:${sellerB}:ship-1`)
+	})
+})

--- a/src/lib/cart-persistence.ts
+++ b/src/lib/cart-persistence.ts
@@ -1,0 +1,212 @@
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import type { NormalizedCart } from '@/lib/stores/cart'
+import {
+	CART_PERSISTENCE_KIND,
+	CART_PERSISTENCE_VERSION,
+	MAX_PERSISTED_CART_ITEMS,
+	MAX_PERSISTED_CART_ITEM_QUANTITY,
+	parseCartPersistenceContent,
+	isExpectedCartSnapshot,
+	isValidCartProductRef,
+	isValidCartShippingRef,
+	type PersistedCartContent,
+	type PersistedCartItem,
+} from '@/lib/schemas/cartPersistence'
+
+type LiveProductRecord = {
+	productRef: string
+	sellerPubkey: string
+	productId: string
+	shippingRefs: string[]
+}
+
+type LiveShippingRecord = {
+	shippingRef: string
+	sellerPubkey: string
+}
+
+export interface RehydratedCart {
+	cart: NormalizedCart
+	updatedAt: number
+}
+
+function clampQuantity(quantity: number): number {
+	return Math.min(Math.max(Math.floor(quantity), 1), MAX_PERSISTED_CART_ITEM_QUANTITY)
+}
+
+function compareStrings(a: string, b: string): number {
+	if (a < b) return -1
+	if (a > b) return 1
+	return 0
+}
+
+export function serializeCartIntent(cart: NormalizedCart): PersistedCartContent {
+	const items = Object.values(cart.products)
+		.map((product) => {
+			if (!product.id || !product.sellerPubkey) return null
+			const productRef = `30402:${product.sellerPubkey}:${product.id}`
+			if (!isValidCartProductRef(productRef)) return null
+			const shippingRef =
+				product.shippingMethodId && isValidCartShippingRef(product.shippingMethodId) ? product.shippingMethodId : undefined
+
+			return {
+				productRef,
+				quantity: clampQuantity(product.amount),
+				...(shippingRef ? { shippingRef } : {}),
+			} satisfies PersistedCartItem
+		})
+		.filter((item): item is PersistedCartItem => item !== null)
+		.sort((a, b) => compareStrings(a.productRef, b.productRef))
+		.slice(0, MAX_PERSISTED_CART_ITEMS)
+
+	return {
+		version: CART_PERSISTENCE_VERSION,
+		updatedAt: Math.floor(Date.now() / 1000),
+		items,
+	}
+}
+
+export function normalizePersistedCart(content: PersistedCartContent): PersistedCartContent {
+	const deduped = new Map<string, PersistedCartItem>()
+
+	for (const rawItem of content.items) {
+		if (!isValidCartProductRef(rawItem.productRef)) continue
+
+		deduped.set(rawItem.productRef, {
+			productRef: rawItem.productRef,
+			quantity: clampQuantity(rawItem.quantity),
+			shippingRef: rawItem.shippingRef && isValidCartShippingRef(rawItem.shippingRef) ? rawItem.shippingRef : undefined,
+		})
+	}
+
+	const items = Array.from(deduped.values())
+		.sort((a, b) => compareStrings(a.productRef, b.productRef))
+		.slice(0, MAX_PERSISTED_CART_ITEMS)
+
+	return {
+		version: CART_PERSISTENCE_VERSION,
+		updatedAt: Math.max(1, Math.floor(content.updatedAt)),
+		items,
+	}
+}
+
+export function chooseNewerCartSnapshot(events: Array<Pick<NDKEvent, 'kind' | 'tags' | 'content' | 'created_at' | 'id'>>): NDKEvent | null {
+	const validEvents = events.filter((event): event is NDKEvent => {
+		if (!isExpectedCartSnapshot(event)) return false
+		return parseCartPersistenceContent(event.content) !== null
+	})
+
+	if (validEvents.length === 0) return null
+
+	validEvents.sort((a, b) => {
+		const byCreatedAt = (b.created_at || 0) - (a.created_at || 0)
+		if (byCreatedAt !== 0) return byCreatedAt
+		return compareStrings(b.id || '', a.id || '')
+	})
+
+	return validEvents[0] ?? null
+}
+
+export function normalizeShippingForRestore(
+	items: PersistedCartItem[],
+	liveProducts: Record<string, LiveProductRecord>,
+	liveShipping: Record<string, LiveShippingRecord>,
+): PersistedCartItem[] {
+	const sellerSelections = new Map<string, string | null>()
+
+	const prelim = items.map((item) => {
+		const product = liveProducts[item.productRef]
+		if (!product) return { ...item, shippingRef: undefined }
+
+		const shippingRef = item.shippingRef
+		if (!shippingRef) return { ...item, shippingRef: undefined }
+
+		const shipping = liveShipping[shippingRef]
+		const validForProduct = product.shippingRefs.includes(shippingRef)
+		const sameSeller = shipping?.sellerPubkey === product.sellerPubkey
+
+		if (!shipping || !validForProduct || !sameSeller) {
+			return { ...item, shippingRef: undefined }
+		}
+
+		const existing = sellerSelections.get(product.sellerPubkey)
+		if (existing === undefined) {
+			sellerSelections.set(product.sellerPubkey, shippingRef)
+		} else if (existing !== shippingRef) {
+			sellerSelections.set(product.sellerPubkey, null)
+		}
+
+		return { ...item, shippingRef }
+	})
+
+	return prelim.map((item) => {
+		const product = liveProducts[item.productRef]
+		if (!product || !item.shippingRef) return item
+		if (sellerSelections.get(product.sellerPubkey) === null) {
+			return { ...item, shippingRef: undefined }
+		}
+		return item
+	})
+}
+
+export function rehydrateCartFromLiveData(
+	snapshot: PersistedCartContent,
+	liveProducts: Record<string, LiveProductRecord>,
+	liveShipping: Record<string, LiveShippingRecord>,
+): RehydratedCart {
+	const normalized = normalizePersistedCart(snapshot)
+	const items = normalizeShippingForRestore(normalized.items, liveProducts, liveShipping)
+
+	const cart: NormalizedCart = {
+		sellers: {},
+		products: {},
+		orders: {},
+		invoices: {},
+	}
+
+	for (const item of items) {
+		const product = liveProducts[item.productRef]
+		if (!product) continue
+
+		cart.products[product.productId] = {
+			id: product.productId,
+			amount: clampQuantity(item.quantity),
+			shippingMethodId: item.shippingRef ?? null,
+			shippingMethodName: null,
+			shippingCost: 0,
+			shippingCostCurrency: null,
+			sellerPubkey: product.sellerPubkey,
+		}
+
+		if (!cart.sellers[product.sellerPubkey]) {
+			cart.sellers[product.sellerPubkey] = {
+				pubkey: product.sellerPubkey,
+				productIds: [],
+				currency: '',
+				shippingMethodId: null,
+				shippingMethodName: null,
+				shippingCost: 0,
+				shippingCostCurrency: null,
+				v4vShares: [],
+			}
+		}
+
+		cart.sellers[product.sellerPubkey].productIds.push(product.productId)
+	}
+
+	for (const seller of Object.values(cart.sellers)) {
+		const sellerShippingRefs = seller.productIds
+			.map((productId) => cart.products[productId]?.shippingMethodId)
+			.filter((shippingRef): shippingRef is string => !!shippingRef)
+
+		const uniqueShippingRefs = Array.from(new Set(sellerShippingRefs))
+		if (uniqueShippingRefs.length === 1) {
+			seller.shippingMethodId = uniqueShippingRefs[0]
+		}
+	}
+
+	return {
+		cart,
+		updatedAt: normalized.updatedAt,
+	}
+}

--- a/src/lib/schemas/cartPersistence.test.ts
+++ b/src/lib/schemas/cartPersistence.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	CART_PERSISTENCE_D_TAG,
+	CART_PERSISTENCE_KIND,
+	CART_PERSISTENCE_VERSION,
+	MAX_PERSISTED_CART_ITEMS,
+	MAX_PERSISTED_CART_ITEM_QUANTITY,
+	getCartPersistenceDTag,
+	isCartPersistenceEvent,
+	isExpectedCartSnapshot,
+	parseCartPersistenceContent,
+} from '@/lib/schemas/cartPersistence'
+
+describe('cartPersistence schema helpers', () => {
+	test('valid snapshot parses', () => {
+		const parsed = parseCartPersistenceContent(
+			JSON.stringify({
+				version: CART_PERSISTENCE_VERSION,
+				updatedAt: 1774300000,
+				items: [
+					{
+						productRef: `30402:${'a'.repeat(64)}:nested:product-1`,
+						quantity: 2,
+						shippingRef: `30406:${'a'.repeat(64)}:shipping:1`,
+						extraField: 'ignored',
+					},
+				],
+				extraRoot: true,
+			}),
+		)
+
+		expect(parsed).not.toBeNull()
+		expect(parsed?.items[0]?.productRef).toBe(`30402:${'a'.repeat(64)}:nested:product-1`)
+		expect((parsed?.items[0] as any).extraField).toBeUndefined()
+		expect((parsed as any)?.extraRoot).toBeUndefined()
+	})
+
+	test('malformed json rejected', () => {
+		expect(parseCartPersistenceContent('{nope')).toBeNull()
+	})
+
+	test('item caps enforced by schema', () => {
+		const parsed = parseCartPersistenceContent(
+			JSON.stringify({
+				version: CART_PERSISTENCE_VERSION,
+				updatedAt: 1774300000,
+				items: Array.from({ length: MAX_PERSISTED_CART_ITEMS + 1 }, (_, index) => ({
+					productRef: `30402:${'a'.repeat(64)}:product-${index}`,
+					quantity: 1,
+				})),
+			}),
+		)
+
+		expect(parsed).toBeNull()
+	})
+
+	test('quantity caps enforced by schema', () => {
+		const parsed = parseCartPersistenceContent(
+			JSON.stringify({
+				version: CART_PERSISTENCE_VERSION,
+				updatedAt: 1774300000,
+				items: [
+					{
+						productRef: `30402:${'a'.repeat(64)}:product-1`,
+						quantity: MAX_PERSISTED_CART_ITEM_QUANTITY + 1,
+					},
+				],
+			}),
+		)
+
+		expect(parsed).toBeNull()
+	})
+
+	test('kind and d-tag helpers reject wrong event shape', () => {
+		const event = {
+			kind: CART_PERSISTENCE_KIND,
+			tags: [['d', CART_PERSISTENCE_D_TAG]],
+		} as any
+		const wrongKind = {
+			kind: 1,
+			tags: [['d', CART_PERSISTENCE_D_TAG]],
+		} as any
+		const wrongTag = {
+			kind: CART_PERSISTENCE_KIND,
+			tags: [['d', 'something-else']],
+		} as any
+
+		expect(isCartPersistenceEvent(event)).toBe(true)
+		expect(getCartPersistenceDTag(event)).toBe(CART_PERSISTENCE_D_TAG)
+		expect(isExpectedCartSnapshot(event)).toBe(true)
+		expect(isExpectedCartSnapshot(wrongKind)).toBe(false)
+		expect(isExpectedCartSnapshot(wrongTag)).toBe(false)
+	})
+})

--- a/src/lib/schemas/cartPersistence.ts
+++ b/src/lib/schemas/cartPersistence.ts
@@ -1,0 +1,67 @@
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { z } from 'zod'
+
+export const CART_PERSISTENCE_KIND = 30078
+export const CART_PERSISTENCE_D_TAG = 'plebeian-market-cart'
+export const CART_PERSISTENCE_VERSION = 1 as const
+
+export const MAX_PERSISTED_CART_ITEMS = 100
+export const MAX_PERSISTED_CART_ITEM_QUANTITY = 999
+
+const HEX_64_REGEX = /^[a-f0-9]{64}$/i
+const PRODUCT_REF_REGEX = /^30402:[a-f0-9]{64}:[^\s]+$/i
+const SHIPPING_REF_REGEX = /^30406:[a-f0-9]{64}:[^\s]+$/i
+
+export const ProductRefSchema = z.string().trim().regex(PRODUCT_REF_REGEX, 'Invalid product reference')
+export const ShippingRefSchema = z.string().trim().regex(SHIPPING_REF_REGEX, 'Invalid shipping reference')
+
+export const PersistedCartItemSchema = z
+	.object({
+		productRef: ProductRefSchema,
+		quantity: z.number().int().min(1).max(MAX_PERSISTED_CART_ITEM_QUANTITY),
+		shippingRef: ShippingRefSchema.nullish(),
+	})
+	.strip()
+
+export const PersistedCartContentSchema = z
+	.object({
+		version: z.literal(CART_PERSISTENCE_VERSION),
+		updatedAt: z.number().int().positive(),
+		items: z.array(PersistedCartItemSchema).max(MAX_PERSISTED_CART_ITEMS),
+	})
+	.strip()
+
+export type PersistedCartItem = z.infer<typeof PersistedCartItemSchema>
+export type PersistedCartContent = z.infer<typeof PersistedCartContentSchema>
+
+export function getCartPersistenceDTag(event: Pick<NDKEvent, 'tags'> | null | undefined): string | undefined {
+	return event?.tags.find((tag) => tag[0] === 'd')?.[1]
+}
+
+export function isCartPersistenceEvent(event: Pick<NDKEvent, 'kind' | 'tags'> | null | undefined): boolean {
+	return event?.kind === CART_PERSISTENCE_KIND
+}
+
+export function isExpectedCartSnapshot(event: Pick<NDKEvent, 'kind' | 'tags'> | null | undefined): boolean {
+	return isCartPersistenceEvent(event) && getCartPersistenceDTag(event) === CART_PERSISTENCE_D_TAG
+}
+
+export function parseCartPersistenceContent(content: string): PersistedCartContent | null {
+	try {
+		return PersistedCartContentSchema.parse(JSON.parse(content))
+	} catch {
+		return null
+	}
+}
+
+export function isValidCartProductRef(value: string): boolean {
+	return ProductRefSchema.safeParse(value).success
+}
+
+export function isValidCartShippingRef(value: string): boolean {
+	return ShippingRefSchema.safeParse(value).success
+}
+
+export function isValidCartPubkey(value: string): boolean {
+	return HEX_64_REGEX.test(value)
+}

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -101,6 +101,8 @@ export const authActions = {
 				isAuthenticated: true,
 			}))
 
+			void cartActions.reconcileRemoteCartForUser(user.pubkey, signer, ndk)
+
 			return user
 		} catch (error) {
 			authStore.setState((state) => ({
@@ -155,6 +157,8 @@ export const authActions = {
 				isAuthenticated: true,
 			}))
 
+			void cartActions.reconcileRemoteCartForUser(user.pubkey, signer, ndk)
+
 			return user
 		} catch (error) {
 			authStore.setState((state) => ({
@@ -189,6 +193,8 @@ export const authActions = {
 				isAuthenticated: true,
 			}))
 
+			void cartActions.reconcileRemoteCartForUser(user.pubkey, signer, ndk)
+
 			return user
 		} catch (error) {
 			authStore.setState((state) => ({
@@ -210,7 +216,7 @@ export const authActions = {
 		localStorage.removeItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
 		localStorage.removeItem(NOSTR_AUTO_LOGIN)
 		// Clear cart when user logs out
-		cartActions.clear()
+		cartActions.clear({ publishRemote: false, reason: 'logout' })
 		authStore.setState(() => initialState)
 	},
 

--- a/src/lib/stores/cart.test.ts
+++ b/src/lib/stores/cart.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { cartActions, cartStore, cartTestUtils, type NormalizedCart } from '@/lib/stores/cart'
+
+class MemoryStorage {
+	private store = new Map<string, string>()
+
+	getItem(key: string) {
+		return this.store.has(key) ? this.store.get(key)! : null
+	}
+
+	setItem(key: string, value: string) {
+		this.store.set(key, value)
+	}
+
+	removeItem(key: string) {
+		this.store.delete(key)
+	}
+
+	clear() {
+		this.store.clear()
+	}
+}
+
+const sellerPubkey = 'a'.repeat(64)
+
+function buildCart(productId: string = 'product-1'): NormalizedCart {
+	return {
+		sellers: {
+			[sellerPubkey]: {
+				pubkey: sellerPubkey,
+				productIds: [productId],
+				currency: '',
+				shippingMethodId: null,
+				shippingMethodName: null,
+				shippingCost: 0,
+				shippingCostCurrency: null,
+				v4vShares: [],
+			},
+		},
+		products: {
+			[productId]: {
+				id: productId,
+				amount: 1,
+				shippingMethodId: null,
+				shippingMethodName: null,
+				shippingCost: 0,
+				shippingCostCurrency: null,
+				sellerPubkey,
+			},
+		},
+		orders: {},
+		invoices: {},
+	}
+}
+
+describe('cart store persistence orchestration', () => {
+	beforeEach(() => {
+		;(globalThis as any).sessionStorage = new MemoryStorage()
+		cartTestUtils.resetSyncDependencies()
+		cartTestUtils.setPublishDebounceMs(0)
+		cartTestUtils.resetStore()
+		cartTestUtils.setSyncDependencies({
+			now: () => 100,
+			getSigner: () => ({ user: async () => ({ pubkey: 'buyer' }) }) as any,
+			getNDK: () => ({}) as any,
+			getProductEvent: async (id, seller) =>
+				({
+					pubkey: seller ?? sellerPubkey,
+					tags: [
+						['d', id],
+						['price', '10', 'SATS'],
+						['shipping_option', `30406:${seller ?? sellerPubkey}:ship:1`],
+					],
+				}) as any,
+			getShippingEvent: async (shippingRef) => {
+				const firstSeparator = shippingRef.indexOf(':')
+				const secondSeparator = shippingRef.indexOf(':', firstSeparator + 1)
+				const pubkey = shippingRef.slice(firstSeparator + 1, secondSeparator)
+				const dTag = shippingRef.slice(secondSeparator + 1)
+				return {
+					pubkey,
+					tags: [
+						['d', dTag],
+						['price', '5', 'SATS'],
+						['service', 'standard'],
+					],
+				} as any
+			},
+		})
+	})
+
+	test('local boot with no remote snapshot keeps local cart', async () => {
+		const localCart = buildCart()
+		;(globalThis as any).sessionStorage.setItem(
+			'cart',
+			JSON.stringify({
+				version: 1,
+				updatedAt: 200,
+				cart: localCart,
+			}),
+		)
+		cartStore.setState((state) => ({
+			...state,
+			cart: localCart,
+			productsBySeller: {
+				[sellerPubkey]: [localCart.products['product-1']],
+			},
+			lastCartIntentUpdatedAt: 200,
+		}))
+
+		cartTestUtils.setSyncDependencies({
+			fetchLatestCartSnapshot: async () => null,
+		})
+
+		await cartActions.reconcileRemoteCartForUser('buyer', {} as any, {} as any)
+
+		expect(Object.keys(cartStore.state.cart.products)).toEqual(['product-1'])
+		expect(cartStore.state.hasRemoteCartHydrated).toBe(true)
+	})
+
+	test('empty local plus valid remote restores remote cart', async () => {
+		cartTestUtils.setSyncDependencies({
+			now: () => 500,
+			fetchLatestCartSnapshot: async () => ({
+				version: 1,
+				updatedAt: 300,
+				items: [
+					{
+						productRef: `30402:${sellerPubkey}:remote:product`,
+						quantity: 2,
+						shippingRef: `30406:${sellerPubkey}:ship:1`,
+					},
+				],
+			}),
+		})
+
+		await cartActions.reconcileRemoteCartForUser('buyer', {} as any, {} as any)
+
+		expect(cartStore.state.cart.products['remote:product']?.amount).toBe(2)
+		expect(cartStore.state.cart.products['remote:product']?.shippingMethodId).toBe(`30406:${sellerPubkey}:ship:1`)
+		expect(cartStore.state.lastCartIntentUpdatedAt).toBe(300)
+	})
+
+	test('user mutation schedules debounced publish', async () => {
+		const published: any[] = []
+		cartTestUtils.setSyncDependencies({
+			publishCartSnapshot: async (snapshot) => {
+				published.push(snapshot)
+				return 'event-id'
+			},
+		})
+
+		await cartActions.addProduct('buyer', {
+			id: 'product-1',
+			amount: 1,
+			shippingMethodId: null,
+			shippingMethodName: null,
+			shippingCost: 0,
+			shippingCostCurrency: null,
+			sellerPubkey,
+		})
+
+		await new Promise((resolve) => setTimeout(resolve, 1))
+
+		expect(published).toHaveLength(1)
+		expect(published[0]?.items).toEqual([
+			{
+				productRef: `30402:${sellerPubkey}:product-1`,
+				quantity: 1,
+			},
+		])
+	})
+
+	test('remote reconciliation does not publish', async () => {
+		let publishCount = 0
+		cartTestUtils.setSyncDependencies({
+			fetchLatestCartSnapshot: async () => ({
+				version: 1,
+				updatedAt: 300,
+				items: [{ productRef: `30402:${sellerPubkey}:remote-product`, quantity: 1 }],
+			}),
+			publishCartSnapshot: async () => {
+				publishCount += 1
+				return 'event-id'
+			},
+		})
+
+		await cartActions.reconcileRemoteCartForUser('buyer', {} as any, {} as any)
+		await new Promise((resolve) => setTimeout(resolve, 1))
+
+		expect(publishCount).toBe(0)
+	})
+
+	test('logout clear does not publish', async () => {
+		let publishCount = 0
+		cartStore.setState((state) => ({
+			...state,
+			cart: buildCart(),
+		}))
+		cartTestUtils.setSyncDependencies({
+			publishCartSnapshot: async () => {
+				publishCount += 1
+				return 'event-id'
+			},
+		})
+
+		cartActions.clear({ publishRemote: false, reason: 'logout' })
+		await new Promise((resolve) => setTimeout(resolve, 1))
+
+		expect(publishCount).toBe(0)
+		expect(Object.keys(cartStore.state.cart.products)).toHaveLength(0)
+	})
+
+	test('explicit clear publishes empty snapshot', async () => {
+		const published: any[] = []
+		cartStore.setState((state) => ({
+			...state,
+			cart: buildCart(),
+		}))
+		cartTestUtils.setSyncDependencies({
+			publishCartSnapshot: async (snapshot) => {
+				published.push(snapshot)
+				return 'event-id'
+			},
+		})
+
+		cartActions.clearForUserIntent()
+		await new Promise((resolve) => setTimeout(resolve, 1))
+
+		expect(published).toHaveLength(1)
+		expect(published[0]?.items).toEqual([])
+	})
+
+	test('clear is local-only by default', async () => {
+		let publishCount = 0
+		cartStore.setState((state) => ({
+			...state,
+			cart: buildCart(),
+		}))
+		cartTestUtils.setSyncDependencies({
+			publishCartSnapshot: async () => {
+				publishCount += 1
+				return 'event-id'
+			},
+		})
+
+		cartActions.clear()
+		await new Promise((resolve) => setTimeout(resolve, 1))
+
+		expect(publishCount).toBe(0)
+	})
+})

--- a/src/lib/stores/cart.ts
+++ b/src/lib/stores/cart.ts
@@ -678,29 +678,47 @@ export const cartActions = {
 	removeProduct: async (buyerPubkey: string, productId: string) => {
 		const updatedAt = cartSyncDependencies.now()
 		cartStore.setState((state) => {
-			const cart = { ...state.cart }
-			const product = cart.products[productId]
+			const existingProduct = state.cart.products[productId]
+			if (!existingProduct) {
+				return state
+			}
 
-			if (product && product.sellerPubkey) {
-				const seller = cart.sellers[product.sellerPubkey]
+			const nextProducts = { ...state.cart.products }
+			delete nextProducts[productId]
+
+			const nextSellers = { ...state.cart.sellers }
+			if (existingProduct.sellerPubkey) {
+				const seller = nextSellers[existingProduct.sellerPubkey]
 				if (seller) {
-					seller.productIds = seller.productIds.filter((id) => id !== productId)
-
-					// Clean up empty seller
-					if (seller.productIds.length === 0) {
-						delete cart.sellers[product.sellerPubkey]
+					const nextProductIds = seller.productIds.filter((id) => id !== productId)
+					if (nextProductIds.length === 0) {
+						delete nextSellers[existingProduct.sellerPubkey]
+					} else {
+						nextSellers[existingProduct.sellerPubkey] = {
+							...seller,
+							productIds: nextProductIds,
+						}
 					}
 				}
 			}
 
-			delete cart.products[productId]
+			const cart = {
+				...state.cart,
+				sellers: nextSellers,
+				products: nextProducts,
+			}
+			const nextProductsBySeller = computeProductsBySeller(nextProducts)
 
 			cartActions.persistCartIntentLocally(cart, updatedAt)
-			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
+			return {
+				...state,
+				cart,
+				productsBySeller: nextProductsBySeller,
+				lastCartIntentUpdatedAt: updatedAt,
+			}
 		})
 
 		await cartActions.updateV4VShares()
-		await cartActions.groupProductsBySeller()
 		await cartActions.updateSellerData()
 		cartActions.scheduleRemotePublish()
 	},
@@ -811,13 +829,17 @@ export const cartActions = {
 	handleProductUpdate: async (action: string, productId: string, amount?: number) => {
 		const updatedAt = cartSyncDependencies.now()
 		cartStore.setState((state) => {
-			const cart = { ...state.cart }
-			const product = cart.products[productId]
+			const nextProducts = { ...state.cart.products }
+			const nextSellers = { ...state.cart.sellers }
+			const product = nextProducts[productId]
 
 			switch (action) {
 				case 'increment':
 					if (product) {
-						product.amount += 1
+						nextProducts[productId] = {
+							...product,
+							amount: product.amount + 1,
+						}
 					}
 					break
 				case 'decrement':
@@ -826,16 +848,24 @@ export const cartActions = {
 
 						if (newAmount === 0) {
 							// Remove product from seller's product list
-							const seller = cart.sellers[product.sellerPubkey]
+							const seller = nextSellers[product.sellerPubkey]
 							if (seller) {
-								seller.productIds = seller.productIds.filter((id: string) => id !== productId)
-								if (seller.productIds.length === 0) {
-									delete cart.sellers[product.sellerPubkey]
+								const nextProductIds = seller.productIds.filter((id: string) => id !== productId)
+								if (nextProductIds.length === 0) {
+									delete nextSellers[product.sellerPubkey]
+								} else {
+									nextSellers[product.sellerPubkey] = {
+										...seller,
+										productIds: nextProductIds,
+									}
 								}
 							}
-							delete cart.products[productId]
+							delete nextProducts[productId]
 						} else {
-							product.amount = newAmount
+							nextProducts[productId] = {
+								...product,
+								amount: newAmount,
+							}
 						}
 					}
 					break
@@ -843,41 +873,65 @@ export const cartActions = {
 					if (amount !== undefined && product) {
 						if (amount <= 0) {
 							// Remove product from seller's product list
-							const seller = cart.sellers[product.sellerPubkey]
+							const seller = nextSellers[product.sellerPubkey]
 							if (seller) {
-								seller.productIds = seller.productIds.filter((id: string) => id !== productId)
-								if (seller.productIds.length === 0) {
-									delete cart.sellers[product.sellerPubkey]
+								const nextProductIds = seller.productIds.filter((id: string) => id !== productId)
+								if (nextProductIds.length === 0) {
+									delete nextSellers[product.sellerPubkey]
+								} else {
+									nextSellers[product.sellerPubkey] = {
+										...seller,
+										productIds: nextProductIds,
+									}
 								}
 							}
-							delete cart.products[productId]
+							delete nextProducts[productId]
 						} else {
-							product.amount = amount
+							nextProducts[productId] = {
+								...product,
+								amount,
+							}
 						}
 					}
 					break
 				case 'remove': {
 					if (product) {
 						// Remove product from seller's product list
-						const seller = cart.sellers[product.sellerPubkey]
+						const seller = nextSellers[product.sellerPubkey]
 						if (seller) {
-							seller.productIds = seller.productIds.filter((id: string) => id !== productId)
-							if (seller.productIds.length === 0) {
-								delete cart.sellers[product.sellerPubkey]
+							const nextProductIds = seller.productIds.filter((id: string) => id !== productId)
+							if (nextProductIds.length === 0) {
+								delete nextSellers[product.sellerPubkey]
+							} else {
+								nextSellers[product.sellerPubkey] = {
+									...seller,
+									productIds: nextProductIds,
+								}
 							}
 						}
-						delete cart.products[productId]
+						delete nextProducts[productId]
 					}
 					break
 				}
 			}
 
+			const cart = {
+				...state.cart,
+				sellers: nextSellers,
+				products: nextProducts,
+			}
+			const nextProductsBySeller = computeProductsBySeller(nextProducts)
+
 			cartActions.persistCartIntentLocally(cart, updatedAt)
-			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
+			return {
+				...state,
+				cart,
+				productsBySeller: nextProductsBySeller,
+				lastCartIntentUpdatedAt: updatedAt,
+			}
 		})
 
 		await cartActions.updateV4VShares()
-		await cartActions.groupProductsBySeller()
 		await cartActions.updateSellerData()
 		cartActions.scheduleRemotePublish()
 	},

--- a/src/lib/stores/cart.ts
+++ b/src/lib/stores/cart.ts
@@ -1,9 +1,5 @@
 import { CURRENCIES, HEX_KEYS_REGEX } from '@/lib/constants'
-import {
-	normalizePersistedCart,
-	rehydrateCartFromLiveData,
-	serializeCartIntent,
-} from '@/lib/cart-persistence'
+import { normalizePersistedCart, rehydrateCartFromLiveData, serializeCartIntent } from '@/lib/cart-persistence'
 import { fetchLatestCartSnapshot } from '@/queries/cart'
 import type { SupportedCurrency } from '@/queries/external'
 import { btcExchangeRatesQueryOptions, currencyConversionQueryOptions } from '@/queries/external'
@@ -509,10 +505,7 @@ export const cartActions = {
 			}
 
 			if (shouldAdoptRemote) {
-				const liveProducts: Record<
-					string,
-					{ productRef: string; sellerPubkey: string; productId: string; shippingRefs: string[] }
-				> = {}
+				const liveProducts: Record<string, { productRef: string; sellerPubkey: string; productId: string; shippingRefs: string[] }> = {}
 				const liveShipping: Record<string, { shippingRef: string; sellerPubkey: string }> = {}
 
 				for (const item of normalizedRemote.items) {
@@ -527,9 +520,7 @@ export const cartActions = {
 						productRef: item.productRef,
 						sellerPubkey: productEvent.pubkey,
 						productId: productDTag,
-						shippingRefs: productEvent.tags
-							.filter((tag) => tag[0] === 'shipping_option' && tag[1])
-							.map((tag) => tag[1]),
+						shippingRefs: productEvent.tags.filter((tag) => tag[0] === 'shipping_option' && tag[1]).map((tag) => tag[1]),
 					}
 
 					if (item.shippingRef && !liveShipping[item.shippingRef]) {

--- a/src/lib/stores/cart.ts
+++ b/src/lib/stores/cart.ts
@@ -1,4 +1,10 @@
 import { CURRENCIES, HEX_KEYS_REGEX } from '@/lib/constants'
+import {
+	normalizePersistedCart,
+	rehydrateCartFromLiveData,
+	serializeCartIntent,
+} from '@/lib/cart-persistence'
+import { fetchLatestCartSnapshot } from '@/queries/cart'
 import type { SupportedCurrency } from '@/queries/external'
 import { btcExchangeRatesQueryOptions, currencyConversionQueryOptions } from '@/queries/external'
 import { getProductId, getProductPrice, getProductSellerPubkey, productQueryOptions, productByATagQueryOptions } from '@/queries/products'
@@ -10,7 +16,10 @@ import {
 	shippingOptionByCoordinatesQueryOptions,
 } from '@/queries/shipping'
 import { v4VForUserQuery } from '@/queries/v4v'
-import { NDKEvent } from '@nostr-dev-kit/ndk'
+import { publishCartSnapshot } from '@/publish/cart'
+import type { PersistedCartContent } from '@/lib/schemas/cartPersistence'
+import { ndkActions } from '@/lib/stores/ndk'
+import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { QueryClient } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
 import { Store } from '@tanstack/store'
@@ -114,11 +123,33 @@ interface CartState {
 	shippingByCurrency: Record<string, number>
 	totalByCurrency: Record<string, number>
 	sellerShippingOptions: Record<string, RichShippingInfo[]>
+	hasRemoteCartHydrated: boolean
+	isReconcilingRemoteCart: boolean
+	suppressRemotePublish: boolean
+	lastRemoteSnapshotUpdatedAt: number | null
+	lastCartIntentUpdatedAt: number | null
+}
+
+const CART_STORAGE_KEY = 'cart'
+const V4V_SHARES_STORAGE_KEY = 'v4vShares'
+const LOCAL_CART_STORAGE_VERSION = 1 as const
+
+const createEmptyNormalizedCart = (): NormalizedCart => ({
+	sellers: {},
+	products: {},
+	orders: {},
+	invoices: {},
+})
+
+type LocalCartEnvelope = {
+	version: typeof LOCAL_CART_STORAGE_VERSION
+	updatedAt: number | null
+	cart: NormalizedCart
 }
 
 function loadInitialV4VShares(): Record<string, V4VDTO[]> {
 	if (typeof sessionStorage !== 'undefined') {
-		const storedShares = sessionStorage.getItem('v4vShares')
+		const storedShares = sessionStorage.getItem(V4V_SHARES_STORAGE_KEY)
 		if (storedShares) {
 			try {
 				return JSON.parse(storedShares)
@@ -141,6 +172,11 @@ const initialState: CartState = {
 	shippingByCurrency: {},
 	totalByCurrency: {},
 	sellerShippingOptions: {},
+	hasRemoteCartHydrated: false,
+	isReconcilingRemoteCart: false,
+	suppressRemotePublish: false,
+	lastRemoteSnapshotUpdatedAt: null,
+	lastCartIntentUpdatedAt: null,
 }
 
 // Helper function to compute productsBySeller from products (used during init and updates)
@@ -161,9 +197,11 @@ function computeProductsBySeller(products: Record<string, CartProduct>): Record<
 
 function loadInitialCart(): NormalizedCart {
 	if (typeof sessionStorage !== 'undefined') {
-		const storedCart = sessionStorage.getItem('cart')
+		const storedCart = sessionStorage.getItem(CART_STORAGE_KEY)
 		if (storedCart) {
-			const cart: NormalizedCart = JSON.parse(storedCart)
+			const parsed = JSON.parse(storedCart)
+			const cart: NormalizedCart =
+				parsed && typeof parsed === 'object' && 'cart' in parsed ? (parsed.cart as NormalizedCart) : (parsed as NormalizedCart)
 
 			// Validate products - filter out any with invalid/missing sellerPubkey
 			// This prevents count mismatch between badge and cart display
@@ -195,7 +233,22 @@ function loadInitialCart(): NormalizedCart {
 			return cart
 		}
 	}
-	return { sellers: {}, products: {}, orders: {}, invoices: {} }
+	return createEmptyNormalizedCart()
+}
+
+function loadInitialCartIntentUpdatedAt(): number | null {
+	if (typeof sessionStorage === 'undefined') return null
+
+	const raw = sessionStorage.getItem(CART_STORAGE_KEY)
+	if (!raw) return null
+
+	try {
+		const parsed = JSON.parse(raw) as Partial<LocalCartEnvelope>
+		const updatedAt = parsed?.updatedAt
+		return typeof updatedAt === 'number' && Number.isFinite(updatedAt) && updatedAt > 0 ? updatedAt : null
+	} catch {
+		return null
+	}
 }
 
 // Load cart and compute initial productsBySeller synchronously
@@ -207,9 +260,12 @@ const initialCartState: CartState = {
 	cart: loadedCart,
 	v4vShares: loadInitialV4VShares(),
 	productsBySeller: initialProductsBySeller,
+	lastCartIntentUpdatedAt: loadInitialCartIntentUpdatedAt(),
 }
 
 const numSatsInBtc = 100000000 // 100 million sats in 1 BTC
+let cartRemotePublishDebounceMs = 500
+let remotePublishTimeout: ReturnType<typeof setTimeout> | null = null
 
 export const cartStore = new Store<CartState>(initialCartState)
 
@@ -226,12 +282,53 @@ const cartQueryClient = new QueryClient({
 // Helper to check if an ID looks like a Nostr event ID (64-hex characters)
 const isEventId = (id: string): boolean => /^[a-f0-9]{64}$/i.test(id)
 
+type CartSyncDependencies = {
+	now: () => number
+	fetchLatestCartSnapshot: (userPubkey: string) => Promise<PersistedCartContent | null>
+	publishCartSnapshot: (snapshot: PersistedCartContent, signer: NDKSigner, ndk: NDK) => Promise<string>
+	getSigner: () => NDKSigner | undefined
+	getNDK: () => NDK | null
+	getProductEvent: (id: string, sellerPubkey?: string) => Promise<NDKEvent | null>
+	getShippingEvent: (shippingReferenceId: string) => Promise<NDKEvent | null>
+}
+
+function defaultNow(): number {
+	return Math.floor(Date.now() / 1000)
+}
+
+function clearRemotePublishTimeout() {
+	if (remotePublishTimeout) {
+		clearTimeout(remotePublishTimeout)
+		remotePublishTimeout = null
+	}
+}
+
+function toLocalCartEnvelope(cart: NormalizedCart, updatedAt: number | null): LocalCartEnvelope {
+	return {
+		version: LOCAL_CART_STORAGE_VERSION,
+		updatedAt,
+		cart,
+	}
+}
+
+function parseCoordinateRef(reference: string, expectedKind: string): { pubkey: string; identifier: string } | null {
+	const firstSeparator = reference.indexOf(':')
+	const secondSeparator = reference.indexOf(':', firstSeparator + 1)
+	if (firstSeparator <= 0 || secondSeparator <= firstSeparator + 1) return null
+	if (reference.slice(0, firstSeparator) !== expectedKind) return null
+
+	return {
+		pubkey: reference.slice(firstSeparator + 1, secondSeparator),
+		identifier: reference.slice(secondSeparator + 1),
+	}
+}
+
 /**
  * Fetches a product event by ID.
  * Supports both event IDs (64-hex characters) and d-tags.
  * For d-tags, the sellerPubkey is required.
  */
-const getProductEvent = async (id: string, sellerPubkey?: string): Promise<NDKEvent | null> => {
+const fetchProductEventFromQueries = async (id: string, sellerPubkey?: string): Promise<NDKEvent | null> => {
 	try {
 		// If it looks like an event ID (64 hex chars), query by event ID
 		if (isEventId(id)) {
@@ -254,7 +351,7 @@ const getProductEvent = async (id: string, sellerPubkey?: string): Promise<NDKEv
 	}
 }
 
-const getShippingEvent = async (shippingReferenceId: string): Promise<NDKEvent | null> => {
+const fetchShippingEventFromQueries = async (shippingReferenceId: string): Promise<NDKEvent | null> => {
 	try {
 		if (shippingReferenceId.startsWith(`${SHIPPING_KIND}:`)) {
 			const parts = shippingReferenceId.split(':')
@@ -276,10 +373,30 @@ const getShippingEvent = async (shippingReferenceId: string): Promise<NDKEvent |
 	}
 }
 
+const defaultCartSyncDependencies: CartSyncDependencies = {
+	now: defaultNow,
+	fetchLatestCartSnapshot,
+	publishCartSnapshot,
+	getSigner: () => ndkActions.getSigner(),
+	getNDK: () => ndkActions.getNDK() as NDK | null,
+	getProductEvent: fetchProductEventFromQueries,
+	getShippingEvent: fetchShippingEventFromQueries,
+}
+
+let cartSyncDependencies: CartSyncDependencies = {
+	...defaultCartSyncDependencies,
+}
+
+const getProductEvent = async (id: string, sellerPubkey?: string): Promise<NDKEvent | null> =>
+	cartSyncDependencies.getProductEvent(id, sellerPubkey)
+
+export const getShippingEvent = async (shippingReferenceId: string): Promise<NDKEvent | null> =>
+	cartSyncDependencies.getShippingEvent(shippingReferenceId)
+
 export const cartActions = {
-	saveToStorage: async (cart: NormalizedCart) => {
+	saveToStorage: async (cart: NormalizedCart, updatedAt: number | null = cartStore.state.lastCartIntentUpdatedAt) => {
 		if (typeof sessionStorage !== 'undefined') {
-			const serializableCart = JSON.parse(
+			const serializableCart: NormalizedCart = JSON.parse(
 				JSON.stringify({
 					sellers: cart.sellers,
 					products: cart.products,
@@ -288,13 +405,165 @@ export const cartActions = {
 				}),
 			)
 
-			sessionStorage.setItem('cart', JSON.stringify(serializableCart))
+			sessionStorage.setItem(CART_STORAGE_KEY, JSON.stringify(toLocalCartEnvelope(serializableCart, updatedAt)))
 		}
+	},
+
+	persistCartIntentLocally: (cart: NormalizedCart, updatedAt: number = cartSyncDependencies.now()) => {
+		cartActions.saveToStorage(cart, updatedAt)
+		return updatedAt
 	},
 
 	saveV4VSharesToStorage: (shares: Record<string, V4VDTO[]>) => {
 		if (typeof sessionStorage !== 'undefined') {
-			sessionStorage.setItem('v4vShares', JSON.stringify(shares))
+			sessionStorage.setItem(V4V_SHARES_STORAGE_KEY, JSON.stringify(shares))
+		}
+	},
+
+	scheduleRemotePublish: () => {
+		clearRemotePublishTimeout()
+
+		const state = cartStore.state
+		const signer = cartSyncDependencies.getSigner()
+		const ndk = cartSyncDependencies.getNDK()
+
+		if (!signer || !ndk) return
+		if (state.isReconcilingRemoteCart || state.suppressRemotePublish) return
+
+		remotePublishTimeout = setTimeout(async () => {
+			remotePublishTimeout = null
+
+			const latestState = cartStore.state
+			const latestSigner = cartSyncDependencies.getSigner()
+			const latestNdk = cartSyncDependencies.getNDK()
+
+			if (!latestSigner || !latestNdk) return
+			if (latestState.isReconcilingRemoteCart || latestState.suppressRemotePublish) return
+
+			try {
+				const snapshot = serializeCartIntent(latestState.cart)
+				await cartSyncDependencies.publishCartSnapshot(snapshot, latestSigner, latestNdk)
+				cartStore.setState((currentState) => ({
+					...currentState,
+					lastRemoteSnapshotUpdatedAt: snapshot.updatedAt,
+				}))
+			} catch (error) {
+				console.error('Failed to publish cart snapshot:', error)
+			}
+		}, cartRemotePublishDebounceMs)
+	},
+
+	applyRemoteCartLocally: async (cart: NormalizedCart, updatedAt: number) => {
+		clearRemotePublishTimeout()
+		const nextCart = {
+			...cartStore.state.cart,
+			sellers: cart.sellers,
+			products: cart.products,
+		}
+		cartStore.setState((state) => ({
+			...state,
+			cart: nextCart,
+			productsBySeller: computeProductsBySeller(cart.products),
+			lastCartIntentUpdatedAt: updatedAt,
+			lastRemoteSnapshotUpdatedAt: updatedAt,
+		}))
+		cartActions.persistCartIntentLocally(nextCart, updatedAt)
+		await cartActions.updateV4VShares()
+		await cartActions.updateSellerData()
+		await cartActions.fetchAndSetSellerShippingOptions()
+	},
+
+	reconcileRemoteCartForUser: async (pubkey: string, signer?: NDKSigner, ndk?: NDK | null) => {
+		if (!pubkey || !signer || !ndk) return
+
+		clearRemotePublishTimeout()
+		cartStore.setState((state) => ({
+			...state,
+			isReconcilingRemoteCart: true,
+			suppressRemotePublish: true,
+		}))
+
+		try {
+			const remoteSnapshot = await cartSyncDependencies.fetchLatestCartSnapshot(pubkey)
+			if (!remoteSnapshot) {
+				cartStore.setState((state) => ({
+					...state,
+					hasRemoteCartHydrated: true,
+					isReconcilingRemoteCart: false,
+					suppressRemotePublish: false,
+				}))
+				return
+			}
+
+			const normalizedRemote = normalizePersistedCart(remoteSnapshot)
+			const localUpdatedAt = cartStore.state.lastCartIntentUpdatedAt
+			const localHasItems = Object.keys(cartStore.state.cart.products).length > 0
+
+			let shouldAdoptRemote = false
+			if (!localHasItems) {
+				shouldAdoptRemote = true
+			} else if (localUpdatedAt && localUpdatedAt > 0) {
+				shouldAdoptRemote = normalizedRemote.updatedAt > localUpdatedAt
+			} else {
+				shouldAdoptRemote = false
+			}
+
+			if (shouldAdoptRemote) {
+				const liveProducts: Record<
+					string,
+					{ productRef: string; sellerPubkey: string; productId: string; shippingRefs: string[] }
+				> = {}
+				const liveShipping: Record<string, { shippingRef: string; sellerPubkey: string }> = {}
+
+				for (const item of normalizedRemote.items) {
+					const productCoords = parseCoordinateRef(item.productRef, '30402')
+					if (!productCoords) continue
+
+					const productEvent = await cartSyncDependencies.getProductEvent(productCoords.identifier, productCoords.pubkey)
+					const productDTag = getProductId(productEvent)
+					if (!productEvent || !productDTag || productEvent.pubkey !== productCoords.pubkey) continue
+
+					liveProducts[item.productRef] = {
+						productRef: item.productRef,
+						sellerPubkey: productEvent.pubkey,
+						productId: productDTag,
+						shippingRefs: productEvent.tags
+							.filter((tag) => tag[0] === 'shipping_option' && tag[1])
+							.map((tag) => tag[1]),
+					}
+
+					if (item.shippingRef && !liveShipping[item.shippingRef]) {
+						const shippingCoords = parseCoordinateRef(item.shippingRef, String(SHIPPING_KIND))
+						if (!shippingCoords) continue
+						const shippingEvent = await cartSyncDependencies.getShippingEvent(item.shippingRef)
+						if (!shippingEvent || shippingEvent.pubkey !== shippingCoords.pubkey) continue
+
+						liveShipping[item.shippingRef] = {
+							shippingRef: item.shippingRef,
+							sellerPubkey: shippingEvent.pubkey,
+						}
+					}
+				}
+
+				const rehydrated = rehydrateCartFromLiveData(normalizedRemote, liveProducts, liveShipping)
+				await cartActions.applyRemoteCartLocally(rehydrated.cart, rehydrated.updatedAt)
+			}
+
+			cartStore.setState((state) => ({
+				...state,
+				hasRemoteCartHydrated: true,
+				isReconcilingRemoteCart: false,
+				suppressRemotePublish: false,
+				lastRemoteSnapshotUpdatedAt: normalizedRemote.updatedAt,
+			}))
+		} catch (error) {
+			console.error('Failed to reconcile remote cart:', error)
+			cartStore.setState((state) => ({
+				...state,
+				hasRemoteCartHydrated: true,
+				isReconcilingRemoteCart: false,
+				suppressRemotePublish: false,
+			}))
 		}
 	},
 
@@ -339,6 +608,7 @@ export const cartActions = {
 		let productId: string
 		let sellerPubkey: string
 		let amount = 1
+		const updatedAt = cartSyncDependencies.now()
 
 		if (typeof productData === 'string') {
 			productId = productData
@@ -388,30 +658,34 @@ export const cartActions = {
 				seller.productIds.push(productId)
 			}
 
-			cartActions.saveToStorage(cart)
-			return { ...state, cart }
+			cartActions.persistCartIntentLocally(cart, updatedAt)
+			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
 		})
 
 		await cartActions.updateV4VShares()
 		await cartActions.groupProductsBySeller()
 		await cartActions.updateSellerData()
+		cartActions.scheduleRemotePublish()
 	},
 
 	updateProductAmount: async (buyerPubkey: string, productId: string, amount: number) => {
+		const updatedAt = cartSyncDependencies.now()
 		cartStore.setState((state) => {
 			const cart = { ...state.cart }
 			const product = cart.products[productId]
 			if (product) {
 				product.amount = amount
 			}
-			cartActions.saveToStorage(cart)
-			return { ...state, cart }
+			cartActions.persistCartIntentLocally(cart, updatedAt)
+			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
 		})
 
 		await cartActions.updateSellerData()
+		cartActions.scheduleRemotePublish()
 	},
 
 	removeProduct: async (buyerPubkey: string, productId: string) => {
+		const updatedAt = cartSyncDependencies.now()
 		cartStore.setState((state) => {
 			const cart = { ...state.cart }
 			const product = cart.products[productId]
@@ -430,18 +704,20 @@ export const cartActions = {
 
 			delete cart.products[productId]
 
-			cartActions.saveToStorage(cart)
-			return { ...state, cart }
+			cartActions.persistCartIntentLocally(cart, updatedAt)
+			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
 		})
 
 		await cartActions.updateV4VShares()
 		await cartActions.groupProductsBySeller()
 		await cartActions.updateSellerData()
+		cartActions.scheduleRemotePublish()
 	},
 
 	setShippingMethod: async (productId: string, shipping: Partial<RichShippingInfo>) => {
 		const prevState = cartStore.state
 		const prevProduct = prevState.cart.products[productId]
+		const updatedAt = cartSyncDependencies.now()
 
 		// Only update shipping for products that are already in the cart
 		// This prevents creating corrupted entries when ShippingSelector is used on product detail page
@@ -477,15 +753,17 @@ export const cartActions = {
 					},
 				},
 			}
-			cartActions.saveToStorage(newCart)
+			cartActions.persistCartIntentLocally(newCart, updatedAt)
 			return {
 				...state,
 				cart: newCart,
+				lastCartIntentUpdatedAt: updatedAt,
 			}
 		})
 
 		// Immediately update seller data to recalculate shipping costs
 		await cartActions.updateSellerData()
+		cartActions.scheduleRemotePublish()
 	},
 
 	getShippingMethod: (productId: string): string | null => {
@@ -493,19 +771,39 @@ export const cartActions = {
 		return state.cart.products[productId]?.shippingMethodId || null
 	},
 
-	clear: () => {
+	clear: (options?: { publishRemote?: boolean; reason?: 'explicit' | 'logout' | 'remote-reconcile' }) => {
+		const publishRemote = options?.publishRemote ?? false
+		const updatedAt = publishRemote ? cartSyncDependencies.now() : null
+
+		clearRemotePublishTimeout()
+
 		// Clear sessionStorage first to prevent reloading
 		if (typeof sessionStorage !== 'undefined') {
-			sessionStorage.removeItem('cart')
-			sessionStorage.removeItem('v4vShares')
+			sessionStorage.removeItem(V4V_SHARES_STORAGE_KEY)
+			if (updatedAt === null) {
+				sessionStorage.removeItem(CART_STORAGE_KEY)
+			} else {
+				sessionStorage.setItem(CART_STORAGE_KEY, JSON.stringify(toLocalCartEnvelope(createEmptyNormalizedCart(), updatedAt)))
+			}
 		}
 
 		// Reset cart store to initial state
-		cartStore.setState(() => ({
+		cartStore.setState((state) => ({
 			...initialState,
-			cart: { sellers: {}, products: {}, orders: {}, invoices: {} },
+			cart: createEmptyNormalizedCart(),
 			v4vShares: {},
+			hasRemoteCartHydrated: state.hasRemoteCartHydrated,
+			lastRemoteSnapshotUpdatedAt: state.lastRemoteSnapshotUpdatedAt,
+			lastCartIntentUpdatedAt: updatedAt,
 		}))
+
+		if (publishRemote) {
+			cartActions.scheduleRemotePublish()
+		}
+	},
+
+	clearForUserIntent: () => {
+		cartActions.clear({ publishRemote: true, reason: 'explicit' })
 	},
 
 	clearKeys: (keys: (keyof NormalizedCart)[]) => {
@@ -520,6 +818,7 @@ export const cartActions = {
 	},
 
 	handleProductUpdate: async (action: string, productId: string, amount?: number) => {
+		const updatedAt = cartSyncDependencies.now()
 		cartStore.setState((state) => {
 			const cart = { ...state.cart }
 			const product = cart.products[productId]
@@ -582,13 +881,14 @@ export const cartActions = {
 				}
 			}
 
-			cartActions.saveToStorage(cart)
-			return { ...state, cart }
+			cartActions.persistCartIntentLocally(cart, updatedAt)
+			return { ...state, cart, lastCartIntentUpdatedAt: updatedAt }
 		})
 
 		await cartActions.updateV4VShares()
 		await cartActions.groupProductsBySeller()
 		await cartActions.updateSellerData()
+		cartActions.scheduleRemotePublish()
 	},
 
 	convertToSats: async (currency: string, amount: number): Promise<number> => {
@@ -1363,6 +1663,43 @@ export const cartActions = {
 		cartStore.setState((state) => ({
 			...state,
 			sellerShippingOptions: newSellerShippingOptions,
+		}))
+	},
+}
+
+export const cartTestUtils = {
+	setSyncDependencies: (overrides: Partial<CartSyncDependencies>) => {
+		cartSyncDependencies = {
+			...cartSyncDependencies,
+			...overrides,
+		}
+	},
+	resetSyncDependencies: () => {
+		cartSyncDependencies = {
+			...defaultCartSyncDependencies,
+		}
+	},
+	setPublishDebounceMs: (value: number) => {
+		cartRemotePublishDebounceMs = value
+	},
+	clearScheduledRemotePublish: () => {
+		clearRemotePublishTimeout()
+	},
+	resetStore: () => {
+		clearRemotePublishTimeout()
+		if (typeof sessionStorage !== 'undefined') {
+			sessionStorage.removeItem(CART_STORAGE_KEY)
+			sessionStorage.removeItem(V4V_SHARES_STORAGE_KEY)
+		}
+		cartStore.setState(() => ({
+			...initialState,
+			cart: createEmptyNormalizedCart(),
+			v4vShares: {},
+			lastCartIntentUpdatedAt: null,
+			lastRemoteSnapshotUpdatedAt: null,
+			hasRemoteCartHydrated: false,
+			isReconcilingRemoteCart: false,
+			suppressRemotePublish: false,
 		}))
 	},
 }

--- a/src/publish/cart.tsx
+++ b/src/publish/cart.tsx
@@ -1,0 +1,19 @@
+import { ndkActions } from '@/lib/stores/ndk'
+import {
+	CART_PERSISTENCE_D_TAG,
+	CART_PERSISTENCE_KIND,
+	type PersistedCartContent,
+} from '@/lib/schemas/cartPersistence'
+import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
+
+export async function publishCartSnapshot(snapshot: PersistedCartContent, signer: NDKSigner, ndk: NDK): Promise<string> {
+	const event = new NDKEvent(ndk)
+	event.kind = CART_PERSISTENCE_KIND
+	event.content = JSON.stringify(snapshot)
+	event.tags = [['d', CART_PERSISTENCE_D_TAG]]
+
+	await event.sign(signer)
+	await ndkActions.publishEvent(event)
+
+	return event.id
+}

--- a/src/publish/cart.tsx
+++ b/src/publish/cart.tsx
@@ -1,9 +1,5 @@
 import { ndkActions } from '@/lib/stores/ndk'
-import {
-	CART_PERSISTENCE_D_TAG,
-	CART_PERSISTENCE_KIND,
-	type PersistedCartContent,
-} from '@/lib/schemas/cartPersistence'
+import { CART_PERSISTENCE_D_TAG, CART_PERSISTENCE_KIND, type PersistedCartContent } from '@/lib/schemas/cartPersistence'
 import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
 
 export async function publishCartSnapshot(snapshot: PersistedCartContent, signer: NDKSigner, ndk: NDK): Promise<string> {

--- a/src/queries/cart.tsx
+++ b/src/queries/cart.tsx
@@ -1,0 +1,42 @@
+import { chooseNewerCartSnapshot, normalizePersistedCart } from '@/lib/cart-persistence'
+import { ndkActions } from '@/lib/stores/ndk'
+import {
+	CART_PERSISTENCE_D_TAG,
+	CART_PERSISTENCE_KIND,
+	parseCartPersistenceContent,
+	type PersistedCartContent,
+} from '@/lib/schemas/cartPersistence'
+import { cartKeys } from '@/queries/queryKeyFactory'
+import { queryOptions } from '@tanstack/react-query'
+
+export { cartKeys }
+
+export async function fetchLatestCartSnapshot(userPubkey: string): Promise<PersistedCartContent | null> {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	if (!userPubkey) return null
+
+	const events = await ndkActions.fetchEventsWithTimeout({
+		kinds: [CART_PERSISTENCE_KIND],
+		authors: [userPubkey],
+		'#d': [CART_PERSISTENCE_D_TAG],
+		limit: 20,
+	})
+
+	const latestEvent = chooseNewerCartSnapshot(Array.from(events))
+	if (!latestEvent) return null
+
+	const parsed = parseCartPersistenceContent(latestEvent.content)
+	if (!parsed) return null
+
+	return normalizePersistedCart(parsed)
+}
+
+export const cartSnapshotQueryOptions = (userPubkey: string) =>
+	queryOptions({
+		queryKey: cartKeys.byPubkey(userPubkey),
+		queryFn: () => fetchLatestCartSnapshot(userPubkey),
+		enabled: !!userPubkey,
+		staleTime: 60 * 1000,
+		gcTime: 5 * 60 * 1000,
+	})

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -33,9 +33,12 @@ export { productKeys }
 // Persisted to localStorage so deletions survive page reloads.
 
 const DELETED_PRODUCTS_STORAGE_KEY = 'plebeian_deleted_product_ids'
+const hasLocalStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
 // Map of d-tag -> deletion timestamp (unix seconds)
 const loadDeletedProductIds = (): Map<string, number> => {
+	if (!hasLocalStorage()) return new Map()
+
 	try {
 		const stored = localStorage.getItem(DELETED_PRODUCTS_STORAGE_KEY)
 		if (stored) {
@@ -57,6 +60,8 @@ const loadDeletedProductIds = (): Map<string, number> => {
 }
 
 const saveDeletedProductIds = (ids: Map<string, number>) => {
+	if (!hasLocalStorage()) return
+
 	try {
 		localStorage.setItem(DELETED_PRODUCTS_STORAGE_KEY, JSON.stringify(Object.fromEntries(ids)))
 	} catch (e) {

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -133,3 +133,8 @@ export const migrationKeys = {
 	nip15Products: (userPubkey: string) => [...migrationKeys.all, 'nip15Products', userPubkey] as const,
 	migratedEvents: (userPubkey: string) => [...migrationKeys.all, 'migratedEvents', userPubkey] as const,
 } as const
+
+export const cartKeys = {
+	all: ['cart'] as const,
+	byPubkey: (pubkey: string) => [...cartKeys.all, 'byPubkey', pubkey] as const,
+} as const

--- a/src/queries/shipping.tsx
+++ b/src/queries/shipping.tsx
@@ -18,9 +18,12 @@ export { shippingKeys }
 // Persisted to localStorage so deletions survive page reloads.
 
 const DELETED_SHIPPING_STORAGE_KEY = 'plebeian_deleted_shipping_ids'
+const hasLocalStorage = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
 // Map of d-tag -> deletion timestamp (unix seconds)
 const loadDeletedShippingIds = (): Map<string, number> => {
+	if (!hasLocalStorage()) return new Map()
+
 	try {
 		const stored = localStorage.getItem(DELETED_SHIPPING_STORAGE_KEY)
 		if (stored) {
@@ -42,6 +45,8 @@ const loadDeletedShippingIds = (): Map<string, number> => {
 }
 
 const saveDeletedShippingIds = (ids: Map<string, number>) => {
+	if (!hasLocalStorage()) return
+
 	try {
 		localStorage.setItem(DELETED_SHIPPING_STORAGE_KEY, JSON.stringify(Object.fromEntries(ids)))
 	} catch (e) {


### PR DESCRIPTION
## Summary

This adds cross-device cart persistence using a single application-specific replaceable snapshot.

## What this does

- persists cart intent using a `30078` app-data snapshot with a stable `d` tag
- stores only:
  - `productRef`
  - `quantity`
  - optional `shippingRef`
  - `updatedAt`
  - `version`
- rehydrates cart state against live product/shipping data
- uses last-write-wins snapshot semantics
- avoids publishing an empty remote cart on logout

## What this does not do

This does **not** persist:

- prices
- totals
- payment state
- wallet state
- buyer contact/address data
- derived checkout state

## Design notes

- local cart remains the immediate UI source of truth
- remote snapshot is used for persistence/sync only
- restore path validates and normalizes persisted state before rehydrating
- invalid/missing products are dropped during restore
- invalid shipping selections are cleared rather than trusted

## Why this is structured this way

This issue is about cross-device cart persistence, not a full cart event log. A single replaceable snapshot keeps the implementation small, reviewable, and aligned with current store/query/publish boundaries.

## Validation

- targeted cart tests passed
- manual smoke test passed in a second browser context using the same signer
- add-to-cart flow remained stable after integrating remote persistence

## Base branch

This PR is based on `pr/fix-server-safe-localstorage` for runtime stability during review. Once that base branch merges, this PR can be retargeted to `master`.

Note: this branch currently includes the small runtime fix from PR #2 (`fix(queries): guard browser localStorage in shared query modules`). Once that base fix merges, this PR can be rebased or retargeted to show only the cart feature delta.