### PR TITLE
fix: make shipping quick-create attachment identity-driven

### DIFF
--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -10,13 +10,13 @@ import type { RichShippingInfo } from '@/lib/stores/cart'
 import { useNDK } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductShippingForm } from '@/lib/stores/product'
 import { uiStore } from '@/lib/stores/ui'
+import { attachShippingOptionByRef } from '@/lib/utils/productShippingQuickCreate'
 import { resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
 import { MempoolService } from '@/lib/utils/mempool'
 import { useBtcExchangeRates, type SupportedCurrency } from '@/queries/external'
 import { usePublishShippingOptionMutation, type ShippingFormData } from '@/publish/shipping'
-import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, shippingKeys } from '@/queries/shipping'
+import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useForm } from '@tanstack/react-form'
-import { useQueryClient } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
 import { Info, ArrowRightLeft, DownloadIcon, Loader2, PackageIcon, PlusIcon, TruckIcon, X, AlertTriangle } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
@@ -658,7 +658,6 @@ const QUICK_SHIPPING_TEMPLATES: Array<{
 export function ShippingTab() {
 	const { shippings } = useStore(productFormStore)
 	const { getUser } = useNDK()
-	const queryClient = useQueryClient()
 	const [user, setUser] = useState<any>(null)
 	const [isCreatingShipping, setIsCreatingShipping] = useState(false)
 	const [showPickupForm, setShowPickupForm] = useState(false)
@@ -677,42 +676,6 @@ export function ShippingTab() {
 	}, [getUser])
 
 	const shippingOptionsQuery = useShippingOptionsByPubkey(user?.pubkey || '')
-
-	// Helper to auto-add a shipping option after creation
-	const autoAddShippingOption = async (templateName: string) => {
-		// Wait for the query to refetch and use the result directly
-		const refetchResult = await shippingOptionsQuery.refetch()
-
-		// Find the newly created option by name
-		const refetchedData = refetchResult.data || []
-		const newOption = refetchedData
-			.map((event) => {
-				const info = getShippingInfo(event)
-				if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return null
-				const id = createShippingReference(user.pubkey, info.id)
-				return {
-					id,
-					name: info.title,
-					cost: parseFloat(info.price.amount),
-					currency: info.price.currency,
-					countries: info.countries || [],
-					service: info.service || '',
-					carrier: info.carrier || '',
-				}
-			})
-			.filter(Boolean)
-			.find((opt) => opt && opt.name === templateName) as RichShippingInfo | undefined
-
-		if (newOption && !shippings.some((s) => s.shippingRef === newOption.id)) {
-			const newShipping: ProductShippingForm = {
-				shippingRef: newOption.id,
-				extraCost: '',
-			}
-			productFormActions.updateValues({
-				shippings: [...shippings, newShipping],
-			})
-		}
-	}
 
 	// Quick-create a shipping option from template
 	const handleQuickCreate = async (template: (typeof QUICK_SHIPPING_TEMPLATES)[number]) => {
@@ -735,14 +698,11 @@ export function ShippingTab() {
 				service: template.service,
 			}
 
-			await publishShippingMutation.mutateAsync(formData)
+			const publishedShipping = await publishShippingMutation.mutateAsync(formData)
 
-			// Invalidate and refetch shipping options with the correct pubkey
-			await queryClient.invalidateQueries({ queryKey: shippingKeys.byPubkey(user.pubkey) })
-			await queryClient.invalidateQueries({ queryKey: shippingKeys.all })
-
-			// Auto-add the newly created shipping option
-			await autoAddShippingOption(template.name)
+			productFormActions.updateValues({
+				shippings: attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef),
+			})
 
 			toast.success(`${template.name} shipping option created and added!`)
 		} catch (error) {
@@ -779,14 +739,11 @@ export function ShippingTab() {
 				pickupAddress: pickupAddress,
 			}
 
-			await publishShippingMutation.mutateAsync(formData)
+			const publishedShipping = await publishShippingMutation.mutateAsync(formData)
 
-			// Invalidate and refetch shipping options with the correct pubkey
-			await queryClient.invalidateQueries({ queryKey: shippingKeys.byPubkey(user.pubkey) })
-			await queryClient.invalidateQueries({ queryKey: shippingKeys.all })
-
-			// Auto-add the newly created shipping option
-			await autoAddShippingOption('Local Pickup')
+			productFormActions.updateValues({
+				shippings: attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef),
+			})
 
 			toast.success('Local Pickup shipping option created and added!')
 			setShowPickupForm(false)

