### PR TITLE
fix: separate product form navigation from draft mutation

### DIFF
--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -101,7 +101,7 @@ export function ProductFormContent({
 		// 2. User should see shipping first (no shipping options)
 		// 3. We're NOT already on the shipping tab
 		if (handledSessionIdRef.current !== formSessionId && shouldShowShippingFirst && activeTab !== 'shipping') {
-			productFormActions.updateValues({ activeTab: 'shipping' })
+			productFormActions.setActiveTab('shipping')
 			handledSessionIdRef.current = formSessionId
 		}
 	}, [shouldShowShippingFirst, activeTab, formSessionId])
@@ -121,7 +121,7 @@ export function ProductFormContent({
 	useEffect(() => {
 		if (startedWithShippingFirstRef.current && hasValidShipping && activeTab === 'shipping') {
 			// First shipping option added, navigate to name tab
-			productFormActions.updateValues({ activeTab: 'name' })
+			productFormActions.setActiveTab('name')
 			// Reset the flag so we don't auto-navigate again
 			startedWithShippingFirstRef.current = false
 		}
@@ -169,7 +169,7 @@ export function ProductFormContent({
 			} else {
 				// No product to reload, just reset but restore tabs
 				productFormActions.reset()
-				productFormActions.setTabState(currentActiveTab)
+				productFormActions.setActiveTab(currentActiveTab)
 			}
 
 			setHasDraft(false)
@@ -266,7 +266,7 @@ export function ProductFormContent({
 				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
 				<Tabs
 					value={activeTab}
-					onValueChange={(value) => productFormActions.updateValues({ activeTab: value as ProductFormTab })}
+					onValueChange={(value) => productFormActions.setActiveTab(value as ProductFormTab)}
 					className="w-full flex flex-col flex-1 min-h-0 overflow-hidden"
 				>
 					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
@@ -367,7 +367,7 @@ export function ProductFormContent({
 								type="button"
 								variant="secondary"
 								className="flex-1 uppercase"
-								onClick={() => productFormActions.updateValues({ activeTab: 'name' })}
+								onClick={() => productFormActions.setActiveTab('name')}
 								data-testid="product-next-button"
 							>
 								Next

--- a/src/lib/stores/product-navigation.test.ts
+++ b/src/lib/stores/product-navigation.test.ts
@@ -8,11 +8,11 @@ describe('product form navigation semantics', () => {
 
 	beforeEach(() => {
 		timeoutCalls = 0
-		globalThis.setTimeout = (((_handler: TimerHandler, _timeout?: number) => {
+		globalThis.setTimeout = ((_handler: TimerHandler, _timeout?: number) => {
 			timeoutCalls += 1
 			return timeoutCalls as unknown as ReturnType<typeof setTimeout>
-		}) as typeof setTimeout)
-		globalThis.clearTimeout = (((_id?: ReturnType<typeof setTimeout>) => {}) as typeof clearTimeout)
+		}) as typeof setTimeout
+		globalThis.clearTimeout = ((_id?: ReturnType<typeof setTimeout>) => {}) as typeof clearTimeout
 
 		productFormStore.setState(() => DEFAULT_FORM_STATE)
 	})

--- a/src/lib/stores/product-navigation.test.ts
+++ b/src/lib/stores/product-navigation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
+
+describe('product form navigation semantics', () => {
+	let timeoutCalls = 0
+	const originalSetTimeout = globalThis.setTimeout
+	const originalClearTimeout = globalThis.clearTimeout
+
+	beforeEach(() => {
+		timeoutCalls = 0
+		globalThis.setTimeout = (((_handler: TimerHandler, _timeout?: number) => {
+			timeoutCalls += 1
+			return timeoutCalls as unknown as ReturnType<typeof setTimeout>
+		}) as typeof setTimeout)
+		globalThis.clearTimeout = (((_id?: ReturnType<typeof setTimeout>) => {}) as typeof clearTimeout)
+
+		productFormStore.setState(() => DEFAULT_FORM_STATE)
+	})
+
+	afterEach(() => {
+		globalThis.setTimeout = originalSetTimeout
+		globalThis.clearTimeout = originalClearTimeout
+	})
+
+	test('changing active tab does not mark the draft dirty or schedule autosave', () => {
+		productFormActions.setActiveTab('shipping')
+
+		expect(productFormStore.state.activeTab).toBe('shipping')
+		expect(productFormStore.state.isDirty).toBe(false)
+		expect(timeoutCalls).toBe(0)
+	})
+
+	test('changing active tab does not mutate product fields', () => {
+		productFormStore.setState((state) => ({
+			...state,
+			name: 'Existing name',
+			description: 'Existing description',
+			price: '42',
+		}))
+
+		productFormActions.setActiveTab('images')
+
+		expect(productFormStore.state).toMatchObject({
+			name: 'Existing name',
+			description: 'Existing description',
+			price: '42',
+			activeTab: 'images',
+			isDirty: false,
+		})
+		expect(timeoutCalls).toBe(0)
+	})
+
+	test('real product field edits still mark the draft dirty and schedule autosave', () => {
+		productFormActions.updateValues({ name: 'Updated product' })
+
+		expect(productFormStore.state.name).toBe('Updated product')
+		expect(productFormStore.state.isDirty).toBe(true)
+		expect(timeoutCalls).toBe(1)
+	})
+
+	test('reset restores the initial tab without marking the draft dirty', () => {
+		productFormActions.updateValues({ name: 'Abandoned draft' })
+		productFormActions.setActiveTab('shipping')
+
+		productFormActions.reset()
+
+		expect(productFormStore.state.activeTab).toBe('name')
+		expect(productFormStore.state.isDirty).toBe(false)
+	})
+})

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -318,7 +318,7 @@ export const productFormActions = {
 	},
 
 	// Update tab state without marking as dirty (used for navigation, restore after discard, etc.)
-	setTabState: (activeTab: ProductFormTab) => {
+	setActiveTab: (activeTab: ProductFormTab) => {
 		productFormStore.setState((state) => ({
 			...state,
 			activeTab,


### PR DESCRIPTION
Implements PR 2 of the #724 workstream.

## Summary

This PR separates product-form navigation changes from product draft mutation.

Previously, activeTab changes were routed through the generic draft update path, which incorrectly marked the form dirty and scheduled autosave for pure tab movement. This PR introduces a dedicated `setActiveTab()` action and updates the product form UI to use it for tab clicks and internal workflow navigation.

## What this changes

- adds a dedicated action for active-tab/navigation changes
- removes tab changes from the generic draft mutation path
- preserves existing dirty/autosave behavior for real product field edits
- adds focused regression tests for non-dirty navigation semantics

## Invariants enforced by this PR

- changing tabs does not mark the form dirty
- changing tabs does not trigger autosave
- product field edits still mark the form dirty
- initial/reset tab behavior remains non-dirty

## What this PR intentionally does NOT do

This PR does **not** yet:

- normalize shipping selection storage to canonical refs
- change quick-create shipping attachment logic
- implement the V4V semantic split
- redesign initial-step/workflow resolution
- redesign validation/publish readiness