### PR TITLE
fix: normalize product shipping selection model

### DIFF
--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -6,7 +6,7 @@ import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
-import { useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
+import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
 import { useV4VShares } from '@/queries/v4v'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
@@ -38,7 +38,6 @@ export function ProductFormContent({
 	const { activeTab, editingProductId, isDirty, shippings, formSessionId, name, description, images } = formState
 
 	// Compute validation states
-	const hasValidShipping = shippings.some((ship) => ship.shipping && ship.shipping.id)
 	const hasValidName = name.trim().length > 0
 	const hasValidDescription = description.trim().length > 0
 	const hasValidImages = images.length > 0
@@ -70,6 +69,23 @@ export function ProductFormContent({
 		isFetched: isShippingFetched,
 	} = useShippingOptionsByPubkey(userPubkey)
 
+	const resolvedShippingRefs = useMemo(() => {
+		if (!userShippingOptions) return new Set<string>()
+
+		return new Set(
+			userShippingOptions
+				.filter((event) => {
+					const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
+					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+				})
+				.map((event) => {
+					const info = getShippingInfo(event)
+					return info ? createShippingReference(event.pubkey, info.id) : null
+				})
+				.filter((shippingRef): shippingRef is string => !!shippingRef),
+		)
+	}, [userShippingOptions])
+
 	// Determine if we should show shipping tab first (user has no shipping options)
 	const shouldShowShippingFirst = useMemo(() => {
 		// Don't redirect if editing an existing product
@@ -90,6 +106,10 @@ export function ProductFormContent({
 		})
 		return activeShippingOptions.length === 0
 	}, [editingProductId, userShippingOptions, isLoadingUserShipping, userPubkey, isShippingFetched])
+
+	const hasValidShipping = useMemo(() => {
+		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
+	}, [shippings, isShippingFetched, resolvedShippingRefs])
 
 	// Set initial tab to Shipping when user has no shipping options
 	// Track which formSessionId we've handled to avoid re-triggering on same session

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -911,9 +911,7 @@ export function ShippingTab() {
 												• {option.service || 'Unknown service'}
 											</div>
 										) : shippingOptionsQuery.isFetched ? (
-											<div className="text-sm text-amber-600">
-												This shipping reference is no longer available: {shipping.shippingRef}
-											</div>
+											<div className="text-sm text-amber-600">This shipping reference is no longer available: {shipping.shippingRef}</div>
 										) : (
 											<div className="text-sm text-gray-500">Looking up current shipping metadata...</div>
 										)}

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -10,6 +10,7 @@ import type { RichShippingInfo } from '@/lib/stores/cart'
 import { useNDK } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductShippingForm } from '@/lib/stores/product'
 import { uiStore } from '@/lib/stores/ui'
+import { resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
 import { MempoolService } from '@/lib/utils/mempool'
 import { useBtcExchangeRates, type SupportedCurrency } from '@/queries/external'
 import { usePublishShippingOptionMutation, type ShippingFormData } from '@/publish/shipping'
@@ -702,12 +703,9 @@ export function ShippingTab() {
 			.filter(Boolean)
 			.find((opt) => opt && opt.name === templateName) as RichShippingInfo | undefined
 
-		if (newOption && !shippings.some((s) => s.shipping?.id === newOption.id)) {
+		if (newOption && !shippings.some((s) => s.shippingRef === newOption.id)) {
 			const newShipping: ProductShippingForm = {
-				shipping: {
-					id: newOption.id,
-					name: newOption.name || '',
-				},
+				shippingRef: newOption.id,
 				extraCost: '',
 			}
 			productFormActions.updateValues({
@@ -825,17 +823,14 @@ export function ShippingTab() {
 
 	const addShippingOption = (option: RichShippingInfo) => {
 		// Check if shipping option is already added
-		const isAlreadyAdded = shippings.some((s) => s.shipping?.id === option.id)
+		const isAlreadyAdded = shippings.some((s) => s.shippingRef === option.id)
 		if (isAlreadyAdded) {
 			toast.error('This shipping option is already added')
 			return
 		}
 
 		const newShipping: ProductShippingForm = {
-			shipping: {
-				id: option.id,
-				name: option.name || '',
-			},
+			shippingRef: option.id,
 			extraCost: '',
 		}
 
@@ -873,7 +868,14 @@ export function ShippingTab() {
 		}
 	}
 
-	const hasValidShipping = shippings.some((s) => s.shipping && s.shipping.id)
+	const resolvedSelectedShippings = useMemo(
+		() => resolveProductShippingSelections(shippings, availableShippingOptions),
+		[shippings, availableShippingOptions],
+	)
+
+	const hasValidShipping = shippingOptionsQuery.isFetched
+		? resolvedSelectedShippings.some((shipping) => shipping.isResolved)
+		: shippings.some((shipping) => !!shipping.shippingRef)
 
 	return (
 		<div className="space-y-6">
@@ -891,14 +893,16 @@ export function ShippingTab() {
 				<div className="space-y-4">
 					<h3 className="font-medium">Selected Shipping Options</h3>
 					<div className="space-y-3">
-						{shippings.map((shipping, index) => {
-							const option = availableShippingOptions.find((opt) => opt.id === shipping.shipping?.id)
+						{resolvedSelectedShippings.map((shipping, index) => {
+							const option = shipping.option
 							return (
 								<div key={index} className="flex items-center gap-3 p-3 border rounded-md bg-gray-50">
-									{option && option.service && <ServiceIcon service={option.service} />}
+									{option?.service ? <ServiceIcon service={option.service} /> : <AlertTriangle className="w-4 h-4 text-amber-500" />}
 									<div className="flex-1">
-										<div className="font-medium">{shipping.shipping?.name}</div>
-										{option && (
+										<div className="font-medium">
+											{option?.name || (shippingOptionsQuery.isFetched ? 'Unavailable shipping option' : 'Resolving shipping option...')}
+										</div>
+										{option ? (
 											<div className="text-sm text-gray-500">
 												{option.cost} {option.currency} •{' '}
 												{option.countries && option.countries.length > 1
@@ -906,6 +910,12 @@ export function ShippingTab() {
 													: option.countries?.[0] || 'No countries'}{' '}
 												• {option.service || 'Unknown service'}
 											</div>
+										) : shippingOptionsQuery.isFetched ? (
+											<div className="text-sm text-amber-600">
+												This shipping reference is no longer available: {shipping.shippingRef}
+											</div>
+										) : (
+											<div className="text-sm text-gray-500">Looking up current shipping metadata...</div>
 										)}
 									</div>
 									<div className="flex items-center gap-2">
@@ -1078,7 +1088,7 @@ export function ShippingTab() {
 				) : (
 					<div className="grid gap-3">
 						{availableShippingOptions
-							.filter((option) => !shippings.some((s) => s.shipping?.id === option.id))
+							.filter((option) => !shippings.some((s) => s.shippingRef === option.id))
 							.map((option) => (
 								<div key={option.id} className="flex items-center gap-3 p-3 border rounded-md hover:bg-gray-50">
 									{option.service && <ServiceIcon service={option.service} />}

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -21,7 +21,7 @@ import {
 } from '@/queries/products'
 import { productKeys } from '@/queries/queryKeyFactory'
 import { clearProductFormDraft, getProductFormDraft, saveProductFormDraft } from '@/lib/utils/productFormStorage'
-import type { RichShippingInfo } from './cart'
+import { normalizeProductShippingSelections, type ProductShippingSelection } from '@/lib/utils/productShippingSelections'
 import { uiStore } from '@/lib/stores/ui'
 import NDK, { type NDKSigner } from '@nostr-dev-kit/ndk'
 import { QueryClient } from '@tanstack/react-query'
@@ -36,10 +36,7 @@ export type ProductShipping = {
 	cost: string
 }
 
-export type ProductShippingForm = {
-	shipping: Pick<RichShippingInfo, 'id' | 'name'> | null
-	extraCost: string
-}
+export type ProductShippingForm = ProductShippingSelection
 
 export type ProductSpec = {
 	key: string
@@ -201,23 +198,10 @@ export const productFormActions = {
 			}))
 
 			// Parse shipping options
-			const shippingOptions: ProductShippingForm[] = shippingTags.map((tag) => {
-				// tag format: ['shipping_option', 'shipping_reference', 'extra_cost?']
-				const shippingRef = tag[1] // e.g., "30406:pubkey:shippingId"
-				const extraCost = tag[2] || ''
-
-				// Extract shipping name from reference (we'll use a simplified version for now)
-				// In a real app, you'd want to fetch the actual shipping option details
-				const shippingName = `Shipping Option (${shippingRef.split(':')[2] || 'unknown'})`
-
-				return {
-					shipping: {
-						id: shippingRef,
-						name: shippingName,
-					},
-					extraCost,
-				}
-			})
+			const shippingOptions: ProductShippingForm[] = shippingTags.map((tag) => ({
+				shippingRef: tag[1] || '',
+				extraCost: tag[2] || '',
+			}))
 
 			// Use preserved tab state if provided, otherwise default to 'name'
 			const activeTab = options?.preserveTabState?.activeTab ?? 'name'
@@ -309,9 +293,17 @@ export const productFormActions = {
 	},
 
 	updateValues: (values: Partial<ProductFormState>) => {
+		const normalizedValues =
+			values.shippings !== undefined
+				? {
+						...values,
+						shippings: normalizeProductShippingSelections(values.shippings as ProductShippingForm[]),
+					}
+				: values
+
 		productFormStore.setState((state) => ({
 			...state,
-			...values,
+			...normalizedValues,
 			isDirty: true,
 		}))
 		debouncedSave()
@@ -347,9 +339,12 @@ export const productFormActions = {
 		try {
 			const draft = await getProductFormDraft(productId)
 			if (draft) {
+				const normalizedShippings = normalizeProductShippingSelections(draft.shippings as ProductShippingForm[])
+
 				productFormStore.setState((state) => ({
 					...state,
 					...draft,
+					shippings: normalizedShippings,
 					// Restore tab state to defaults since we don't persist them
 					activeTab: 'name',
 					// Mark as dirty since we're loading unsaved changes
@@ -423,7 +418,7 @@ export const productFormActions = {
 			categories: state.categories,
 			images: state.images,
 			specs: state.specs,
-			shippings: state.shippings,
+			shippings: normalizeProductShippingSelections(state.shippings),
 			weight: state.weight,
 			dimensions: state.dimensions,
 			isNSFW: state.isNSFW,

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { normalizeProductShippingSelections, resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
+
+describe('product shipping selection normalization', () => {
+	beforeEach(() => {
+		productFormStore.setState(() => DEFAULT_FORM_STATE)
+	})
+
+	test('legacy draft/input shape normalizes into canonical shipping refs at the boundary', () => {
+		productFormActions.updateValues({
+			shippings: [
+				{
+					shipping: {
+						id: '30406:merchant:standard',
+						name: 'Standard Shipping',
+					},
+					extraCost: '5',
+				},
+			] as any,
+		})
+
+		expect(productFormStore.state.shippings).toEqual([
+			{
+				shippingRef: '30406:merchant:standard',
+				extraCost: '5',
+			},
+		])
+	})
+
+	test('canonical selections stay canonical after normalization', () => {
+		expect(
+			normalizeProductShippingSelections([
+				{
+					shippingRef: '30406:merchant:pickup',
+					extraCost: '0',
+				},
+			]),
+		).toEqual([
+			{
+				shippingRef: '30406:merchant:pickup',
+				extraCost: '0',
+			},
+		])
+	})
+
+	test('unresolved shipping refs are surfaced as unavailable', () => {
+		const resolvedSelections = resolveProductShippingSelections(
+			[
+				{
+					shippingRef: '30406:merchant:missing',
+					extraCost: '2',
+				},
+			],
+			[],
+		)
+
+		expect(resolvedSelections).toEqual([
+			{
+				shippingRef: '30406:merchant:missing',
+				extraCost: '2',
+				option: null,
+				isResolved: false,
+			},
+		])
+	})
+})

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -1,0 +1,58 @@
+import type { RichShippingInfo } from '@/lib/stores/cart'
+
+export type ProductShippingSelection = {
+	shippingRef: string
+	extraCost: string
+}
+
+export type LegacyProductShippingSelection = {
+	shippingRef?: string | null
+	shipping?: Pick<RichShippingInfo, 'id' | 'name'> | null
+	extraCost?: string | null
+}
+
+export type ProductShippingSelectionInput = ProductShippingSelection | LegacyProductShippingSelection
+
+export type ResolvedProductShippingSelection = ProductShippingSelection & {
+	option: RichShippingInfo | null
+	isResolved: boolean
+}
+
+export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {
+	const shippingRef =
+		(typeof input.shippingRef === 'string' && input.shippingRef.trim()) ||
+		(typeof input.shipping?.id === 'string' && input.shipping.id.trim()) ||
+		''
+
+	if (!shippingRef) return null
+
+	return {
+		shippingRef,
+		extraCost: typeof input.extraCost === 'string' ? input.extraCost : '',
+	}
+}
+
+export const normalizeProductShippingSelections = (
+	inputs: ProductShippingSelectionInput[] | null | undefined,
+): ProductShippingSelection[] => {
+	if (!inputs || inputs.length === 0) return []
+
+	return inputs
+		.map((input) => normalizeProductShippingSelection(input))
+		.filter((input): input is ProductShippingSelection => input !== null)
+}
+
+export const resolveProductShippingSelections = (
+	selections: ProductShippingSelection[],
+	availableOptions: RichShippingInfo[],
+): ResolvedProductShippingSelection[] => {
+	return selections.map((selection) => {
+		const option = availableOptions.find((availableOption) => availableOption.id === selection.shippingRef) ?? null
+
+		return {
+			...selection,
+			option,
+			isResolved: option !== null,
+		}
+	})
+}

--- a/src/publish/products.test.ts
+++ b/src/publish/products.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { createProductEvent } from '@/publish/products'
+
+const BASE_FORM_DATA = {
+	name: 'Product',
+	summary: 'Summary',
+	description: 'Description',
+	price: '1000',
+	quantity: '1',
+	currency: 'SATS',
+	status: 'on-sale' as const,
+	productType: 'single' as const,
+	mainCategory: 'Bitcoin',
+	selectedCollection: null,
+	categories: [],
+	images: [{ imageUrl: 'https://example.com/product.png', imageOrder: 0 }],
+	specs: [],
+	weight: null,
+	dimensions: null,
+	isNSFW: false,
+}
+
+describe('product publish shipping tags', () => {
+	test('publish transformation uses canonical shipping refs only', () => {
+		const event = createProductEvent(
+			{
+				...BASE_FORM_DATA,
+				shippings: [{ shippingRef: '30406:merchant:standard', extraCost: '5' }],
+			},
+			{} as any,
+			{} as any,
+		)
+
+		expect(event.tags).toContainEqual(['shipping_option', '30406:merchant:standard', '5'])
+	})
+
+	test('legacy shipping input normalizes to canonical shipping refs before publishing', () => {
+		const event = createProductEvent(
+			{
+				...BASE_FORM_DATA,
+				shippings: [
+					{
+						shipping: {
+							id: '30406:merchant:pickup',
+							name: 'Local Pickup',
+						},
+						extraCost: '',
+					},
+				] as any,
+			},
+			{} as any,
+			{} as any,
+		)
+
+		expect(event.tags).toContainEqual(['shipping_option', '30406:merchant:pickup'])
+		expect(event.tags.some((tag) => tag[0] === 'shipping_option' && tag[1] === 'Local Pickup')).toBe(false)
+	})
+})

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -1,9 +1,6 @@
 import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 import { ndkActions } from '@/lib/stores/ndk'
-import {
-	normalizeProductShippingSelections,
-	type ProductShippingSelectionInput,
-} from '@/lib/utils/productShippingSelections'
+import { normalizeProductShippingSelections, type ProductShippingSelectionInput } from '@/lib/utils/productShippingSelections'
 import { productKeys } from '@/queries/queryKeyFactory'
 import { markProductAsDeleted } from '@/queries/products'
 import NDK, { NDKEvent, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -1,6 +1,9 @@
 import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
-import type { RichShippingInfo } from '@/lib/stores/cart'
 import { ndkActions } from '@/lib/stores/ndk'
+import {
+	normalizeProductShippingSelections,
+	type ProductShippingSelectionInput,
+} from '@/lib/utils/productShippingSelections'
 import { productKeys } from '@/queries/queryKeyFactory'
 import { markProductAsDeleted } from '@/queries/products'
 import NDK, { NDKEvent, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
@@ -22,10 +25,7 @@ export interface ProductFormData {
 	categories: Array<{ key: string; name: string; checked: boolean }>
 	images: Array<{ imageUrl: string; imageOrder: number }>
 	specs: Array<{ key: string; value: string }>
-	shippings: Array<{
-		shipping: Pick<RichShippingInfo, 'id' | 'name'> | null
-		extraCost: string
-	}>
+	shippings: ProductShippingSelectionInput[]
 	weight: { value: string; unit: string } | null
 	dimensions: { value: string; unit: string } | null
 	isNSFW: boolean
@@ -63,13 +63,14 @@ export const createProductEvent = (
 
 	const specTags = formData.specs.map((spec) => ['spec', spec.key, spec.value] as NDKTag)
 
-	const shippingTags = formData.shippings
-		.filter((ship) => ship.shipping && ship.shipping.id)
+	const normalizedShippings = normalizeProductShippingSelections(formData.shippings)
+
+	const shippingTags = normalizedShippings
+		.filter((ship) => ship.shippingRef)
 		.map((ship) => {
-			// shipping.id is already a full reference like "30406:pubkey:id"
 			return ship.extraCost
-				? (['shipping_option', ship.shipping!.id, ship.extraCost] as NDKTag)
-				: (['shipping_option', ship.shipping!.id] as NDKTag)
+				? (['shipping_option', ship.shippingRef, ship.extraCost] as NDKTag)
+				: (['shipping_option', ship.shippingRef] as NDKTag)
 		})
 
 	const weightTag = formData.weight ? [['weight', formData.weight.value, formData.weight.unit] as NDKTag] : []
@@ -137,7 +138,7 @@ export const publishProduct = async (formData: ProductFormData, signer: NDKSigne
 	}
 
 	// Validate shipping options
-	const validShippings = formData.shippings.filter((ship) => ship.shipping && ship.shipping.id)
+	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
 	if (validShippings.length === 0) {
 		throw new Error('At least one shipping option is required')
 	}
@@ -189,7 +190,7 @@ export const updateProduct = async (
 	}
 
 	// Validate shipping options
-	const validShippings = formData.shippings.filter((ship) => ship.shipping && ship.shipping.id)
+	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
 	if (validShippings.length === 0) {
 		throw new Error('At least one shipping option is required')
 	}


### PR DESCRIPTION
Implements PR 3 of the #724 workstream.

## Summary

This PR normalizes product shipping selection state so the draft stores canonical shipping references instead of denormalized UI-shaped shipping objects.

Previously, the product form mixed shipping identity and display metadata inside draft state. This PR changes shipping selection truth to a canonical ref-based model, derives rendered shipping metadata from current shipping query results, and ensures the publish path uses canonical refs only.

## What this changes

- normalizes product shipping selections to canonical refs plus extra cost
- removes shipping labels/names as draft truth
- derives rendered shipping metadata from current shipping query/catalog data
- updates publish transformation to consume canonical refs only
- adds focused regression tests for normalized shipping state and unresolved ref handling

## Invariants enforced by this PR

- draft shipping selections are stored by canonical `shippingRef` only
- legacy shipping shapes are normalized once at the boundary
- in-memory runtime state remains canonical-ref based after normalization
- rendered shipping metadata is derived, not stored as truth
- publish uses canonical refs only
- unresolved shipping refs are surfaced honestly and are not treated as valid authoritative selections after fetch completes

## What this PR intentionally does NOT do

This PR does **not** yet:

- redesign quick-create shipping identity flow beyond minimal compatibility needs
- implement the V4V semantic split
- redesign workflow/tab resolution
- redesign validation/publish readiness