--- a/src/lib/utils/productShippingQuickCreate.test.ts
+++ b/src/lib/utils/productShippingQuickCreate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import { attachShippingOptionByRef } from '@/lib/utils/productShippingQuickCreate'
+
+describe('product shipping quick-create attachment', () => {
+	test('attaches the created shipping option by canonical shipping ref', () => {
+		expect(attachShippingOptionByRef([], '30406:merchant:new-option')).toEqual([
+			{
+				shippingRef: '30406:merchant:new-option',
+				extraCost: '',
+			},
+		])
+	})
+
+	test('dedupe keys off canonical shipping ref, not title', () => {
+		const existing = [
+			{
+				shippingRef: '30406:merchant:existing-option',
+				extraCost: '',
+			},
+		]
+
+		expect(attachShippingOptionByRef(existing, '30406:merchant:existing-option')).toEqual(existing)
+		expect(attachShippingOptionByRef(existing, '30406:merchant:new-option')).toEqual([
+			...existing,
+			{
+				shippingRef: '30406:merchant:new-option',
+				extraCost: '',
+			},
+		])
+	})
+
+	test('attachment correctness does not depend on fetched catalog contents or title collisions', () => {
+		const existing = [
+			{
+				shippingRef: '30406:merchant:older-standard',
+				extraCost: '',
+			},
+		]
+
+		const attached = attachShippingOptionByRef(existing, '30406:merchant:new-standard')
+
+		expect(attached).toEqual([
+			existing[0],
+			{
+				shippingRef: '30406:merchant:new-standard',
+				extraCost: '',
+			},
+		])
+	})
+})

--- a/src/lib/utils/productShippingQuickCreate.ts
+++ b/src/lib/utils/productShippingQuickCreate.ts
@@ -1,9 +1,6 @@
 import type { ProductShippingForm } from '@/lib/stores/product'
 
