### PR TITLE
fix: split V4V setup semantics for add-product flow

### DIFF
--- a/e2e-new/tests/v4v-product-creation.spec.ts
+++ b/e2e-new/tests/v4v-product-creation.spec.ts
@@ -5,13 +5,14 @@ import { resetV4VForUser } from '../scenarios'
 test.use({ scenario: 'base' })
 
 test.describe('V4V Product Creation Flow', () => {
-	test('new user creating first product triggers V4V dialog and value is reflected on dashboard', async ({ newUserPage }) => {
-		// This test covers shipping quick-create, full form fill, V4V dialog, and dashboard
-		// verification — give it more time than the default 30s, especially on CI.
+	test('configured-zero user can publish first product without V4V setup blocker', async ({ newUserPage }) => {
+		// This test covers the PR 5 semantic-gating contract only:
+		// configured-zero must not block first-product publish.
+		// Give it more time than the default 30s, especially on CI.
 		test.setTimeout(60_000)
 
-		// Reset V4V shares so the V4V setup dialog will appear during product creation.
-		// This is needed because previous test runs may have saved V4V shares for devUser3.
+		// Reset V4V shares by publishing an empty event. Under the semantic split,
+		// this is a valid configured-zero state rather than "never configured".
 		await resetV4VForUser(devUser3.sk)
 
 		await newUserPage.goto('/dashboard/products/products/new')
@@ -41,11 +42,11 @@ test.describe('V4V Product Creation Flow', () => {
 		const descriptionInput = newUserPage.getByTestId('product-description-input')
 		await expect(descriptionInput).toBeVisible({ timeout: 10_000 })
 
-		await titleInput.fill('V4V Test Product')
-		await descriptionInput.fill('Product for testing V4V setup flow')
+		await titleInput.fill('V4V Zero Test Product')
+		await descriptionInput.fill('Product for testing configured-zero V4V publish flow')
 
 		// Verify values stuck before navigating (guards against form re-renders clearing values)
-		await expect(titleInput).toHaveValue('V4V Test Product')
+		await expect(titleInput).toHaveValue('V4V Zero Test Product')
 
 		await newUserPage.getByTestId('product-next-button').click()
 
@@ -85,38 +86,19 @@ test.describe('V4V Product Creation Flow', () => {
 			await addButton.click()
 		}
 
-		// --- V4V Dialog ---
-		// Since we reset V4V shares, "Setup V4V First" button should appear
+		// --- Publish Without V4V Blocker ---
+		// Configured-zero is a valid configured state, so product creation should
+		// not be blocked by the V4V setup button.
 		const v4vButton = newUserPage.getByTestId('product-setup-v4v-button')
+		const publishButton = newUserPage.getByTestId('product-publish-button')
 		await expect(newUserPage.getByTestId('product-tab-shipping')).toHaveAttribute('data-state', 'active')
 		await expect(newUserPage.getByTestId('product-next-button')).not.toBeVisible()
-		await expect(v4vButton).toBeVisible({ timeout: 20_000 })
-		await v4vButton.click()
-
-		// Dialog opens with default 10% V4V for new users
-		await expect(newUserPage.getByText('Set up Value for Value (V4V)')).toBeVisible({ timeout: 5_000 })
-
-		// Verify the slider defaults to 10% (non-zero)
-		const slider = newUserPage.locator('[role="slider"]').first()
-		await expect(slider).toHaveAttribute('aria-valuenow', '10')
-
-		// Verify the percentage labels
-		await expect(newUserPage.getByText('V4V: 10%')).toBeVisible()
-		await expect(newUserPage.getByText('Seller: 90%')).toBeVisible()
-
-		// Confirm & Save (publishes Kind 30078, then triggers product publish)
-		await newUserPage.getByTestId('confirm-v4v-setup-button').click()
+		await expect(v4vButton).not.toBeVisible()
+		await expect(publishButton).toBeVisible({ timeout: 20_000 })
+		await publishButton.click()
 
 		// --- Product Published ---
 		// App redirects to product page after publish
-		await expect(newUserPage.getByRole('heading', { name: 'V4V Test Product', level: 1 })).toBeVisible({ timeout: 15_000 })
-
-		// --- Verify V4V on Circular Economy Dashboard ---
-		await newUserPage.goto('/dashboard/sales/circular-economy')
-		await expect(newUserPage.getByRole('heading', { name: 'Circular Economy' })).toBeVisible({ timeout: 10_000 })
-
-		// The saved 10% V4V should be reflected
-		await expect(newUserPage.getByText('V4V: 10%')).toBeVisible({ timeout: 10_000 })
-		await expect(newUserPage.getByText('Seller: 90%')).toBeVisible()
+		await expect(newUserPage.getByRole('heading', { name: 'V4V Zero Test Product', level: 1 })).toBeVisible({ timeout: 15_000 })
 	})
 })

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -6,7 +6,7 @@ import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
-import { useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
+import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
 import { useV4VConfiguration } from '@/queries/v4v'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
@@ -73,6 +73,23 @@ export function ProductFormContent({
 		isFetched: isShippingFetched,
 	} = useShippingOptionsByPubkey(userPubkey)
 
+	const resolvedShippingRefs = useMemo(() => {
+		if (!userShippingOptions) return new Set<string>()
+
+		return new Set(
+			userShippingOptions
+				.filter((event) => {
+					const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
+					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+				})
+				.map((event) => {
+					const info = getShippingInfo(event)
+					return info ? createShippingReference(event.pubkey, info.id) : null
+				})
+				.filter((shippingRef): shippingRef is string => !!shippingRef),
+		)
+	}, [userShippingOptions])
+
 	// Determine if we should show shipping tab first (user has no shipping options)
 	const shouldShowShippingFirst = useMemo(() => {
 		// Don't redirect if editing an existing product
@@ -95,8 +112,8 @@ export function ProductFormContent({
 	}, [editingProductId, userShippingOptions, isLoadingUserShipping, userPubkey, isShippingFetched])
 
 	const hasValidShipping = useMemo(() => {
-		return shippings.some((ship) => ship.shippingRef)
-	}, [shippings])
+		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
+	}, [shippings, isShippingFetched, resolvedShippingRefs])
 
 	// Set initial tab to Shipping when user has no shipping options
 	// Track which formSessionId we've handled to avoid re-triggering on same session

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -6,8 +6,8 @@ import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
-import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
-import { useV4VShares } from '@/queries/v4v'
+import { useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
+import { useV4VConfiguration } from '@/queries/v4v'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { NameTab } from './NameTab'
 import { CategoryTab, DetailTab, ImagesTab, ShippingTab, SpecTab } from './tabs'
+import { shouldRequireV4VSetup } from './v4vSetup'
 
 export function ProductFormContent({
 	className = '',
@@ -56,10 +57,13 @@ export function ProductFormContent({
 	const authState = useStore(authStore)
 	const userPubkey = authState.user?.pubkey || ''
 
-	// Check V4V shares (only for new products)
-	const { data: v4vShares, isLoading: isLoadingV4V } = useV4VShares(userPubkey)
-	const hasV4VSetup = v4vShares && v4vShares.length > 0
-	const needsV4VSetup = !editingProductId && !hasV4VSetup && !isLoadingV4V
+	// Check semantic V4V setup state for new products.
+	const { data: v4vConfiguration, isLoading: isLoadingV4V } = useV4VConfiguration(userPubkey)
+	const needsV4VSetup = shouldRequireV4VSetup({
+		editingProductId,
+		isLoadingV4V,
+		v4vConfigurationState: v4vConfiguration?.state ?? 'unknown',
+	})
 
 	// Check if user has any shipping options configured (for tab ordering)
 	// Query is only enabled when userPubkey is available
@@ -68,23 +72,6 @@ export function ProductFormContent({
 		isLoading: isLoadingUserShipping,
 		isFetched: isShippingFetched,
 	} = useShippingOptionsByPubkey(userPubkey)
-
-	const resolvedShippingRefs = useMemo(() => {
-		if (!userShippingOptions) return new Set<string>()
-
-		return new Set(
-			userShippingOptions
-				.filter((event) => {
-					const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-	}, [userShippingOptions])
 
 	// Determine if we should show shipping tab first (user has no shipping options)
 	const shouldShowShippingFirst = useMemo(() => {
@@ -108,8 +95,8 @@ export function ProductFormContent({
 	}, [editingProductId, userShippingOptions, isLoadingUserShipping, userPubkey, isShippingFetched])
 
 	const hasValidShipping = useMemo(() => {
-		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
-	}, [shippings, isShippingFetched, resolvedShippingRefs])
+		return shippings.some((ship) => ship.shippingRef)
+	}, [shippings])
 
 	// Set initial tab to Shipping when user has no shipping options
 	// Track which formSessionId we've handled to avoid re-triggering on same session

--- a/src/components/sheet-contents/products/v4vSetup.test.ts
+++ b/src/components/sheet-contents/products/v4vSetup.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { shouldRequireV4VSetup } from './v4vSetup'
+
+describe('shouldRequireV4VSetup', () => {
+	test('requires V4V setup for create flow when merchant never configured V4V', () => {
+		expect(
+			shouldRequireV4VSetup({
+				editingProductId: null,
+				isLoadingV4V: false,
+				v4vConfigurationState: 'never-configured',
+			}),
+		).toBe(true)
+	})
+
+	test('does not require V4V setup for create flow when merchant configured 0%', () => {
+		expect(
+			shouldRequireV4VSetup({
+				editingProductId: null,
+				isLoadingV4V: false,
+				v4vConfigurationState: 'configured-zero',
+			}),
+		).toBe(false)
+	})
+
+	test('does not require V4V setup for edit flow when merchant never configured V4V', () => {
+		expect(
+			shouldRequireV4VSetup({
+				editingProductId: 'existing-product',
+				isLoadingV4V: false,
+				v4vConfigurationState: 'never-configured',
+			}),
+		).toBe(false)
+	})
+
+	test('does not require V4V setup for edit flow when merchant configured 0%', () => {
+		expect(
+			shouldRequireV4VSetup({
+				editingProductId: 'existing-product',
+				isLoadingV4V: false,
+				v4vConfigurationState: 'configured-zero',
+			}),
+		).toBe(false)
+	})
+})

--- a/src/components/sheet-contents/products/v4vSetup.ts
+++ b/src/components/sheet-contents/products/v4vSetup.ts
@@ -1,0 +1,16 @@
+import type { V4VConfigurationState } from '@/queries/v4v'
+
+export function shouldRequireV4VSetup({
+	editingProductId,
+	isLoadingV4V,
+	v4vConfigurationState,
+}: {
+	editingProductId?: string | null
+	isLoadingV4V: boolean
+	v4vConfigurationState: V4VConfigurationState
+}): boolean {
+	if (editingProductId) return false
+	if (isLoadingV4V) return false
+
+	return v4vConfigurationState === 'never-configured'
+}

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -87,6 +87,7 @@ export const currencyKeys = {
 
 export const v4vKeys = {
 	all: ['v4v'] as const,
+	userConfig: (pubkey: string) => [...v4vKeys.all, 'config', pubkey] as const,
 	userShares: (pubkey: string) => [...v4vKeys.all, 'shares', pubkey] as const,
 	publishShare: () => [...v4vKeys.all, 'publish'] as const,
 	merchants: () => [...v4vKeys.all, 'merchants'] as const,

--- a/src/queries/v4v.test.ts
+++ b/src/queries/v4v.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveV4VConfigurationState } from '@/queries/v4v'
+
+describe('resolveV4VConfigurationState', () => {
+	test('resolves no V4V event to never-configured', () => {
+		expect(resolveV4VConfigurationState(null)).toBe('never-configured')
+	})
+
+	test('resolves empty V4V event content to configured-zero', () => {
+		expect(resolveV4VConfigurationState({ content: '[]' } as any)).toBe('configured-zero')
+	})
+
+	test('resolves non-empty V4V event content to configured-nonzero', () => {
+		expect(resolveV4VConfigurationState({ content: '[["zap","abc","0.05"]]' } as any)).toBe('configured-nonzero')
+	})
+})

--- a/src/queries/v4v.tsx
+++ b/src/queries/v4v.tsx
@@ -7,6 +7,13 @@ import { v4 as uuidv4 } from 'uuid'
 import { v4vKeys } from './queryKeyFactory'
 import { filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
 
+export type V4VConfigurationState = 'unknown' | 'never-configured' | 'configured-zero' | 'configured-nonzero'
+
+export interface V4VConfiguration {
+	shares: V4VDTO[]
+	state: V4VConfigurationState
+}
+
 function padHexString(hex: string): string {
 	return hex.length % 2 === 1 ? '0' + hex : hex
 }
@@ -43,28 +50,113 @@ function normalizeAndEncodePubkey(value: string): { pubkey: string; npub: string
 	}
 }
 
-/**
- * Fetches V4V shares for a user
- *
- * Three distinct states:
- * 1. No V4V event exists → returns [] (user never configured V4V)
- * 2. V4V event with empty content [] → returns [] (user configured V4V but chose 0%, takes 100%)
- * 3. V4V event with shares → returns shares array
- *
- * NOTE: States 1 and 2 both return [], but state 2 has an event published.
- * The difference is important for UI logic (has the user made a choice vs never configured).
- */
-export const fetchV4VShares = async (pubkey: string): Promise<V4VDTO[]> => {
+function getMostRecentV4VEvent(events: Set<NDKEvent>): NDKEvent | null {
+	let mostRecentEvent: NDKEvent | null = null
+	let mostRecentTimestamp = 0
+
+	for (const event of Array.from(events)) {
+		if (event.created_at && event.created_at > mostRecentTimestamp) {
+			mostRecentEvent = event
+			mostRecentTimestamp = event.created_at
+		}
+	}
+
+	return mostRecentEvent
+}
+
+export function resolveV4VConfigurationState(event: Pick<NDKEvent, 'content'> | null | undefined): V4VConfigurationState {
+	if (!event) {
+		return 'never-configured'
+	}
+
+	try {
+		const content = JSON.parse(event.content)
+		if (!Array.isArray(content)) {
+			console.warn('V4V event content is not an array')
+			return 'unknown'
+		}
+
+		return content.length === 0 ? 'configured-zero' : 'configured-nonzero'
+	} catch (error) {
+		console.error('Error parsing V4V share content:', error)
+		return 'unknown'
+	}
+}
+
+async function parseV4VSharesFromEvent(event: NDKEvent, ndk: ReturnType<typeof ndkActions.getNDK>): Promise<V4VDTO[]> {
+	const content = JSON.parse(event.content)
+	if (!Array.isArray(content) || content.length === 0) {
+		return []
+	}
+
+	const seenPubkeys = new Set<string>()
+	const dedupedContent = content.filter((zapTag) => {
+		if (zapTag[0] === 'zap' && zapTag[1]) {
+			const normalized = normalizeAndEncodePubkey(zapTag[1])
+			if (normalized && !seenPubkeys.has(normalized.pubkey)) {
+				seenPubkeys.add(normalized.pubkey)
+				return true
+			}
+			return false
+		}
+		return false
+	})
+
+	const shares = await Promise.all(
+		dedupedContent
+			.map(async (zapTag, index) => {
+				if (zapTag[0] === 'zap' && zapTag[1] && zapTag[2]) {
+					const pubkeyValue = zapTag[1]
+					const percentage = parseFloat(zapTag[2]) || 5
+
+					const normalized = normalizeAndEncodePubkey(pubkeyValue)
+					if (!normalized) {
+						return null
+					}
+
+					let name = ''
+					try {
+						if (ndk) {
+							const user = ndk.getUser({
+								pubkey: normalized.pubkey,
+							})
+							await user.fetchProfile()
+							if (user.profile?.name) {
+								name = user.profile.name
+							} else if (user.profile?.displayName) {
+								name = user.profile.displayName
+							}
+						}
+					} catch (error) {
+						console.warn('Error fetching profile for V4V share:', error)
+					}
+
+					return {
+						id: `v4v-${index}-${normalized.pubkey.substring(0, 8)}`,
+						pubkey: normalized.pubkey,
+						name,
+						percentage,
+					}
+				}
+				return null
+			})
+			.filter(Boolean),
+	)
+
+	return shares.filter(Boolean) as V4VDTO[]
+}
+
+export const fetchV4VConfiguration = async (pubkey: string): Promise<V4VConfiguration> => {
 	try {
 		if (!pubkey || pubkey.trim() === '') {
-			console.warn('fetchV4VShares: Empty pubkey provided')
-			return []
+			console.warn('fetchV4VConfiguration: Empty pubkey provided')
+			return { shares: [], state: 'unknown' }
 		}
 
 		const ndk = ndkActions.getNDK()
 		if (!ndk) {
-			console.warn('NDK not ready, returning empty V4V shares')
-			return []
+			console.warn('NDK not ready, returning unknown V4V configuration')
+			return { shares: [], state: 'unknown' }
 		}
 
 		const events = await ndk.fetchEvents({
@@ -73,117 +165,53 @@ export const fetchV4VShares = async (pubkey: string): Promise<V4VDTO[]> => {
 			'#l': ['v4v_share'],
 		})
 
-		// State 1: No V4V event exists (never configured)
 		if (!events || events.size === 0) {
-			return []
+			return { shares: [], state: 'never-configured' }
 		}
 
-		let mostRecentEvent: NDKEvent | null = null
-		let mostRecentTimestamp = 0
+		const mostRecentEvent = getMostRecentV4VEvent(events)
+		const state = resolveV4VConfigurationState(mostRecentEvent)
 
-		const eventsArray = Array.from(events)
-
-		for (const event of eventsArray) {
-			if (event.created_at && event.created_at > mostRecentTimestamp) {
-				mostRecentEvent = event
-				mostRecentTimestamp = event.created_at
-			}
+		if (!mostRecentEvent || state === 'never-configured' || state === 'configured-zero') {
+			return { shares: [], state }
 		}
 
-		if (!mostRecentEvent) {
-			return []
+		if (state === 'unknown') {
+			return { shares: [], state }
 		}
 
-		try {
-			const content = JSON.parse(mostRecentEvent.content)
-
-			if (!Array.isArray(content)) {
-				console.warn('V4V event content is not an array')
-				return []
-			}
-
-			// State 2: V4V event exists but with empty array (user takes 100%)
-			if (content.length === 0) {
-				return []
-			}
-
-			// State 3: V4V event with actual shares
-			// First, deduplicate by pubkey (keep the first occurrence)
-			const seenPubkeys = new Set<string>()
-			const dedupedContent = content.filter((zapTag) => {
-				if (zapTag[0] === 'zap' && zapTag[1]) {
-					const normalized = normalizeAndEncodePubkey(zapTag[1])
-					if (normalized && !seenPubkeys.has(normalized.pubkey)) {
-						seenPubkeys.add(normalized.pubkey)
-						return true
-					}
-					return false
-				}
-				return false
-			})
-
-			const shares = await Promise.all(
-				dedupedContent
-					.map(async (zapTag, index) => {
-						if (zapTag[0] === 'zap' && zapTag[1] && zapTag[2]) {
-							const pubkeyValue = zapTag[1]
-							const percentage = parseFloat(zapTag[2]) || 5 // Default to 5% if invalid
-
-							const normalized = normalizeAndEncodePubkey(pubkeyValue)
-							if (!normalized) {
-								return null
-							}
-
-							let name = ''
-							try {
-								if (ndk) {
-									const user = ndk.getUser({
-										pubkey: normalized.pubkey,
-									})
-									await user.fetchProfile()
-									if (user.profile?.name) {
-										name = user.profile.name
-									} else if (user.profile?.displayName) {
-										name = user.profile.displayName
-									}
-								}
-							} catch (error) {
-								console.warn('Error fetching profile for V4V share:', error)
-							}
-
-							const shareObj = {
-								id: `v4v-${index}-${normalized.pubkey.substring(0, 8)}`,
-								pubkey: normalized.pubkey,
-								name,
-								percentage,
-							}
-
-							return shareObj
-						}
-						return null
-					})
-					.filter(Boolean),
-			)
-
-			return shares.filter(Boolean) as V4VDTO[]
-		} catch (error) {
-			console.error('Error parsing V4V share content:', error)
-			return []
+		const shares = await parseV4VSharesFromEvent(mostRecentEvent, ndk)
+		return {
+			shares,
+			state: shares.length > 0 ? 'configured-nonzero' : 'unknown',
 		}
+	} catch (error) {
+		console.error('Error fetching V4V configuration:', error)
+		return { shares: [], state: 'unknown' }
+	}
+}
+
+export const fetchV4VShares = async (pubkey: string): Promise<V4VDTO[]> => {
+	const { shares } = await fetchV4VConfiguration(pubkey)
+	return shares
+}
+
+export const v4VForUserQuery = async (userPubkey: string): Promise<V4VDTO[]> => {
+	try {
+		const { shares } = await fetchV4VConfiguration(userPubkey)
+		return shares
 	} catch (error) {
 		console.error('Error fetching V4V shares:', error)
 		return []
 	}
 }
 
-export const v4VForUserQuery = async (userPubkey: string): Promise<V4VDTO[]> => {
-	try {
-		const shares = await fetchV4VShares(userPubkey)
-		return shares
-	} catch (error) {
-		console.error('Error fetching V4V shares:', error)
-		return []
-	}
+export const useV4VConfiguration = (pubkey: string) => {
+	return useQuery({
+		queryKey: v4vKeys.userConfig(pubkey),
+		queryFn: () => fetchV4VConfiguration(pubkey),
+		enabled: !!pubkey,
+	})
 }
 
 export const useV4VShares = (pubkey: string) => {
@@ -245,6 +273,7 @@ export const usePublishV4VShares = () => {
 		mutationFn: (params: { shares: V4VDTO[]; userPubkey: string; appPubkey?: string }) =>
 			publishV4VShares(params.shares, params.userPubkey, params.appPubkey),
 		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({ queryKey: v4vKeys.userConfig(variables.userPubkey) })
 			// Invalidate the specific user's V4V shares query
 			queryClient.invalidateQueries({ queryKey: v4vKeys.userShares(variables.userPubkey) })
 			// Also invalidate all V4V queries to be safe


### PR DESCRIPTION
Implements PR 5 of the #724 workstream.

## Summary

This PR fixes the semantic model for V4V setup state in the Add Product flow.

Previously, product-flow logic collapsed “never configured” and “configured to 0%” into the same boolean outcome by treating `shares.length > 0` as the definition of setup. This PR introduces explicit semantic V4V state and updates Add Product logic to distinguish:

- never configured
- configured-zero
- configured-nonzero

## What this changes

- introduces explicit semantic V4V setup state
- stops using `shares.length > 0` as setup truth
- treats empty V4V configuration as a valid configured state
- updates Add Product gating/visibility logic to use semantic V4V state
- adds focused regression tests for semantic V4V resolution

## Invariants enforced by this PR

- “never configured” and “configured zero” are distinct states
- empty V4V event content is treated as a valid configured state
- Add Product no longer uses `shares.length > 0` as setup truth
- edit flow is not newly blocked by `never-configured` or `configured-zero` state

## What this PR intentionally does NOT do

This PR does **not** yet:

- redesign the final V4V create-flow step
- redesign workflow/tab resolution
- redesign validation/publish readiness
- force edit flow through V4V onboarding