### PR TITLE
fix: harden product create session boundaries across entrypoints

### DIFF
--- a/src/lib/stores/product-session.test.ts
+++ b/src/lib/stores/product-session.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore, type ProductFormState } from '@/lib/stores/product'
+import { uiStore } from '@/lib/stores/ui'
+
+const DIRTY_CREATE_STATE: ProductFormState = {
+	...DEFAULT_FORM_STATE,
+	formSessionId: 7,
+	activeTab: 'shipping',
+	name: 'Leaked draft',
+	summary: 'summary',
+	description: 'stale description',
+	price: '42',
+	quantity: '2',
+	mainCategory: 'Bitcoin',
+	images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
+	shippings: [{ shipping: { id: 'ship-1', name: 'Standard' }, extraCost: '10' }],
+	isDirty: true,
+}
+
+const seedCreateDraft = () => {
+	productFormStore.setState(() => ({
+		...DIRTY_CREATE_STATE,
+		images: [...DIRTY_CREATE_STATE.images],
+		shippings: [...DIRTY_CREATE_STATE.shippings],
+	}))
+}
+
+describe('product form session boundaries', () => {
+	beforeEach(() => {
+		productFormStore.setState(() => DEFAULT_FORM_STATE)
+		uiStore.setState((state) => ({
+			...state,
+			drawers: {
+				...state.drawers,
+				createProduct: false,
+			},
+			activeElement: undefined,
+			selectedCurrency: 'USD',
+		}))
+	})
+
+	test('route create session starts from a fresh create contract', () => {
+		seedCreateDraft()
+
+		productFormActions.startCreateProductSession()
+
+		expect(productFormStore.state).toMatchObject({
+			...DEFAULT_FORM_STATE,
+			currency: 'USD',
+			currencyMode: 'fiat',
+			formSessionId: DIRTY_CREATE_STATE.formSessionId + 1,
+		})
+	})
+
+	test('drawer create uses the same fresh session contract', () => {
+		seedCreateDraft()
+		productFormActions.startCreateProductSession()
+		const routeSessionState = productFormStore.state
+
+		seedCreateDraft()
+		productFormActions.openCreateProductDrawer()
+
+		expect(productFormStore.state).toEqual(routeSessionState)
+		expect(uiStore.state.drawers.createProduct).toBe(true)
+		expect(uiStore.state.activeElement).toBe('drawer-createProduct')
+	})
+
+	test('repeated create sessions do not inherit prior mutable state', () => {
+		productFormActions.startCreateProductSession()
+		const firstSessionId = productFormStore.state.formSessionId
+
+		productFormActions.updateValues({
+			name: 'Abandoned product',
+			description: 'should be cleared',
+			activeTab: 'shipping',
+			shippings: [{ shipping: { id: 'ship-2', name: 'Express' }, extraCost: '5' }],
+		})
+
+		productFormActions.startCreateProductSession()
+
+		expect(productFormStore.state.name).toBe('')
+		expect(productFormStore.state.description).toBe('')
+		expect(productFormStore.state.activeTab).toBe('name')
+		expect(productFormStore.state.shippings).toEqual([])
+		expect(productFormStore.state.editingProductId).toBeNull()
+		expect(productFormStore.state.formSessionId).toBe(firstSessionId + 1)
+	})
+
+	test('create after an abandoned attempt starts fresh again', () => {
+		seedCreateDraft()
+
+		productFormActions.openCreateProductDrawer()
+
+		expect(productFormStore.state).toMatchObject({
+			...DEFAULT_FORM_STATE,
+			currency: 'USD',
+			currencyMode: 'fiat',
+			formSessionId: DIRTY_CREATE_STATE.formSessionId + 1,
+		})
+	})
+
+	test('edit session initialization does not reuse mutable create state', () => {
+		seedCreateDraft()
+
+		productFormActions.startEditProductSession('existing-product-d-tag')
+
+		expect(productFormStore.state).toMatchObject({
+			...DEFAULT_FORM_STATE,
+			editingProductId: 'existing-product-d-tag',
+			currency: 'USD',
+			currencyMode: 'fiat',
+			formSessionId: DIRTY_CREATE_STATE.formSessionId + 1,
+		})
+		expect(productFormStore.state.name).toBe('')
+		expect(productFormStore.state.shippings).toEqual([])
+	})
+})

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -307,6 +307,8 @@ export const productFormActions = {
 		})
 	},
 