-export const attachShippingOptionByRef = (
-	shippings: ProductShippingForm[],
-	shippingRef: string,
-): ProductShippingForm[] => {
+export const attachShippingOptionByRef = (shippings: ProductShippingForm[], shippingRef: string): ProductShippingForm[] => {
 	if (!shippingRef.trim()) return shippings
 
 	if (shippings.some((shipping) => shipping.shippingRef === shippingRef)) {

--- a/src/lib/utils/productShippingQuickCreate.ts
+++ b/src/lib/utils/productShippingQuickCreate.ts
@@ -1,0 +1,20 @@
+import type { ProductShippingForm } from '@/lib/stores/product'
+
+export const attachShippingOptionByRef = (
+	shippings: ProductShippingForm[],
+	shippingRef: string,
+): ProductShippingForm[] => {
+	if (!shippingRef.trim()) return shippings
+
+	if (shippings.some((shipping) => shipping.shippingRef === shippingRef)) {
+		return shippings
+	}
+
+	return [
+		...shippings,
+		{
+			shippingRef,
+			extraCost: '',
+		},
+	]
+}

--- a/src/publish/shipping.test.ts
+++ b/src/publish/shipping.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test'
+import { buildPublishedShippingOption } from '@/publish/shipping'
+
+describe('published shipping option identity', () => {
+	test('derives canonical shippingRef from mutation result identity', () => {
+		expect(buildPublishedShippingOption('event-123', 'merchant-pubkey', 'shipping_abc')).toEqual({
+			eventId: 'event-123',
+			shippingDTag: 'shipping_abc',
+			shippingRef: '30406:merchant-pubkey:shipping_abc',
+		})
+	})
+})

--- a/src/publish/shipping.tsx
+++ b/src/publish/shipping.tsx
@@ -1,7 +1,7 @@
 import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 import { ndkActions } from '@/lib/stores/ndk'
 import { shippingKeys } from '@/queries/queryKeyFactory'
-import { markShippingAsDeleted } from '@/queries/shipping'
+import { createShippingReference, markShippingAsDeleted } from '@/queries/shipping'
 import NDK, { NDKEvent, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -44,6 +44,18 @@ export interface ShippingFormData {
 		distance?: { value: string; unit: string }
 	}
 }
+
+export interface PublishedShippingOption {
+	eventId: string
+	shippingDTag: string
+	shippingRef: string
+}
+
+export const buildPublishedShippingOption = (eventId: string, pubkey: string, shippingDTag: string): PublishedShippingOption => ({
+	eventId,
+	shippingDTag,
+	shippingRef: createShippingReference(pubkey, shippingDTag),
+})
 
 /**
  * Creates a new shipping option event (kind 30406)
@@ -171,7 +183,11 @@ export const createShippingEvent = (
 /**
  * Publishes a new shipping option
  */
-export const publishShippingOption = async (formData: ShippingFormData, signer: NDKSigner, ndk: NDK): Promise<string> => {
+export const publishShippingOption = async (
+	formData: ShippingFormData,
+	signer: NDKSigner,
+	ndk: NDK,
+): Promise<PublishedShippingOption> => {
 	// Validation
 	if (!formData.title.trim()) {
 		throw new Error('Shipping title is required')
@@ -227,7 +243,13 @@ export const publishShippingOption = async (formData: ShippingFormData, signer: 
 	await event.sign(signer)
 	await ndkActions.publishEvent(event)
 
-	return event.id
+	const shippingDTag = event.tags.find((tag) => tag[0] === 'd')?.[1]
+	if (!shippingDTag) {
+		throw new Error('Published shipping option is missing d tag')
+	}
+
+	const user = await signer.user()
+	return buildPublishedShippingOption(event.id, user.pubkey, shippingDTag)
 }
 
 /**
@@ -337,7 +359,7 @@ export const usePublishShippingOptionMutation = () => {
 			if (!signer) throw new Error('No signer available')
 			return publishShippingOption(formData, signer, ndk)
 		},
-		onSuccess: async (eventId) => {
+		onSuccess: async () => {
 			// Invalidate and refetch shipping options queries
 			await queryClient.invalidateQueries({ queryKey: shippingKeys.all })
 

--- a/src/publish/shipping.tsx
+++ b/src/publish/shipping.tsx
@@ -183,11 +183,7 @@ export const createShippingEvent = (
 /**
  * Publishes a new shipping option
  */
-export const publishShippingOption = async (
-	formData: ShippingFormData,
-	signer: NDKSigner,
-	ndk: NDK,
-): Promise<PublishedShippingOption> => {
+export const publishShippingOption = async (formData: ShippingFormData, signer: NDKSigner, ndk: NDK): Promise<PublishedShippingOption> => {
 	// Validation
 	if (!formData.title.trim()) {
 		throw new Error('Shipping title is required')


### PR DESCRIPTION
Implements PR 4 of the #724 workstream.

## Summary

This PR makes the Add Product shipping quick-create flow attach the newly created shipping option by canonical identity instead of rediscovering it by title or waiting for refetch timing.

Previously, quick-create attachment depended on finding the created option in the refreshed catalog, which made correctness dependent on name matching and query timing. This PR makes mutation result identity the source of truth for attachment while keeping catalog refetch for eventual display convergence.

## What this changes

- attaches newly created shipping options by canonical `shippingRef`
- removes name/title matching as the source of attachment truth
- makes attachment correctness independent of refetch timing
- preserves canonical shipping selection state and dedupe by `shippingRef`
- adds focused regression tests for created-option attachment correctness

## What this PR intentionally does NOT do

This PR does **not** yet:

- redesign shipping tab UX
- implement the V4V semantic split
- redesign workflow/tab resolution
- redesign validation/publish readiness