### PR TITLE
fix(products): harden create-product workflow validation and ordering

### DIFF
--- a/e2e-new/tests/products.spec.ts
+++ b/e2e-new/tests/products.spec.ts
@@ -1,8 +1,66 @@
-import { seedShippingOptionForUser } from 'e2e-new/scenarios'
+import type { Browser, Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
-import { devUser2 } from '@/lib/fixtures'
+import { setupAuthContext } from '../fixtures/auth'
+import { ensureScenario } from '../scenarios'
+import { bytesToHex } from '@noble/hashes/utils'
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 
 test.use({ scenario: 'merchant' })
+
+async function waitForProductForm(page: Page) {
+	const productForm = page.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
+	await expect(productForm).toBeVisible({ timeout: 15_000 })
+	return productForm
+}
+
+async function addProductImage(page: Page, imageUrl = 'https://placehold.co/600x600') {
+	const imageInput = page.getByTestId('image-url-input')
+	await expect(imageInput).toBeVisible({ timeout: 5_000 })
+	await imageInput.fill(imageUrl)
+	await page.getByTestId('image-save-button').click()
+}
+
+async function fillRequiredStepsUntilShipping(page: Page, productName = 'Workflow Product') {
+	await page.getByTestId('product-name-input').fill(productName)
+	await page.getByTestId('product-description-input').fill('Workflow test description')
+	await page.getByTestId('product-next-button').click()
+
+	await page.getByLabel(/price/i).first().fill('10000')
+	await page
+		.getByTestId('product-quantity-input')
+		.or(page.getByLabel(/quantity/i))
+		.fill('5')
+	await page.getByTestId('product-next-button').click()
+
+	await page.getByTestId('product-next-button').click()
+
+	await page.getByTestId('product-main-category-select').click()
+	await page.getByTestId('main-category-bitcoin').click()
+	await page.getByTestId('product-next-button').click()
+
+	await addProductImage(page)
+	await page.getByTestId('product-next-button').click()
+}
+
+async function createFreshUserPage(browser: Browser) {
+	await ensureScenario('base')
+
+	const sk = generateSecretKey()
+	const user = {
+		sk: bytesToHex(sk),
+		pk: getPublicKey(sk),
+	}
+
+	const context = await browser.newContext()
+	await setupAuthContext(context, user)
+
+	const page = await context.newPage()
+	await page.goto('/')
+	await page.waitForLoadState('networkidle')
+	await expect(page.locator('header')).toBeVisible({ timeout: 10_000 })
+
+	return { context, page }
+}
 
 test.describe('Product Management', () => {
 	test('products list page shows seeded products', async ({ merchantPage }) => {
@@ -23,12 +81,160 @@ test.describe('Product Management', () => {
 		await expect(merchantPage.getByTestId('product-name-input')).toBeVisible({ timeout: 5_000 })
 	})
 
+	test('cannot advance from name tab when title is missing', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await merchantPage.getByTestId('product-description-input').fill('Description without a title')
+
+		await expect(merchantPage.getByTestId('product-next-button')).toBeDisabled()
+		await expect(merchantPage.getByTestId('product-name-input')).toBeVisible()
+		await expect(merchantPage.getByLabel(/price/i).first()).not.toBeVisible()
+	})
+
+	test('new account starts on the correct first step', async ({ browser }) => {
+		const { context, page } = await createFreshUserPage(browser)
+
+		try {
+			await page.goto('/dashboard/products/products/new')
+			await waitForProductForm(page)
+
+			await expect(page.getByTestId('product-name-input')).toBeVisible({ timeout: 10_000 })
+			await expect(page.getByTestId('product-tab-name')).toHaveAttribute('data-state', 'active')
+			await expect(page.getByRole('button', { name: /Digital Delivery/i })).not.toBeVisible()
+		} finally {
+			await context.close()
+		}
+	})
+
+	test('required indicators match the workflow validation model', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await expect(merchantPage.getByTestId('product-tab-name')).toContainText('*')
+		await expect(merchantPage.getByTestId('product-tab-detail')).toContainText('*')
+		await expect(merchantPage.getByTestId('product-tab-spec')).not.toContainText('*')
+		await expect(merchantPage.getByTestId('product-tab-category')).toContainText('*')
+		await expect(merchantPage.getByTestId('product-tab-images')).toContainText('*')
+		await expect(merchantPage.getByTestId('product-tab-shipping')).toContainText('*')
+	})
+
+	test('cannot click forward to later tabs when earlier required tabs are incomplete', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await merchantPage.getByRole('tab', { name: 'Images' }).click()
+
+		await expect(merchantPage.getByText('Complete Name before moving to Images').first()).toBeVisible({ timeout: 5_000 })
+		await expect(merchantPage.getByTestId('product-name-input')).toBeVisible()
+		await expect(merchantPage.getByTestId('image-url-input')).not.toBeVisible()
+	})
+
+	test('missing required fields block progression on detail and category steps', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await merchantPage.getByTestId('product-name-input').fill('Step Blocking Product')
+		await merchantPage.getByTestId('product-description-input').fill('Step validation should block progress')
+		await merchantPage.getByTestId('product-next-button').click()
+
+		await expect(merchantPage.getByTestId('product-next-button')).toBeDisabled()
+		await merchantPage.getByLabel(/price/i).first().fill('10000')
+		await expect(merchantPage.getByTestId('product-next-button')).toBeDisabled()
+		await merchantPage
+			.getByTestId('product-quantity-input')
+			.or(merchantPage.getByLabel(/quantity/i))
+			.fill('5')
+		await expect(merchantPage.getByTestId('product-next-button')).toBeEnabled()
+
+		await merchantPage.getByTestId('product-next-button').click()
+		await merchantPage.getByTestId('product-next-button').click()
+
+		await expect(merchantPage.getByTestId('product-next-button')).toBeDisabled()
+		await merchantPage.getByTestId('product-main-category-select').click()
+		await merchantPage.getByTestId('main-category-bitcoin').click()
+		await expect(merchantPage.getByTestId('product-next-button')).toBeEnabled()
+	})
+
+	test('backward navigation still works', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await merchantPage.getByTestId('product-name-input').fill('Back Nav Product')
+		await merchantPage.getByTestId('product-description-input').fill('Back navigation should still work')
+		await merchantPage.getByTestId('product-next-button').click()
+
+		await expect(merchantPage.getByLabel(/price/i).first()).toBeVisible({ timeout: 5_000 })
+
+		await merchantPage.getByTestId('product-back-button').click()
+
+		await expect(merchantPage.getByTestId('product-name-input')).toBeVisible()
+		await expect(merchantPage.getByTestId('product-name-input')).toHaveValue('Back Nav Product')
+	})
+
+	test('publish remains disabled until the full required set is valid', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+
+		await fillRequiredStepsUntilShipping(merchantPage, 'Publish Guard Product')
+
+		const publishButton = merchantPage.getByTestId('product-publish-button')
+		await expect(publishButton).toBeDisabled()
+
+		const addButton = merchantPage.getByRole('button', { name: /^add$/i }).first()
+		await expect(addButton).toBeVisible({ timeout: 5_000 })
+		await addButton.click()
+
+		await expect(publishButton).toBeEnabled({ timeout: 5_000 })
+	})
+
+	test('last step uses final action semantics instead of wrapping to the first tab', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+		await fillRequiredStepsUntilShipping(merchantPage, 'Terminal Step Product')
+
+		await expect(merchantPage.getByTestId('product-tab-shipping')).toHaveAttribute('data-state', 'active')
+		await expect(merchantPage.getByTestId('product-next-button')).not.toBeVisible()
+		await expect(merchantPage.getByTestId('product-publish-button')).toBeVisible()
+		await expect(merchantPage.getByTestId('product-name-input')).not.toBeVisible()
+	})
+
+	test('images tab uses a single effective scroll container', async ({ merchantPage }) => {
+		await merchantPage.goto('/dashboard/products/products/new')
+		await waitForProductForm(merchantPage)
+		await fillRequiredStepsUntilShipping(merchantPage, 'Images Scroll Product')
+
+		await merchantPage.getByTestId('product-back-button').click()
+		await expect(merchantPage.getByTestId('product-images-tab-panel')).toBeVisible()
+
+		const scrollInfo = await merchantPage.evaluate(() => {
+			const panel = document.querySelector('[data-testid="product-images-tab-panel"]') as HTMLElement | null
+			const scrollContainer = document.querySelector('[data-testid="product-form-scroll-container"]') as HTMLElement | null
+
+			if (!panel || !scrollContainer) {
+				return null
+			}
+
+			const nestedScrollableDescendants = Array.from(panel.querySelectorAll<HTMLElement>('*')).filter((element) => {
+				const style = window.getComputedStyle(element)
+				return ['auto', 'scroll'].includes(style.overflowY) && element.scrollHeight > element.clientHeight
+			})
+
+			return {
+				outerOverflowY: window.getComputedStyle(scrollContainer).overflowY,
+				nestedScrollableCount: nestedScrollableDescendants.length,
+			}
+		})
+
+		expect(scrollInfo).not.toBeNull()
+		expect(scrollInfo?.outerOverflowY).toBe('auto')
+		expect(scrollInfo?.nestedScrollableCount).toBe(0)
+	})
+
 	test('can create a new product', async ({ merchantPage }) => {
 		await merchantPage.goto('/dashboard/products/products/new')
 
-		// Wait for the product form's shipping query to complete before interacting.
-		// This prevents a race condition where the form briefly shows the Name tab,
-		// then redirects to Shipping tab once the query confirms shipping state.
+		// Wait for product-form initialization to settle before interacting.
 		const productForm = merchantPage.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
 		await expect(productForm).toBeVisible({ timeout: 15_000 })
 

--- a/src/components/sheet-contents/products/NameTab.tsx
+++ b/src/components/sheet-contents/products/NameTab.tsx
@@ -65,9 +65,7 @@ export function NameTab() {
 			</div>
 
 			<div className="grid w-full gap-1.5">
-				<Label>
-					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Product Type</span>
-				</Label>
+				<Label>Product Type</Label>
 				<Select
 					value={productType}
 					onValueChange={(value) => productFormActions.updateValues({ productType: value as 'single' | 'variable' })}

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -3,10 +3,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
-import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
+import { productFormActions, productFormStore, type ProductFormState, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
-import { useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
+import { useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useV4VShares } from '@/queries/v4v'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
@@ -16,6 +16,75 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { NameTab } from './NameTab'
 import { CategoryTab, DetailTab, ImagesTab, ShippingTab, SpecTab } from './tabs'
+
+const PRODUCT_FORM_TAB_ORDER: ProductFormTab[] = ['name', 'detail', 'spec', 'category', 'images', 'shipping']
+
+const PRODUCT_FORM_TAB_LABELS: Record<ProductFormTab, string> = {
+	name: 'Name',
+	detail: 'Detail',
+	spec: 'Spec',
+	category: 'Category',
+	images: 'Images',
+	shipping: 'Shipping',
+}
+
+type ProductFormWorkflowState = Pick<
+	ProductFormState,
+	'name' | 'description' | 'price' | 'quantity' | 'mainCategory' | 'images' | 'shippings'
+>
+
+function isValidNumberString(value: string): boolean {
+	return value.trim().length > 0 && !isNaN(Number(value))
+}
+
+function getTabValidationIssues(state: ProductFormWorkflowState, tab: ProductFormTab): string[] {
+	switch (tab) {
+		case 'name': {
+			const issues: string[] = []
+			if (state.name.trim().length === 0) issues.push('Product name is required')
+			if (state.description.trim().length === 0) issues.push('Description is required')
+			return issues
+		}
+		case 'detail': {
+			const issues: string[] = []
+			if (!isValidNumberString(state.price)) issues.push('Valid product price is required')
+			if (!isValidNumberString(state.quantity)) issues.push('Valid product quantity is required')
+			return issues
+		}
+		case 'category':
+			return state.mainCategory ? [] : ['Main category is required']
+		case 'images':
+			return state.images.length > 0 ? [] : ['At least one image is required']
+		case 'shipping':
+			return state.shippings.some((shipping) => shipping.shipping?.id) ? [] : ['At least one shipping option is required']
+		case 'spec':
+			return []
+	}
+}
+
+function getFormValidationIssues(state: ProductFormWorkflowState): string[] {
+	return PRODUCT_FORM_TAB_ORDER.flatMap((tab) => getTabValidationIssues(state, tab))
+}
+
+function getFirstBlockingTab(state: ProductFormWorkflowState, targetTab: ProductFormTab): ProductFormTab | null {
+	const targetIndex = PRODUCT_FORM_TAB_ORDER.indexOf(targetTab)
+
+	if (targetIndex <= 0) return null
+
+	for (const tab of PRODUCT_FORM_TAB_ORDER.slice(0, targetIndex)) {
+		if (getTabValidationIssues(state, tab).length > 0) {
+			return tab
+		}
+	}
+
+	return null
+}
+
+function getAdjacentTab(currentTab: ProductFormTab, direction: 'next' | 'previous'): ProductFormTab | null {
+	const currentIndex = PRODUCT_FORM_TAB_ORDER.indexOf(currentTab)
+	const offset = direction === 'next' ? 1 : -1
+	return PRODUCT_FORM_TAB_ORDER[currentIndex + offset] ?? null
+}
 
 export function ProductFormContent({
 	className = '',
@@ -35,23 +104,18 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { activeTab, editingProductId, isDirty, shippings, formSessionId, name, description, images } = formState
+	const { activeTab, editingProductId, isDirty } = formState
 
-	// Compute validation states
-	const hasValidShipping = shippings.some((ship) => ship.shipping && ship.shipping.id)
-	const hasValidName = name.trim().length > 0
-	const hasValidDescription = description.trim().length > 0
-	const hasValidImages = images.length > 0
-
-	// Compute validation message for tooltip
-	const getValidationMessage = () => {
-		const issues: string[] = []
-		if (!hasValidName) issues.push('Product name is required')
-		if (!hasValidDescription) issues.push('Description is required')
-		if (!hasValidImages) issues.push('At least one image is required')
-		if (!hasValidShipping) issues.push('At least one shipping option is required')
-		return issues
-	}
+	const validationIssuesByTab = useMemo(
+		() =>
+			Object.fromEntries(PRODUCT_FORM_TAB_ORDER.map((tab) => [tab, getTabValidationIssues(formState, tab)])) as Record<
+				ProductFormTab,
+				string[]
+			>,
+		[formState],
+	)
+	const currentTabValidationIssues = validationIssuesByTab[activeTab]
+	const formValidationIssues = useMemo(() => getFormValidationIssues(formState), [formState])
 
 	// Get user pubkey from auth store directly to avoid timing issues
 	const authState = useStore(authStore)
@@ -64,68 +128,7 @@ export function ProductFormContent({
 
 	// Check if user has any shipping options configured (for tab ordering)
 	// Query is only enabled when userPubkey is available
-	const {
-		data: userShippingOptions,
-		isLoading: isLoadingUserShipping,
-		isFetched: isShippingFetched,
-	} = useShippingOptionsByPubkey(userPubkey)
-
-	// Determine if we should show shipping tab first (user has no shipping options)
-	const shouldShowShippingFirst = useMemo(() => {
-		// Don't redirect if editing an existing product
-		if (editingProductId) return false
-		// Don't redirect if pubkey not loaded yet (query is disabled)
-		if (!userPubkey) return false
-		// Don't redirect if we haven't fetched shipping data yet
-		if (!isShippingFetched) return false
-		// Don't redirect while loading
-		if (isLoadingUserShipping) return false
-		// Check if user has any non-deleted shipping options
-		// (query data might be cached and include deleted items)
-		if (!userShippingOptions || userShippingOptions.length === 0) return true
-		// Filter out any deleted shipping options from cached data
-		const activeShippingOptions = userShippingOptions.filter((event) => {
-			const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
-			return dTag ? !isShippingDeleted(dTag) : true
-		})
-		return activeShippingOptions.length === 0
-	}, [editingProductId, userShippingOptions, isLoadingUserShipping, userPubkey, isShippingFetched])
-
-	// Set initial tab to Shipping when user has no shipping options
-	// Track which formSessionId we've handled to avoid re-triggering on same session
-	const handledSessionIdRef = useRef<number | null>(null)
-
-	useEffect(() => {
-		// Only auto-switch to shipping tab if:
-		// 1. We haven't handled this session yet
-		// 2. User should see shipping first (no shipping options)
-		// 3. We're NOT already on the shipping tab
-		if (handledSessionIdRef.current !== formSessionId && shouldShowShippingFirst && activeTab !== 'shipping') {
-			productFormActions.updateValues({ activeTab: 'shipping' })
-			handledSessionIdRef.current = formSessionId
-		}
-	}, [shouldShowShippingFirst, activeTab, formSessionId])
-
-	// Track if we started with shipping first (no shipping options)
-	// This is used to determine if we should auto-navigate to name tab after first shipping is added
-	const startedWithShippingFirstRef = useRef<boolean>(false)
-
-	// Track if we've started with shipping first in this session
-	useEffect(() => {
-		if (shouldShowShippingFirst && activeTab === 'shipping') {
-			startedWithShippingFirstRef.current = true
-		}
-	}, [shouldShowShippingFirst, activeTab])
-
-	// Auto-navigate to 'name' tab after first shipping option is added when we started with shipping first
-	useEffect(() => {
-		if (startedWithShippingFirstRef.current && hasValidShipping && activeTab === 'shipping') {
-			// First shipping option added, navigate to name tab
-			productFormActions.updateValues({ activeTab: 'name' })
-			// Reset the flag so we don't auto-navigate again
-			startedWithShippingFirstRef.current = false
-		}
-	}, [hasValidShipping, activeTab])
+	const { isFetched: isShippingFetched } = useShippingOptionsByPubkey(userPubkey)
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {
@@ -251,6 +254,54 @@ export function ProductFormContent({
 		},
 	})
 
+	const handleTabChange = useCallback(
+		(value: string) => {
+			const targetTab = value as ProductFormTab
+			if (targetTab === activeTab) return
+
+			if (editingProductId) {
+				productFormActions.setTabState(targetTab)
+				return
+			}
+
+			const currentIndex = PRODUCT_FORM_TAB_ORDER.indexOf(activeTab)
+			const targetIndex = PRODUCT_FORM_TAB_ORDER.indexOf(targetTab)
+
+			if (targetIndex < currentIndex) {
+				productFormActions.setTabState(targetTab)
+				return
+			}
+
+			const blockingTab = getFirstBlockingTab(formState, targetTab)
+			if (blockingTab) {
+				toast.error(`Complete ${PRODUCT_FORM_TAB_LABELS[blockingTab]} before moving to ${PRODUCT_FORM_TAB_LABELS[targetTab]}`)
+				return
+			}
+
+			productFormActions.setTabState(targetTab)
+		},
+		[activeTab, editingProductId, formState],
+	)
+
+	const handleNext = useCallback(() => {
+		if (currentTabValidationIssues.length > 0) return
+
+		const nextTab = getAdjacentTab(activeTab, 'next')
+		if (nextTab) {
+			productFormActions.setTabState(nextTab)
+		}
+	}, [activeTab, currentTabValidationIssues])
+
+	const handleBack = useCallback(() => {
+		const previousTab = getAdjacentTab(activeTab, 'previous')
+		if (previousTab) {
+			productFormActions.setTabState(previousTab)
+		}
+	}, [activeTab])
+
+	const previousTab = getAdjacentTab(activeTab, 'previous')
+	const isCurrentTabBlocked = currentTabValidationIssues.length > 0
+
 	return (
 		<form
 			onSubmit={(e) => {
@@ -258,17 +309,13 @@ export function ProductFormContent({
 				e.stopPropagation()
 				form.handleSubmit()
 			}}
-			className={`flex flex-col h-full ${className}`}
+			className={`flex h-full min-h-0 flex-col overflow-hidden ${className}`}
 			data-testid="product-form"
-			data-shipping-loaded={isShippingFetched || !!editingProductId}
+			data-shipping-loaded={isShippingFetched || !userPubkey || !!editingProductId}
 		>
 			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
 				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
-				<Tabs
-					value={activeTab}
-					onValueChange={(value) => productFormActions.updateValues({ activeTab: value as ProductFormTab })}
-					className="w-full flex flex-col flex-1 min-h-0 overflow-hidden"
-				>
+				<Tabs value={activeTab} onValueChange={handleTabChange} className="w-full flex flex-col flex-1 min-h-0 overflow-hidden">
 					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
 						<TabsTrigger
 							value="name"
@@ -276,7 +323,7 @@ export function ProductFormContent({
 							data-testid="product-tab-name"
 						>
 							Name
-							{(!hasValidName || !hasValidDescription) && <span className="ml-1 text-red-500">*</span>}
+							{validationIssuesByTab.name.length > 0 && <span className="ml-1 text-red-500">*</span>}
 						</TabsTrigger>
 						<TabsTrigger
 							value="detail"
@@ -284,6 +331,7 @@ export function ProductFormContent({
 							data-testid="product-tab-detail"
 						>
 							Detail
+							{validationIssuesByTab.detail.length > 0 && <span className="ml-1 text-red-500">*</span>}
 						</TabsTrigger>
 						<TabsTrigger
 							value="spec"
@@ -298,6 +346,7 @@ export function ProductFormContent({
 							data-testid="product-tab-category"
 						>
 							Category
+							{validationIssuesByTab.category.length > 0 && <span className="ml-1 text-red-500">*</span>}
 						</TabsTrigger>
 						<TabsTrigger
 							value="images"
@@ -305,7 +354,7 @@ export function ProductFormContent({
 							data-testid="product-tab-images"
 						>
 							Images
-							{!hasValidImages && <span className="ml-1 text-red-500">*</span>}
+							{validationIssuesByTab.images.length > 0 && <span className="ml-1 text-red-500">*</span>}
 						</TabsTrigger>
 						<TabsTrigger
 							value="shipping"
@@ -313,11 +362,11 @@ export function ProductFormContent({
 							data-testid="product-tab-shipping"
 						>
 							Shipping
-							{!hasValidShipping && <span className="ml-1 text-red-500">*</span>}
+							{validationIssuesByTab.shipping.length > 0 && <span className="ml-1 text-red-500">*</span>}
 						</TabsTrigger>
 					</TabsList>
 
-					<div className="flex-1 overflow-y-auto min-h-0">
+					<div className="flex-1 overflow-y-auto min-h-0" data-testid="product-form-scroll-container">
 						<TabsContent value="name" className="mt-4">
 							<NameTab />
 						</TabsContent>
@@ -348,12 +397,12 @@ export function ProductFormContent({
 			{showFooter && (
 				<div className="bg-white border-t pt-4 pb-4 mt-4">
 					<div className="flex gap-2 w-full">
-						{activeTab !== 'name' && (
+						{previousTab && (
 							<Button
 								type="button"
 								variant="outline"
 								className="flex-1 gap-2 uppercase"
-								onClick={productFormActions.previousTab}
+								onClick={handleBack}
 								data-testid="product-back-button"
 							>
 								<span className="i-back w-6 h-6"></span>
@@ -361,23 +410,15 @@ export function ProductFormContent({
 							</Button>
 						)}
 
-						{/* Show 'Next' button when shipping tab is shown first and user is on shipping tab */}
-						{shouldShowShippingFirst && activeTab === 'shipping' && !hasValidShipping ? (
-							<Button
-								type="button"
-								variant="secondary"
-								className="flex-1 uppercase"
-								onClick={() => productFormActions.updateValues({ activeTab: 'name' })}
-								data-testid="product-next-button"
-							>
-								Next
-							</Button>
-						) : activeTab === 'shipping' || editingProductId ? (
+						{activeTab === 'shipping' || editingProductId ? (
 							<form.Subscribe
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
-								children={([canSubmit, isSubmitting]) => {
+								children={([, isSubmitting]) => {
+									const hasValidationErrors = formValidationIssues.length > 0
+									const isDisabled = isSubmitting || isPublishing || hasValidationErrors
+
 									// Check if we need V4V setup for new products
-									if (needsV4VSetup && !editingProductId) {
+									if (needsV4VSetup && !editingProductId && !hasValidationErrors) {
 										return (
 											<TooltipProvider>
 												<Tooltip>
@@ -406,10 +447,6 @@ export function ProductFormContent({
 										)
 									}
 
-									const validationIssues = getValidationMessage()
-									const hasValidationErrors = validationIssues.length > 0
-									const isDisabled = isSubmitting || isPublishing || hasValidationErrors
-
 									return (
 										<TooltipProvider>
 											<Tooltip>
@@ -435,7 +472,7 @@ export function ProductFormContent({
 												{hasValidationErrors && (
 													<TooltipContent>
 														<ul className="list-disc list-inside space-y-1">
-															{validationIssues.map((issue, i) => (
+															{formValidationIssues.map((issue, i) => (
 																<li key={i}>{issue}</li>
 															))}
 														</ul>
@@ -447,15 +484,33 @@ export function ProductFormContent({
 								}}
 							/>
 						) : (
-							<Button
-								type="button"
-								variant="secondary"
-								className="flex-1 uppercase"
-								onClick={productFormActions.nextTab}
-								data-testid="product-next-button"
-							>
-								Next
-							</Button>
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span className="flex-1">
+											<Button
+												type="button"
+												variant="secondary"
+												className="w-full uppercase"
+												onClick={handleNext}
+												disabled={isCurrentTabBlocked}
+												data-testid="product-next-button"
+											>
+												Next
+											</Button>
+										</span>
+									</TooltipTrigger>
+									{isCurrentTabBlocked && (
+										<TooltipContent>
+											<ul className="list-disc list-inside space-y-1">
+												{currentTabValidationIssues.map((issue, i) => (
+													<li key={i}>{issue}</li>
+												))}
+											</ul>
+										</TooltipContent>
+									)}
+								</Tooltip>
+							</TooltipProvider>
 						)}
 					</div>
 				</div>

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -589,7 +589,7 @@ export function ImagesTab() {
 	}
 
 	return (
-		<div className="space-y-4">
+		<div className="space-y-4 overflow-visible" data-testid="product-images-tab-panel">
 			<p className="text-gray-600">We recommend using square images of 1600x1600 and under 2mb.</p>
 
 			<div className="flex flex-col gap-4">


### PR DESCRIPTION
## Summary

Fixes #724 by correcting the create-product workflow in `PlebeianApp/market`.

This change addresses:

- new accounts incorrectly landing on the last step
- missing required fields only surfacing at the end of the flow
- incorrect last-step navigation behavior
- double-scroll behavior on the Images tab

## What changed

### Workflow / ordering

- removed the shipping-first auto-routing behavior that sent new users to the last step
- kept the create-product flow starting from the correct first step

### Step validation

- added explicit step-level validation in the workflow controller
- required steps now block forward progression instead of allowing users to continue until publish
- aligned required tab indicators with the actual publish contract

### Required fields now enforced during the flow

- Name: product name + description
- Detail: price + quantity
- Category: main category
- Images: at least one image
- Shipping: at least one shipping option

### Terminal step behavior

- last step no longer rotates back to the first tab
- final action semantics are preserved at the end of the flow

### Images UX

- cleaned up scroll containment so the Images step uses a single effective scroll container

## Source-of-truth alignment

This PR aligns the workflow controller with the current publish contract in `src/publish/products.ts`, which requires:

- name
- description
- valid price
- valid quantity
- main category
- at least one image
- at least one shipping option

## Tests

Added/updated product flow coverage for:

- new account starts on the correct first step
- required indicators match workflow rules
- missing required fields block progression on detail and category
- later tabs cannot be reached while earlier required steps are incomplete
- last step no longer wraps to the first tab
- images tab uses a single effective scroll container

## Notes

This PR focuses on workflow correctness and validation/order behavior only.
It does not attempt a broader UX redesign of the product form inputs.
Validated with the full E2E suite (`96 passed`) after updating a brittle toast assertion in the product workflow tests.
Rebased this branch onto current upstream/master and force-pushed the updated history.

Local verification after rebase:

- e2e-new/tests/products.spec.ts
- e2e-new/tests/products.spec.ts + e2e-new/tests/v4v-product-creation.spec.ts

Both passed locally.