### PR TITLE
feat: add top-level product comments for listings

### DIFF
--- a/src/components/products/ProductCommentsPanel.test.tsx
+++ b/src/components/products/ProductCommentsPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import { ProductCommentsPanelContent } from '@/components/products/ProductCommentsPanel'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+describe('ProductCommentsPanelContent', () => {
+	test('renders loading state', () => {
+		const html = renderToStaticMarkup(
+			<ProductCommentsPanelContent
+				comments={[]}
+				isLoading
+				canCompose={false}
+				isPending={false}
+				draft=""
+				onDraftChange={() => {}}
+				onPublish={() => {}}
+			/>,
+		)
+
+		expect(html).toContain('Loading comments')
+	})
+
+	test('renders empty state and unauthenticated prompt', () => {
+		const html = renderToStaticMarkup(
+			<ProductCommentsPanelContent
+				comments={[]}
+				isLoading={false}
+				canCompose={false}
+				isPending={false}
+				draft=""
+				onDraftChange={() => {}}
+				onPublish={() => {}}
+			/>,
+		)
+
+		expect(html).toContain('No comments yet.')
+		expect(html).toContain('Connect a Nostr signer to post a comment.')
+	})
+})

--- a/src/components/products/ProductCommentsPanel.tsx
+++ b/src/components/products/ProductCommentsPanel.tsx
@@ -1,0 +1,137 @@
+import { AvatarUser } from '@/components/AvatarUser'
+import { ProfileName } from '@/components/ProfileName'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { ndkStore } from '@/lib/stores/ndk'
+import { publishProductComment } from '@/publish/productComments'
+import { productCommentKeys } from '@/queries/queryKeyFactory'
+import { MAX_COMMENT_LENGTH, useProductComments } from '@/queries/productComments'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useStore } from '@tanstack/react-store'
+import { useState } from 'react'
+import { toast } from 'sonner'
+
+interface ProductCommentsPanelProps {
+	productCoords: string
+	merchantPubkey: string
+}
+
+interface ProductCommentsPanelContentProps {
+	comments: NDKEvent[]
+	isLoading: boolean
+	canCompose: boolean
+	isPending: boolean
+	draft: string
+	onDraftChange: (value: string) => void
+	onPublish: () => void
+}
+
+const formatCommentTimestamp = (createdAt?: number): string | null => {
+	if (!createdAt) return null
+	return new Date(createdAt * 1000).toISOString()
+}
+
+export function ProductCommentsPanelContent({
+	comments,
+	isLoading,
+	canCompose,
+	isPending,
+	draft,
+	onDraftChange,
+	onPublish,
+}: ProductCommentsPanelContentProps) {
+	if (isLoading) {
+		return (
+			<div className="rounded-lg bg-white p-6 shadow-md" data-testid="product-comments-loading">
+				<p className="text-gray-600">Loading comments…</p>
+			</div>
+		)
+	}
+
+	return (
+		<div className="rounded-lg bg-white p-6 shadow-md space-y-6">
+			<div className="space-y-3">
+				<h3 className="text-lg font-medium">Comments</h3>
+				{canCompose ? (
+					<div className="space-y-3">
+						<Textarea
+							value={draft}
+							onChange={(event) => onDraftChange(event.target.value)}
+							placeholder="Share a comment about this product"
+							maxLength={MAX_COMMENT_LENGTH}
+							rows={4}
+							disabled={isPending}
+						/>
+						<div className="flex items-center justify-between gap-3">
+							<p className="text-sm text-gray-500">
+								{draft.trim().length}/{MAX_COMMENT_LENGTH}
+							</p>
+							<Button onClick={onPublish} disabled={isPending || draft.trim().length === 0}>
+								{isPending ? 'Posting…' : 'Post comment'}
+							</Button>
+						</div>
+					</div>
+				) : (
+					<p className="text-sm text-gray-600" data-testid="product-comments-auth-required">
+						Connect a Nostr signer to post a comment.
+					</p>
+				)}
+			</div>
+
+			<div className="space-y-4" data-testid="product-comments-list">
+				{comments.length === 0 ? (
+					<p className="text-gray-600" data-testid="product-comments-empty">
+						No comments yet.
+					</p>
+				) : (
+					comments.map((comment) => (
+						<div key={comment.id} className="border border-gray-200 rounded-lg p-4 space-y-3">
+							<div className="flex items-center gap-3">
+								<AvatarUser pubkey={comment.pubkey} className="w-8 h-8" />
+								<div className="min-w-0">
+									<ProfileName pubkey={comment.pubkey} className="font-medium text-gray-900" />
+									{formatCommentTimestamp(comment.created_at) && (
+										<p className="text-xs text-gray-500">{formatCommentTimestamp(comment.created_at)}</p>
+									)}
+								</div>
+							</div>
+							<p className="whitespace-pre-wrap break-words text-gray-700">{comment.content}</p>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	)
+}
+
+export function ProductCommentsPanel({ productCoords, merchantPubkey }: ProductCommentsPanelProps) {
+	const queryClient = useQueryClient()
+	const canCompose = useStore(ndkStore, (state) => Boolean(state.signer))
+	const [draft, setDraft] = useState('')
+	const commentsQuery = useProductComments(productCoords, merchantPubkey)
+
+	const publishMutation = useMutation({
+		mutationFn: () => publishProductComment(productCoords, merchantPubkey, draft),
+		onSuccess: async () => {
+			setDraft('')
+			await queryClient.invalidateQueries({ queryKey: productCommentKeys.list(productCoords) })
+			toast.success('Comment posted')
+		},
+		onError: (error) => {
+			toast.error(error instanceof Error ? error.message : 'Failed to post comment')
+		},
+	})
+
+	return (
+		<ProductCommentsPanelContent
+			comments={commentsQuery.data ?? []}
+			isLoading={commentsQuery.isLoading}
+			canCompose={canCompose}
+			isPending={publishMutation.isPending}
+			draft={draft}
+			onDraftChange={setDraft}
+			onPublish={() => publishMutation.mutate()}
+		/>
+	)
+}

--- a/src/lib/schemas/productComment.test.ts
+++ b/src/lib/schemas/productComment.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+import { isValidTopLevelComment, MAX_COMMENT_LENGTH, PRODUCT_COMMENT_KIND } from '@/lib/schemas/productComment'
+
+const productCoords = `30402:${'a'.repeat(64)}:product-1`
+const merchantPubkey = 'b'.repeat(64)
+
+const createEvent = (overrides: Record<string, unknown> = {}) =>
+	({
+		kind: PRODUCT_COMMENT_KIND,
+		content: 'Solid product',
+		pubkey: 'c'.repeat(64),
+		tags: [
+			['A', productCoords],
+			['K', '30402'],
+			['P', merchantPubkey],
+			['a', productCoords],
+			['k', '30402'],
+			['p', merchantPubkey],
+		],
+		...overrides,
+	}) as any
+
+describe('productComment schema', () => {
+	test('accepts a valid top-level product comment', () => {
+		expect(isValidTopLevelComment(createEvent(), productCoords, merchantPubkey)).toBe(true)
+	})
+
+	test('rejects empty and overlong content', () => {
+		expect(isValidTopLevelComment(createEvent({ content: '   ' }), productCoords, merchantPubkey)).toBe(false)
+		expect(isValidTopLevelComment(createEvent({ content: 'x'.repeat(MAX_COMMENT_LENGTH + 1) }), productCoords, merchantPubkey)).toBe(false)
+	})
+
+	test('rejects invalid or mismatched structural tags', () => {
+		expect(
+			isValidTopLevelComment(
+				createEvent({
+					tags: [
+						['A', productCoords],
+						['K', '30402'],
+						['P', merchantPubkey],
+						['a', productCoords],
+						['k', '30402'],
+					],
+				}),
+				productCoords,
+				merchantPubkey,
+			),
+		).toBe(false)
+
+		expect(
+			isValidTopLevelComment(
+				createEvent({
+					tags: [
+						['A', `${productCoords}-wrong`],
+						['K', '30402'],
+						['P', merchantPubkey],
+						['a', productCoords],
+						['k', '30402'],
+						['p', merchantPubkey],
+					],
+				}),
+				productCoords,
+				merchantPubkey,
+			),
+		).toBe(false)
+
+		expect(
+			isValidTopLevelComment(
+				createEvent({
+					tags: [
+						['A', productCoords],
+						['K', '30402'],
+						['P', merchantPubkey],
+						['a', productCoords],
+						['k', '30402'],
+						['p', merchantPubkey],
+						['e', 'unexpected'],
+					],
+				}),
+				productCoords,
+				merchantPubkey,
+			),
+		).toBe(false)
+	})
+
+	test('rejects duplicate structural tags', () => {
+		expect(
+			isValidTopLevelComment(
+				createEvent({
+					tags: [
+						['A', productCoords],
+						['A', productCoords],
+						['K', '30402'],
+						['P', merchantPubkey],
+						['a', productCoords],
+						['k', '30402'],
+						['p', merchantPubkey],
+					],
+				}),
+				productCoords,
+				merchantPubkey,
+			),
+		).toBe(false)
+	})
+})

--- a/src/lib/schemas/productComment.ts
+++ b/src/lib/schemas/productComment.ts
@@ -1,0 +1,46 @@
+import type { NDKEvent, NDKTag } from '@nostr-dev-kit/ndk'
+
+export const MAX_COMMENT_LENGTH = 1000
+export const PRODUCT_COMMENT_KIND = 1111
+
+const REQUIRED_TAG_KEYS = ['A', 'K', 'P', 'a', 'k', 'p'] as const
+
+type ProductCommentEventLike = Pick<NDKEvent, 'kind' | 'content' | 'pubkey' | 'tags'>
+
+const getSingleTagValue = (tags: NDKTag[], key: (typeof REQUIRED_TAG_KEYS)[number]): string | null => {
+	const matches = tags.filter((tag) => tag[0] === key)
+	if (matches.length !== 1) return null
+	return matches[0]?.[1] ?? null
+}
+
+export const isValidTopLevelComment = (event: ProductCommentEventLike, productCoords: string, merchantPubkey: string): boolean => {
+	if (event.kind !== PRODUCT_COMMENT_KIND) return false
+
+	const trimmedContent = event.content.trim()
+	if (!trimmedContent) return false
+	if (trimmedContent.length > MAX_COMMENT_LENGTH) return false
+
+	if (event.tags.length !== REQUIRED_TAG_KEYS.length) return false
+
+	for (const key of REQUIRED_TAG_KEYS) {
+		if (event.tags.filter((tag) => tag[0] === key).length !== 1) {
+			return false
+		}
+	}
+
+	const rootCoordsUpper = getSingleTagValue(event.tags, 'A')
+	const rootKindUpper = getSingleTagValue(event.tags, 'K')
+	const rootPubkeyUpper = getSingleTagValue(event.tags, 'P')
+	const rootCoordsLower = getSingleTagValue(event.tags, 'a')
+	const rootKindLower = getSingleTagValue(event.tags, 'k')
+	const rootPubkeyLower = getSingleTagValue(event.tags, 'p')
+
+	return (
+		rootCoordsUpper === productCoords &&
+		rootCoordsLower === productCoords &&
+		rootKindUpper === '30402' &&
+		rootKindLower === '30402' &&
+		rootPubkeyUpper === merchantPubkey &&
+		rootPubkeyLower === merchantPubkey
+	)
+}

--- a/src/publish/productComments.test.ts
+++ b/src/publish/productComments.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { NDKEvent } from '@nostr-dev-kit/ndk'
+import { MAX_COMMENT_LENGTH } from '@/lib/schemas/productComment'
+import { ndkActions } from '@/lib/stores/ndk'
+import { createProductCommentEvent, publishProductComment } from '@/publish/productComments'
+
+const productCoords = `30402:${'a'.repeat(64)}:product-1`
+const merchantPubkey = 'b'.repeat(64)
+
+describe('product comment publishing', () => {
+	const originalGetNdk = ndkActions.getNDK
+	const originalGetSigner = ndkActions.getSigner
+	const originalPublishEvent = ndkActions.publishEvent
+	const originalSign = NDKEvent.prototype.sign
+
+	beforeEach(() => {
+		ndkActions.getNDK = mock(() => ({}) as any)
+		ndkActions.getSigner = mock(() => ({ user: async () => ({ pubkey: 'c'.repeat(64) }) }) as any)
+		ndkActions.publishEvent = mock(async () => new Set()) as any
+		NDKEvent.prototype.sign = mock(async function (this: NDKEvent) {
+			this.id = 'published-comment-id'
+			return 'sig'
+		}) as any
+	})
+
+	afterEach(() => {
+		ndkActions.getNDK = originalGetNdk
+		ndkActions.getSigner = originalGetSigner
+		ndkActions.publishEvent = originalPublishEvent
+		NDKEvent.prototype.sign = originalSign
+	})
+
+	test('builds the exact six v1 structural tags', () => {
+		const event = createProductCommentEvent(productCoords, merchantPubkey, 'Hello world', {} as any)
+
+		expect(event.kind).toBe(1111)
+		expect(event.content).toBe('Hello world')
+		expect(event.tags).toEqual([
+			['A', productCoords],
+			['K', '30402'],
+			['P', merchantPubkey],
+			['a', productCoords],
+			['k', '30402'],
+			['p', merchantPubkey],
+		])
+	})
+
+	test('rejects empty and overlong comments before publish', async () => {
+		await expect(publishProductComment(productCoords, merchantPubkey, '   ')).rejects.toThrow('Comment cannot be empty')
+		await expect(publishProductComment(productCoords, merchantPubkey, 'x'.repeat(MAX_COMMENT_LENGTH + 1))).rejects.toThrow(
+			`Comment cannot exceed ${MAX_COMMENT_LENGTH} characters`,
+		)
+	})
+
+	test('signs and publishes through ndkActions.publishEvent', async () => {
+		const commentId = await publishProductComment(productCoords, merchantPubkey, '  Valid comment  ')
+
+		expect(commentId).toBe('published-comment-id')
+		expect(ndkActions.publishEvent).toHaveBeenCalledTimes(1)
+		const publishedEvent = (ndkActions.publishEvent as any).mock.calls[0][0]
+		expect(publishedEvent.content).toBe('Valid comment')
+		expect(publishedEvent.tags).toHaveLength(6)
+	})
+})

--- a/src/publish/productComments.ts
+++ b/src/publish/productComments.ts
@@ -1,0 +1,48 @@
+import { MAX_COMMENT_LENGTH, PRODUCT_COMMENT_KIND } from '@/lib/schemas/productComment'
+import { ndkActions } from '@/lib/stores/ndk'
+import NDK, { NDKEvent, type NDKTag } from '@nostr-dev-kit/ndk'
+
+export type PublishedProductCommentId = string
+
+export const createProductCommentEvent = (productCoords: string, merchantPubkey: string, content: string, ndk: NDK): NDKEvent => {
+	const event = new NDKEvent(ndk)
+	event.kind = PRODUCT_COMMENT_KIND
+	event.content = content
+	event.tags = [
+		['A', productCoords],
+		['K', '30402'],
+		['P', merchantPubkey],
+		['a', productCoords],
+		['k', '30402'],
+		['p', merchantPubkey],
+	] satisfies NDKTag[]
+	return event
+}
+
+/**
+ * Publishes a comment and returns the signed comment event id.
+ */
+export const publishProductComment = async (
+	productCoords: string,
+	merchantPubkey: string,
+	rawContent: string,
+): Promise<PublishedProductCommentId> => {
+	const content = rawContent.trim()
+	if (!productCoords) throw new Error('Product coordinates are required')
+	if (!merchantPubkey) throw new Error('Merchant pubkey is required')
+	if (!content) throw new Error('Comment cannot be empty')
+	if (content.length > MAX_COMMENT_LENGTH) throw new Error(`Comment cannot exceed ${MAX_COMMENT_LENGTH} characters`)
+
+	const ndk = ndkActions.getNDK()
+	const signer = ndkActions.getSigner()
+
+	if (!ndk) throw new Error('NDK not initialized')
+	if (!signer) throw new Error('No signer available')
+
+	const event = createProductCommentEvent(productCoords, merchantPubkey, content, ndk)
+	await event.sign(signer)
+	await ndkActions.publishEvent(event)
+	if (!event.id) throw new Error('Comment publish did not produce an event id')
+
+	return event.id
+}

--- a/src/queries/productComments.test.ts
+++ b/src/queries/productComments.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { ndkActions } from '@/lib/stores/ndk'
+import { blacklistActions } from '@/lib/stores/blacklist'
+import { fetchProductComments } from '@/queries/productComments'
+
+const productCoords = `30402:${'a'.repeat(64)}:product-1`
+const merchantPubkey = 'b'.repeat(64)
+
+const validEvent = {
+	id: 'event-1',
+	kind: 1111,
+	content: 'Newest valid comment',
+	pubkey: 'c'.repeat(64),
+	created_at: 200,
+	tags: [
+		['A', productCoords],
+		['K', '30402'],
+		['P', merchantPubkey],
+		['a', productCoords],
+		['k', '30402'],
+		['p', merchantPubkey],
+	],
+}
+
+describe('fetchProductComments', () => {
+	const originalGetNdk = ndkActions.getNDK
+	const originalFetchEventsWithTimeout = ndkActions.fetchEventsWithTimeout
+	const originalIsBlacklistLoaded = blacklistActions.isBlacklistLoaded
+	const originalIsPubkeyBlacklisted = blacklistActions.isPubkeyBlacklisted
+
+	beforeEach(() => {
+		ndkActions.getNDK = mock(() => ({}) as any)
+		blacklistActions.isBlacklistLoaded = mock(() => true)
+		blacklistActions.isPubkeyBlacklisted = mock((pubkey: string) => pubkey === 'd'.repeat(64))
+	})
+
+	afterEach(() => {
+		ndkActions.getNDK = originalGetNdk
+		ndkActions.fetchEventsWithTimeout = originalFetchEventsWithTimeout
+		blacklistActions.isBlacklistLoaded = originalIsBlacklistLoaded
+		blacklistActions.isPubkeyBlacklisted = originalIsPubkeyBlacklisted
+	})
+
+	test('filters invalid comments, blacklisted authors, dedupes by id, and sorts newest first', async () => {
+		ndkActions.fetchEventsWithTimeout = mock(
+			async () =>
+				new Set([
+					validEvent,
+					{ ...validEvent, id: 'event-1', created_at: 150, content: 'Older duplicate' },
+					{ ...validEvent, id: 'event-2', created_at: 175, content: 'Second valid comment' },
+					{ ...validEvent, id: 'event-3', pubkey: 'd'.repeat(64), content: 'Blocked author' },
+					{ ...validEvent, id: 'event-4', tags: [['a', productCoords]] },
+				] as any[]),
+		) as any
+
+		const result = await fetchProductComments(productCoords, merchantPubkey)
+
+		expect(result.map((event) => event.id)).toEqual(['event-1', 'event-2'])
+		expect(result[0]?.content).toBe('Newest valid comment')
+	})
+
+	test('returns an empty array when ndk is unavailable', async () => {
+		ndkActions.getNDK = mock(() => null as any)
+
+		await expect(fetchProductComments(productCoords, merchantPubkey)).resolves.toEqual([])
+	})
+})

--- a/src/queries/productComments.tsx
+++ b/src/queries/productComments.tsx
@@ -1,0 +1,51 @@
+import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
+import { MAX_COMMENT_LENGTH, isValidTopLevelComment, PRODUCT_COMMENT_KIND } from '@/lib/schemas/productComment'
+import { ndkActions } from '@/lib/stores/ndk'
+import { productCommentKeys } from './queryKeyFactory'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import type { NDKFilter, NDKEvent } from '@nostr-dev-kit/ndk'
+
+export { MAX_COMMENT_LENGTH }
+
+export const fetchProductComments = async (productCoords: string, merchantPubkey: string): Promise<NDKEvent[]> => {
+	if (!productCoords || !merchantPubkey) return []
+
+	const ndk = ndkActions.getNDK()
+	if (!ndk) {
+		console.warn('NDK not ready, returning empty product comments list')
+		return []
+	}
+
+	const filter: NDKFilter = {
+		kinds: [PRODUCT_COMMENT_KIND],
+		'#a': [productCoords],
+		limit: 100,
+	}
+
+	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
+	const filtered = filterBlacklistedEvents(Array.from(events)).filter((event) =>
+		isValidTopLevelComment(event, productCoords, merchantPubkey),
+	)
+	const dedupedById = new Map<string, NDKEvent>()
+
+	for (const event of filtered) {
+		if (!event.id) continue
+		const existing = dedupedById.get(event.id)
+		if (!existing || (event.created_at ?? 0) >= (existing.created_at ?? 0)) {
+			dedupedById.set(event.id, event)
+		}
+	}
+
+	return Array.from(dedupedById.values()).sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
+}
+
+export const productCommentsQueryOptions = (productCoords: string, merchantPubkey: string) =>
+	queryOptions({
+		queryKey: productCommentKeys.list(productCoords),
+		queryFn: () => fetchProductComments(productCoords, merchantPubkey),
+		enabled: !!productCoords && !!merchantPubkey,
+		staleTime: 30000,
+	})
+
+export const useProductComments = (productCoords: string, merchantPubkey: string) =>
+	useQuery(productCommentsQueryOptions(productCoords, merchantPubkey))

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -50,6 +50,11 @@ export const postKeys = {
 	details: (id: string) => [...postKeys.all, id] as const,
 } as const
 
+export const productCommentKeys = {
+	all: ['productComments'] as const,
+	list: (productCoords: string) => [...productCommentKeys.all, productCoords] as const,
+} as const
+
 export const userKeys = {
 	all: ['users'] as const,
 	details: (pubkey: string) => ['user', pubkey] as const,

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -5,6 +5,7 @@ import { ImageViewerModal } from '@/components/ImageViewerModal'
 import { ItemGrid } from '@/components/ItemGrid'
 import { PriceDisplay } from '@/components/PriceDisplay'
 import { ProductCard } from '@/components/ProductCard'
+import { ProductCommentsPanel } from '@/components/products/ProductCommentsPanel'
 import { ShippingSelector } from '@/components/ShippingSelector'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -626,7 +627,6 @@ function RouteComponent() {
 								<TabsTrigger
 									value="comments"
 									className="px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-									disabled
 								>
 									Comments
 								</TabsTrigger>
@@ -742,6 +742,10 @@ function RouteComponent() {
 										</div>
 									</div>
 								</div>
+							</TabsContent>
+
+							<TabsContent value="comments" className="mt-4 border-t-3 border-secondary bg-tertiary">
+								<ProductCommentsPanel productCoords={productCoords} merchantPubkey={product.pubkey} />
 							</TabsContent>
 						</Tabs>
 					)}


### PR DESCRIPTION
## Summary

Implements Issue #460 by enabling top-level product comments on the product detail page.

## What changed

- Added NIP-22-based product comment schema validation with strict six-tag v1 invariants
- Added product comment query keys and bounded comment fetching
- Added product comment publish flow through repo-native NDK actions
- Added ProductCommentsPanel UI and enabled the Comments tab on product pages
- Added focused tests for schema, query, publish, and panel behavior

## Scope

This PR intentionally supports top-level comments only.
It does not add replies, ratings/reviews, pagination, deletion UI, trust partitioning, or relay-routing changes.

## Notes

- Comments are scoped to the product coordinate
- Publish requires an available signer
- Comment timestamps are rendered deterministically