### PR TITLE
docs: add Add Product workflow architecture artifacts

### DIFF
--- a/docs/adr/ADR-add-product-workflow-boundaries.md
+++ b/docs/adr/ADR-add-product-workflow-boundaries.md
@@ -31,27 +31,33 @@ The work will be delivered as a sequence of small, reviewable PRs rather than a 
 ## Architecture boundaries
 
 ### 1. Product draft truth
+
 Product draft state is the source of truth for product authoring data only.
 
 It must not be used as the place where:
+
 - merchant prerequisite/setup truth is persisted
 - workflow navigation truth is reconstructed indirectly
 - external/provider display metadata becomes authoritative identity
 
 Key direction:
+
 - navigation state is not draft mutation
 - canonical refs are preferred over denormalized display objects
 - create/edit session state must not leak across boundaries
 
 ### 2. Merchant setup truth
+
 Merchant setup/prerequisite state is query-derived and semantically explicit.
 
 It must not be collapsed into:
+
 - boolean shortcuts like `shares.length > 0`
 - draft-state persistence
 - product-authoring assumptions that blur create vs edit behavior
 
 Key direction:
+
 - preserve distinctions like:
   - never configured
   - configured zero
@@ -59,7 +65,9 @@ Key direction:
 - treat setup state as prerequisite truth, not draft truth
 
 ### 3. Workflow/session truth
+
 Workflow/session truth determines:
+
 - create vs edit flow mode
 - initial/current step determination
 - prerequisite-driven routing
@@ -68,6 +76,7 @@ Workflow/session truth determines:
 It must become explicit and deterministic rather than effect-driven.
 
 Key direction:
+
 - a new create session always starts fresh
 - initial/current step logic should eventually be centralized in an explicit resolver
 - create-only onboarding rules must not accidentally block edit flow
@@ -86,6 +95,7 @@ Key direction:
 ## Consequences
 
 ### Positive
+
 - clearer source-of-truth boundaries
 - fewer hidden couplings
 - more deterministic workflow behavior
@@ -93,6 +103,7 @@ Key direction:
 - better regression testing around each boundary
 
 ### Costs
+
 - short-term increase in architectural surface area while transitional helpers exist
 - some test contracts need to be updated as semantic truth becomes more accurate
 - workflow logic may temporarily be split between legacy behavior and the new resolver until later slices land
@@ -100,24 +111,31 @@ Key direction:
 ## Rollout / PR sequence
 
 ### PR 1 — create/edit session boundary hardening
+
 Introduce a shared session initializer and ensure all create entry surfaces use it.
 
 ### PR 2 — separate navigation from draft mutation
+
 Make tab changes workflow-only and non-dirty.
 
 ### PR 3 — normalize shipping selection model
+
 Store canonical shipping refs in draft state and derive display metadata.
 
 ### PR 4 — quick-create shipping identity flow
+
 Attach newly created shipping by canonical identity rather than name-based rediscovery.
 
 ### PR 5 — V4V semantic split
+
 Introduce explicit V4V semantic state and stop using share-array length as setup truth.
 
 ### PR 6 — explicit workflow resolver / initial step determination
+
 Centralize create/edit step resolution and remove effect-driven prerequisite routing where touched.
 
 ### PR 7 — canonical validation / publish-readiness alignment
+
 Unify workflow readiness and publish gating under one explicit validation model.
 
 ## Notes

