### PR TITLE
test(v4v): assert terminal step before setup gate

### DIFF
--- a/e2e-new/tests/v4v-product-creation.spec.ts
+++ b/e2e-new/tests/v4v-product-creation.spec.ts
@@ -88,7 +88,9 @@ test.describe('V4V Product Creation Flow', () => {
 		// --- V4V Dialog ---
 		// Since we reset V4V shares, "Setup V4V First" button should appear
 		const v4vButton = newUserPage.getByTestId('product-setup-v4v-button')
-		await expect(v4vButton).toBeVisible({ timeout: 10_000 })
+		await expect(newUserPage.getByTestId('product-tab-shipping')).toHaveAttribute('data-state', 'active')
+		await expect(newUserPage.getByTestId('product-next-button')).not.toBeVisible()
+		await expect(v4vButton).toBeVisible({ timeout: 20_000 })
 		await v4vButton.click()
 
 		// Dialog opens with default 10% V4V for new users


### PR DESCRIPTION
## Summary

Hardens the flaky V4V first-product E2E by asserting the UI has actually reached the terminal Shipping step before checking for the V4V setup gate.

## Changes

- assert `product-tab-shipping` is active
- assert the normal `product-next-button` is no longer visible
- then wait for `product-setup-v4v-button` with a modestly longer timeout

## Why

This avoids checking the V4V gate before the workflow has fully transitioned to the terminal step. It is a test-only stabilization change and does not modify application code.

## Scope

- no app-code changes
- no product workflow changes
- no arbitrary sleeps