### PR TITLE
e2e: flaky e2e tests fixed

### DIFF
--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -340,6 +340,74 @@ async function seedProduct(
 	console.log(`    Published product: ${opts.title}`)
 }
 
+export async function seedShippingOptionForUser(skUser: string) {
+	const relay = await Relay.connect(RELAY_URL)
+
+	const id = `shipping_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
+
+	await publish(relay, skUser, {
+		kind: 30402,
+		created_at: Math.floor(Date.now() / 1000),
+		content: '',
+		tags: [
+			['d', id],
+			['title', 'seeded shipping option - digital'],
+			['price', '0', 'USD'],
+			['service', 'digital'],
+		],
+	})
+
+	console.log(`    Published shipping option with ID: ${id}`)
+}
+
+/**
+ * Resets entire blacklist (Users, Products, Collections) using admin secret key
+ */
+export async function resetAppBlacklist() {
+	const relay = await Relay.connect(RELAY_URL)
+	const skAdmin = devUser1.sk
+
+	await publish(relay, skAdmin, {
+		kind: 10000, // NIP-51 mute list
+		created_at: Math.floor(Date.now() / 1000),
+		content: '',
+		tags: [],
+	})
+
+	console.log(`    Reset app Blacklist.`)
+}
+
+export async function resetAppFeaturedList() {
+	const relay = await Relay.connect(RELAY_URL)
+	const skAdmin = devUser1.sk
+
+	await Promise.all([
+		// Products
+		publish(relay, skAdmin, {
+			kind: 30405,
+			created_at: Math.floor(Date.now() / 1000),
+			content: '',
+			tags: [['d', 'featured_products']],
+		}),
+		// Collections
+		publish(relay, skAdmin, {
+			kind: 30003,
+			created_at: Math.floor(Date.now() / 1000),
+			content: '',
+			tags: [['d', 'featured_collections']],
+		}),
+		// Users
+		publish(relay, skAdmin, {
+			kind: 30000,
+			created_at: Math.floor(Date.now() / 1000),
+			content: '',
+			tags: [['d', 'featured_users']],
+		}),
+	])
+
+	console.log(`    Reset app Featured list.`)
+}
+
 async function seedV4VShares(relay: Relay, skHex: string, shares: string[][] = []) {
 	await publish(relay, skHex, {
 		kind: 30078,

--- a/e2e-new/tests/app-settings.spec.ts
+++ b/e2e-new/tests/app-settings.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect, type Page } from '../fixtures'
-import { devUser1, devUser2 } from '../../src/lib/fixtures'
+import { devUser1, devUser2, devUser3 } from '../../src/lib/fixtures'
 import { nip19 } from 'nostr-tools'
+import { resetAppBlacklist, resetAppFeaturedList } from 'e2e-new/scenarios'
+import { npubEncode } from 'nostr-tools/nip19'
 
 test.use({ scenario: 'merchant' })
 
@@ -60,8 +62,11 @@ async function clickDestructiveButtonForText(page: Page, text: string) {
 	await expect(rowText).toBeVisible({ timeout: 15_000 })
 
 	const row = rowText.locator('xpath=ancestor::div[contains(@class,"flex") and contains(@class,"items-center")]')
-	await row.locator('button[class*="destructive"]').click()
-	await expect(rowText).not.toBeVisible({ timeout: 15_000 })
+	const destructiveButton = row.locator('button[class*="destructive"]')
+
+	await expect(destructiveButton).toBeVisible()
+	await destructiveButton.click({ timeout: 15_000 })
+	await expect(rowText).toBeHidden({ timeout: 15_000 })
 }
 
 const compactNpub = (pubkey: string) => {
@@ -91,6 +96,11 @@ test.describe('App Settings', () => {
 })
 
 // --- Featured Items ---
+
+test.beforeEach(async () => {
+	console.log('TEST === RUNNING BEFORE EACH')
+	await resetAppFeaturedList()
+})
 
 test.describe('Featured Items', () => {
 	test('admin can view featured items page with tabs', async ({ merchantPage }) => {
@@ -163,10 +173,12 @@ test.describe('Featured Items', () => {
 		const usersPanel = merchantPage.getByRole('tabpanel', { name: /Users/ })
 		await expect(usersPanel).toBeVisible()
 
-		await fillAndAdd(merchantPage, 'newUser', devUser2.pk)
+		await fillAndAdd(merchantPage, 'newUser', devUser3.pk)
 
-		// User should appear — at least one remove button should exist in the Users tab
-		await expect(usersPanel.locator('button[class*="destructive"]').first()).toBeVisible({ timeout: 15_000 })
+		// User should appear - Verify for first & last 6 digits of npub are displayed
+		const userNpub = npubEncode(devUser3.pk)
+		await expect(usersPanel.getByText(userNpub.slice(0, 6))).toBeVisible({ timeout: 15_000 })
+		await expect(usersPanel.getByText(userNpub.slice(-6))).toBeVisible({ timeout: 15_000 })
 	})
 
 	test('permissions section shows admin role', async ({ merchantPage }) => {
@@ -188,6 +200,10 @@ test.describe('Featured Items', () => {
 })
 
 // --- Blacklists ---
+
+test.beforeEach(async () => {
+	await resetAppBlacklist()
+})
 
 test.describe('Blacklists', () => {
 	test('admin can view blacklists page with tabs', async ({ merchantPage }) => {
@@ -213,18 +229,9 @@ test.describe('Blacklists', () => {
 	test('can remove a user from blacklist', async ({ merchantPage }) => {
 		await gotoAdminRoute(merchantPage, '/dashboard/app-settings/blacklists')
 		await expectPageHeading(merchantPage, 'Blacklists')
+		await fillAndAdd(merchantPage, 'newUser', devUser3.pk)
 
-		const userLabel = compactNpub(devUser2.pk)
-
-		if (
-			!(await merchantPage
-				.getByText(userLabel)
-				.isVisible()
-				.catch(() => false))
-		) {
-			await fillAndAdd(merchantPage, 'newUser', devUser2.pk)
-			await expectInputCleared(merchantPage, 'newUser')
-		}
+		const userLabel = compactNpub(devUser3.pk)
 
 		await clickDestructiveButtonForText(merchantPage, userLabel)
 	})

--- a/e2e-new/tests/app-settings.spec.ts
+++ b/e2e-new/tests/app-settings.spec.ts
@@ -98,7 +98,6 @@ test.describe('App Settings', () => {
 // --- Featured Items ---
 
 test.beforeEach(async () => {
-	console.log('TEST === RUNNING BEFORE EACH')
 	await resetAppFeaturedList()
 })
 

--- a/e2e-new/tests/cart.spec.ts
+++ b/e2e-new/tests/cart.spec.ts
@@ -1,7 +1,8 @@
 import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
-import { devUser2 } from '../../src/lib/fixtures'
+import { devUser1, devUser2 } from '../../src/lib/fixtures'
 import { waitForLatestCartSnapshotToBeEmpty } from '../utils/relay-query'
+import { resetRemoteCartForUser } from 'e2e-new/scenarios'
 
 test.use({ scenario: 'marketplace' })
 
@@ -89,6 +90,11 @@ async function waitForProducts(page: Page): Promise<void> {
 // A. Remove Items from Cart
 // ---------------------------------------------------------------------------
 
+test.beforeEach(async () => {
+	// Clear cart for active user
+	await resetRemoteCartForUser(devUser1.sk)
+})
+
 test.describe('Cart - Remove Items', () => {
 	test('can remove a single item from cart', async ({ newUserPage }) => {
 		await safeGoto(newUserPage, '/products')
@@ -137,6 +143,11 @@ test.describe('Cart - Remove Items', () => {
 // ---------------------------------------------------------------------------
 // B. Change Quantity
 // ---------------------------------------------------------------------------
+
+test.beforeEach(async () => {
+	// Clear cart for active user
+	await resetRemoteCartForUser(devUser1.sk)
+})
 
 test.describe('Cart - Change Quantity', () => {
 	test('can increment product quantity using the plus button', async ({ newUserPage }) => {

--- a/e2e-new/tests/checkout.spec.ts
+++ b/e2e-new/tests/checkout.spec.ts
@@ -135,7 +135,8 @@ test.describe('Checkout', () => {
 
 		// ─── 9. Verify seller sees the order ─────────────────────────
 		await merchantPage.goto('/dashboard/sales/sales')
-		await expect(merchantPage.getByRole('heading', { name: 'Sales' })).toBeVisible({ timeout: 15_000 })
+		await expect(merchantPage.getByText('Loading sales...')).toBeVisible({ timeout: 15_000 })
+
 		// Wait for order rows to render (innerText only returns visible text,
 		// avoiding the hidden mobile-layout duplicates)
 		await merchantPage.waitForFunction(() => document.body.innerText.includes('sats') && document.body.innerText.includes('Pending'), {

--- a/e2e-new/tests/order-lifecycle.spec.ts
+++ b/e2e-new/tests/order-lifecycle.spec.ts
@@ -173,7 +173,7 @@ test.describe('Order Lifecycle', () => {
 
 		// ─── 2. Merchant: navigate to order detail ────────────────────
 		await merchantPage.goto('/dashboard/sales/sales')
-		await expect(merchantPage.getByRole('heading', { name: 'Sales' })).toBeVisible({ timeout: 15_000 })
+		await expect(merchantPage.getByText('Loading sales...')).toBeVisible({ timeout: 15_000 })
 
 		// Wait for order with Pending status
 		await merchantPage.waitForFunction(() => document.body.innerText.includes('sats') && document.body.innerText.includes('Pending'), {

--- a/e2e-new/tests/products.spec.ts
+++ b/e2e-new/tests/products.spec.ts
@@ -1,4 +1,6 @@
+import { seedShippingOptionForUser } from 'e2e-new/scenarios'
 import { test, expect } from '../fixtures'
+import { devUser2 } from '@/lib/fixtures'
 
 test.use({ scenario: 'merchant' })
 


### PR DESCRIPTION
Flaky tests were fixed.

**Issue:** Some tests (app-settings, cart persistence) were failing due to data state persisting across tests leading to inconsistent results.
**Fix:** Added "reset" fixtures to cover the scenarios that were flaky.

**Issue:** Some dashboard-related tests were expecting the "Sales" tab name to be visible as a placeholder for loading state, however this conflicted with the "Sales" category header in the left side view.
**Fix:** Changed the text to be detected to be "Loading Sales" which corresponds to the loading indicator.

**Issue:** When running "create product" flow, the page would sometime switch to the last tab (add shipping option), which would break the initial tab content detection to fill out name, etc.
**[No Fix]:** Since this issue only happened once, I think it's a better direction to fix the product itself (no more unexpected tab switching) than to correct the tests to filter incorrect behaviour. This would be resolved by PR #732 for a more stable product creation flow.

Tests are otherwise all working when running. Let's see if they work in the CI as well :D

Fixes #733