--- a/docs/adr/ADR-add-product-workflow-boundaries.md
+++ b/docs/adr/ADR-add-product-workflow-boundaries.md
@@ -1,0 +1,125 @@
+# ADR: Stabilize “Start selling → Add a product” workflow boundaries, normalize draft state, and remove effect-driven onboarding/publish gating
+
+## Status
+
+Proposed
+
+## Context
+
+The “Start selling → Add a product” flow currently mixes multiple sources of truth and workflow concerns in ways that produce recurring instability:
+
+- mutable product draft state reused across create/edit/session boundaries
+- merchant setup/prerequisite state derived from async queries
+- workflow/navigation state embedded in component logic
+- effect-driven prerequisite routing and onboarding gating
+- publish gating not yet aligned with one canonical validation contract
+
+This has produced a class of bugs rather than one isolated defect, including repeated create-session contamination, stale navigation behavior, brittle shipping selection state, and incorrect V4V setup semantics.
+
+A symptom-level patch would not solve the underlying problem. The workflow needs explicit architectural boundaries and a staged refactor sequence.
+
+## Decision
+
+The Add Product flow will be stabilized by separating three distinct truth domains:
+
+1. **product draft truth**
+2. **merchant setup truth**
+3. **workflow/session truth**
+
+The work will be delivered as a sequence of small, reviewable PRs rather than a single redesign.
+
+## Architecture boundaries
+
+### 1. Product draft truth
+Product draft state is the source of truth for product authoring data only.
+
+It must not be used as the place where:
+- merchant prerequisite/setup truth is persisted
+- workflow navigation truth is reconstructed indirectly
+- external/provider display metadata becomes authoritative identity
+
+Key direction:
+- navigation state is not draft mutation
+- canonical refs are preferred over denormalized display objects
+- create/edit session state must not leak across boundaries
+
+### 2. Merchant setup truth
+Merchant setup/prerequisite state is query-derived and semantically explicit.
+
+It must not be collapsed into:
+- boolean shortcuts like `shares.length > 0`
+- draft-state persistence
+- product-authoring assumptions that blur create vs edit behavior
+
+Key direction:
+- preserve distinctions like:
+  - never configured
+  - configured zero
+  - configured non-zero
+- treat setup state as prerequisite truth, not draft truth
+
+### 3. Workflow/session truth
+Workflow/session truth determines:
+- create vs edit flow mode
+- initial/current step determination
+- prerequisite-driven routing
+- onboarding visibility/blocking rules
+
+It must become explicit and deterministic rather than effect-driven.
+
+Key direction:
+- a new create session always starts fresh
+- initial/current step logic should eventually be centralized in an explicit resolver
+- create-only onboarding rules must not accidentally block edit flow
+
+## Invariants
+
+- create and edit never share mutable session state
+- merchant setup state is query-derived prerequisite state and must not be persisted inside product draft state
+- navigation/tab movement is workflow state, not draft mutation
+- draft shipping truth uses canonical refs
+- quick-created shipping attaches by canonical identity
+- `configured-zero` V4V is a valid configured state
+- initial/current step determination is explicit and centralized
+- publish readiness should eventually come from one canonical validation model
+
+## Consequences
+
+### Positive
+- clearer source-of-truth boundaries
+- fewer hidden couplings
+- more deterministic workflow behavior
+- smaller, more reviewable PRs
+- better regression testing around each boundary
+
+### Costs
+- short-term increase in architectural surface area while transitional helpers exist
+- some test contracts need to be updated as semantic truth becomes more accurate
+- workflow logic may temporarily be split between legacy behavior and the new resolver until later slices land
+
+## Rollout / PR sequence
+
+### PR 1 — create/edit session boundary hardening
+Introduce a shared session initializer and ensure all create entry surfaces use it.
+
+### PR 2 — separate navigation from draft mutation
+Make tab changes workflow-only and non-dirty.
+
+### PR 3 — normalize shipping selection model
+Store canonical shipping refs in draft state and derive display metadata.
+
+### PR 4 — quick-create shipping identity flow
+Attach newly created shipping by canonical identity rather than name-based rediscovery.
+
+### PR 5 — V4V semantic split
+Introduce explicit V4V semantic state and stop using share-array length as setup truth.
+
+### PR 6 — explicit workflow resolver / initial step determination
+Centralize create/edit step resolution and remove effect-driven prerequisite routing where touched.
+
+### PR 7 — canonical validation / publish-readiness alignment
+Unify workflow readiness and publish gating under one explicit validation model.
+
+## Notes
+
+This ADR is the design anchor for the Add Product stabilization workstream. It is intentionally architecture-first and does not attempt to redesign the entire visible UX in one decision.