+	// Legacy compatibility alias.
+	// Prefer startCreateProductSession() for explicit create-mode initialization.
 	reset: () => {
 		productFormActions.startCreateProductSession()
 	},

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -22,7 +22,7 @@ import {
 import { productKeys } from '@/queries/queryKeyFactory'
 import { clearProductFormDraft, getProductFormDraft, saveProductFormDraft } from '@/lib/utils/productFormStorage'
 import { normalizeProductShippingSelections, type ProductShippingSelection } from '@/lib/utils/productShippingSelections'
-import { uiStore } from '@/lib/stores/ui'
+import { uiActions, uiStore } from '@/lib/stores/ui'
 import NDK, { type NDKSigner } from '@nostr-dev-kit/ndk'
 import { QueryClient } from '@tanstack/react-query'
 import { Store } from '@tanstack/store'
@@ -144,8 +144,39 @@ const debouncedSave = () => {
 	}, SAVE_DEBOUNCE_MS)
 }
 
+const getFreshSessionState = (state: ProductFormState, overrides: Partial<ProductFormState> = {}): ProductFormState => {
+	const selectedCurrency = uiStore.state.selectedCurrency
+
+	return {
+		...DEFAULT_FORM_STATE,
+		formSessionId: state.formSessionId + 1,
+		currency: selectedCurrency === 'BTC' ? 'SATS' : selectedCurrency,
+		currencyMode: ['BTC', 'SATS'].includes(selectedCurrency) ? 'sats' : 'fiat',
+		...overrides,
+	}
+}
+
 // Create actions object
 export const productFormActions = {
+	startCreateProductSession: () => {
+		// Cancel any pending auto-save to prevent stale data from being written
+		cancelPendingSave()
+
+		productFormStore.setState((state) => getFreshSessionState(state, { editingProductId: null }))
+	},
+
+	startEditProductSession: (productId: string) => {
+		// Cancel any pending auto-save to prevent stale data from being written
+		cancelPendingSave()
+
+		productFormStore.setState((state) => getFreshSessionState(state, { editingProductId: productId }))
+	},
+
+	openCreateProductDrawer: () => {
+		productFormActions.startCreateProductSession()
+		uiActions.openDrawer('createProduct')
+	},
+
 	setEditingProductId: (productId: string | null) => {
 		productFormStore.setState((state) => ({
 			...state,
@@ -211,37 +242,38 @@ export const productFormActions = {
 			const priceValue = priceTag?.[1] || ''
 			const isFiatCurrency = priceCurrency !== 'SATS' && priceCurrency !== 'BTC'
 
-			productFormStore.setState((state) => ({
-				...DEFAULT_FORM_STATE,
-				editingProductId: productDTag, // Use the d tag value, not the event ID!
-				name: title,
-				summary: summary,
-				description: description,
-				price: priceValue,
-				fiatPrice: isFiatCurrency ? priceValue : '', // Set fiatPrice if currency is fiat
-				currency: priceCurrency,
-				currencyMode: isFiatCurrency ? 'fiat' : 'sats',
-				bitcoinUnit: priceCurrency === 'BTC' ? 'BTC' : 'SATS',
-				quantity: stockTag?.[1] || '',
-				status: visibilityTag?.[1] || 'hidden',
-				productType: typeTag?.[1] === 'simple' ? 'single' : 'variable',
-				mainCategory: mainCategoryFromTags || null,
-				selectedCollection: collection,
-				categories: subCategoriesFromTags || [],
-				images: images.map((img, index) => ({
-					imageUrl: img[1],
-					imageOrder: parseInt(img[3] || index.toString(), 10),
-				})),
-				specs: specs.map((spec) => ({ key: spec[1], value: spec[2] })),
-				weight: weightTag ? { value: weightTag[1], unit: weightTag[2] } : null,
-				dimensions: dimensionsTag ? { value: dimensionsTag[1], unit: dimensionsTag[2] } : null,
-				shippings: shippingOptions,
-				activeTab,
-				isNSFW: isNSFWProduct(event),
-			}))
+			productFormStore.setState((state) =>
+				getFreshSessionState(state, {
+					editingProductId: productDTag, // Use the d tag value, not the event ID!
+					name: title,
+					summary: summary,
+					description: description,
+					price: priceValue,
+					fiatPrice: isFiatCurrency ? priceValue : '', // Set fiatPrice if currency is fiat
+					currency: priceCurrency,
+					currencyMode: isFiatCurrency ? 'fiat' : 'sats',
+					bitcoinUnit: priceCurrency === 'BTC' ? 'BTC' : 'SATS',
+					quantity: stockTag?.[1] || '',
+					status: visibilityTag?.[1] || 'hidden',
+					productType: typeTag?.[1] === 'simple' ? 'single' : 'variable',
+					mainCategory: mainCategoryFromTags || null,
+					selectedCollection: collection,
+					categories: subCategoriesFromTags || [],
+					images: images.map((img, index) => ({
+						imageUrl: img[1],
+						imageOrder: parseInt(img[3] || index.toString(), 10),
+					})),
+					specs: specs.map((spec) => ({ key: spec[1], value: spec[2] })),
+					weight: weightTag ? { value: weightTag[1], unit: weightTag[2] } : null,
+					dimensions: dimensionsTag ? { value: dimensionsTag[1], unit: dimensionsTag[2] } : null,
+					shippings: shippingOptions,
+					activeTab,
+					isNSFW: isNSFWProduct(event),
+				}),
+			)
 		} catch (error) {
 			console.error('Error loading product for edit:', error)
-			productFormActions.reset()
+			productFormActions.startCreateProductSession()
 		}
 	},
 
@@ -276,20 +308,7 @@ export const productFormActions = {
 	},
 
 	reset: () => {
-		// Cancel any pending auto-save to prevent stale data from being written
-		cancelPendingSave()
-
-		productFormStore.setState((state) => {
-			const selectedCurrency = uiStore.state.selectedCurrency
-
-			return {
-				...DEFAULT_FORM_STATE,
-				// Increment formSessionId to signal new form session
-				formSessionId: state.formSessionId + 1,
-				currency: selectedCurrency === 'BTC' ? 'SATS' : selectedCurrency,
-				currencyMode: ['BTC', 'SATS'].includes(selectedCurrency) ? 'sats' : 'fiat',
-			}
-		})
+		productFormActions.startCreateProductSession()
 	},
 
 	updateValues: (values: Partial<ProductFormState>) => {
@@ -339,17 +358,25 @@ export const productFormActions = {
 		try {
 			const draft = await getProductFormDraft(productId)
 			if (draft) {
-				const normalizedShippings = normalizeProductShippingSelections(draft.shippings as ProductShippingForm[])
+				const {
+					editingProductId: _editingProductId,
+					formSessionId: _formSessionId,
+					activeTab: _activeTab,
+					isDirty: _isDirty,
+					...draftValues
+				} = draft
 
-				productFormStore.setState((state) => ({
-					...state,
-					...draft,
-					shippings: normalizedShippings,
-					// Restore tab state to defaults since we don't persist them
-					activeTab: 'name',
-					// Mark as dirty since we're loading unsaved changes
-					isDirty: true,
-				}))
+				const normalizedShippings = normalizeProductShippingSelections((draftValues.shippings as ProductShippingForm[] | undefined) ?? [])
+
+				productFormStore.setState((state) =>
+					getFreshSessionState(state, {
+						...draftValues,
+						shippings: normalizedShippings,
+						editingProductId: productId,
+						activeTab: 'name',
+						isDirty: true,
+					}),
+				)
 				return true
 			}
 			return false

--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -264,8 +264,6 @@ function ProductsOverviewComponent() {
 	const deleteMutation = useDeleteProductMutation()
 
 	const handleAddProductClick = () => {
-		productFormActions.reset()
-		productFormActions.setEditingProductId(null)
 		navigate({
 			to: '/dashboard/products/products/new',
 		})

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -54,13 +54,10 @@ function EditProductComponent() {
 			if (hasDraft) {
 				// Auto-load the draft instead of prompting
 				setInitState('loading-draft')
-				productFormActions.setEditingProductId(productDTag)
 				await productFormActions.loadDraftForProduct(productDTag)
 				setInitState('ready')
 			} else {
 				setInitState('loading-product')
-				productFormActions.reset()
-				productFormActions.setEditingProductId(productDTag)
 				await productFormActions.loadProductForEdit(productId)
 				setInitState('ready')
 			}

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -12,9 +12,7 @@ function NewProductComponent() {
 	useDashboardTitle('Add a Product')
 
 	useEffect(() => {
-		// Reset form and set to creation mode when component mounts
-		productFormActions.reset()
-		productFormActions.setEditingProductId(null)
+		productFormActions.startCreateProductSession()
 	}, [])
 
 	return (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { productFormActions } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { authStore } from '@/lib/stores/auth'
 import { useStore } from '@tanstack/react-store'
@@ -91,7 +92,7 @@ function Index() {
 
 	const handleStartSelling = () => {
 		if (isAuthenticated) {
-			uiActions.openDrawer('createProduct')
+			productFormActions.openCreateProductDrawer()
 		} else {
 			uiActions.openDialog('login')
 		}

--- a/src/routes/products.index.tsx
+++ b/src/routes/products.index.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { PRODUCT_CATEGORIES } from '@/lib/constants'
 import { authStore } from '@/lib/stores/auth'
+import { productFormActions } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQueries, useQuery } from '@tanstack/react-query'
@@ -178,7 +179,7 @@ function ProductsRoute() {
 
 	const handleStartSelling = () => {
 		if (isAuthenticated) {
-			uiActions.openDrawer('createProduct')
+			productFormActions.openCreateProductDrawer()
 		} else {
 			uiActions.openDialog('login')
 		}


### PR DESCRIPTION
## Summary

Fixes #724
This PR implements PR 1 of issue #724 by introducing a shared create-session initializer for the Add Product flow and wiring all create entry surfaces to it.

It fixes the lifecycle inconsistency where route-based create reset differently from drawer/sheet and “Start selling” entrypoints, which allowed repeated-create contamination and stale form state leakage.

## What this changes

- introduces a shared create/edit session initialization contract in the product form store layer
- aligns create entry surfaces around the same initializer:
  - route `/dashboard/products/products/new`
  - drawer/sheet create
  - “Start selling” entrypoints
- removes duplicated create-path initialization where it was bypassing or overlapping the shared contract
- adds focused regression tests for create-session isolation and entrypoint parity

## Invariants enforced by this PR

- a new create session always starts fresh
- create and edit do not share mutable session state
- route, drawer/sheet, and “Start selling” create paths use the same create-session contract
- starting create after an abandoned or failed attempt still starts fresh
- initial active step and mutable create state are consistent across entry surfaces

## What this PR intentionally does NOT do

This PR does **not** yet:

- normalize shipping selection storage to canonical refs
- change quick-create shipping attachment logic
- implement the V4V semantic split
- redesign tab/workflow resolution
- redesign validation/publish readiness

Those are follow-up slices in the broader #724 workstream.

## Testing

Focused session-boundary tests were added/updated to verify:

- route create starts fresh
- drawer/sheet create starts fresh
- repeated create does not inherit prior mutable state
- create after abandoned/failed attempt starts fresh
- edit flow initialization does not regress