### PR TITLE
fix(ui): remove nested profile links and stabilize UserCard hooks

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -1,8 +1,6 @@
 import { uiActions } from '@/lib/stores/ui'
 import { getCollectionId, getCollectionImages, getCollectionSummary, getCollectionTitle } from '@/queries/collections.tsx'
-import { profileByIdentifierQueryOptions, useProfileName } from '@/queries/profiles'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
-import { useQuery } from '@tanstack/react-query'
 import { Link, useLocation } from '@tanstack/react-router'
 import { UserCard } from './UserCard'
 
@@ -12,7 +10,6 @@ export function CollectionCard({ collection }: { collection: NDKEvent }) {
 	const pubkey = collection.pubkey
 	const summary = getCollectionSummary(collection)
 	const images = getCollectionImages(collection)
-	const { data: name, isLoading } = useProfileName(pubkey)
 	const location = useLocation()
 
 	const handleCollectionClick = () => {
@@ -20,12 +17,6 @@ export function CollectionCard({ collection }: { collection: NDKEvent }) {
 		// This will also store it as originalResultsPath if not already set
 		uiActions.setCollectionSourcePath(location.pathname)
 	}
-	const { data: profileData, isLoading: isLoadingProfile } = useQuery({
-		...profileByIdentifierQueryOptions(pubkey),
-		enabled: !!pubkey,
-	})
-	const { profile, user } = profileData || {}
-
 	return (
 		<div className="border border-zinc-800 rounded-lg bg-white shadow-sm flex flex-col" data-testid="product-card">
 			{/* Square aspect ratio container for image */}
@@ -58,11 +49,9 @@ export function CollectionCard({ collection }: { collection: NDKEvent }) {
 
 				{/* Add a flex spacer to push the collection author to the bottom */}
 				<div className="flex-grow"></div>
-				<Link to={`/profile/${pubkey}`}>
-					<div className="text-sm flex flex-row items-center gap-2">
-						by <UserCard pubkey={pubkey} size="xs" />
-					</div>
-				</Link>
+				<div className="text-sm flex flex-row items-center gap-2">
+					by <UserCard pubkey={pubkey} size="xs" />
+				</div>
 			</div>
 		</div>
 	)

--- a/src/components/Nip05Badge.tsx
+++ b/src/components/Nip05Badge.tsx
@@ -1,6 +1,6 @@
-import { getProfileNip05, nip05ValidationQueryOptions, useProfile } from '@/queries/profiles'
+import { nip05ValidationQueryOptions, useProfile } from '@/queries/profiles'
 import { useQuery } from '@tanstack/react-query'
-import { BadgeAlert, BadgeCheck, CircleQuestionMark, Loader2 } from 'lucide-react'
+import { BadgeAlert, BadgeCheck, Loader2 } from 'lucide-react'
 
 interface Nip05BadgeProps {
 	pubkey?: string
@@ -21,17 +21,20 @@ function elideNip05Address(nip05: string): string {
 }
 
 export function Nip05Badge({ pubkey, className = '', showAddress = true }: Nip05BadgeProps) {
-	if (pubkey == null) return null
-
-	const { data: profile, error } = useProfile(pubkey)
+	const safePubkey = pubkey ?? ''
+	const { data: profile } = useProfile(safePubkey)
 	const nip05 = profile?.profile?.nip05
+	const shouldValidate = Boolean(safePubkey && nip05 && nip05.length > 0)
+
+	const { data: isVerified, isLoading } = useQuery({
+		...nip05ValidationQueryOptions(safePubkey),
+		enabled: shouldValidate,
+	})
 
 	// Handle "no NIP-05" case - no badge, no text
-	if (profile == null || nip05 == null || nip05.length == 0) {
+	if (!safePubkey || profile == null || nip05 == null || nip05.length == 0) {
 		return null
 	}
-
-	const { data: isVerified, isLoading } = useQuery(nip05ValidationQueryOptions(pubkey))
 
 	return (
 		<div className="flex items-end gap-1">

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,12 +1,10 @@
-import { profileByIdentifierQueryOptions, useProfile } from '@/queries/profiles'
+import { useProfile } from '@/queries/profiles'
 import { AvatarUser } from './AvatarUser'
-import { useSuspenseQuery } from 'node_modules/@tanstack/react-query/build/modern/useSuspenseQuery'
 import { useState } from 'react'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { Nip05Badge } from './Nip05Badge'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Link, useNavigate } from '@tanstack/react-router'
-import { authStore, useAuth } from '@/lib/stores/auth'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Link } from '@tanstack/react-router'
 
 interface UserCardProps {
 	pubkey: string
@@ -18,8 +16,8 @@ interface UserCardProps {
 }
 
 export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
-	const { data: profileData, error } = useProfile(pubkey)
-	const { profile, user } = profileData || {}
+	const { data: profileData } = useProfile(pubkey)
+	const { user } = profileData || {}
 
 	const breakpoint = useBreakpoint()
 	const compact = breakpoint === 'md' || breakpoint === 'sm'
@@ -135,7 +133,9 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 					) : (
 						<h2 className={classSizeName + ' truncate min-w-0 ' + className}>{textTitle}</h2>
 					)}
-					<Nip05Badge pubkey={user?.pubkey} className={classSizeNIP05 + ' ' + className} showAddress={showNip05AddressAfterBadge} />
+					{user?.pubkey && (
+						<Nip05Badge pubkey={user.pubkey} className={classSizeNIP05 + ' ' + className} showAddress={showNip05AddressAfterBadge} />
+					)}
 				</div>
 
 				{showSubtitle &&


### PR DESCRIPTION
## Summary

Fixes local React/hydration warnings in the collection author card path.

## What changed

- Removed nested profile link composition in `CollectionCard` so `UserCard` remains the single source of profile navigation for the author row
- Stabilized hook ordering in `Nip05Badge` by keeping hooks unconditional and gating validation with React Query `enabled`
- Updated `UserCard` to only mount `Nip05Badge` when a real `user.pubkey` exists
- Removed a few dead imports in `UserCard` / `Nip05Badge`

## Why

The collection card path was triggering:

- invalid nested anchor warnings (`<a>` inside `<a>`)
- React dev warnings in the `UserCard -> Nip05Badge` render path

This PR fixes the structural DOM issue and removes hook-order instability in the badge path without changing the UI design.

## Scope

This PR is intentionally narrow:

- no styling redesign
- no routing changes beyond link ownership cleanup
- no behavior expansion outside the collection/profile card warning path

## Expected result

- no nested anchor warning in the collection card author row
- no remaining `Expected static flag was missing` warning from the `UserCard` / `Nip05Badge` path
- collection and profile navigation behavior preserved