--- a/docs/github-issues/add-product-workflow-boundaries-issue.md
+++ b/docs/github-issues/add-product-workflow-boundaries-issue.md
@@ -1,0 +1,135 @@
+# Stabilize “Start selling → Add a product” workflow boundaries, normalize draft state, and remove effect-driven onboarding/publish gating
+
+## Problem statement
+
+The current “Start selling → Add a product” flow is not failing because of one isolated shipping-tab bug. It is failing because the workflow mixes multiple concerns without one explicit workflow source of truth:
+
+- singleton draft state
+- merchant prerequisite/setup state derived from async queries
+- UI navigation state
+- effect-driven routing between tabs/steps
+- publish gating logic
+
+This creates a class of failures rather than one bug:
+
+- repeated create-session contamination
+- stale tab position or unexpected tab jumps
+- shipping selection persistence inconsistencies
+- onboarding/setup state leaking into authoring flow
+- publish gating that is difficult to reason about or test
+
+The workflow needs to be stabilized by separating truth boundaries and refactoring the flow into small, reviewable slices.
+
+## Goals
+
+- establish explicit boundaries between product draft truth, merchant setup truth, and workflow/session truth
+- ensure a new create session always starts cleanly
+- make navigation semantics distinct from draft mutation semantics
+- normalize product shipping selection truth to canonical refs
+- remove effect-driven identity and setup heuristics where explicit state should exist
+- make V4V setup semantics explicit
+- make the workflow deterministic and easier to test
+- sequence the work into the smallest meaningful PRs
+
+## Non-goals
+
+- full Add Product UX redesign in one PR
+- introducing a full workflow state machine immediately
+- redesigning validation and publish-readiness in the same slice as truth-model fixes
+- merging unrelated E2E stabilization or unrelated product bugs into this workstream
+- replacing existing UI order without first centralizing workflow truth
+
+## Invariants
+
+### Product draft truth
+- product draft state must not be the place where merchant prerequisite/setup truth is persisted
+- create and edit must not share mutable session state
+- navigation state must not be treated as product-data mutation
+- canonical draft truth should favor stable internal refs over display metadata
+
+### Merchant setup truth
+- merchant setup state is query-derived prerequisite state and must not be persisted inside product draft state
+- semantic distinctions such as “never configured” vs “configured zero” must be preserved explicitly
+- provider/external integration metadata must not become draft truth
+
+### Workflow/session truth
+- a new create session always starts fresh
+- initial/current step determination must come from explicit workflow logic, not scattered effects
+- create-only onboarding rules must not accidentally block edit flow
+- publish readiness must eventually come from one canonical validation contract
+
+## Proposed PR sequence / checklist
+
+- [ ] **PR 1 — create/edit session boundary hardening**
+  - shared create-session initializer
+  - all create entry surfaces use the same session contract
+  - repeated create attempts start cleanly
+
+- [ ] **PR 2 — separate navigation from draft mutation**
+  - tab/step movement is workflow state, not draft mutation
+  - tab changes do not dirty the form or trigger autosave
+
+- [ ] **PR 3 — normalize shipping selection model**
+  - draft shipping truth uses canonical refs
+  - display metadata is derived
+  - publish uses canonical refs only
+
+- [ ] **PR 4 — quick-create shipping identity flow**
+  - newly created shipping attaches by canonical identity
+  - no title/name rediscovery dependency
+  - no refetch-timing dependency for correctness
+
+- [ ] **PR 5 — V4V semantic split**
+  - distinguish `never-configured`, `configured-zero`, `configured-nonzero`
+  - stop using `shares.length > 0` as setup truth
+
+- [ ] **PR 6 — explicit workflow resolver / initial step determination**
+  - centralize create/edit step resolution
+  - remove effect-driven prerequisite routing where touched
+
+- [ ] **PR 7 — canonical validation / publish-readiness alignment**
+  - unify workflow readiness and publish gating
+  - reduce false-ready UI states
+
+## Acceptance criteria
+
+### Functional
+- starting create after a failed or abandoned create attempt produces a fresh session with no inherited shipping selections, active step, or stale setup state
+- create and edit no longer leak mutable state into each other
+- tab changes do not dirty the form or trigger autosave
+- shipping selections are canonical-ref based
+- quick-created shipping attaches by canonical identity
+- empty V4V configuration is treated as configured-zero, not “not configured”
+- create/edit initial-step resolution is explicit and deterministic
+- publish gating eventually aligns with one canonical validation contract
+
+### Architectural
+- product draft truth, merchant setup truth, and workflow truth are clearly separated
+- query-derived prerequisite state is not persisted as draft truth
+- effect-driven onboarding/publish gating is incrementally removed in favor of explicit semantic/workflow logic
+- each PR is reviewable on its own and does not collapse multiple architectural concerns into one diff
+
+### Testing
+- each slice adds focused regression coverage for the exact boundary it changes
+- deterministic tests exist for:
+  - create/edit session isolation
+  - non-dirty navigation semantics
+  - canonical shipping truth
+  - quick-create identity handoff
+  - V4V semantic state resolution
+  - workflow step resolution
+  - validation/publish-readiness alignment
+
+## Rollout notes
+
+- land the work as a sequence of small PRs, not one giant refactor
+- keep unrelated suite stabilization separate unless a branch is explicitly dedicated to test-only stabilization
+- when an E2E expectation conflicts with a corrected semantic model, update the test contract rather than reintroducing the old bug
+- document the target architecture in an ADR and link it from this issue
+- use this issue as the workstream anchor; use PRs to land one boundary fix at a time
+
+## ADR
+
+The design anchor for this workstream should live at:
+
+`docs/adr/ADR-add-product-workflow-boundaries.md`

