### PR TITLE
fix(e2e): use mock LNURL domain for payment tests

### DIFF
--- a/e2e-new/helpers/lnurl-mock.ts
+++ b/e2e-new/helpers/lnurl-mock.ts
@@ -9,9 +9,9 @@ const FAKE_BOLT11 =
 	'lnbc500u1pjtest0pp5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsp5qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9q7sqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgpqysgqa0a0a'
 
 export interface LnurlMockOptions {
-	/** The Lightning address domain to intercept (default: coinos.io) */
+	/** The Lightning address domain to intercept (default: lnurl.e2e.test) */
 	domain?: string
-	/** The Lightning address username to intercept (default: plebeianuser) */
+	/** The Lightning address username to intercept (default: test) */
 	username?: string
 	/** If true, fail the LNURL metadata fetch before invoice generation starts */
 	failMetadata?: boolean
@@ -37,8 +37,8 @@ export interface LnurlMockOptions {
  * This mock intercepts both requests so no real HTTP calls leave the browser.
  */
 export async function setupLnurlMock(page: Page, options?: LnurlMockOptions): Promise<void> {
-	const domain = options?.domain ?? 'coinos.io'
-	const username = options?.username ?? 'plebeianuser'
+	const domain = options?.domain ?? 'lnurl.e2e.test'
+	const username = options?.username ?? 'test'
 	const bolt11 = options?.bolt11 ?? FAKE_BOLT11
 	const minSendable = options?.minSendable ?? 1_000
 	const maxSendable = options?.maxSendable ?? 100_000_000_000

--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -2,7 +2,7 @@ import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
 import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
 import { hexToBytes } from '@noble/hashes/utils'
 import WebSocket from 'ws'
-import { devUser1, devUser2, WALLETED_USER_LUD16 } from '../../src/lib/fixtures'
+import { devUser1, devUser2, TEST_WALLETED_USER_LUD16 } from '../../src/lib/fixtures'
 import { RELAY_URL, TEST_APP_PRIVATE_KEY, TEST_APP_PUBLIC_KEY } from '../test-config'
 
 useWebSocketImplementation(WebSocket)
@@ -128,7 +128,7 @@ async function seedMerchant(relay: Relay) {
 
 	await seedPaymentDetail(relay, devUser1.sk, TEST_APP_PUBLIC_KEY, {
 		method: 'LIGHTNING_NETWORK',
-		detail: WALLETED_USER_LUD16,
+		detail: TEST_WALLETED_USER_LUD16,
 	})
 
 	// Seed V4V shares with 10% going to the app (community share)
@@ -204,7 +204,7 @@ async function seedMarketplace(relay: Relay) {
 
 	await seedPaymentDetail(relay, devUser2.sk, TEST_APP_PUBLIC_KEY, {
 		method: 'LIGHTNING_NETWORK',
-		detail: WALLETED_USER_LUD16,
+		detail: TEST_WALLETED_USER_LUD16,
 	})
 
 	// Seed V4V shares for second merchant (10% to app, matching devUser1)
@@ -232,7 +232,7 @@ async function seedUserProfile(relay: Relay, user: { sk: string; pk: string }, n
 			name,
 			display_name: displayName,
 			about: `Test user ${name}`,
-			lud16: WALLETED_USER_LUD16,
+			lud16: TEST_WALLETED_USER_LUD16,
 		}),
 		tags: [],
 	})

--- a/e2e-new/tests/payments.spec.ts
+++ b/e2e-new/tests/payments.spec.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
 import { setupLnurlMock } from '../helpers/lnurl-mock'
 import { queryRelayEvents, filterByTag } from '../utils/relay-query'
-import { WALLETED_USER_LUD16, devUser1, devUser2 } from '../../src/lib/fixtures'
+import { TEST_WALLETED_USER_LUD16, devUser1, devUser2 } from '../../src/lib/fixtures'
 
 test.use({ scenario: 'merchant' })
 
@@ -88,7 +88,7 @@ test.describe('Receiving Payments Configuration', () => {
 
 		// The seeded Lightning address should appear on the page (multiple elements may match
 		// since the address shows in both the profile card and payment detail list items)
-		await expect(merchantPage.getByText(WALLETED_USER_LUD16).first()).toBeVisible({ timeout: 10_000 })
+		await expect(merchantPage.getByText(TEST_WALLETED_USER_LUD16).first()).toBeVisible({ timeout: 10_000 })
 
 		// Payment method label should show "Lightning Address"
 		await expect(merchantPage.getByText(/lightning address/i).first()).toBeVisible()
@@ -121,7 +121,7 @@ test.describe('Receiving Payments Configuration', () => {
 
 		// Wait for auth + the seeded payment detail to load
 		await expect(merchantPage.getByRole('heading', { name: /receiving payments/i })).toBeVisible({ timeout: 15_000 })
-		await expect(merchantPage.getByText(WALLETED_USER_LUD16).first()).toBeVisible({ timeout: 10_000 })
+		await expect(merchantPage.getByText(TEST_WALLETED_USER_LUD16).first()).toBeVisible({ timeout: 10_000 })
 
 		// Count delete buttons before deletion
 		const deleteButtons = merchantPage.getByRole('button', { name: /delete payment detail/i })

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -30,4 +30,7 @@ export const devUser5 = {
 export const XPUB = 'xpub6CK51df37SEz9q2EztLtHX6mE1NoAGBAKaQamafguE2vPq6pBuW5i9KVeb1SeJuhTsgD4ED8L8y66ocN68WEVc7BHYxHU6dmxHVJBHPLkYa'
 export const WALLETED_USER_LUD16 = 'plebeianuser@coinos.io'
 
+// For e2e tests - uses mock domain that Playwright can intercept
+export const TEST_WALLETED_USER_LUD16 = 'test@lnurl.e2e.test'
+
 // nsec18cmyxjcca6y8s3yhegt7nmrcxw9pn4ugnqe68jfc8km3sr2c5d2srsltll


### PR DESCRIPTION
- Change default LNURL mock domain from coinos.io to lnurl.e2e.test
- Add TEST_WALLETED_USER_LUD16 fixture for e2e tests
- Update scenarios and tests to use the mock domain
- Playwright can now intercept all LNURL requests internally

This fixes #705 - payment tests that were failing due to NDKZapper making HTTP calls that bypassed the browser mock.