### PR TITLE
fix: disable zap message for logged out users

### DIFF
--- a/src/components/messages/ConversationView.tsx
+++ b/src/components/messages/ConversationView.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
 import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 interface ConversationViewProps {
 	/** The pubkey of the other user in the conversation */
@@ -75,7 +76,7 @@ export function ConversationView({ otherUserPubkey, onTitleChange }: Conversatio
 		onError: (err) => {
 			setIsSending(false)
 			console.error('Error sending message:', err)
-			alert(`Failed to send message: ${err instanceof Error ? err.message : 'Unknown error'}`)
+			toast.error(`Failed to send message: ${err instanceof Error ? err.message : 'Unknown error'}`)
 		},
 	})
 

--- a/src/components/messages/MessageInput.tsx
+++ b/src/components/messages/MessageInput.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
+import { authStore } from '@/lib/stores/auth'
+import { useStore } from '@tanstack/react-store'
 import { Send } from 'lucide-react'
 import { useState } from 'react'
 
@@ -10,6 +12,8 @@ interface MessageInputProps {
 
 export function MessageInput({ onSendMessage, isSending }: MessageInputProps) {
 	const [message, setMessage] = useState('')
+	const { user } = useStore(authStore)
+	const isLoggedIn = !!user
 
 	const handleSend = async () => {
 		if (message.trim() === '') return
@@ -31,14 +35,14 @@ export function MessageInput({ onSendMessage, isSending }: MessageInputProps) {
 					value={message}
 					onChange={(e) => setMessage(e.target.value)}
 					onKeyPress={handleKeyPress}
-					placeholder="Type your message..."
+					placeholder={isLoggedIn ? 'Type your message...' : 'Log in to send messages'}
 					className="w-full flex-grow resize-none p-2 pr-12 border rounded-lg focus:ring-2 focus:ring-primary"
 					rows={1}
-					disabled={isSending}
+					disabled={isSending || !isLoggedIn}
 				/>
 				<Button
 					onClick={handleSend}
-					disabled={isSending || message.trim() === ''}
+					disabled={isSending || !isLoggedIn || message.trim() === ''}
 					size="icon"
 					className="absolute right-2.5 top-1/2 -translate-y-1/2 h-7 w-7"
 				>

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -118,6 +118,7 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	const handleMessageClick = () => {
 		if (user?.pubkey) {
 			uiActions.openConversation(user.pubkey)
+			console.log('Opening conversation with', user.pubkey)
 		}
 	}
 

--- a/src/queries/messages.tsx
+++ b/src/queries/messages.tsx
@@ -4,6 +4,7 @@ import { authStore } from '@/lib/stores/auth'
 import { useStore } from '@tanstack/react-store'
 import { NDKEvent, type NDKUser, type NDKFilter } from '@nostr-dev-kit/ndk'
 import { messageKeys } from './queryKeyFactory'
+import { toast } from 'sonner'
 
 const MESSAGE_KINDS = [14, 16, 17]
 
@@ -111,14 +112,14 @@ export async function sendChatMessage(recipientPubkey: string, content: string, 
 	if (!ndk || !currentUser) {
 		// Simplified check, main check is for ndk.signer below
 		console.error('NDK or current user not available for sending message')
-		alert('User not available. Please ensure you are logged in.')
+		toast.error('User not available. Please ensure you are logged in.')
 		return undefined
 	}
 
 	if (!ndk.signer) {
 		// Check for ndk.signer directly
 		console.error('NDK signer not available for sending message')
-		alert('Signer not available. Please ensure you are logged in correctly.')
+		toast.error('Signer not available. Please ensure you are logged in correctly.')
 		return undefined
 	}
 
@@ -136,7 +137,7 @@ export async function sendChatMessage(recipientPubkey: string, content: string, 
 		return event
 	} catch (error) {
 		console.error('Error sending chat message:', error)
-		alert(`Error sending message: ${error instanceof Error ? error.message : String(error)}`)
+		toast.error(`Error sending message: ${error instanceof Error ? error.message : String(error)}`)
 		return undefined
 	}
 }

--- a/src/routes/_dashboard-layout/dashboard/sales/messages/$pubkey.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/messages/$pubkey.tsx
@@ -12,6 +12,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { Loader2 } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/sales/messages/$pubkey')({
 	component: ConversationDetailComponent,
@@ -67,7 +68,7 @@ function ConversationDetailComponent() {
 		onError: (err) => {
 			setIsSending(false)
 			console.error('Error sending message:', err)
-			alert(`Failed to send message: ${err instanceof Error ? err.message : 'Unknown error'}`)
+			toast.error(`Failed to send message: ${err instanceof Error ? err.message : 'Unknown error'}`)
 		},
 	})
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/25745f48-9d6e-4eae-b213-44594255af12

This replaces the generic browser alerts with a toast for errors in conversations

closes #729