--- a/docs/github-issues/add-product-workflow-boundaries-issue.md
+++ b/docs/github-issues/add-product-workflow-boundaries-issue.md
@@ -42,17 +42,20 @@ The workflow needs to be stabilized by separating truth boundaries and refactori
 ## Invariants
 
 ### Product draft truth
+
 - product draft state must not be the place where merchant prerequisite/setup truth is persisted
 - create and edit must not share mutable session state
 - navigation state must not be treated as product-data mutation
 - canonical draft truth should favor stable internal refs over display metadata
 
 ### Merchant setup truth
+
 - merchant setup state is query-derived prerequisite state and must not be persisted inside product draft state
 - semantic distinctions such as “never configured” vs “configured zero” must be preserved explicitly
 - provider/external integration metadata must not become draft truth
 
 ### Workflow/session truth
+
 - a new create session always starts fresh
 - initial/current step determination must come from explicit workflow logic, not scattered effects
 - create-only onboarding rules must not accidentally block edit flow
@@ -94,6 +97,7 @@ The workflow needs to be stabilized by separating truth boundaries and refactori
 ## Acceptance criteria
 
 ### Functional
+
 - starting create after a failed or abandoned create attempt produces a fresh session with no inherited shipping selections, active step, or stale setup state
 - create and edit no longer leak mutable state into each other
 - tab changes do not dirty the form or trigger autosave
@@ -104,12 +108,14 @@ The workflow needs to be stabilized by separating truth boundaries and refactori
 - publish gating eventually aligns with one canonical validation contract
 
 ### Architectural
+
 - product draft truth, merchant setup truth, and workflow truth are clearly separated
 - query-derived prerequisite state is not persisted as draft truth
 - effect-driven onboarding/publish gating is incrementally removed in favor of explicit semantic/workflow logic
 - each PR is reviewable on its own and does not collapse multiple architectural concerns into one diff
 
 ### Testing
+
 - each slice adds focused regression coverage for the exact boundary it changes
 - deterministic tests exist for:
   - create/edit session isolation

--- a/docs/github-issues/add-product-workflow-boundaries-opening-comment.md
+++ b/docs/github-issues/add-product-workflow-boundaries-opening-comment.md
@@ -1,0 +1,25 @@
+This workstream should be reviewed as a **workflow/source-of-truth stabilization effort**, not as a one-off shipping-tab bugfix.
+
+The important framing is:
+
+- **product draft truth**
+- **merchant setup truth**
+- **workflow/session truth**
+
+are currently too entangled, which is why the flow has shown repeated create-session contamination, brittle shipping behavior, and incorrect V4V setup semantics.
+
+The intended approach is to land this in **small PR slices**, each fixing one architectural boundary at a time:
+
+1. create/edit session boundaries
+2. navigation vs draft mutation
+3. shipping truth normalization
+4. quick-create shipping identity
+5. V4V semantic split
+6. explicit workflow resolver
+7. canonical validation / publish-readiness
+
+The ADR for this workstream should live at:
+
+`docs/adr/ADR-add-product-workflow-boundaries.md`
+
+Please review each PR against that architecture, rather than as isolated symptom patches.


### PR DESCRIPTION
## Summary

This PR adds maintainer-facing workstream artifacts for the Add Product architecture refactor:

- GitHub issue body
- ADR markdown
- opening comment for the issue/PR thread

## Files added

- `docs/github-issues/add-product-workflow-boundaries-issue.md`
- `docs/adr/ADR-add-product-workflow-boundaries.md`
- `docs/github-issues/add-product-workflow-boundaries-opening-comment.md`

## Purpose

These artifacts package the Add Product workflow refactor as a structured architecture workstream with explicit boundaries, invariants, rollout sequence, and small-PR slicing guidance.