### PR TITLE
Refactor/shadcn component cleanup

### DIFF
--- a/e2e-new/tests/app-settings.spec.ts
+++ b/e2e-new/tests/app-settings.spec.ts
@@ -63,7 +63,7 @@ async function clickDestructiveButtonForText(page: Page, text: string) {
 	await expect(rowText).toBeVisible({ timeout: 15_000 })
 
 	const row = rowText.locator('xpath=ancestor::div[contains(@class,"flex") and contains(@class,"items-center")]')
-	const destructiveButton = row.locator('button[class*="destructive"]')
+	const destructiveButton = row.locator('button[data-variant="destructive"]')
 
 	await expect(destructiveButton).toBeVisible()
 	await destructiveButton.click({ timeout: 15_000 })

--- a/scripts/shadcn-pull-components.sh
+++ b/scripts/shadcn-pull-components.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script pulls components from ui.shadcn.com. The components are 
+# documented at https://ui.shadcn.com/docs/components where you can add
+# more to the list.
+
+# The script automatically pulls the components into src/components/ui.
+
+# ==============================================================================
+# CONFIGURATION: Edit this list to change which components are updated
+# Use kebab-case (e.g., 'alert-dialog', 'input-otp')
+# ==============================================================================
+COMPONENTS=(
+  accordion
+  alert
+  badge
+  button
+  card
+  carousel
+  checkbox
+  collapsible
+  dialog
+  drawer
+  dropdown-menu
+  input
+  label
+  popover
+  progress
+  radio-group
+  scroll-area
+  select
+  separator
+  sheet
+  skeleton
+  slider
+  sonner
+  spinner
+  switch
+  table
+  tabs
+  textarea
+  tooltip
+)
+
+# ==============================================================================
+# EXECUTION LOGIC
+# ==============================================================================
+
+echo "🚀 Starting ShadCN component update..."
+echo "📦 Target components: ${#COMPONENTS[@]}"
+
+# Convert array to space-separated string for the command
+COMPONENT_LIST="${COMPONENTS[*]}"
+
+# Run the command using Bun
+# We use --bun to ensure it uses the Bun runtime for speed
+if bunx --bun shadcn@latest add $COMPONENT_LIST; then
+  echo "✅ Successfully updated all components!"
+else
+  echo "❌ Error: Component update failed. Check the output above."
+  exit 1
+fi

--- a/src/components/BugReportModal.tsx
+++ b/src/components/BugReportModal.tsx
@@ -339,30 +339,30 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 
 	return (
 		<div
-			className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+			className="z-50 fixed inset-0 flex justify-center items-center bg-black/50 backdrop-blur-sm"
 			onClick={onClose}
 			onKeyDown={handleKeyDown}
 		>
-			<div className="bg-white rounded-lg shadow-xl w-[40em] h-[80vh] flex flex-col" onClick={(e) => e.stopPropagation()}>
+			<div className="flex flex-col bg-white shadow-xl rounded-lg w-[40em] h-[80vh]" onClick={(e) => e.stopPropagation()}>
 				{/* Header */}
-				<div className="flex items-center justify-between border-b border-gray-200 p-6">
+				<div className="flex justify-between items-center p-6 border-gray-200 border-b">
 					<div className="flex items-center gap-2">
 						<Button
-							variant={activeTab === 'report' ? 'primary' : 'outline'}
+							variant={activeTab === 'report' ? 'default' : 'outline'}
 							size="sm"
 							onClick={() => setActiveTab('report')}
 							className={cn('flex items-center gap-2', activeTab !== 'report' && 'text-gray-700 border-gray-300')}
 						>
-							<span className="i-warning w-4 h-4" />
+							<span className="w-4 h-4 i-warning" />
 							Bug Report
 						</Button>
 						<Button
-							variant={activeTab === 'viewer' ? 'primary' : 'outline'}
+							variant={activeTab === 'viewer' ? 'default' : 'outline'}
 							size="sm"
 							onClick={() => setActiveTab('viewer')}
 							className={cn('flex items-center gap-2', activeTab !== 'viewer' && 'text-gray-700 border-gray-300')}
 						>
-							<span className="i-search w-4 h-4" />
+							<span className="w-4 h-4 i-search" />
 							Report Viewer
 						</Button>
 					</div>
@@ -370,24 +370,24 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 						variant="ghost"
 						size="icon"
 						onClick={onClose}
-						className="h-8 w-8 text-gray-500 hover:text-gray-700"
+						className="w-8 h-8 text-gray-500 hover:text-gray-700"
 						aria-label="Close bug report modal"
 					>
-						<span className="i-close w-5 h-5" />
+						<span className="w-5 h-5 i-close" />
 					</Button>
 				</div>
 
 				{/* Content */}
-				<div className="flex-1 flex flex-col px-6 pt-0 pb-6 min-h-0">
+				<div className="flex flex-col flex-1 px-6 pt-0 pb-6 min-h-0">
 					{activeTab === 'report' ? (
 						<>
-							<Alert className="bg-blue-100 text-blue-800 border-blue-200 mb-4">
+							<Alert className="bg-blue-100 mb-4 border-blue-200 text-blue-800">
 								<AlertDescription>
 									Report a bug you have found. Use the drag and drop or paste to add images of the problem. The details of your system
 									configuration have been automatically added.
 								</AlertDescription>
 							</Alert>
-							<div className="flex-1 flex flex-col min-h-0">
+							<div className="flex flex-col flex-1 min-h-0">
 								<textarea
 									ref={textareaRef}
 									value={bugReport}
@@ -398,7 +398,7 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 									onDrop={handleDrop}
 									placeholder="Describe the bug you encountered..."
 									className={cn(
-										'flex-1 w-full p-4 border border-gray-300 rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-secondary focus:border-transparent text-gray-900 placeholder:text-gray-400',
+										'flex-1 p-4 border border-gray-300 focus:border-transparent rounded-lg focus:outline-none focus:ring-2 focus:ring-secondary w-full text-gray-900 placeholder:text-gray-400 resize-none',
 										isDragOver && 'border-secondary bg-secondary/5',
 										isUploading && 'opacity-50',
 									)}
@@ -406,31 +406,31 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 									disabled={isUploading}
 								/>
 								{isDragOver && (
-									<div className="absolute inset-0 flex items-center justify-center bg-secondary/10 border-2 border-dashed border-secondary rounded-lg pointer-events-none">
-										<p className="text-secondary font-medium">Drop image files here</p>
+									<div className="absolute inset-0 flex justify-center items-center bg-secondary/10 border-2 border-secondary border-dashed rounded-lg pointer-events-none">
+										<p className="font-medium text-secondary">Drop image files here</p>
 									</div>
 								)}
 								{isUploading && (
-									<div className="absolute inset-0 flex items-center justify-center bg-white/80 rounded-lg pointer-events-none">
-										<p className="text-gray-600 font-medium">Uploading image...</p>
+									<div className="absolute inset-0 flex justify-center items-center bg-white/80 rounded-lg pointer-events-none">
+										<p className="font-medium text-gray-600">Uploading image...</p>
 									</div>
 								)}
 							</div>
 						</>
 					) : (
 						<>
-							<Alert className="bg-blue-100 text-blue-800 border-blue-200 mb-4">
+							<Alert className="bg-blue-100 mb-4 border-blue-200 text-blue-800">
 								<AlertDescription>View bug reports from the community</AlertDescription>
 							</Alert>
-							<div className="flex-1 overflow-y-auto min-h-0">
+							<div className="flex-1 min-h-0 overflow-y-auto">
 								{isLoadingReports && reports.length === 0 ? (
-									<div className="flex flex-col items-center justify-center py-12">
-										<Loader2 className="w-8 h-8 animate-spin mb-4" />
+									<div className="flex flex-col justify-center items-center py-12">
+										<Loader2 className="mb-4 w-8 h-8 animate-spin" />
 										<p className="text-gray-600">Loading bug reports...</p>
 									</div>
 								) : reports.length === 0 ? (
-									<div className="flex flex-col items-center justify-center py-12 text-center">
-										<h3 className="text-lg font-semibold text-gray-900 mb-2">No bug reports found</h3>
+									<div className="flex flex-col justify-center items-center py-12 text-center">
+										<h3 className="mb-2 font-semibold text-gray-900 text-lg">No bug reports found</h3>
 										<p className="text-gray-600">There are no bug reports available at the moment.</p>
 									</div>
 								) : (
@@ -443,7 +443,7 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 												<Button onClick={loadMore} variant="outline" disabled={isLoadingReports}>
 													{isLoadingReports ? (
 														<>
-															<Loader2 className="w-4 h-4 animate-spin mr-2" />
+															<Loader2 className="mr-2 w-4 h-4 animate-spin" />
 															Loading...
 														</>
 													) : (
@@ -461,13 +461,13 @@ Cookies: ${info.cookieEnabled ? 'Enabled' : 'Disabled'}`
 
 				{/* Footer */}
 				{activeTab === 'report' && (
-					<div className="flex justify-end items-center p-6 border-t border-gray-200">
+					<div className="flex justify-end items-center p-6 border-gray-200 border-t">
 						<Button
 							onClick={handleSend}
 							disabled={!bugReport.trim() || isUploading}
 							className="flex items-center gap-2 bg-secondary hover:bg-secondary/90 text-white"
 						>
-							<span className="i-send-message w-4 h-4" />
+							<span className="w-4 h-4 i-send-message" />
 							Send
 						</Button>
 					</div>

--- a/src/components/CurrencyDropdown.tsx
+++ b/src/components/CurrencyDropdown.tsx
@@ -24,12 +24,11 @@ export function CurrencyDropdown() {
 			<Tooltip open={isOpen ? false : undefined}>
 				<TooltipTrigger asChild>
 					<Button
-						variant="primary"
-						className="p-2 px-3 relative flex items-center gap-1 hover:[&>span]:text-secondary hover:[&>svg]:text-secondary"
+						className="relative flex items-center gap-1 p-2 px-3 btn-border-highlight hover:[&>span]:text-secondary hover:[&>svg]:text-secondary"
 						onClick={toggleDropdown}
 						data-testid="currency-dropdown-button"
 					>
-						<span className="text-sm font-medium">{selectedCurrency}</span>
+						<span className="font-medium text-sm">{selectedCurrency}</span>
 						<ChevronDown className={`w-4 h-4 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} />
 					</Button>
 				</TooltipTrigger>
@@ -39,10 +38,10 @@ export function CurrencyDropdown() {
 			{isOpen && (
 				<>
 					{/* Backdrop to close dropdown when clicking outside */}
-					<div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+					<div className="z-40 fixed inset-0" onClick={() => setIsOpen(false)} />
 
 					{/* Dropdown menu */}
-					<div className="absolute right-0 top-full mt-1 bg-primary rounded-lg shadow-lg z-50 min-w-24 max-h-60 overflow-y-auto">
+					<div className="top-full right-0 z-50 absolute bg-primary shadow-lg mt-1 rounded-lg min-w-24 max-h-60 overflow-y-auto">
 						{CURRENCIES.map((currency) => (
 							<Button
 								key={currency}

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -11,6 +11,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Button } from '@/components/ui/button'
 import { hasAcceptedTerms } from '@/components/dialogs/TermsConditionsDialog'
 import { uiActions } from '@/lib/stores/ui'
+import { cn } from '@/lib/utils'
 
 interface LoginDialogProps {
 	open: boolean
@@ -34,6 +35,26 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 		}
 	}
 
+	const classNameTab = cn(
+		// Layout & Spacing
+		'flex-1 px-1 sm:px-2 py-2 text-sm sm:text-base font-medium rounded-none',
+
+		// Reset Shadows (Crucial for removing the "glow" or drop shadow)
+		'shadow-none!',
+
+		// Base State (Inactive): Thin Primary Border
+		'border-x-0 border-t-0 border-b border-primary',
+		'text-black hover:text-secondary',
+
+		// Active State: Switch to Secondary Border, Remove Shadow
+		'data-[state=active]:border-secondary',
+		'data-[state=active]:text-secondary',
+		'data-[state=active]:shadow-none',
+
+		// Hide the internal ShadCN "after:" line indicator
+		'after:hidden',
+	)
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent
@@ -41,7 +62,7 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 				data-testid="login-dialog"
 			>
 				{/* Header Section */}
-				<div className="relative bg-black text-white px-4 sm:px-6 py-6 overflow-hidden w-full max-w-full">
+				<div className="relative bg-black px-4 sm:px-6 py-6 w-full max-w-full overflow-hidden text-white">
 					<div
 						className="absolute inset-0 opacity-80"
 						style={{
@@ -50,32 +71,25 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 							backgroundRepeat: 'repeat',
 						}}
 					/>
-					<div className="relative z-10">
-						<h2 className="text-xl font-semibold mb-2">Login</h2>
-						<p className="text-sm text-gray-300">Choose your preferred login method below.</p>
+					<div className="z-10 relative">
+						<h2 className="mb-2 font-semibold text-xl">Login</h2>
+						<p className="text-gray-300 text-sm">Choose your preferred login method below.</p>
 					</div>
 				</div>
-				<div className="px-4 sm:px-6 pt-0 pb-6 overflow-hidden w-full max-w-full">
-					<Tabs defaultValue="extension" className="w-full max-w-full min-w-0" value={activeTab} onValueChange={setActiveTab}>
-						<TabsList className="w-full rounded-none bg-transparent h-auto p-0 flex">
-							<TabsTrigger
-								value="extension"
-								data-testid="extension-tab"
-								className="flex-1 px-1 sm:px-2 py-2 text-sm sm:text-base font-medium data-[state=active]:text-secondary border-b-1 data-[state=active]:border-secondary data-[state=inactive]:text-black rounded-none"
-							>
+				<div className="px-4 sm:px-6 pt-0 pb-6 w-full max-w-full overflow-hidden">
+					<Tabs defaultValue="extension" className="w-full min-w-0 max-w-full" value={activeTab}>
+						<TabsList className="flex bg-transparent p-0 rounded-none w-full h-auto">
+							<TabsTrigger value="extension" data-testid="extension-tab" className={classNameTab} onClick={() => setActiveTab('extension')}>
 								Extension
 							</TabsTrigger>
-							<TabsTrigger
-								value="connect"
-								data-testid="connect-tab"
-								className="flex-1 px-1 sm:px-2 py-2 text-sm sm:text-base font-medium data-[state=active]:text-secondary border-b-1 data-[state=active]:border-secondary data-[state=inactive]:text-black rounded-none"
-							>
+							<TabsTrigger value="connect" data-testid="connect-tab" className={classNameTab} onClick={() => setActiveTab('connect')}>
 								N-Connect
 							</TabsTrigger>
 							<TabsTrigger
 								value="private-key"
 								data-testid="private-key-tab"
-								className="flex-1 px-1 sm:px-2 py-2 text-sm sm:text-base font-medium data-[state=active]:text-secondary border-b-1 data-[state=active]:border-secondary data-[state=inactive]:text-black rounded-none"
+								className={classNameTab}
+								onClick={() => setActiveTab('private-key')}
 							>
 								Private Key
 							</TabsTrigger>
@@ -84,19 +98,19 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 							<PrivateKeyLogin onError={handleError} onSuccess={handleLoginSuccess} />
 						</TabsContent>
 						<TabsContent value="connect" className="w-full max-w-full overflow-hidden">
-							<Tabs defaultValue="qr" className="w-full max-w-full min-w-0">
-								<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
+							<Tabs defaultValue="qr" className="w-full min-w-0 max-w-full">
+								<TabsList className="flex flex-wrap gap-[1px] bg-transparent p-0 w-full h-auto">
 									<TabsTrigger
 										value="qr"
 										data-testid="qr-tab"
-										className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+										className="flex-1 data-[state=active]:bg-secondary data-[state=inactive]:bg-gray-100 px-4 py-2 rounded-none font-medium data-[state=active]:text-white data-[state=inactive]:text-black text-xs"
 									>
 										QR Code
 									</TabsTrigger>
 									<TabsTrigger
 										value="bunker"
 										data-testid="bunker-tab"
-										className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+										className="flex-1 data-[state=active]:bg-secondary data-[state=inactive]:bg-gray-100 px-4 py-2 rounded-none font-medium data-[state=active]:text-white data-[state=inactive]:text-black text-xs"
 									>
 										Bunker URL
 									</TabsTrigger>
@@ -113,9 +127,9 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 						</TabsContent>
 						<TabsContent value="extension" className="w-full max-w-full overflow-hidden">
 							<div className="space-y-4 py-4">
-								<p className="text-sm text-muted-foreground">Login using your Nostr browser extension (e.g., Alby, nos2x).</p>
+								<p className="text-muted-foreground text-sm">Login using your Nostr browser extension (e.g., Alby, nos2x).</p>
 								{extensionError && (
-									<div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded text-sm" role="alert">
+									<div className="bg-red-50 px-4 py-3 border border-red-200 rounded text-red-700 text-sm" role="alert">
 										<p className="font-medium">Login Failed</p>
 										<p>{extensionError}</p>
 									</div>
@@ -139,7 +153,7 @@ export function LoginDialog({ open, onOpenChange }: LoginDialogProps) {
 						</TabsContent>
 					</Tabs>
 					<div className="flex items-center space-x-2">
-						<Label htmlFor="auto-login" className=" flex gap-2 text-sm text-muted-foreground items-center">
+						<Label htmlFor="auto-login" className="flex items-center gap-2 text-muted-foreground text-sm">
 							<Checkbox
 								id="auto-login"
 								checked={enableAutoLogin}

--- a/src/components/dialogs/ShareProductDialog.tsx
+++ b/src/components/dialogs/ShareProductDialog.tsx
@@ -108,7 +108,7 @@ ${productUrl}
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-[40em] max-w-[calc(100%-2rem)] max-h-[90vh] overflow-x-hidden overflow-y-auto bg-white">
+			<DialogContent className="bg-white max-w-[calc(100%-2rem)] sm:max-w-[40em] max-h-[90vh] overflow-x-hidden overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>Share Product</DialogTitle>
 					<DialogDescription id="share-dialog-description">Share this product with others or post it to your Nostr feed.</DialogDescription>
@@ -117,7 +117,7 @@ ${productUrl}
 				<div className="space-y-6 py-4 overflow-x-hidden">
 					{isAuthenticated && (
 						<div className="space-y-2">
-							<label htmlFor="share-text" className="text-sm font-medium text-gray-700">
+							<label htmlFor="share-text" className="font-medium text-gray-700 text-sm">
 								Content to post to Nostr
 							</label>
 							<Textarea
@@ -126,15 +126,15 @@ ${productUrl}
 								value={shareText}
 								onChange={(e) => setShareText(e.target.value)}
 								rows={8}
-								className="resize-none break-words whitespace-pre-wrap w-full overflow-wrap-anywhere"
+								className="w-full overflow-wrap-anywhere break-words whitespace-pre-wrap resize-none"
 								placeholder="Write something about this product..."
 							/>
 						</div>
 					)}
 
-					<div className="flex gap-2 flex-wrap">
-						<Button variant="tertiary" onClick={handleCopyUrl} className="shrink-0">
-							{isCopied ? <Check className="h-4 w-4 mr-2" /> : <Copy className="h-4 w-4 mr-2" />}
+					<div className="flex flex-wrap gap-2">
+						<Button variant="outline" onClick={handleCopyUrl} className="shrink-0">
+							{isCopied ? <Check className="mr-2 w-4 h-4" /> : <Copy className="mr-2 w-4 h-4" />}
 							{isCopied ? 'Copied!' : 'Copy URL'}
 						</Button>
 
@@ -142,9 +142,9 @@ ${productUrl}
 							<Button
 								onClick={handlePostToNostr}
 								disabled={isPosting || !shareText.trim()}
-								className="flex-1 flex items-center justify-center gap-2 bg-secondary hover:bg-secondary/90 text-white"
+								className="flex flex-1 justify-center items-center gap-2"
 							>
-								<span className="i-send-message w-4 h-4" />
+								<span className="w-4 h-4 i-send-message" />
 								{isPosting ? 'Posting...' : 'Post to Nostr'}
 							</Button>
 						)}

--- a/src/components/dialogs/ShareProfileDialog.tsx
+++ b/src/components/dialogs/ShareProfileDialog.tsx
@@ -32,7 +32,7 @@ export function ShareProfileDialog({ open, onOpenChange, pubkey, profileName }: 
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="sm:max-w-md max-w-[calc(100%-2rem)] bg-white">
+			<DialogContent className="bg-white max-w-[calc(100%-2rem)] sm:max-w-md">
 				<DialogHeader>
 					<DialogTitle>Share Profile</DialogTitle>
 					<DialogDescription>
@@ -43,12 +43,12 @@ export function ShareProfileDialog({ open, onOpenChange, pubkey, profileName }: 
 				<div className="flex flex-col items-center gap-6 py-4">
 					<QRCode value={npub} size={200} showBorder={false} />
 
-					<div className="w-full space-y-2">
-						<p className="text-xs text-gray-500 text-center">npub</p>
+					<div className="space-y-2 w-full">
+						<p className="text-gray-500 text-xs text-center">npub</p>
 						<div className="flex items-center gap-2">
-							<code className="flex-1 p-2 bg-gray-100 rounded text-xs break-all select-all">{npub}</code>
-							<Button variant="tertiary" size="icon" onClick={handleCopyNpub} className="shrink-0">
-								{isCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+							<code className="flex-1 bg-gray-100 p-2 rounded text-xs break-all select-all">{npub}</code>
+							<Button variant="outline" size="icon" onClick={handleCopyNpub} className="shrink-0">
+								{isCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
 							</Button>
 						</div>
 					</div>

--- a/src/components/dialogs/ZapDialog.tsx
+++ b/src/components/dialogs/ZapDialog.tsx
@@ -217,8 +217,8 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 					<DialogHeader>
 						<DialogTitle>Loading Zap Information...</DialogTitle>
 					</DialogHeader>
-					<div className="flex items-center justify-center py-8">
-						<Loader2 className="h-8 w-8 animate-spin" />
+					<div className="flex justify-center items-center py-8">
+						<Loader2 className="w-8 h-8 animate-spin" />
 						<span className="ml-2">Fetching zap data...</span>
 					</div>
 					<DialogFooter>
@@ -249,12 +249,11 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 						<div className="py-2">
 							<div className="space-y-2">
 								<Label className="font-bold">Amount</Label>
-								<div className="grid grid-cols-3 gap-2">
+								<div className="gap-2 grid grid-cols-3">
 									{DEFAULT_ZAP_AMOUNTS.map(({ displayText, amount: presetAmount }) => (
 										<Button
 											key={presetAmount}
-											variant={numericAmount === presetAmount ? 'focus' : 'outline'}
-											className={numericAmount === presetAmount ? 'border-2' : 'border-2 border-black'}
+											variant={numericAmount === presetAmount ? 'default' : 'outline'}
 											onClick={() => handleAmountButtonClick(presetAmount)}
 										>
 											{displayText}
@@ -295,7 +294,7 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 									{amount === '' && <span className="text-red-500 text-sm">Amount is required</span>}
 								</div>
 
-								<div className="flex items-center justify-between gap-4">
+								<div className="flex justify-between items-center gap-4">
 									<Label htmlFor="isAnonymousZap" className="font-bold">
 										Anonymous zap
 									</Label>
@@ -309,16 +308,16 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 							<div className="flex flex-col gap-2">
 								{hasNip60Wallet && recipientZapSupport.hasNip61 && (
 									<Button onClick={handleSendNutzap} className="w-full" variant="secondary" disabled={!canSendNutzap}>
-										{isSubmittingNutzap ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Zap className="mr-2 h-4 w-4" />}
+										{isSubmittingNutzap ? <Loader2 className="mr-2 w-4 h-4 animate-spin" /> : <Zap className="mr-2 w-4 h-4" />}
 										Zap with Nutzap (NIP-60)
 									</Button>
 								)}
-								<Button onClick={handleContinueToPayment} className="w-full" variant="focus" disabled={!canProceedToPayment}>
-									<Zap className="mr-2 h-4 w-4" />
+								<Button onClick={handleContinueToPayment} className="w-full" disabled={!canProceedToPayment}>
+									<Zap className="mr-2 w-4 h-4" />
 									Continue to payment
 								</Button>
 							</div>
-							<div className="text-xs text-muted-foreground mt-2">
+							<div className="mt-2 text-muted-foreground text-xs">
 								{!recipientZapSupport.canReceiveZaps
 									? 'This user does not advertise zap methods.'
 									: !recipientZapSupport.hasNip57
@@ -334,11 +333,11 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 				{step === 'generateInvoice' && (
 					<>
 						{/* Amount and Message Info */}
-						<div className="text-center mb-4">
-							<p className="text-sm font-medium">
+						<div className="mb-4 text-center">
+							<p className="font-medium text-sm">
 								Amount: <span className="font-bold">{isValidAmount ? numericAmount : '0'} sats</span>
 							</p>
-							{effectiveZapMessage && <p className="text-sm text-muted-foreground mt-1">Message: "{effectiveZapMessage}"</p>}
+							{effectiveZapMessage && <p className="mt-1 text-muted-foreground text-sm">Message: "{effectiveZapMessage}"</p>}
 						</div>
 
 						{/* Payment Processor Section */}
@@ -353,7 +352,7 @@ export function ZapDialog({ isOpen, onOpenChange, event, onZapComplete }: ZapDia
 								/>
 							</div>
 						) : (
-							<div className="text-center py-8 text-muted-foreground">
+							<div className="py-8 text-muted-foreground text-center">
 								<p>Lightning zap method unavailable</p>
 								<p className="text-sm">This user does not advertise a NIP-57 zap endpoint.</p>
 							</div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,35 +19,35 @@ import { AvatarUser } from '@/components/AvatarUser'
 import { cn } from '@/lib/utils'
 import { useProfile } from '@/queries/profiles'
 import { BugReportModal } from '../BugReportModal'
+import { TooltipButton } from '../shared/TooltipButton'
 
 const LoginButton = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>((props, ref) => {
 	return (
-		<Button
-			variant="primary"
-			className="p-2 relative hover:[&>span]:text-secondary"
-			icon={<span className="i-account w-6 h-6" />}
+		<TooltipButton
+			className="relative p-2 btn-border-highlight hover:[&>span]:text-secondary"
 			data-testid="login-button"
 			ref={ref}
 			tooltip="Log In"
 			{...props}
 			onClick={() => uiActions.openDialog('login')}
-		/>
+		>
+			<span className="w-6 h-6 i-account" />
+		</TooltipButton>
 	)
 })
 
 const LogoutButton = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>((props, ref) => {
 	return (
-		<Button
-			variant="primary"
-			className="p-2 relative hover:[&>svg]:text-secondary"
+		<TooltipButton
+			className="relative p-2 btn-border-highlight hover:[&>svg]:text-secondary"
 			data-testid="logout-button"
 			ref={ref}
 			tooltip="Log Out"
 			{...props}
 			onClick={() => authActions.logout()}
 		>
-			<LogOut className="w-6 h-6" />
-		</Button>
+			<LogOut className="size-4" />
+		</TooltipButton>
 	)
 })
 
@@ -67,42 +67,23 @@ const ProfileButton = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<H
 		}
 	}
 
-	// Only show spinner while actively fetching for the first time
-	if (isPending && fetchStatus === 'fetching') {
-		return (
-			<Button variant="ghost" size={'icon'} disabled>
-				<Loader2 className={cn('h-4 w-4 animate-spin')} />
-			</Button>
-		)
+	// Note: Loading Spinner, Unauthenticated etc. handled in parent.
+	// If not authenticated, return empty.
+	if ((isPending && fetchStatus === 'fetching') || !authState.isAuthenticated) {
+		return <></>
 	}
 
 	// Both desktop and mobile - simple button that navigates to profile when authenticated
 	return (
-		<Button
-			variant={authState.isAuthenticated ? 'primary' : 'outline'}
-			size={'icon'}
-			className={cn(
-				'p-2 w-full relative',
-				!authState.isAuthenticated && 'text-muted-foreground hover:text-foreground',
-				isOnOwnProfile && 'bg-secondary text-black hover:bg-secondary hover:text-black',
-			)}
+		<TooltipButton
+			className={cn('relative p-2 btn-border-highlight', isOnOwnProfile && 'btn-active')}
 			ref={ref}
 			tooltip="Go to profile"
 			{...props}
 			onClick={handleProfileClick}
 		>
-			{authState.isAuthenticated ? (
-				<AvatarUser pubkey={authState.user?.pubkey} className="w-6 h-6" />
-			) : (
-				<>
-					{authState.isAuthenticated ? (
-						<span className={cn('i-account w-6 h-6', isOnOwnProfile && 'text-black')} />
-					) : (
-						<span className="i-account w-6 h-6" />
-					)}
-				</>
-			)}
-		</Button>
+			<AvatarUser pubkey={authState.user?.pubkey} className="mx-1 w-6 h-6" />
+		</TooltipButton>
 	)
 })
 
@@ -118,14 +99,20 @@ const CartButton = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTML
 	}
 
 	return (
-		<Button variant="primary" tooltip="View cart" className="p-2 relative hover:text-secondary" ref={ref} {...props} onClick={handleClick}>
-			<span className="i-basket w-6 h-6" />
+		<TooltipButton
+			tooltip="View cart"
+			className="relative p-2 btn-border-highlight hover:text-secondary"
+			ref={ref}
+			{...props}
+			onClick={handleClick}
+		>
+			<span className="w-6 h-6 i-basket" />
 			{totalItems > 0 && (
-				<span className="absolute -top-2.5 -right-2.5 bg-secondary text-black text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
+				<span className="-top-2.5 -right-2.5 absolute flex justify-center items-center bg-secondary rounded-full w-5 h-5 font-bold text-black text-xs">
 					{totalItems > 99 ? '99+' : totalItems}
 				</span>
 			)}
-		</Button>
+		</TooltipButton>
 	)
 })
 
@@ -138,19 +125,19 @@ const DashboardButton = forwardRef<HTMLButtonElement, DashboardButtonProps>((pro
 
 	return (
 		<Link to="/dashboard" data-testid="dashboard-link" className="relative">
-			<Button
-				variant="primary"
-				className={`p-2 relative hover:[&>span]:text-secondary ${
-					location.pathname.startsWith('/dashboard') ? 'bg-secondary text-black [&>span]:text-black' : ''
+			<TooltipButton
+				className={`btn-border-highlight p-2 relative hover:[&>span]:text-secondary ${
+					location.pathname.startsWith('/dashboard') ? 'btn-active' : ''
 				}`}
-				icon={<span className="i-dashboard w-6 h-6" />}
 				data-testid="dashboard-button"
 				tooltip="Dashboard"
 				ref={ref}
 				{...props}
-			/>
+			>
+				<span className="w-6 h-6 i-dashboard" />
+			</TooltipButton>
 			{totalNotifications > 0 && (
-				<span className="absolute -top-2 -right-2 bg-secondary text-black text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
+				<span className="-top-2 -right-2 absolute flex justify-center items-center bg-secondary rounded-full w-5 h-5 font-bold text-black text-xs">
 					{totalNotifications > 99 ? '99+' : totalNotifications}
 				</span>
 			)}
@@ -162,12 +149,16 @@ function WalletButton() {
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<Button variant="primary" tooltip="Wallet" className="p-2 relative hover:[&>svg]:text-secondary" data-testid="wallet-button">
-					<Wallet className="w-6 h-6" />
-				</Button>
+				<TooltipButton
+					tooltip="Wallet"
+					className="relative p-2 btn-border-highlight hover:[&>svg]:text-secondary"
+					data-testid="wallet-button"
+				>
+					<Wallet className="size-4" />
+				</TooltipButton>
 			</PopoverTrigger>
 
-			<PopoverContent className="md:w-96 w-[calc(100vw-2rem)] bg-primary rounded-lg" align="end">
+			<PopoverContent className="bg-primary rounded-lg w-[calc(100vw-2rem)] md:w-96" align="end">
 				<Nip60Wallet />
 			</PopoverContent>
 		</Popover>
@@ -187,19 +178,19 @@ export function BugReportButton({ className }: BugReportButtonProps) {
 
 	return (
 		<>
-			<Button
+			<TooltipButton
 				variant="outline"
 				size="icon"
 				onClick={handleBugReport}
 				tooltip="Report a bug"
 				className={cn(
-					'fixed bottom-16 right-16 z-50 h-10 w-10 px-4 py-2 rounded-full bg-black text-white hover:bg-black hover:text-secondary shadow-lg transition-colors',
+					'right-16 bottom-16 z-50 fixed bg-black hover:bg-black shadow-lg px-4 py-2 rounded-full w-10 h-10 text-white hover:text-secondary transition-colors',
 					className,
 				)}
 				aria-label="Report a bug"
 			>
-				<span className="i-bug w-6 h-6 px-2 py-0 hover:bg-black hover:text-secondary" />
-			</Button>
+				<span className="hover:bg-black px-2 py-0 w-6 h-6 hover:text-secondary i-bug" />
+			</TooltipButton>
 			<BugReportModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} onReopen={() => setIsModalOpen(true)} />
 		</>
 	)
@@ -295,14 +286,14 @@ export function Header() {
 			className={`sticky top-0 z-50 text-white px-4 ${isNostrPage ? 'bg-black' : getHeaderBackground()}`}
 			style={isNostrPage ? {} : (getHeaderStyle() as React.CSSProperties)}
 		>
-			<div className="container flex h-full max-w-full items-center justify-between py-4">
+			<div className="flex justify-between items-center py-4 max-w-full h-full container">
 				<section className="inline-flex items-center">
 					<Link to="/" data-testid="home-link">
 						{config?.appSettings?.picture && (
-							<img src={config.appSettings.picture} alt={config.appSettings.displayName} className="w-16 px-2" />
+							<img src={config.appSettings.picture} alt={config.appSettings.displayName} className="px-2 w-16" />
 						)}
 					</Link>
-					<div className="hidden sm:flex mx-8 gap-8">
+					<div className="hidden sm:flex gap-8 mx-8">
 						<Link
 							to="/products"
 							className="hover:text-secondary"
@@ -341,7 +332,7 @@ export function Header() {
 					<div className="flex gap-2">
 						{/* Bug Report Button - Only when authenticated */}
 						{isAuthenticated && (
-							<BugReportButton className="!static !w-auto !rounded-lg !shadow-none !bg-primary-border !border-2 !border-transparent hover:!bg-black hover:!border-primary-border-hover p-2 relative hover:[&>span]:text-secondary" />
+							<BugReportButton className="!static relative hover:!bg-black !shadow-none p-2 !bg-primary-border !border-2 !border-transparent hover:!border-primary-border-hover !rounded-lg !w-auto hover:[&>span]:text-secondary" />
 						)}
 
 						{/* Currency Selector - Desktop Only */}
@@ -358,8 +349,8 @@ export function Header() {
 
 						{/* Profile Button/Avatar, or Log-In Button if not authenticated */}
 						{isAuthenticating ? (
-							<Button variant="primary" className="p-2 relative" data-testid="auth-loading">
-								<Loader2 className="h-4 w-4 animate-spin" />
+							<Button className="relative p-2 btn-border-highlight" data-testid="auth-loading">
+								<Loader2 className="w-4 h-4 animate-spin" />
 							</Button>
 						) : isAuthenticated ? (
 							<ProfileButton />
@@ -373,8 +364,7 @@ export function Header() {
 						{/* Mobile Drop-down Menu */}
 						{isMobile && (
 							<Button
-								variant="primary"
-								className="p-2 relative hover:bg-secondary/20"
+								className="relative hover:bg-secondary/20 p-2 btn-border-highlight"
 								onClick={handleMobileMenuClick}
 								data-testid="mobile-menu-button"
 							>

--- a/src/components/lightning/LightningPaymentProcessor.tsx
+++ b/src/components/lightning/LightningPaymentProcessor.tsx
@@ -690,8 +690,8 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 					<CardContent className="space-y-6 p-6">
 						{/* Loading state */}
 						{(isGeneratingInvoice || isPaymentInProgress) && (
-							<div className="flex items-center justify-center py-8">
-								<Loader2 className="h-8 w-8 animate-spin" />
+							<div className="flex justify-center items-center py-8">
+								<Loader2 className="w-8 h-8 animate-spin" />
 								<span className="ml-2">{isGeneratingInvoice ? 'Generating invoice...' : 'Processing payment...'}</span>
 							</div>
 						)}
@@ -699,9 +699,9 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 						{/* Error state - Failed to generate invoice */}
 						{!invoice && !isGeneratingInvoice && !isPaymentInProgress && (
 							<div className="space-y-4 py-4">
-								<div className="text-center text-amber-600">
+								<div className="text-amber-600 text-center">
 									<p className="font-medium">Unable to generate Lightning invoice</p>
-									<p className="text-sm text-gray-600 mt-1">
+									<p className="mt-1 text-gray-600 text-sm">
 										{skippable
 											? 'The recipient may not have Lightning configured. You can skip this payment and pay directly later.'
 											: 'The recipient may not have Lightning configured.'}
@@ -726,14 +726,14 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 
 								{/* Mobile navigation under QR code */}
 								{showNavigation && (totalInvoices || 0) > 1 && (
-									<div className="sm:hidden mt-3 flex gap-2">
+									<div className="sm:hidden flex gap-2 mt-3">
 										<Button
 											variant="outline"
 											className="flex-1"
 											onClick={() => onNavigate?.(Math.max(0, (currentIndex || 0) - 1))}
 											disabled={(currentIndex || 0) === 0}
 										>
-											<ChevronLeft className="w-4 h-4 mr-2" />
+											<ChevronLeft className="mr-2 w-4 h-4" />
 											Previous
 										</Button>
 										<Button
@@ -743,7 +743,7 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 											disabled={(currentIndex || 0) >= (totalInvoices || 0) - 1}
 										>
 											Next
-											<ChevronRight className="w-4 h-4 ml-2" />
+											<ChevronRight className="ml-2 w-4 h-4" />
 										</Button>
 									</div>
 								)}
@@ -754,15 +754,15 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 									<div className="flex gap-2">
 										<Input id="invoice" value={invoice} readOnly className="font-mono text-xs" />
 										<Button variant="outline" size="icon" onClick={() => copyToClipboard(invoice)}>
-											<Copy className="h-4 w-4" />
+											<Copy className="w-4 h-4" />
 										</Button>
 									</div>
 								</div>
 
 								{/* Passive monitoring status */}
 								{isCheckingForReceipt && !isPaymentInProgress && (
-									<div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-										<Loader2 className="h-4 w-4 animate-spin" />
+									<div className="flex justify-center items-center gap-2 text-muted-foreground text-sm">
+										<Loader2 className="w-4 h-4 animate-spin" />
 										<span>Checking for payment…</span>
 									</div>
 								)}
@@ -772,11 +772,11 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 						{/* Payment buttons */}
 						{invoice && !isGeneratingInvoice && (
 							<div className="space-y-3">
-								<div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+								<div className="flex sm:flex-row flex-col sm:flex-wrap gap-2">
 									{/* NIP-60 Payment Button */}
 									{capabilities.hasNip60 && (
-										<Button onClick={handleNip60Payment} disabled={isPaymentInProgress} className="w-full sm:flex-1" variant="outline">
-											<Zap className="h-4 w-4 mr-2" />
+										<Button onClick={handleNip60Payment} disabled={isPaymentInProgress} className="sm:flex-1 w-full" variant="outline">
+											<Zap className="mr-2 w-4 h-4" />
 											Pay with NIP-60 Wallet
 										</Button>
 									)}
@@ -785,9 +785,9 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 									{!capabilities.hasNwc ? (
 										<Tooltip>
 											<TooltipTrigger asChild>
-												<div className="w-full sm:flex-1">
+												<div className="sm:flex-1 w-full">
 													<Button disabled={true} className="w-full" variant="outline">
-														<Zap className="h-4 w-4 mr-2" />
+														<Zap className="mr-2 w-4 h-4" />
 														Pay with NWC
 													</Button>
 												</div>
@@ -797,8 +797,8 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 											</TooltipContent>
 										</Tooltip>
 									) : (
-										<Button onClick={handleNwcPayment} disabled={isPaymentInProgress} className="w-full sm:flex-1" variant="outline">
-											<Zap className="h-4 w-4 mr-2" />
+										<Button onClick={handleNwcPayment} disabled={isPaymentInProgress} className="sm:flex-1 w-full" variant="outline">
+											<Zap className="mr-2 w-4 h-4" />
 											Pay with NWC
 										</Button>
 									)}
@@ -807,9 +807,9 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 									{!capabilities.hasWebLn ? (
 										<Tooltip>
 											<TooltipTrigger asChild>
-												<div className="w-full sm:flex-1">
+												<div className="sm:flex-1 w-full">
 													<Button disabled={true} className="w-full" variant="outline">
-														<CreditCard className="h-4 w-4 mr-2" />
+														<CreditCard className="mr-2 w-4 h-4" />
 														Pay with WebLN
 													</Button>
 												</div>
@@ -819,8 +819,8 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 											</TooltipContent>
 										</Tooltip>
 									) : (
-										<Button onClick={handleWebLnPayment} disabled={isPaymentInProgress} className="w-full sm:flex-1" variant="outline">
-											<CreditCard className="h-4 w-4 mr-2" />
+										<Button onClick={handleWebLnPayment} disabled={isPaymentInProgress} className="sm:flex-1 w-full" variant="outline">
+											<CreditCard className="mr-2 w-4 h-4" />
 											Pay with WebLN
 										</Button>
 									)}
@@ -846,7 +846,7 @@ export const LightningPaymentProcessor = forwardRef<LightningPaymentProcessorRef
 
 								{/* Pay Later / Skip button */}
 								{onSkipPayment && skippable && (
-									<Button onClick={handleSkipPayment} variant="tertiary" className="w-full">
+									<Button onClick={handleSkipPayment} variant="outline" className="w-full">
 										Pay Later
 									</Button>
 								)}

--- a/src/components/orders/OrderActions.tsx
+++ b/src/components/orders/OrderActions.tsx
@@ -122,13 +122,13 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 	const renderStatusIcon = () => {
 		switch (iconName) {
 			case 'truck':
-				return <Truck className="h-4 w-4" />
+				return <Truck className="w-4 h-4" />
 			case 'tick':
-				return <Check className="h-4 w-4" />
+				return <Check className="w-4 h-4" />
 			case 'clock':
-				return <Clock className="h-4 w-4" />
+				return <Clock className="w-4 h-4" />
 			case 'cross':
-				return <X className="h-4 w-4" />
+				return <X className="w-4 h-4" />
 			default:
 				return null
 		}
@@ -153,7 +153,7 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 	const badgeIconOnly = breakpoint === 'sm'
 
 	return (
-		<div className={cn('flex items-center justify-between gap-2 w-full', className)}>
+		<div className={cn('flex justify-between items-center gap-2 w-full', className)}>
 			{/* Cancel Button (Left) - Icon only */}
 			{canCancel ? (
 				<Tooltip>
@@ -163,32 +163,32 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 							size="icon"
 							onClick={() => setIsCancelOpen(true)}
 							disabled={isLoading}
-							className="h-8 w-8 shrink-0 text-destructive border-destructive/50 hover:bg-destructive/10 hover:text-destructive"
+							className="hover:bg-destructive/10 border-destructive/50 w-8 h-8 text-destructive hover:text-destructive shrink-0"
 							aria-label="Cancel order"
 						>
-							<X className="h-4 w-4" />
+							<X className="w-4 h-4" />
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">Cancel order</TooltipContent>
 				</Tooltip>
 			) : (
-				<div className="h-8 w-8 shrink-0" />
+				<div className="w-8 h-8 shrink-0" />
 			)}
 
 			{/* Status Badge (Center) */}
 			{badgeIconOnly ? (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<div className={cn('flex w-8 items-center justify-center rounded-md p-1', bgColor, textColor)}>{renderStatusIcon()}</div>
+						<div className={cn('flex justify-center items-center p-1 rounded-md w-8', bgColor, textColor)}>{renderStatusIcon()}</div>
 					</TooltipTrigger>
 					<TooltipContent side="bottom" className="capitalize">
 						{label}
 					</TooltipContent>
 				</Tooltip>
 			) : (
-				<div className={cn('flex w-[7rem] items-center justify-center gap-1.5 rounded-md px-2 py-1', bgColor, textColor)}>
+				<div className={cn('flex justify-center items-center gap-1.5 px-2 py-1 rounded-md w-[7rem]', bgColor, textColor)}>
 					{renderStatusIcon()}
-					<span className="font-medium capitalize text-xs whitespace-nowrap">{label}</span>
+					<span className="font-medium text-xs capitalize whitespace-nowrap">{label}</span>
 				</div>
 			)}
 
@@ -197,14 +197,14 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 				<Tooltip>
 					<TooltipTrigger asChild>
 						<Button
-							variant="primary"
+							variant="default"
 							size="icon"
 							onClick={nextAction.action}
 							disabled={isLoading}
-							className="h-8 w-8 shrink-0"
+							className="w-8 h-8 shrink-0"
 							aria-label={nextAction.label}
 						>
-							<nextAction.icon className="h-4 w-4" />
+							<nextAction.icon className="w-4 h-4" />
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">{nextAction.label}</TooltipContent>
@@ -212,8 +212,8 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 			) : status === ORDER_STATUS.COMPLETED ? (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<Button variant="ghost" size="icon" disabled className="h-8 w-8 shrink-0 text-green-600" aria-label="Done">
-							<CheckCircle className="h-4 w-4" />
+						<Button variant="ghost" size="icon" disabled className="w-8 h-8 text-green-600 shrink-0" aria-label="Done">
+							<CheckCircle className="w-4 h-4" />
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">Done</TooltipContent>
@@ -221,8 +221,8 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 			) : status === ORDER_STATUS.CANCELLED ? (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<Button variant="ghost" size="icon" disabled className="h-8 w-8 shrink-0 text-muted-foreground" aria-label="Cancelled">
-							<Ban className="h-4 w-4" />
+						<Button variant="ghost" size="icon" disabled className="w-8 h-8 text-muted-foreground shrink-0" aria-label="Cancelled">
+							<Ban className="w-4 h-4" />
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">Cancelled</TooltipContent>
@@ -230,8 +230,8 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 			) : (
 				<Tooltip>
 					<TooltipTrigger asChild>
-						<Button variant="ghost" size="icon" disabled className="h-8 w-8 shrink-0 text-muted-foreground" aria-label="Waiting">
-							<Clock className="h-4 w-4" />
+						<Button variant="ghost" size="icon" disabled className="w-8 h-8 text-muted-foreground shrink-0" aria-label="Waiting">
+							<Clock className="w-4 h-4" />
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent side="bottom">Waiting</TooltipContent>
@@ -249,7 +249,7 @@ export function OrderActions({ order, userPubkey, variant = 'outline', className
 					</DialogHeader>
 
 					<div className="space-y-2 py-4">
-						<p className="text-sm text-muted-foreground">
+						<p className="text-muted-foreground text-sm">
 							By confirming, you acknowledge that the payment has been received and you are ready to process this order.
 						</p>
 					</div>

--- a/src/components/orders/OrderCard.tsx
+++ b/src/components/orders/OrderCard.tsx
@@ -14,10 +14,10 @@ export function OrderCard({ orderData, userPubkey }: OrderCardProps) {
 	const status = statusTag?.[1] || 'pending'
 
 	// Determine badge variant based on status
-	const getBadgeVariant = (status: string): 'primary' | 'outline' | 'secondary' => {
+	const getBadgeVariant = (status: string): 'default' | 'outline' | 'secondary' => {
 		switch (status.toLowerCase()) {
 			case 'completed':
-				return 'primary' // Dark background with light text
+				return 'default' // Dark background with light text
 			case 'processing':
 				return 'outline'
 			case 'cancelled':
@@ -33,15 +33,15 @@ export function OrderCard({ orderData, userPubkey }: OrderCardProps) {
 		<Link
 			to="/dashboard/orders/$orderId"
 			params={{ orderId: orderData.order.id }}
-			className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent transition-colors overflow-hidden"
+			className="flex justify-between items-center hover:bg-accent p-4 border rounded-lg overflow-hidden transition-colors"
 		>
 			<div className="flex items-center gap-4 min-w-0">
-				<div className="flex items-center justify-center w-12 h-12 rounded-full bg-pink-400 text-2xl shrink-0">{isBuyer ? '🛍️' : '💰'}</div>
+				<div className="flex justify-center items-center bg-pink-400 rounded-full w-12 h-12 text-2xl shrink-0">{isBuyer ? '🛍️' : '💰'}</div>
 				<div className="min-w-0">
 					<div className="font-medium truncate">
 						{isBuyer ? 'Purchase' : 'Sale'} #{orderData.order.id.slice(0, 8)}
 					</div>
-					<div className="text-sm text-muted-foreground">{new Date((orderData.order.created_at || 0) * 1000).toLocaleDateString()}</div>
+					<div className="text-muted-foreground text-sm">{new Date((orderData.order.created_at || 0) * 1000).toLocaleDateString()}</div>
 				</div>
 			</div>
 			<Badge variant={getBadgeVariant(status)} className="shrink-0">

--- a/src/components/orders/OrderInvoiceTracking.tsx
+++ b/src/components/orders/OrderInvoiceTracking.tsx
@@ -84,10 +84,10 @@ export function OrderInvoiceTracking({
 			{/* Overall Status */}
 			<Card>
 				<CardHeader>
-					<CardTitle className="flex items-center justify-between">
+					<CardTitle className="flex justify-between items-center">
 						<span>Payment Status</span>
 						<div className="flex items-center gap-2">
-							<Badge variant={invoiceSet.status === 'complete' ? 'primary' : 'secondary'}>{invoiceSet.status.toUpperCase()}</Badge>
+							<Badge variant={invoiceSet.status === 'complete' ? 'default' : 'secondary'}>{invoiceSet.status.toUpperCase()}</Badge>
 							{onRefresh && (
 								<Button variant="outline" size="sm" onClick={onRefresh}>
 									<RefreshCw className="w-4 h-4" />
@@ -107,7 +107,7 @@ export function OrderInvoiceTracking({
 						<Progress value={completionPercentage} className="h-2" />
 					</div>
 
-					<div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+					<div className="gap-4 grid grid-cols-2 md:grid-cols-4 text-sm">
 						<div>
 							<div className="text-gray-600">Total Amount</div>
 							<div className="font-semibold">{invoiceSet.totalAmount.toLocaleString()} sats</div>
@@ -144,23 +144,23 @@ export function OrderInvoiceTracking({
 					<CardContent className="space-y-4">
 						{merchantInvoices.map((invoice) => (
 							<div key={invoice.id} className="space-y-3">
-								<div className="flex items-center justify-between">
+								<div className="flex justify-between items-center">
 									<div className="flex items-center gap-2">
 										{getStatusIcon(invoice.status)}
 										<span className="font-medium">Invoice {invoice.id.substring(0, 8)}...</span>
 										<Badge className={getStatusColor(invoice.status)}>{invoice.status}</Badge>
 									</div>
-									<div className="text-sm text-gray-600">{invoice.amountSats.toLocaleString()} sats</div>
+									<div className="text-gray-600 text-sm">{invoice.amountSats.toLocaleString()} sats</div>
 								</div>
 
 								{invoice.bolt11 && showQRCodes && invoice.status === 'pending' && (
-									<div className="flex flex-col md:flex-row gap-4">
+									<div className="flex md:flex-row flex-col gap-4">
 										<div className="flex-shrink-0">
 											<QRCode value={invoice.bolt11} size={150} title="Lightning Invoice" description="Scan to pay with Lightning" />
 										</div>
 										<div className="flex-1 space-y-2">
-											<div className="text-sm text-gray-600">Lightning Invoice</div>
-											<div className="bg-gray-50 p-2 rounded border text-xs font-mono break-all">{invoice.bolt11}</div>
+											<div className="text-gray-600 text-sm">Lightning Invoice</div>
+											<div className="bg-gray-50 p-2 border rounded font-mono text-xs break-all">{invoice.bolt11}</div>
 											<div className="flex gap-2">
 												<Button
 													variant="outline"
@@ -172,13 +172,13 @@ export function OrderInvoiceTracking({
 													{copySuccess === invoice.id ? 'Copied!' : 'Copy Invoice'}
 												</Button>
 											</div>
-											{invoice.expiresAt && <div className="text-xs text-gray-500">{formatTimeRemaining(invoice.expiresAt)}</div>}
+											{invoice.expiresAt && <div className="text-gray-500 text-xs">{formatTimeRemaining(invoice.expiresAt)}</div>}
 										</div>
 									</div>
 								)}
 
 								{invoice.status === 'paid' && (
-									<div className="bg-green-50 p-3 rounded border border-green-200">
+									<div className="bg-green-50 p-3 border border-green-200 rounded">
 										<div className="flex items-center gap-2 text-green-800">
 											<Check className="w-4 h-4" />
 											<span className="font-medium">Payment Confirmed</span>
@@ -187,8 +187,8 @@ export function OrderInvoiceTracking({
 								)}
 
 								{(invoice.status === 'failed' || invoice.status === 'expired') && onReattemptPayment && (
-									<div className="bg-red-50 p-3 rounded border border-red-200">
-										<div className="flex items-center justify-between">
+									<div className="bg-red-50 p-3 border border-red-200 rounded">
+										<div className="flex justify-between items-center">
 											<div className="flex items-center gap-2 text-red-800">
 												<AlertTriangle className="w-4 h-4" />
 												<span className="font-medium">Payment {invoice.status === 'expired' ? 'Expired' : 'Failed'}</span>
@@ -197,13 +197,13 @@ export function OrderInvoiceTracking({
 												variant="outline"
 												size="sm"
 												onClick={() => onReattemptPayment(invoice.id, invoice.sellerPubkey, invoice.amountSats)}
-												className="text-red-700 border-red-300 hover:bg-red-100"
+												className="hover:bg-red-100 border-red-300 text-red-700"
 											>
-												<RefreshCw className="w-4 h-4 mr-1" />
+												<RefreshCw className="mr-1 w-4 h-4" />
 												Request New Invoice
 											</Button>
 										</div>
-										<div className="text-sm text-red-700 mt-1">
+										<div className="mt-1 text-red-700 text-sm">
 											{invoice.status === 'expired'
 												? 'This payment request has expired. Request a new invoice to continue.'
 												: 'Payment failed. Request a new invoice to try again.'}
@@ -229,23 +229,23 @@ export function OrderInvoiceTracking({
 					<CardContent className="space-y-4">
 						{v4vInvoices.map((invoice) => (
 							<div key={invoice.id} className="space-y-3">
-								<div className="flex items-center justify-between">
+								<div className="flex justify-between items-center">
 									<div className="flex items-center gap-2">
 										{getStatusIcon(invoice.status)}
 										<span className="font-medium">V4V {invoice.id.substring(0, 8)}...</span>
 										<Badge className={getStatusColor(invoice.status)}>{invoice.status}</Badge>
 									</div>
-									<div className="text-sm text-gray-600">{invoice.amountSats.toLocaleString()} sats</div>
+									<div className="text-gray-600 text-sm">{invoice.amountSats.toLocaleString()} sats</div>
 								</div>
 
 								{invoice.bolt11 && showQRCodes && invoice.status === 'pending' && (
-									<div className="flex flex-col md:flex-row gap-4">
+									<div className="flex md:flex-row flex-col gap-4">
 										<div className="flex-shrink-0">
 											<QRCode value={invoice.bolt11} size={120} title="V4V Lightning Invoice" description="Value for Value payment" />
 										</div>
 										<div className="flex-1 space-y-2">
-											<div className="text-sm text-gray-600">V4V Lightning Invoice</div>
-											<div className="bg-gray-50 p-2 rounded border text-xs font-mono break-all">{invoice.bolt11}</div>
+											<div className="text-gray-600 text-sm">V4V Lightning Invoice</div>
+											<div className="bg-gray-50 p-2 border rounded font-mono text-xs break-all">{invoice.bolt11}</div>
 											<div className="flex gap-2">
 												<Button
 													variant="outline"
@@ -257,14 +257,14 @@ export function OrderInvoiceTracking({
 													{copySuccess === invoice.id ? 'Copied!' : 'Copy'}
 												</Button>
 											</div>
-											{invoice.expiresAt && <div className="text-xs text-gray-500">{formatTimeRemaining(invoice.expiresAt)}</div>}
+											{invoice.expiresAt && <div className="text-gray-500 text-xs">{formatTimeRemaining(invoice.expiresAt)}</div>}
 										</div>
 									</div>
 								)}
 
 								{(invoice.status === 'failed' || invoice.status === 'expired') && onReattemptPayment && (
-									<div className="bg-red-50 p-3 rounded border border-red-200">
-										<div className="flex items-center justify-between">
+									<div className="bg-red-50 p-3 border border-red-200 rounded">
+										<div className="flex justify-between items-center">
 											<div className="flex items-center gap-2 text-red-800">
 												<AlertTriangle className="w-4 h-4" />
 												<span className="font-medium">V4V Payment {invoice.status === 'expired' ? 'Expired' : 'Failed'}</span>
@@ -273,13 +273,13 @@ export function OrderInvoiceTracking({
 												variant="outline"
 												size="sm"
 												onClick={() => onReattemptPayment(invoice.id, invoice.sellerPubkey, invoice.amountSats)}
-												className="text-red-700 border-red-300 hover:bg-red-100"
+												className="hover:bg-red-100 border-red-300 text-red-700"
 											>
-												<RefreshCw className="w-4 h-4 mr-1" />
+												<RefreshCw className="mr-1 w-4 h-4" />
 												Request New Invoice
 											</Button>
 										</div>
-										<div className="text-sm text-red-700 mt-1">
+										<div className="mt-1 text-red-700 text-sm">
 											{invoice.status === 'expired'
 												? 'This V4V payment request has expired. Request a new invoice to continue.'
 												: 'V4V payment failed. Request a new invoice to try again.'}
@@ -294,7 +294,7 @@ export function OrderInvoiceTracking({
 
 			{/* Summary Actions */}
 			{pendingInvoices.length > 0 && (
-				<Card className="border-yellow-200 bg-yellow-50">
+				<Card className="bg-yellow-50 border-yellow-200">
 					<CardContent className="p-4">
 						<div className="flex items-center gap-2 text-yellow-800">
 							<Clock className="w-4 h-4" />
@@ -302,13 +302,13 @@ export function OrderInvoiceTracking({
 								{pendingInvoices.length} invoice{pendingInvoices.length !== 1 ? 's' : ''} awaiting payment
 							</span>
 						</div>
-						<div className="text-sm text-yellow-700 mt-1">Please complete all payments to finalize your order.</div>
+						<div className="mt-1 text-yellow-700 text-sm">Please complete all payments to finalize your order.</div>
 					</CardContent>
 				</Card>
 			)}
 
 			{failedInvoices.length > 0 && (
-				<Card className="border-red-200 bg-red-50">
+				<Card className="bg-red-50 border-red-200">
 					<CardContent className="p-4">
 						<div className="flex items-center gap-2 text-red-800">
 							<AlertTriangle className="w-4 h-4" />
@@ -316,7 +316,7 @@ export function OrderInvoiceTracking({
 								{failedInvoices.length} invoice{failedInvoices.length !== 1 ? 's' : ''} failed or expired
 							</span>
 						</div>
-						<div className="text-sm text-red-700 mt-1">Contact support if you need assistance with failed payments.</div>
+						<div className="mt-1 text-red-700 text-sm">Contact support if you need assistance with failed payments.</div>
 					</CardContent>
 				</Card>
 			)}

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -28,6 +28,7 @@ import { Edit, MapPin, MessageCircle, Minus, Plus, Share2, Timer } from 'lucide-
 import { useState, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 import { UserCard } from '../UserCard'
+import { TooltipButton } from '../shared/TooltipButton'
 
 interface ProfilePageProps {
 	profileId: string
@@ -188,10 +189,10 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	}, [profile?.banner])
 
 	return (
-		<div className="relative min-h-screen flex flex-col">
-			<div className="absolute top-0 left-0 right-0 z-0 h-[40vh] sm:h-[40vh] md:h-[50vh] overflow-hidden bg-hero-image-margin">
+		<div className="relative flex flex-col min-h-screen">
+			<div className="top-0 right-0 left-0 z-0 absolute bg-hero-image-margin h-[40vh] sm:h-[40vh] md:h-[50vh] overflow-hidden">
 				{profile?.banner && bannerIsLoadable === true ? (
-					<div className="w-[150%] sm:w-full h-full -ml-[25%] sm:ml-0">
+					<div className="-ml-[25%] sm:ml-0 w-[150%] sm:w-full h-full">
 						<img src={profile.banner} alt="profile-banner" className="w-full h-full object-cover" />
 					</div>
 				) : (
@@ -204,27 +205,38 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 					/>
 				)}
 			</div>
-			<div className="flex flex-col relative z-10 pt-[18vh] sm:pt-[22vh] md:pt-[30vh] flex-1">
-				<div className="flex flex-row justify-between px-4 py-4 bg-black items-center">
+			<div className="z-10 relative flex flex-col flex-1 pt-[18vh] sm:pt-[22vh] md:pt-[30vh]">
+				<div className="flex flex-row justify-between items-center bg-black px-4 py-4">
 					<UserCard pubkey={user?.pubkey ?? ''} className="[&>h2]:text-white" subtitle="npub" onPress="copy-npub" />
 					{!isSmallScreen && (
 						<div className="flex gap-2">
 							{user && <ZapButton event={user} />}
-							<Button variant="focus" size="icon" tooltip="Message" onClick={handleMessageClick}>
-								<MessageCircle className="w-5 h-5" />
-							</Button>
+							<TooltipButton
+								variant="outline"
+								size="icon"
+								tooltip="Message"
+								onClick={handleMessageClick}
+								className="bg-transparent hover:bg-background border-2 border-background rounded text-background hover:text-foreground"
+							>
+								<MessageCircle className="size-5" />
+							</TooltipButton>
 							{pickupLocations.length > 0 && (
-								<Button variant="secondary" size="icon" tooltip="Set Pickup Location" onClick={() => setPickupLocationDialogOpen(true)}>
-									<MapPin className="w-5 h-5" />
-								</Button>
+								<TooltipButton
+									variant="secondary"
+									size="icon"
+									tooltip="Set Pickup Location"
+									onClick={() => setPickupLocationDialogOpen(true)}
+								>
+									<MapPin className="size-5" />
+								</TooltipButton>
 							)}
-							<Button variant="secondary" size="icon" tooltip="Share" onClick={() => setShareDialogOpen(true)}>
-								<Share2 className="w-5 h-5" />
-							</Button>
+							<TooltipButton variant="secondary" size="icon" tooltip="Share" onClick={() => setShareDialogOpen(true)}>
+								<Share2 className="size-5" />
+							</TooltipButton>
 							{/* Edit button for profile owner */}
 							{permissions.canEdit && (
 								<Button variant="secondary" onClick={handleEdit} className="flex items-center gap-2">
-									<Edit className="h-5 w-5" />
+									<Edit className="size-5" />
 									<span className="hidden md:inline">Edit Profile</span>
 								</Button>
 							)}
@@ -247,7 +259,7 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 
 				<div
 					ref={animationParent}
-					className="flex flex-row items-center justify-between px-4 py-4 bg-zinc-900 text-white text-xs sm:text-sm min-h-[52px]"
+					className="flex flex-row justify-between items-center bg-zinc-900 px-4 py-4 min-h-[52px] text-white text-xs sm:text-sm"
 				>
 					{hasAbout ? (
 						shouldTruncateAbout ? (
@@ -265,13 +277,13 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 					)}
 				</div>
 
-				<div className="p-4 flex-1 flex flex-col">
+				<div className="flex flex-col flex-1 p-4">
 					{sellerProducts && sellerProducts.length > 0 ? (
 						<ItemGrid
 							title={
-								<div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-center sm:text-left">
-									<span className="text-2xl font-heading">Products from</span>
-									<ProfileName pubkey={user?.pubkey || ''} className="text-2xl font-heading" />
+								<div className="flex sm:flex-row flex-col sm:items-center sm:gap-2 sm:text-left text-center">
+									<span className="font-heading text-2xl">Products from</span>
+									<ProfileName pubkey={user?.pubkey || ''} className="font-heading text-2xl" />
 								</div>
 							}
 						>
@@ -280,11 +292,11 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 							))}
 						</ItemGrid>
 					) : (
-						<div className="flex flex-col items-center justify-center flex-1 gap-4">
-							<span className="text-2xl font-heading">No products found</span>
+						<div className="flex flex-col flex-1 justify-center items-center gap-4">
+							<span className="font-heading text-2xl">No products found</span>
 							{permissions.canEdit && (
 								<Button onClick={handleAddProduct} className="flex items-center gap-2">
-									<Plus className="h-5 w-5" />
+									<Plus className="w-5 h-5" />
 									Add Your First Product
 								</Button>
 							)}

--- a/src/components/shared/ButtonProps.tsx
+++ b/src/components/shared/ButtonProps.tsx
@@ -1,0 +1,7 @@
+import type { Button } from '@/components/ui/button'
+
+/** Helper type to extract "ButtonProps" type from shadcn "Button" component */
+export type ButtonProps = React.ComponentPropsWithoutRef<typeof Button>
+
+/** Helper type to use valid string values for Button Variants */
+export type ButtonVariant = 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link'

--- a/src/components/shared/SelectableBadge.tsx
+++ b/src/components/shared/SelectableBadge.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react'
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+
+type BadgeProps = React.ComponentPropsWithoutRef<typeof Badge>
+
+interface SelectableBadgeProps extends BadgeProps {
+	/** Whether the badge is currently selected */
+	isSelected?: boolean
+}
+
+const SelectableBadge = React.forwardRef<HTMLSpanElement, SelectableBadgeProps>(({ isSelected = false, className, ...props }, ref) => {
+	// Define the specific styles requested
+	const notSelectedStyles =
+		'bg-primary border-primary hover:border-primary-border-hover text-primary-foreground-hover active:bg-primary-border-hover'
+
+	const selectedStyles = 'bg-primary border-primary-border-hover text-primary-foreground-hover active:bg-primary-border-hover'
+
+	// Apply selection styles before the incoming className
+	const selectionClasses = isSelected ? selectedStyles : notSelectedStyles
+
+	return <Badge ref={ref} data-selected={isSelected} className={cn(selectionClasses, 'py-1.5 px-3 my-1', className)} {...props} />
+})
+
+SelectableBadge.displayName = 'SelectableBadge'
+
+export { SelectableBadge }

--- a/src/components/shared/TooltipButton.tsx
+++ b/src/components/shared/TooltipButton.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import type { ButtonProps } from './ButtonProps'
+
+interface TooltipButtonProps extends ButtonProps {
+	/** Tooltip text shown when button is enabled */
+	tooltip?: string
+	/** Tooltip text shown when button is disabled */
+	disabledTooltip?: string
+}
+
+const TooltipButton = React.forwardRef<HTMLButtonElement, TooltipButtonProps>(
+	({ tooltip, disabledTooltip, disabled, children, ...props }, ref) => {
+		const hasTooltip = Boolean(tooltip || disabledTooltip)
+
+		// If no tooltip is needed, render Button directly
+		if (!hasTooltip) {
+			return (
+				<Button ref={ref} disabled={disabled} {...props}>
+					{children}
+				</Button>
+			)
+		}
+
+		// Determine which tooltip to show
+		const tooltipContent = disabled && disabledTooltip ? disabledTooltip : tooltip
+
+		if (tooltipContent) {
+			// If there's a tooltip, wrap Button with Tooltip
+			return (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button ref={ref} disabled={disabled} {...props}>
+							{children}
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">{tooltipContent}</TooltipContent>
+				</Tooltip>
+			)
+		}
+
+		// Else, return button without tooltip
+		return (
+			<Button ref={ref} disabled={disabled} {...props}>
+				{children}
+			</Button>
+		)
+	},
+)
+
+TooltipButton.displayName = 'TooltipButton'
+
+export { TooltipButton, type TooltipButtonProps }

--- a/src/components/social/CommentButton.tsx
+++ b/src/components/social/CommentButton.tsx
@@ -1,4 +1,3 @@
-import { Button, type ButtonProps, type ButtonVariant } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -8,10 +7,12 @@ import { useRef, useState, type ReactNode } from 'react'
 import { toast } from 'sonner'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
+import { TooltipButton, type TooltipButtonProps } from '../shared/TooltipButton'
+import { Button } from '../ui/button'
 
-interface CommentButtonProps extends ButtonProps {
+interface CommentButtonProps extends TooltipButtonProps {
 	event: NDKEvent
-	variant?: ButtonVariant
+	icon: ReactNode
 }
 
 export function CommentButton({ event, className, onClick, onPointerDown, variant, ...props }: CommentButtonProps) {
@@ -49,26 +50,27 @@ export function CommentButton({ event, className, onClick, onPointerDown, varian
 	}
 
 	// Default values for props
-	const icon = props.icon ?? <MessageSquare className="w-6 h-6" />
+	const icon = props.icon ?? <MessageSquare className="size-6" strokeWidth={2} />
 	const tooltip = props.tooltip ?? 'Comment'
 
 	return (
 		<>
-			<Button
+			<TooltipButton
 				variant={variant ?? 'outline'}
 				size="icon"
-				className={'border-foreground border-2 bg-transparent hover:bg-foreground hover:text-background ' + className}
+				className={'border-foreground rounded border-2 bg-transparent hover:bg-foreground hover:text-background ' + className}
 				type="button"
 				{...props}
 				tooltip={tooltip}
-				icon={icon}
 				data-testid="comment-button"
 				onClick={(e) => {
 					handleButtonInteraction(e)
 				}}
 				onPointerDown={handleButtonPointerDown}
 				disabled={props.disabled || !event.ndk}
-			/>
+			>
+				{icon}
+			</TooltipButton>
 
 			{/* Comment Dialog */}
 			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>

--- a/src/components/social/ReactionButton.tsx
+++ b/src/components/social/ReactionButton.tsx
@@ -1,4 +1,3 @@
-import { Button, type ButtonVariant } from '@/components/ui/button'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
@@ -8,11 +7,11 @@ import { useEventReactions } from '@/queries/reactions'
 import { useAuth } from '@/lib/stores/auth'
 import { usePublishDeletionMutation } from '@/publish/reactions'
 import { toast } from 'sonner'
-import { ndkActions } from '@/lib/stores/ndk'
+import type { ButtonProps } from '../shared/ButtonProps'
+import { TooltipButton } from '../shared/TooltipButton'
 
-interface ReactionButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ReactionButtonProps extends ButtonProps {
 	event: NDKEvent
-	variant?: ButtonVariant
 }
 
 export function ReactionButton({ event, className, variant, ...props }: ReactionButtonProps) {
@@ -104,10 +103,10 @@ export function ReactionButton({ event, className, variant, ...props }: Reaction
 		<>
 			<Popover open={isOpen}>
 				<PopoverTrigger asChild>
-					<Button
+					<TooltipButton
 						variant={variant ?? 'outline'}
 						size="icon"
-						className={'border-2 focus:outline-none ' + classNameButtonGhost + ' ' + className}
+						className={'border-2 rounded focus:outline-none ' + classNameButtonGhost + ' ' + className}
 						{...props}
 						type="button"
 						data-testid="reaction-button"
@@ -132,29 +131,28 @@ export function ReactionButton({ event, className, variant, ...props }: Reaction
 						disabled={!event.ndk}
 						/** Only show tooltip when not conflicting with popover */
 						tooltip={isAuthenticated ? undefined : 'React'}
-						icon={
-							latestReaction ? (
-								latestReaction.emoji === '❤️' ? (
-									<span className="i-heart-fill w-6 h-6" />
-								) : (
-									<span className="text-2xl">{latestReaction.emoji}</span>
-								)
+					>
+						{latestReaction ? (
+							latestReaction.emoji === '❤️' ? (
+								<span className="w-6 h-6 i-heart-fill" />
 							) : (
-								<span className="i-heart w-6 h-6" />
+								<span className="text-2xl">{latestReaction.emoji}</span>
 							)
-						}
-					/>
+						) : (
+							<span className="w-6 h-6 i-heart" />
+						)}
+					</TooltipButton>
 				</PopoverTrigger>
 				<PopoverContent
 					onMouseEnter={handlePopoverOpen}
 					onMouseLeave={scheduleClose}
 					style={{ width: 'auto' }}
-					className="flex flex-wrap gap-0 p-2 bg-primary/60 border-tertiary-hover/60 rounded-xl"
+					className="flex flex-wrap gap-0 bg-primary/60 p-2 border-tertiary-hover/60 rounded-xl"
 				>
 					{commonEmojis.map((emoji) => (
 						<button
 							key={emoji}
-							className="text-3xl px-2 py-1 border-2 rounded border-transparent hover:border-light-gray/30 active:border-light-gray/40 active:bg-light-gray/20"
+							className="active:bg-light-gray/20 px-2 py-1 border-2 border-transparent hover:border-light-gray/30 active:border-light-gray/40 rounded text-3xl"
 							onClick={() => {
 								handlePublishReaction(emoji)
 							}}

--- a/src/components/social/ShareButton.tsx
+++ b/src/components/social/ShareButton.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react'
 import { ShareProductDialog } from '../dialogs/ShareProductDialog'
-import { Button, type ButtonVariant } from '../ui/button'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import type { ButtonProps } from '../shared/ButtonProps'
+import { TooltipButton } from '../shared/TooltipButton'
 
-interface ShareButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ShareButtonProps extends ButtonProps {
 	event: NDKEvent
-	variant?: ButtonVariant
 	itemName?: string
 }
 
@@ -16,16 +16,17 @@ export const ShareButton = ({ event, itemName: itemNameProp, className, onClick,
 
 	return (
 		<>
-			<Button
+			<TooltipButton
 				variant={variant ?? 'outline'}
 				size="icon"
-				className={'border-foreground border-2 bg-transparent hover:bg-foreground hover:text-background ' + className}
-				icon={<span className="i-sharing w-6 h-6" />}
+				className={'border-foreground rounded border-2 bg-transparent hover:bg-foreground hover:text-background ' + className}
 				tooltip="Share"
 				{...props}
 				onClick={() => setShareDialogOpen(true)}
 				data-testid="share-button"
-			/>
+			>
+				<span className="w-6 h-6 i-sharing" />
+			</TooltipButton>
 
 			{/* Share Dialog */}
 			<ShareProductDialog

--- a/src/components/social/SocialInteractions.tsx
+++ b/src/components/social/SocialInteractions.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { ZapButton } from './ZapButton'
 import NDK, { NDKEvent } from '@nostr-dev-kit/ndk'
-import { Button, type ButtonVariant } from '../ui/button'
 import { ShareButton } from './ShareButton'
 import { ReactionButton } from './ReactionButton'
 import { CommentButton } from './CommentButton'
@@ -11,6 +10,7 @@ import type { Reaction } from '@/queries/reactions'
 import { ReactionsList } from './ReactionsList'
 import { ZapsList } from './ZapsList'
 import { Reply } from 'lucide-react'
+import type { ButtonVariant } from '../shared/ButtonProps'
 
 interface SocialInteractionsProps extends React.ComponentProps<'div'> {
 	event: NDKEvent

--- a/src/components/social/ZapButton.tsx
+++ b/src/components/social/ZapButton.tsx
@@ -4,12 +4,12 @@ import { useZapCapability } from '@/queries/profiles'
 import { NDKEvent, NDKUser } from '@nostr-dev-kit/ndk'
 import * as React from 'react'
 import { useState } from 'react'
-import { Button, type ButtonVariant } from '../ui/button'
 import { Spinner } from '../ui/spinner'
+import { TooltipButton } from '../shared/TooltipButton'
+import type { ButtonProps } from '../shared/ButtonProps'
 
-interface ZapButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+interface ZapButtonProps extends ButtonProps {
 	event: NDKEvent | NDKUser
-	variant?: ButtonVariant
 }
 
 export function ZapButton({ event, className, onClick, onPointerDown, type, variant, ...props }: ZapButtonProps) {
@@ -49,14 +49,17 @@ export function ZapButton({ event, className, onClick, onPointerDown, type, vari
 	}
 
 	const isDisabled = checkingZapCapability || !canAuthorReceiveZaps || isZapping
-	const icon = checkingZapCapability ? <Spinner /> : <span className={cn('i-lightning w-6 h-6 group-hover:animate-bounce')} />
+	const icon = checkingZapCapability ? <Spinner /> : <span className={cn('w-6 h-6 group-hover:animate-bounce i-lightning')} />
 
 	return (
 		<>
-			<Button
-				variant={variant ?? 'focus'}
+			<TooltipButton
+				variant={variant ?? 'default'}
 				size="icon"
-				className={cn('group border-focus bg-transparent text-focus hover:bg-focus hover:text-black hover:animate-pulse gap-2', className)}
+				className={cn(
+					'group gap-2 bg-transparent hover:bg-focus border-2 border-focus rounded text-focus hover:text-black hover:animate-pulse',
+					className,
+				)}
 				{...props}
 				type={type ?? 'button'}
 				tooltip="Zap"
@@ -70,8 +73,9 @@ export function ZapButton({ event, className, onClick, onPointerDown, type, vari
 				}}
 				onPointerDown={handleButtonPointerDown}
 				disabled={isDisabled}
-				icon={icon}
-			/>
+			>
+				{icon}
+			</TooltipButton>
 			<ZapDialog isOpen={dialogOpen} onOpenChange={handleOpenChange} event={event} onZapComplete={handleZapComplete} />
 		</>
 	)

--- a/src/components/social/ZapsList.tsx
+++ b/src/components/social/ZapsList.tsx
@@ -40,24 +40,23 @@ export const ZapsList = ({ event, asChildren = false }: ZapsListProps) => {
 		return (
 			<Button
 				key={zap.id}
-				variant="primary"
 				size="sm"
-				className="rounded-full py-1 pl-1 pr-4 flex items-center gap-2 h-auto min-h-[32px] border-light-gray transition-colors"
+				className="flex items-center gap-2 py-1 pr-4 pl-1 border-light-gray rounded-full h-auto min-h-[32px] transition-colors"
 				// Optional: Add click handler to view details or send a reply
 				// onClick={() => handleZapClick(zap)}
 			>
 				{/* Avatar */}
-				<AvatarUser pubkey={zap.senderPubkey} className="w-1.1 h-1.1 shrink-0 border-white" />
+				<AvatarUser pubkey={zap.senderPubkey} className="border-white w-1.1 h-1.1 shrink-0" />
 
 				{/* Amount & Icon */}
 				<div className="flex items-center gap-1 shrink-0">
 					<Zap className={'w-4 h-4'} />
-					<span className="font-medium text-xs tabular-nums">{formatAmount(zap.amountMillisats, 'lightning')}</span>
+					<span className="font-medium tabular-nums text-xs">{formatAmount(zap.amountMillisats, 'lightning')}</span>
 				</div>
 
 				{/* Message (if any) */}
 				{displayMessage && (
-					<div className="flex items-center gap-1 text-xs max-w-[150px] truncate">
+					<div className="flex items-center gap-1 max-w-[150px] text-xs truncate">
 						<span className="truncate">{displayMessage}</span>
 					</div>
 				)}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,45 +1,64 @@
-import * as React from 'react'
-import * as AccordionPrimitive from '@radix-ui/react-accordion'
-import { ChevronDownIcon } from 'lucide-react'
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+import { Accordion as AccordionPrimitive } from "radix-ui"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
-function Accordion({ ...props }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
-	return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
 }
 
-function AccordionItem({ className, ...props }: React.ComponentProps<typeof AccordionPrimitive.Item>) {
-	return <AccordionPrimitive.Item data-slot="accordion-item" className={cn('border-b last:border-b-0', className)} {...props} />
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  )
 }
 
-function AccordionTrigger({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
-	return (
-		<AccordionPrimitive.Header className="flex">
-			<AccordionPrimitive.Trigger
-				data-slot="accordion-trigger"
-				className={cn(
-					'focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180',
-					className,
-				)}
-				{...props}
-			>
-				{children}
-				<ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
-			</AccordionPrimitive.Trigger>
-		</AccordionPrimitive.Header>
-	)
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-muted-foreground transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
 }
 
-function AccordionContent({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
-	return (
-		<AccordionPrimitive.Content
-			data-slot="accordion-content"
-			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
-			{...props}
-		>
-			<div className={cn('pt-0 pb-4', className)}>{children}</div>
-		</AccordionPrimitive.Content>
-	)
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
 }
 
 export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,38 +1,66 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-	'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
-	{
-		variants: {
-			variant: {
-				default: 'bg-background text-foreground',
-				destructive: 'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
-			},
-		},
-		defaultVariants: {
-			variant: 'default',
-		},
-	},
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
 )
 
-const Alert = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>>(
-	({ className, variant, ...props }, ref) => (
-		<div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-	),
-)
-Alert.displayName = 'Alert'
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(({ className, ...props }, ref) => (
-	<h5 ref={ref} className={cn('mb-1 font-medium leading-none tracking-tight', className)} {...props} />
-))
-AlertTitle.displayName = 'AlertTitle'
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const AlertDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-	({ className, ...props }, ref) => <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />,
-)
-AlertDescription.displayName = 'AlertDescription'
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,36 +1,48 @@
-import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-	'inline-flex items-center justify-center rounded-full border px-3 py-1.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
-	{
-		variants: {
-			variant: {
-				primary: 'bg-primary border-primary hover:border-primary-border-hover text-primary-foreground-hover active:bg-primary-border-hover',
-				primaryActive: 'bg-primary border-primary-border-hover text-primary-foreground-hover active:bg-primary-border-hover',
-				secondary: 'bg-light-gray text-primary-foreground hover:bg-primary-border-hover active:bg-primary-border-hover',
-				destructive: 'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-				outline: 'text-foreground',
-			},
-		},
-		defaultVariants: {
-			variant: 'primary',
-		},
-	},
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
 )
 
 function Badge({
-	className,
-	variant,
-	asChild = false,
-	...props
-}: React.ComponentProps<'span'> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-	const Comp = asChild ? Slot : 'span'
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
 
-	return <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
 }
 
 export { Badge, badgeVariants }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,122 +1,64 @@
-import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
 
-import { cn } from '@/lib/utils'
-import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip'
-
-export interface ButtonProps extends React.ComponentProps<'button'> {
-	tooltip?: string
-	disabledTooltip?: string
-	asChild?: boolean
-	icon?: React.ReactNode
-	iconPosition?: IconPosition
-}
-
-export type ButtonVariant = "primary" | "secondary" | "tertiary" | "focus" | "destructive" | "outline" | "ghost" | "link" | "none" | "dark-ghost" | "dark-subtle" | "dark-muted" | "dark-active" | "success" | "warning" | "dark-destructive"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-2 border-black box hover:translated cursor-pointer',
-	{
-		variants: {
-			variant: {
-				primary:
-					'bg-primary text-primary-foreground border-primary-border hover:bg-transparent hover:text-primary-foreground-hover hover:border-primary-border-hover active:ho',
-				secondary:
-					'bg-secondary text-secondary-foreground border-secondary-border hover:bg-transparent hover:text-secondary-foreground-hover hover:border-secondary-border-hover uppercase',
-				tertiary:
-					'bg-tertiary text-tertiary-foreground border-tertiary-border hover:bg-tertiary-hover hover:text-tertiary-foreground-hover hover:border-tertiary-border-hover',
-				focus:
-					'bg-focus text-focus-foreground border-focus-border hover:bg-transparent hover:text-focus-foreground-hover hover:border-focus-border-hover',
-				destructive: 'bg-destructive text-destructive-foreground hover:bg-transparent hover:text-destructive-foreground',
-
-				outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-				ghost: 'hover:border-primary-border border-none',
-				link: 'text-secondary border-none underline-offset-4 hover:underline',
-				none: 'border-0 p-0 text-base justify-start',
-
-				// Dark background variants (for use inside dark containers)
-				'dark-ghost': 'bg-transparent hover:bg-white/10 text-gray-400 hover:text-white border-0',
-				'dark-subtle': 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white border-0',
-				'dark-muted': 'bg-white/10 hover:bg-white/20 text-white border-0',
-				'dark-active': 'bg-white/20 text-white border-0',
-				success: 'bg-green-600 hover:bg-green-700 text-white border-0',
-				warning: 'bg-orange-600 hover:bg-orange-700 text-white border-0',
-				'dark-destructive': 'bg-transparent hover:bg-red-500/20 text-red-400 hover:text-red-300 border-0',
-			},
-			size: {
-				default: 'h-10 px-4 py-2',
-				sm: 'h-9 px-3',
-				lg: 'h-11  px-8',
-				icon: 'h-10 aspect-square',
-				none: 'h-6 w-fit',
-			},
-		},
-		defaultVariants: {
-			variant: 'primary',
-			size: 'default',
-		},
-	},
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-8 gap-1.5 rounded-md px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+        "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
 )
 
-type IconPosition = 'left' | 'right'
-
 function Button({
-	className,
-	variant,
-	size,
-	asChild = false,
-	icon,
-	iconPosition = 'left',
-	children,
-	...props
-}: ButtonProps & VariantProps<typeof buttonVariants>) {
-	const Comp = asChild ? Slot : 'button'
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot.Root : "button"
 
-	const hasIcon = !!icon
-	const buttonClasses = cn(buttonVariants({ variant, size, className }), hasIcon && 'inline-flex items-center gap-2')
-
-	const content = (
-		<Comp data-slot="button" className={buttonClasses} {...props}>
-			{hasIcon && iconPosition === 'right' ? (
-				<>
-					{children}
-					{icon}
-				</>
-			) : (
-				<>
-					{hasIcon && icon}
-					{children}
-				</>
-			)}
-		</Comp>
-	)
-
-	const { tooltip, disabledTooltip } = props
-
-	if (props.disabled && disabledTooltip) {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>
-					<span>
-						{content}
-					</span>
-				</TooltipTrigger>
-				<TooltipContent side="bottom">{disabledTooltip}</TooltipContent>
-			</Tooltip>
-		)
-	}
-	
-	if (tooltip) {
-		return (
-			<Tooltip>
-				<TooltipTrigger asChild>{content}</TooltipTrigger>
-				<TooltipContent side="bottom">{tooltip}</TooltipContent>
-			</Tooltip>
-		)
-	}
-
-	return content
+  return (
+    <Comp
+      data-slot="button"
+      data-variant={variant}
+      data-size={size}
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
 }
 
 export { Button, buttonVariants }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,29 +1,92 @@
-import * as React from 'react'
+import * as React from "react"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
-function Card({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card" className={cn('bg-card text-card-foreground rounded-xl border shadow-sm', className)} {...props} />
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card-header" className={cn('flex flex-col gap-1.5 p-6', className)} {...props} />
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card-title" className={cn('leading-none font-semibold tracking-tight', className)} {...props} />
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card-content" className={cn('p-6 pt-0', className)} {...props} />
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
-	return <div data-slot="card-footer" className={cn('flex items-center p-6 pt-0', className)} {...props} />
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,24 +1,32 @@
-import * as React from 'react'
-import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { CheckIcon } from 'lucide-react'
+"use client"
 
-import { cn } from '@/lib/utils'
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
 
-function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
-	return (
-		<CheckboxPrimitive.Root
-			data-slot="checkbox"
-			className={cn(
-				'peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
-				className,
-			)}
-			{...props}
-		>
-			<CheckboxPrimitive.Indicator data-slot="checkbox-indicator" className="flex items-center justify-center text-current transition-none">
-				<CheckIcon className="size-3.5" />
-			</CheckboxPrimitive.Indicator>
-		</CheckboxPrimitive.Root>
-	)
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
 }
 
 export { Checkbox }

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,4 +1,4 @@
-import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+import { Collapsible as CollapsiblePrimitive } from "radix-ui"
 
 function Collapsible({
   ...props

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,8 +1,11 @@
+"use client"
+
 import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
 
 function Dialog({
   ...props
@@ -30,26 +33,15 @@ function DialogClose({
 
 function DialogOverlay({
   className,
-  onClick,
-  onPointerDown,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
   return (
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
-      onClick={(event) => {
-        // Dialogs often live inside clickable parents (cards/links). Prevent bubbling navigation.
-        event.stopPropagation()
-        onClick?.(event)
-      }}
-      onPointerDown={(event) => {
-        event.stopPropagation()
-        onPointerDown?.(event)
-      }}
       {...props}
     />
   )
@@ -58,34 +50,32 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
-  onClick,
-  onPointerDown,
+  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
-        onClick={(event) => {
-          event.stopPropagation()
-          onClick?.(event)
-        }}
-        onPointerDown={(event) => {
-          event.stopPropagation()
-          onPointerDown?.(event)
-        }}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )
@@ -101,7 +91,14 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
   return (
     <div
       data-slot="dialog-footer"
@@ -110,7 +107,14 @@ function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
         className
       )}
       {...props}
-    />
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
   )
 }
 
@@ -134,7 +138,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,175 +1,133 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { X } from 'lucide-react'
-import { cn } from '@/lib/utils'
-import { useStore } from '@tanstack/react-store'
-import { uiActions, uiStore, type DrawerType } from '@/lib/stores/ui'
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
 
-const drawerVariants = cva('fixed h-full bg-white shadow-xl transform transition-transform duration-300 ease-in-out z-50', {
-	variants: {
-		side: {
-			right: 'top-0 right-0 w-full sm:w-96 translate-x-full data-[state=open]:translate-x-0',
-			left: 'top-0 left-0 w-full sm:w-96 -translate-x-full data-[state=open]:translate-x-0',
-			top: 'top-0 left-0 w-full h-96 -translate-y-full data-[state=open]:translate-y-0',
-			bottom: 'bottom-0 left-0 w-full h-96 translate-y-full data-[state=open]:translate-y-0',
-		},
-	},
-	defaultVariants: {
-		side: 'right',
-	},
-})
+import { cn } from "@/lib/utils"
 
-const backdropVariants = cva('fixed inset-0 bg-black/50 z-40 transition-opacity duration-300', {
-	variants: {
-		state: {
-			open: 'opacity-100',
-			closed: 'opacity-0 pointer-events-none',
-		},
-	},
-	defaultVariants: {
-		state: 'closed',
-	},
-})
-
-export interface DrawerProps extends VariantProps<typeof drawerVariants> {
-	type: DrawerType
-	children: React.ReactNode
-	className?: string
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
 }
 
-export function Drawer({ type, children, side, className }: DrawerProps) {
-	const { drawers } = useStore(uiStore)
-	const isOpen = drawers[type]
-
-	// Handle Escape key to close drawer
-	React.useEffect(() => {
-		const handleEscape = (e: KeyboardEvent) => {
-			if (e.key === 'Escape' && isOpen) {
-				uiActions.closeDrawer(type)
-			}
-		}
-
-		document.addEventListener('keydown', handleEscape)
-
-		// Prevent body scroll when drawer is open
-		if (isOpen) {
-			document.body.style.overflow = 'hidden'
-		} else {
-			document.body.style.overflow = ''
-		}
-
-		return () => {
-			document.removeEventListener('keydown', handleEscape)
-			document.body.style.overflow = ''
-		}
-	}, [isOpen, type])
-
-	return (
-		<>
-			{/* Backdrop - always rendered for smooth transitions */}
-			<div
-				className={cn(backdropVariants({ state: isOpen ? 'open' : 'closed' }))}
-				onClick={() => uiActions.closeDrawer(type)}
-				aria-hidden="true"
-			/>
-
-			{/* Drawer */}
-			<div
-				className={cn(drawerVariants({ side }), className)}
-				data-state={isOpen ? 'open' : 'closed'}
-				role="dialog"
-				aria-modal="true"
-				aria-labelledby={`drawer-${type}-title`}
-			>
-				{children}
-			</div>
-		</>
-	)
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
 }
 
-// Additional drawer components for shadcn/ui compatibility
-interface DrawerContentProps extends React.HTMLAttributes<HTMLDivElement> {}
-
-export function DrawerContent({ className, children, ...props }: DrawerContentProps) {
-	return (
-		<div className={cn("flex flex-col h-full", className)} {...props}>
-			{children}
-		</div>
-	)
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
 }
 
-interface DrawerHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
-
-export function DrawerHeader({ className, ...props }: DrawerHeaderProps) {
-	return (
-		<div className={cn("flex flex-col space-y-1.5 p-4 border-b", className)} {...props} />
-	)
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
 }
 
-interface DrawerFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
-
-export function DrawerFooter({ className, ...props }: DrawerFooterProps) {
-	return (
-		<div className={cn("mt-auto", className)} {...props} />
-	)
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-interface DrawerTitleProps extends React.HTMLAttributes<HTMLHeadingElement> {}
-
-export function DrawerTitle({ className, ...props }: DrawerTitleProps) {
-	return (
-		<h2 className={cn("text-xl font-semibold", className)} {...props} />
-	)
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-background",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  )
 }
 
-interface DrawerDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
-
-export function DrawerDescription({ className, ...props }: DrawerDescriptionProps) {
-	return (
-		<p className={cn("text-sm text-muted-foreground", className)} {...props} />
-	)
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-interface DrawerCloseProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-	asChild?: boolean
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
 }
 
-export function DrawerClose({ className, onClick, asChild, children, ...props }: DrawerCloseProps) {
-	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-		// Get the drawer type from the closest drawer element
-		const drawer = (e.target as HTMLElement).closest('[role="dialog"]');
-		const type = drawer?.getAttribute('aria-labelledby')?.replace('drawer-', '').replace('-title', '') as DrawerType;
-		
-		if (type) {
-			uiActions.closeDrawer(type);
-		}
-		
-		if (onClick) {
-			onClick(e);
-		}
-	};
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
 
-	if (asChild && React.isValidElement(children)) {
-		return React.cloneElement(children as React.ReactElement<any>, {
-			...props,
-			className: cn(className, (children as React.ReactElement<any>).props.className),
-			onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-				handleClick(e);
-				if ((children as React.ReactElement<any>).props.onClick) {
-					(children as React.ReactElement<any>).props.onClick(e);
-				}
-			},
-		});
-	}
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
 
-	return (
-		<button 
-			className={cn("p-2 rounded-full hover:bg-gray-100", className)} 
-			onClick={handleClick}
-			aria-label="Close drawer"
-			{...props}
-		>
-			{children || <X size={24} />}
-		</button>
-	);
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,8 @@
+"use client"
+
 import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -40,7 +42,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}
@@ -72,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -90,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -126,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -168,7 +170,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -182,7 +184,7 @@ function DropdownMenuShortcut({
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
+        "ml-auto text-xs tracking-widest text-muted-foreground",
         className
       )}
       {...props}
@@ -209,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}
@@ -228,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
         className
       )}
       {...props}

--- a/src/components/ui/image-uploader/ImageUploader.tsx
+++ b/src/components/ui/image-uploader/ImageUploader.tsx
@@ -244,9 +244,9 @@ export function ImageUploader({
           style={localSrc ? {} : { backgroundImage: 'url("images/checker.png")', backgroundRepeat: 'repeat' }}
         >
           {/* Floating server selector */}
-          <div className="absolute top-2 left-2 z-10">
+          <div className="top-2 left-2 z-10 absolute">
             <Select value={selectedServer} onValueChange={setSelectedServer}>
-              <SelectTrigger className="w-[280px] bg-white border-2 border-black shadow-sm">
+              <SelectTrigger className="bg-white shadow-sm border-2 border-black w-[280px]">
                 <SelectValue placeholder="Select server" />
               </SelectTrigger>
               <SelectContent>
@@ -266,7 +266,7 @@ export function ImageUploader({
                 <div className="absolute inset-0 bg-gradient-to-l from-gray-300 to-white" style={{ clipPath: 'polygon(100% 0, 100% 100%, 0 100%)' }}></div>
               </div>
 
-              <div className="absolute inset-0 flex items-center justify-center" style={{ backgroundImage: 'url("images/image-bg-pattern.png")', backgroundRepeat: 'repeat' }}>
+              <div className="absolute inset-0 flex justify-center items-center" style={{ backgroundImage: 'url("images/image-bg-pattern.png")', backgroundRepeat: 'repeat' }}>
                 {getMediaType(localSrc) === 'video' ? (
                   <video src={localSrc} controls className="max-w-full max-h-full object-contain">
                     <track kind="captions" />
@@ -277,19 +277,19 @@ export function ImageUploader({
                 )}
               </div>
 
-              <div className="absolute bottom-2 right-2 flex gap-2">
+              <div className="right-2 bottom-2 absolute flex gap-2">
                 {inputEditable && (
                   <Button type="button" variant="outline" size="icon" className="bg-white" onClick={handleEditByUpload}>
-                    <span className="i-upload w-6 h-6" />
+                    <span className="w-6 h-6 i-upload" />
                   </Button>
                 )}
                 <Button type="button" variant="outline" size="icon" className="bg-white" onClick={() => onDelete(index)}>
-                  <span className="i-delete w-4 h-4" />
+                  <span className="w-4 h-4 i-delete" />
                 </Button>
               </div>
 
               {index !== -1 && (
-                <div className="absolute left-2 bottom-2 flex flex-row gap-2">
+                <div className="bottom-2 left-2 absolute flex flex-row gap-2">
                   <Button
                     type="button"
                     variant="outline"
@@ -298,7 +298,7 @@ export function ImageUploader({
                     disabled={index === 0}
                     onClick={() => onPromote && onPromote(index)}
                   >
-                    <span className="i-up w-4 h-4" />
+                    <span className="w-4 h-4 i-up" />
                   </Button>
                   <Button
                     type="button"
@@ -308,7 +308,7 @@ export function ImageUploader({
                     disabled={index === imagesLength - 1}
                     onClick={() => onDemote && onDemote(index)}
                   >
-                    <span className="i-down w-4 h-4" />
+                    <span className="w-4 h-4 i-down" />
                   </Button>
                 </div>
               )}
@@ -325,9 +325,9 @@ export function ImageUploader({
               onDragLeave={handleDragLeave}
               onDrop={handleDrop}
             >
-              <span className="i-upload w-10 h-10" />
+              <span className="w-10 h-10 i-upload" />
               <strong>{isDragging ? 'Drop media here' : 'Click or drag image here'}</strong>
-              <strong className="text-xs text-gray-500">{imageDimensionText}</strong>
+              <strong className="text-gray-500 text-xs">{imageDimensionText}</strong>
             </button>
           )}
         </div>
@@ -338,7 +338,7 @@ export function ImageUploader({
             disabled={!inputEditable && Boolean(localSrc)}
             value={inputValue}
             type="text"
-            className="border-2 border-black pr-12 h-12 rounded-none"
+            className="pr-12 border-2 border-black rounded-none h-12"
             placeholder="Set a remote image URL"
             id="userImageRemote"
             name="imageRemoteInput"
@@ -350,8 +350,7 @@ export function ImageUploader({
             inputEditable ? (
               <Button
                 type="button"
-                variant="primary"
-                className="absolute right-1 top-1 bottom-1 h-10"
+                className="top-1 right-1 bottom-1 absolute h-10"
                 onClick={handleSaveImage}
                 data-testid="image-save-button"
               >
@@ -361,7 +360,7 @@ export function ImageUploader({
               <Button
                 type="button"
                 variant="outline"
-                className="absolute right-1 top-1 bottom-1 h-10 bg-white"
+                className="top-1 right-1 bottom-1 absolute bg-white h-10"
                 onClick={() => setInputEditable(true)}
                 data-testid="image-edit-button"
               >
@@ -371,8 +370,7 @@ export function ImageUploader({
           ) : (
             <Button
               type="button"
-              variant="primary"
-              className="absolute right-1 top-1 bottom-1 h-10"
+              className="top-1 right-1 bottom-1 absolute h-10"
               onClick={handleSaveImage}
               data-testid="image-save-button"
             >
@@ -386,8 +384,8 @@ export function ImageUploader({
         )}
 
         {isLoading && (
-          <div className="flex flex-row gap-2 items-center">
-            <div className="animate-spin w-4 h-4 border-2 border-primary border-t-transparent rounded-full"></div>
+          <div className="flex flex-row items-center gap-2">
+            <div className="border-2 border-primary border-t-transparent rounded-full w-4 h-4 animate-spin"></div>
             <p className="text-sm">Uploading...</p>
           </div>
         )}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,24 +1,21 @@
-import * as React from 'react'
+import * as React from "react"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(({ className, type, ...props }, ref) => {
-	return (
-		<div className="w-full">
-			<input
-				type={type}
-				data-slot="input"
-				className={cn(
-					'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus:border-secondary focus:outline-none focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50',
-					className,
-				)}
-				ref={ref}
-				{...props}
-			/>
-		</div>
-	)
-})
-
-Input.displayName = 'Input'
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,21 +1,22 @@
-'use client'
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
 
-import * as React from 'react'
-import * as LabelPrimitive from '@radix-ui/react-label'
+import { cn } from "@/lib/utils"
 
-import { cn } from '@/lib/utils'
-
-function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
-	return (
-		<LabelPrimitive.Root
-			data-slot="label"
-			className={cn(
-				'text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
-				className,
-			)}
-			{...props}
-		/>
-	)
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
 export { Label }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 import { Popover as PopoverPrimitive } from "radix-ui"
 
@@ -28,7 +30,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import { Progress as ProgressPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -12,14 +12,14 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
         className
       )}
       {...props}
     >
       <ProgressPrimitive.Indicator
         data-slot="progress-indicator"
-        className="bg-primary h-full w-full flex-1 transition-all"
+        className="h-full w-full flex-1 bg-primary transition-all"
         style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
       />
     </ProgressPrimitive.Root>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,6 +1,8 @@
+"use client"
+
 import * as React from "react"
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { CircleIcon } from "lucide-react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -25,7 +27,7 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}
@@ -34,7 +36,7 @@ function RadioGroupItem({
         data-slot="radio-group-indicator"
         className="relative flex items-center justify-center"
       >
-        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   )

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -16,7 +16,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -47,7 +47,7 @@ function ScrollBar({
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-area-thumb"
-        className="bg-border relative flex-1 rounded-full"
+        className="relative flex-1 rounded-full bg-border"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   )

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,135 +1,190 @@
-import * as React from 'react'
-import * as SelectPrimitive from '@radix-ui/react-select'
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react'
+"use client"
 
-import { cn } from '@/lib/utils'
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
 
-function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-	return <SelectPrimitive.Root data-slot="select" {...props} />
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
-function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-	return <SelectPrimitive.Group data-slot="select-group" {...props} />
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
 }
 
-function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-	return <SelectPrimitive.Value data-slot="select-value" {...props} />
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
 }
 
-function SelectTrigger({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Trigger>) {
-	return (
-		<SelectPrimitive.Trigger
-			data-slot="select-trigger"
-			className={cn(
-				"border-input data-[placeholder]:text-muted-foreground aria-invalid:border-destructive ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 [&_svg:not([class*='text-'])]:text-muted-foreground flex h-10 w-full items-center justify-between rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] focus-visible:ring-4 focus-visible:outline-1 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:focus-visible:ring-0 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:line-clamp-1",
-				className,
-			)}
-			{...props}
-		>
-			{children}
-			<SelectPrimitive.Icon asChild>
-				<ChevronDownIcon className="size-4 opacity-50" />
-			</SelectPrimitive.Icon>
-		</SelectPrimitive.Trigger>
-	)
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
 }
 
-function SelectContent({ className, children, position = 'popper', ...props }: React.ComponentProps<typeof SelectPrimitive.Content>) {
-	return (
-		<SelectPrimitive.Portal>
-			<SelectPrimitive.Content
-				data-slot="select-content"
-				className={cn(
-					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border shadow-md',
-					position === 'popper' &&
-						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-					className,
-				)}
-				position={position}
-				{...props}
-			>
-				<SelectScrollUpButton />
-				<SelectPrimitive.Viewport
-					className={cn(
-						'p-1',
-						position === 'popper' && 'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
-					)}
-				>
-					{children}
-				</SelectPrimitive.Viewport>
-				<SelectScrollDownButton />
-			</SelectPrimitive.Content>
-		</SelectPrimitive.Portal>
-	)
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
 }
 
-function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
-	return <SelectPrimitive.Label data-slot="select-label" className={cn('px-2 py-1.5 text-sm font-semibold', className)} {...props} />
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
 }
 
-function SelectItem({ className, children, ...props }: React.ComponentProps<typeof SelectPrimitive.Item>) {
-	return (
-		<SelectPrimitive.Item
-			data-slot="select-item"
-			className={cn(
-				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-				className,
-			)}
-			{...props}
-		>
-			<span className="absolute right-2 flex size-3.5 items-center justify-center">
-				<SelectPrimitive.ItemIndicator>
-					<CheckIcon className="size-4" />
-				</SelectPrimitive.ItemIndicator>
-			</span>
-			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-		</SelectPrimitive.Item>
-	)
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
 }
 
-function SelectSeparator({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Separator>) {
-	return (
-		<SelectPrimitive.Separator
-			data-slot="select-separator"
-			className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
-			{...props}
-		/>
-	)
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
 }
 
-function SelectScrollUpButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
-	return (
-		<SelectPrimitive.ScrollUpButton
-			data-slot="select-scroll-up-button"
-			className={cn('flex cursor-default items-center justify-center py-1', className)}
-			{...props}
-		>
-			<ChevronUpIcon className="size-4" />
-		</SelectPrimitive.ScrollUpButton>
-	)
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
 }
 
-function SelectScrollDownButton({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
-	return (
-		<SelectPrimitive.ScrollDownButton
-			data-slot="select-scroll-down-button"
-			className={cn('flex cursor-default items-center justify-center py-1', className)}
-			{...props}
-		>
-			<ChevronDownIcon className="size-4" />
-		</SelectPrimitive.ScrollDownButton>
-	)
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
 }
 
 export {
-	Select,
-	SelectContent,
-	SelectGroup,
-	SelectItem,
-	SelectLabel,
-	SelectScrollDownButton,
-	SelectScrollUpButton,
-	SelectSeparator,
-	SelectTrigger,
-	SelectValue,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
 }

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,29 +1,26 @@
-import * as React from 'react'
-import * as SeparatorPrimitive from '@radix-ui/react-separator'
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
-const Separator = React.forwardRef<
-	React.ElementRef<typeof SeparatorPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(
-	(
-		{ className, orientation = 'horizontal', decorative = true, ...props },
-		ref
-	) => (
-		<SeparatorPrimitive.Root
-			ref={ref}
-			decorative={decorative}
-			orientation={orientation}
-			className={cn(
-				'shrink-0 bg-border',
-				orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
-				className
-			)}
-			{...props}
-		/>
-	)
-)
-Separator.displayName = SeparatorPrimitive.Root.displayName
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Separator }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,22 +1,13 @@
+"use client"
+
 import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
 import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
-function Sheet({
-  open,
-  onOpenChange,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return (
-    <SheetPrimitive.Root
-      data-slot="sheet"
-      open={open}
-      onOpenChange={onOpenChange}
-      {...props}
-    />
-  )
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
 }
 
 function SheetTrigger({
@@ -45,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -57,9 +48,11 @@ function SheetContent({
   className,
   children,
   side = "right",
+  showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
 }) {
   return (
     <SheetPortal>
@@ -67,25 +60,26 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
-          // For right side sheets (default) we do full width on mobile
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
           side === "right" &&
-            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-full border-l-0 sm:w-3/4 sm:border-l md:max-w-md",
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&
-            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
           side === "top" &&
-            "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
           side === "bottom" &&
-            "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
           className
         )}
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-8" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
       </SheetPrimitive.Content>
     </SheetPortal>
   )
@@ -118,7 +112,7 @@ function SheetTitle({
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-semibold", className)}
+      className={cn("font-semibold text-foreground", className)}
       {...props}
     />
   )
@@ -131,7 +125,7 @@ function SheetDescription({
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,7 +1,13 @@
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils"
 
-function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-	return <div className={cn('animate-pulse rounded-md bg-primary/10', className)} {...props} />
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
 }
 
 export { Skeleton }

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import * as SliderPrimitive from "@radix-ui/react-slider"
+import { Slider as SliderPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -37,13 +37,13 @@ function Slider({
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          "relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
         )}
       >
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
           )}
         />
       </SliderPrimitive.Track>
@@ -51,7 +51,7 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+          className="block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}
     </SliderPrimitive.Root>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,14 @@
+"use client"
+
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -8,11 +17,19 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
       style={
         {
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
         } as React.CSSProperties
       }
       {...props}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,20 +1,16 @@
-import { cn } from '../../lib/utils'
+import { Loader2Icon } from "lucide-react"
 
-type SpinnerProps = {
-  size?: 'sm' | 'md' | 'lg'
-  className?: string
-}
+import { cn } from "@/lib/utils"
 
-export function Spinner({ size = 'md', className }: SpinnerProps) {
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (
-    <div
-      className={cn(
-        'animate-spin rounded-full border-2 border-current border-t-transparent',
-        size === 'sm' && 'h-4 w-4',
-        size === 'md' && 'h-6 w-6',
-        size === 'lg' && 'h-8 w-8',
-        className
-      )}
+    <Loader2Icon
+      role="status"
+      aria-label="Loading"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
     />
   )
-} 
+}
+
+export { Spinner }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,17 +1,21 @@
 import * as React from "react"
-import * as SwitchPrimitive from "@radix-ui/react-switch"
+import { Switch as SwitchPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
 function Switch({
   className,
+  size = "default",
   ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
+      data-size={size}
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
         className
       )}
       {...props}
@@ -19,7 +23,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground"
         )}
       />
     </SwitchPrimitive.Root>

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
@@ -42,7 +44,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
         className
       )}
       {...props}
@@ -55,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
         className
       )}
       {...props}
@@ -68,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -96,7 +98,7 @@ function TableCaption({
   return (
     <caption
       data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,32 +1,54 @@
 import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
 function Tabs({
   className,
+  orientation = "horizontal",
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.Root>) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
-      className={cn("flex flex-col gap-2", className)}
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
       {...props}
     />
   )
 }
 
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
 function TabsList({
   className,
+  variant = "default",
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
-      className={cn(
-        "flex flex-row h-9 w-fit items-center justify-start rounded-lg p-[3px]",
-        className
-      )}
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
   )
@@ -40,14 +62,10 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        // "font-bold text-black bg-muted",
-        "inline-flex items-center justify-center whitespace-nowrap rounded-none px-4 py-2.5 text-sm font-medium",
-        "ring-offset-background transition-all",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        "disabled:pointer-events-none disabled:opacity-50",
-        // "data-[state=active]:bg-secondary data-[state=active]:shadow-sm",
-        "data-[state=active]:text-white",
-        "disabled:border-0 disabled:opacity-100",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
         className
       )}
       {...props}
@@ -68,4 +86,4 @@ function TabsContent({
   )
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
         className
       )}
       {...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,5 +1,7 @@
+"use client"
+
 import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
@@ -19,11 +21,7 @@ function TooltipProvider({
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return (
-    <TooltipProvider>
-      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-    </TooltipProvider>
-  )
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
 function TooltipTrigger({
@@ -44,13 +42,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/src/components/v4v/V4VManager.tsx
+++ b/src/components/v4v/V4VManager.tsx
@@ -81,7 +81,7 @@ export function V4VManager({
 
 	return (
 		<div className={`space-y-6 ${className}`}>
-			<Alert className="bg-blue-100 text-blue-800 border-blue-200">
+			<Alert className="bg-blue-100 border-blue-200 text-blue-800">
 				<AlertDescription>
 					PM (Beta) Is Powered By Your Generosity. Your Contribution Is The Only Thing That Enables Us To Continue Creating Free And Open
 					Source Solutions 🙏
@@ -89,11 +89,11 @@ export function V4VManager({
 			</Alert>
 
 			<div className="space-y-4">
-				<h2 className="text-xl font-semibold">Split of total sales</h2>
+				<h2 className="font-semibold text-xl">Split of total sales</h2>
 
 				{/* Total V4V percentage slider */}
 				<div className="mt-4">
-					<div className="flex justify-between text-sm text-muted-foreground mb-2">
+					<div className="flex justify-between mb-2 text-muted-foreground text-sm">
 						<span>Seller: {formattedSellerPercentage}%</span>
 						<span>V4V: {formattedTotalV4V}%</span>
 					</div>
@@ -101,7 +101,7 @@ export function V4VManager({
 				</div>
 
 				{/* Emoji animation section */}
-				<div className="text-center my-8">
+				<div className="my-8 text-center">
 					<div
 						className={`p-4 rounded-full bg-gray-200 inline-flex items-center justify-center ${emojiClass}`}
 						style={{
@@ -115,16 +115,16 @@ export function V4VManager({
 				</div>
 
 				{/* First bar - Total split between seller and V4V */}
-				<div className="w-full h-12 flex rounded-md overflow-hidden">
+				<div className="flex rounded-md w-full h-12 overflow-hidden">
 					<div
-						className="bg-green-600 flex items-center justify-start pl-4 text-white font-medium"
+						className="flex justify-start items-center bg-green-600 pl-4 font-medium text-white"
 						style={{ width: `${sellerPercentage}%` }}
 					>
 						{formattedSellerPercentage}%
 					</div>
 					{totalV4VPercentage > 0 && (
 						<div
-							className="bg-fuchsia-500 flex items-center justify-center text-white font-medium"
+							className="flex justify-center items-center bg-fuchsia-500 font-medium text-white"
 							style={{ width: `${totalV4VPercentage}%` }}
 						>
 							V4V
@@ -132,11 +132,11 @@ export function V4VManager({
 					)}
 				</div>
 
-				<h2 className="text-xl font-semibold mt-6">V4V split between recipients</h2>
+				<h2 className="mt-6 font-semibold text-xl">V4V split between recipients</h2>
 
 				{/* Second bar - Split between V4V recipients */}
 				{localShares.length > 0 && totalV4VPercentage > 0 ? (
-					<div className="w-full h-12 flex rounded-md overflow-hidden">
+					<div className="flex rounded-md w-full h-12 overflow-hidden">
 						{localShares.map((share, index) => (
 							<div
 								key={share.id}
@@ -172,7 +172,7 @@ export function V4VManager({
 
 				{/* Add new recipient form */}
 				{showAddForm ? (
-					<div className="space-y-4 mt-6 border p-4 rounded-lg">
+					<div className="space-y-4 mt-6 p-4 border rounded-lg">
 						<div className="flex-1">
 							<ProfileSearch onSelect={handleProfileSelect} placeholder="Search profiles or paste npub..." />
 
@@ -187,13 +187,13 @@ export function V4VManager({
 						</div>
 						{localShares.length > 0 && (
 							<div className="space-y-2">
-								<div className="flex justify-between text-sm text-muted-foreground">
+								<div className="flex justify-between text-muted-foreground text-sm">
 									<span>Share percentage: {newRecipientShare}%</span>
 								</div>
 								<Slider value={[newRecipientShare]} min={1} max={100} step={1} onValueChange={(value) => setNewRecipientShare(value[0])} />
 							</div>
 						)}
-						<div className="flex flex-wrap gap-2 items-center">
+						<div className="flex flex-wrap items-center gap-2">
 							<Button
 								className="flex-grow sm:flex-grow-0"
 								onClick={handleAddRecipient}
@@ -208,7 +208,7 @@ export function V4VManager({
 						</div>
 					</div>
 				) : (
-					<div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6">
+					<div className="gap-4 grid grid-cols-1 sm:grid-cols-2 mt-6">
 						<Button
 							variant="outline"
 							onClick={() => setShowAddForm(true)}
@@ -237,7 +237,7 @@ export function V4VManager({
 									Cancel
 								</Button>
 								<Button
-									variant="focus"
+									variant="default"
 									className="flex-1"
 									onClick={handleSave}
 									disabled={publishMutation.isPending || (showChangesIndicator && !hasChanges)}
@@ -254,7 +254,7 @@ export function V4VManager({
 							</div>
 						) : (
 							<Button
-								variant="focus"
+								variant="default"
 								className="w-full"
 								onClick={handleSave}
 								disabled={publishMutation.isPending || (showChangesIndicator && !hasChanges)}

--- a/src/feature/wallet/components/Nip60Wallet.tsx
+++ b/src/feature/wallet/components/Nip60Wallet.tsx
@@ -38,6 +38,7 @@ import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } f
 import { extractProofsByMint, getMintHostname, type ProofInfo } from '@/lib/wallet'
 import { toast } from 'sonner'
 import { QRCodeSVG } from 'qrcode.react'
+import { cn } from '@/lib/utils'
 
 // Unified pending token type for UI
 type UnifiedPendingToken = (PendingToken | PendingNip60Token) & { source: 'cashu' | 'nip60' }
@@ -182,9 +183,19 @@ export function Nip60Wallet() {
 		toast.success('Token removed from history')
 	}
 
+	// Button appearance class definitions
+
+	const classNameGhost = 'hover:bg-white/10 text-gray-400 hover:text-white'
+	const classNameSubtle = 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white'
+	const classNameMuted = 'bg-white/10 hover:bg-white/20 text-white'
+	const classNameActive = 'bg-white/20 text-white'
+	const classNameSuccess = 'bg-green-600 hover:bg-green-700 text-white'
+	const classNameWarning = 'bg-orange-600 hover:bg-orange-700 text-white'
+	const classNameDestructive = 'bg-transparent hover:bg-red-500/20 text-red-400 hover:text-red-300'
+
 	if (!isAuthenticated) {
 		return (
-			<div className="p-4 text-center text-gray-400 bg-primary rounded-lg">
+			<div className="bg-primary p-4 rounded-lg text-gray-400 text-center">
 				<p>Please log in to view your wallet</p>
 			</div>
 		)
@@ -192,15 +203,15 @@ export function Nip60Wallet() {
 
 	if (status === 'idle' || status === 'initializing') {
 		return (
-			<div className="flex items-center justify-center p-4 bg-primary rounded-lg">
-				<Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+			<div className="flex justify-center items-center bg-primary p-4 rounded-lg">
+				<Loader2 className="w-6 h-6 text-gray-400 animate-spin" />
 			</div>
 		)
 	}
 
 	if (status === 'error') {
 		return (
-			<div className="p-4 text-center text-red-400 bg-primary rounded-lg">
+			<div className="bg-primary p-4 rounded-lg text-red-400 text-center">
 				<p>{error}</p>
 			</div>
 		)
@@ -208,14 +219,10 @@ export function Nip60Wallet() {
 
 	if (status === 'no_wallet') {
 		return (
-			<div className="p-4 text-center w-80 bg-primary rounded-lg">
-				<p className="text-gray-400 mb-4">No Cashu wallet found</p>
-				<Button
-					onClick={handleCreateWallet}
-					disabled={isCreating}
-					variant="secondary"
-					icon={isCreating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-				>
+			<div className="bg-primary p-4 rounded-lg w-80 text-center">
+				<p className="mb-4 text-gray-400">No Cashu wallet found</p>
+				<Button onClick={handleCreateWallet} disabled={isCreating} variant="secondary">
+					{isCreating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
 					Create Wallet
 				</Button>
 			</div>
@@ -223,55 +230,47 @@ export function Nip60Wallet() {
 	}
 
 	return (
-		<div className="p-4 max-w-full overflow-hidden bg-primary rounded-lg text-white">
-			<div className="text-center mb-4 relative">
-				<div className="absolute right-0 top-0 flex gap-1">
-					<Button variant="dark-ghost" size="icon" onClick={handleRefresh} disabled={isRefreshing} title="Refresh & sync wallet">
+		<div className="bg-primary p-4 rounded-lg max-w-full overflow-hidden text-white">
+			<div className="relative mb-4 text-center">
+				<div className="top-0 right-0 absolute flex gap-1">
+					<Button className={classNameGhost} size="icon" onClick={handleRefresh} disabled={isRefreshing} title="Refresh & sync wallet">
 						<RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
 					</Button>
 				</div>
-				<p className="text-sm text-gray-400 mb-1">Balance</p>
-				<p className="text-2xl font-bold text-white">{balance.toLocaleString()} sats</p>
+				<p className="mb-1 text-gray-400 text-sm">Balance</p>
+				<p className="font-bold text-white text-2xl">{balance.toLocaleString()} sats</p>
 			</div>
 
 			{/* Action Buttons */}
-			<div className="grid grid-cols-2 gap-2 mb-4">
-				<Button variant="success" size="sm" onClick={() => setOpenModal('deposit')} icon={<Zap className="w-4 h-4" />}>
+			<div className="gap-2 grid grid-cols-2 mb-4">
+				<Button className={classNameSuccess} size="sm" onClick={() => setOpenModal('deposit')}>
+					<Zap className="w-4 h-4" />
 					Deposit
 				</Button>
-				<Button
-					variant="warning"
-					size="sm"
-					onClick={() => setOpenModal('withdraw')}
-					disabled={balance === 0}
-					icon={<Zap className="w-4 h-4" />}
-				>
+				<Button className={classNameWarning} size="sm" onClick={() => setOpenModal('withdraw')} disabled={balance === 0}>
+					<Zap className="w-4 h-4" />
 					Withdraw
 				</Button>
-				<Button variant="dark-muted" size="sm" onClick={() => setOpenModal('receive')} icon={<QrCode className="w-4 h-4" />}>
+				<Button className={classNameMuted} size="sm" onClick={() => setOpenModal('receive')}>
+					<QrCode className="w-4 h-4" />
 					Receive eCash
 				</Button>
-				<Button
-					variant="dark-muted"
-					size="sm"
-					onClick={() => setOpenModal('send')}
-					disabled={balance === 0}
-					icon={<Send className="w-4 h-4" />}
-				>
+				<Button className={classNameMuted} size="sm" onClick={() => setOpenModal('send')} disabled={balance === 0}>
+					<Send className="w-4 h-4" />
 					Send eCash
 				</Button>
 			</div>
 
 			{/* Default Mint Selector */}
-			<div className="pt-2 mb-2 overflow-hidden">
-				<p className="text-sm font-medium mb-2 text-gray-300">Default Mint</p>
+			<div className="mb-2 pt-2 overflow-hidden">
+				<p className="mb-2 font-medium text-gray-300 text-sm">Default Mint</p>
 				{mints.length > 0 ? (
 					<Select value={defaultMint ?? ''} onValueChange={(value) => nip60Actions.setDefaultMint(value || null)}>
-						<SelectTrigger className="w-full bg-white/10 border-white/20 text-white hover:bg-white/15">
+						<SelectTrigger className="bg-white/10 hover:bg-white/15 border-white/20 w-full text-white">
 							<SelectValue placeholder="Select a default mint">
 								{defaultMint ? (
 									<span className="flex items-center gap-2 truncate">
-										<Star className="w-4 h-4 text-yellow-500 fill-current shrink-0" />
+										<Star className="fill-current w-4 h-4 text-yellow-500 shrink-0" />
 										<span className="truncate">{getMintHostname(defaultMint)}</span>
 										{mintBalances[defaultMint] !== undefined && (
 											<span className="text-gray-400 shrink-0">({mintBalances[defaultMint].toLocaleString()})</span>
@@ -282,9 +281,9 @@ export function Nip60Wallet() {
 								)}
 							</SelectValue>
 						</SelectTrigger>
-						<SelectContent className="max-w-[calc(100vw-2rem)] bg-primary border-white/20">
+						<SelectContent className="bg-primary border-white/20 max-w-[calc(100vw-2rem)]">
 							{mints.map((mint) => (
-								<SelectItem key={mint} value={mint} className="text-white hover:bg-white/10 focus:bg-white/10 focus:text-white">
+								<SelectItem key={mint} value={mint} className="hover:bg-white/10 focus:bg-white/10 text-white focus:text-white">
 									<div className="flex items-center gap-2">
 										<Landmark className="w-4 h-4 shrink-0" />
 										<span className="truncate">{getMintHostname(mint)}</span>
@@ -306,30 +305,27 @@ export function Nip60Wallet() {
 				{/* Toggle buttons row */}
 				<div className="flex gap-1 mb-2">
 					<Button
-						variant={openSection === 'mints' ? 'dark-active' : 'dark-subtle'}
+						className={cn(openSection === 'mints' ? classNameActive : classNameSubtle, 'flex-1 gap-1.5 px-2')}
 						size="sm"
 						onClick={() => setOpenSection(openSection === 'mints' ? null : 'mints')}
-						className="flex-1 gap-1.5 px-2"
 						title="Manage mints"
 					>
 						<Landmark className="w-4 h-4 shrink-0" />
 						<span className="text-xs">{mints.length}</span>
 					</Button>
 					<Button
-						variant={openSection === 'transactions' ? 'dark-active' : 'dark-subtle'}
+						className={cn(openSection === 'transactions' ? classNameActive : classNameSubtle, 'flex-1 gap-1.5 px-2')}
 						size="sm"
 						onClick={() => setOpenSection(openSection === 'transactions' ? null : 'transactions')}
-						className="flex-1 gap-1.5 px-2"
 						title="Transactions"
 					>
 						<ArrowUpDown className="w-4 h-4 shrink-0" />
 						<span className="text-xs">{transactions.length}</span>
 					</Button>
 					<Button
-						variant={openSection === 'proofs' ? 'dark-active' : 'dark-subtle'}
+						className={cn(openSection === 'transactions' ? classNameActive : classNameSubtle, 'flex-1 gap-1.5 px-2')}
 						size="sm"
 						onClick={() => setOpenSection(openSection === 'proofs' ? null : 'proofs')}
-						className="flex-1 gap-1.5 px-2"
 						title="Proofs"
 					>
 						<Coins className="w-4 h-4 shrink-0" />
@@ -337,10 +333,9 @@ export function Nip60Wallet() {
 					</Button>
 					{activePendingTokens.length > 0 && (
 						<Button
-							variant={openSection === 'pending' ? 'dark-active' : 'dark-subtle'}
+							className={cn(openSection === 'transactions' ? classNameActive : classNameSubtle, 'flex-1 gap-1.5 px-2')}
 							size="sm"
 							onClick={() => setOpenSection(openSection === 'pending' ? null : 'pending')}
-							className="flex-1 gap-1.5 px-2"
 							title="Pending tokens"
 						>
 							<Clock className="w-4 h-4 shrink-0" />
@@ -351,15 +346,15 @@ export function Nip60Wallet() {
 
 				{/* Content panels */}
 				{openSection === 'mints' && (
-					<div className="space-y-2 pt-2 overflow-hidden border-t border-white/10">
+					<div className="space-y-2 pt-2 border-white/10 border-t overflow-hidden">
 						{mints.map((mint) => (
-							<div key={mint} className="flex items-center justify-between text-sm gap-2">
-								<span className="text-gray-300 truncate min-w-0" title={mint}>
+							<div key={mint} className="flex justify-between items-center gap-2 text-sm">
+								<span className="min-w-0 text-gray-300 truncate" title={mint}>
 									{getMintHostname(mint)}
 								</span>
 								<div className="flex items-center gap-1 shrink-0">
-									{mintBalances[mint] !== undefined && <span className="text-xs text-gray-400">{mintBalances[mint].toLocaleString()}</span>}
-									<Button variant="dark-ghost" size="icon" onClick={() => handleRemoveMint(mint)} title="Remove mint" className="h-6 w-6">
+									{mintBalances[mint] !== undefined && <span className="text-gray-400 text-xs">{mintBalances[mint].toLocaleString()}</span>}
+									<Button className={cn(classNameGhost, 'w-6 h-6')} size="icon" onClick={() => handleRemoveMint(mint)} title="Remove mint">
 										<X className="w-3 h-3" />
 									</Button>
 								</div>
@@ -372,31 +367,25 @@ export function Nip60Wallet() {
 								onChange={(e) => setNewMintUrl(e.target.value)}
 								onKeyDown={(e) => e.key === 'Enter' && handleAddMint()}
 								placeholder="https://mint.example.com"
-								className="flex-1 h-8 text-sm min-w-0 bg-white/10 border-white/20 text-white placeholder:text-gray-500"
+								className="flex-1 bg-white/10 border-white/20 min-w-0 h-8 text-white placeholder:text-gray-500 text-sm"
 							/>
-							<Button variant="dark-muted" size="sm" onClick={handleAddMint} disabled={!newMintUrl.trim()} className="h-8 px-2 shrink-0">
+							<Button className={cn(classNameMuted, 'px-2 h-8 shrink-0')} size="sm" onClick={handleAddMint} disabled={!newMintUrl.trim()}>
 								<Plus className="w-4 h-4" />
 							</Button>
 						</div>
-						<Button
-							variant="dark-active"
-							size="sm"
-							onClick={handleSaveWallet}
-							disabled={isSaving}
-							className="w-full"
-							icon={isSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-						>
+						<Button className={cn(classNameActive, 'w-full')} size="sm" onClick={handleSaveWallet} disabled={isSaving}>
+							{isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
 							Save Wallet
 						</Button>
 					</div>
 				)}
 
 				{openSection === 'transactions' && (
-					<div className="pt-2 overflow-hidden border-t border-white/10">
+					<div className="pt-2 border-white/10 border-t overflow-hidden">
 						{transactions.length > 0 ? (
 							<div className="space-y-2 max-h-48 overflow-y-auto">
 								{transactions.map((tx) => (
-									<div key={tx.id} className="flex items-center justify-between text-sm gap-2">
+									<div key={tx.id} className="flex justify-between items-center gap-2 text-sm">
 										<div className="flex items-center gap-2 min-w-0">
 											{tx.direction === 'in' ? (
 												<ArrowDownLeft className="w-4 h-4 text-green-400 shrink-0" />
@@ -419,30 +408,30 @@ export function Nip60Wallet() {
 				)}
 
 				{openSection === 'proofs' && (
-					<div className="space-y-2 max-h-48 overflow-y-auto overflow-x-hidden pt-2 border-t border-white/10">
+					<div className="space-y-2 pt-2 border-white/10 border-t max-h-48 overflow-x-hidden overflow-y-auto">
 						{proofsByMint.size === 0 ? (
-							<p className="text-sm text-gray-400">No proofs in wallet</p>
+							<p className="text-gray-400 text-sm">No proofs in wallet</p>
 						) : (
 							Array.from(proofsByMint.entries()).map(([mint, proofs]) => (
 								<Collapsible key={mint} open={expandedMints.has(mint)} onOpenChange={() => toggleMintExpanded(mint)}>
-									<div className="bg-white/5 rounded-md p-2 overflow-hidden">
+									<div className="bg-white/5 p-2 rounded-md overflow-hidden">
 										<CollapsibleTrigger asChild>
-											<Button variant="dark-ghost" size="sm" className="w-full justify-start gap-2 px-1 h-auto py-1 overflow-hidden">
-												<ChevronRight className="w-3 h-3 shrink-0 transition-transform [[data-state=open]>&]:rotate-90" />
-												<span className="font-medium truncate flex-1 text-left min-w-0 text-white">{getMintHostname(mint)}</span>
-												<span className="text-gray-400 text-xs shrink-0 whitespace-nowrap">
+											<Button className={cn(classNameGhost, 'justify-start gap-2 px-1 py-1 w-full h-auto overflow-hidden')} size="sm">
+												<ChevronRight className="w-3 h-3 [[data-state=open]>&]:rotate-90 transition-transform shrink-0" />
+												<span className="flex-1 min-w-0 font-medium text-white text-left truncate">{getMintHostname(mint)}</span>
+												<span className="text-gray-400 text-xs whitespace-nowrap shrink-0">
 													{proofs.length} • {proofs.reduce((s, p) => s + p.amount, 0).toLocaleString()}
 												</span>
 											</Button>
 										</CollapsibleTrigger>
 										<CollapsibleContent>
-											<div className="mt-2 space-y-1 pl-5 overflow-hidden">
+											<div className="space-y-1 mt-2 pl-5 overflow-hidden">
 												{proofs.map((proof, idx) => (
 													<div
 														key={`${proof.id}-${proof.secret.slice(0, 8)}-${idx}`}
-														className="flex items-center justify-between text-xs bg-white/10 rounded px-2 py-1 gap-2"
+														className="flex justify-between items-center gap-2 bg-white/10 px-2 py-1 rounded text-xs"
 													>
-														<span className="font-mono text-gray-400 truncate min-w-0" title={`Keyset: ${proof.id}`}>
+														<span className="min-w-0 font-mono text-gray-400 truncate" title={`Keyset: ${proof.id}`}>
 															{proof.id.slice(0, 8)}...
 														</span>
 														<span className="font-medium text-white shrink-0">{proof.amount}</span>
@@ -458,32 +447,30 @@ export function Nip60Wallet() {
 				)}
 
 				{openSection === 'pending' && (
-					<div className="space-y-2 max-h-48 overflow-y-auto pt-2 border-t border-white/10">
+					<div className="space-y-2 pt-2 border-white/10 border-t max-h-48 overflow-y-auto">
 						{activePendingTokens.map((token) => (
-							<div key={token.id} className="flex items-center justify-between p-2 bg-white/5 rounded-lg gap-2">
+							<div key={token.id} className="flex justify-between items-center gap-2 bg-white/5 p-2 rounded-lg">
 								<div className="min-w-0">
-									<p className="font-medium text-sm text-white">{token.amount.toLocaleString()} sats</p>
-									<p className="text-xs text-gray-400 truncate">
+									<p className="font-medium text-white text-sm">{token.amount.toLocaleString()} sats</p>
+									<p className="text-gray-400 text-xs truncate">
 										{getMintHostname(token.mintUrl)} • {new Date(token.createdAt).toLocaleDateString()}
 									</p>
 								</div>
 								<div className="flex gap-0.5 shrink-0">
-									<Button variant="dark-ghost" size="icon" className="h-7 w-7" onClick={() => setViewingToken(token)} title="View token">
+									<Button className={cn(classNameGhost, 'w-7 h-7')} size="icon" onClick={() => setViewingToken(token)} title="View token">
 										<Eye className="w-3.5 h-3.5" />
 									</Button>
 									<Button
-										variant="dark-ghost"
+										className={cn(classNameGhost, 'w-7 h-7')}
 										size="icon"
-										className="h-7 w-7"
 										onClick={() => handleCopyToken(token.token)}
 										title="Copy token"
 									>
 										<Copy className="w-3.5 h-3.5" />
 									</Button>
 									<Button
-										variant="dark-ghost"
+										className={cn(classNameGhost, 'w-7 h-7')}
 										size="icon"
-										className="h-7 w-7"
 										onClick={() => handleReclaim(token)}
 										disabled={isReclaiming === token.id}
 										title="Try to reclaim"
@@ -491,9 +478,8 @@ export function Nip60Wallet() {
 										{isReclaiming === token.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RotateCcw className="w-3.5 h-3.5" />}
 									</Button>
 									<Button
-										variant="dark-destructive"
+										className={cn(classNameDestructive, 'w-7 h-7')}
 										size="icon"
-										className="h-7 w-7"
 										onClick={() => handleRemovePendingToken(token)}
 										title="Remove from list"
 									>
@@ -528,16 +514,16 @@ export function Nip60Wallet() {
 					{viewingToken && (
 						<div className="space-y-4">
 							<div className="flex justify-center">
-								<div className="p-4 bg-white rounded-lg">
+								<div className="bg-white p-4 rounded-lg">
 									<QRCodeSVG value={viewingToken.token} size={200} />
 								</div>
 							</div>
 							<div className="space-y-2">
-								<p className="text-sm font-medium">Cashu Token</p>
+								<p className="font-medium text-sm">Cashu Token</p>
 								<textarea
 									value={viewingToken.token}
 									readOnly
-									className="w-full px-3 py-2 text-sm bg-muted rounded-md font-mono resize-none h-24"
+									className="bg-muted px-3 py-2 rounded-md w-full h-24 font-mono text-sm resize-none"
 								/>
 								<div className="flex justify-end">
 									<Button variant="outline" size="sm" onClick={() => handleCopyToken(viewingToken.token)} className="gap-2">
@@ -546,7 +532,7 @@ export function Nip60Wallet() {
 									</Button>
 								</div>
 							</div>
-							<p className="text-xs text-muted-foreground text-center">Created {new Date(viewingToken.createdAt).toLocaleString()}</p>
+							<p className="text-muted-foreground text-xs text-center">Created {new Date(viewingToken.createdAt).toLocaleString()}</p>
 							<div className="flex justify-end gap-2">
 								<Button
 									variant="outline"
@@ -557,9 +543,9 @@ export function Nip60Wallet() {
 									disabled={isReclaiming === viewingToken.id}
 								>
 									{isReclaiming === viewingToken.id ? (
-										<Loader2 className="w-4 h-4 animate-spin mr-2" />
+										<Loader2 className="mr-2 w-4 h-4 animate-spin" />
 									) : (
-										<RotateCcw className="w-4 h-4 mr-2" />
+										<RotateCcw className="mr-2 w-4 h-4" />
 									)}
 									Reclaim
 								</Button>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -52,884 +52,945 @@ import { Route as DashboardLayoutDashboardProductsCollectionsNewRouteImport } fr
 import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/collections/$collectionId'
 
 const SetupRoute = SetupRouteImport.update({
-	id: '/setup',
-	path: '/setup',
-	getParentRoute: () => rootRouteImport,
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-	id: '/checkout',
-	path: '/checkout',
-	getParentRoute: () => rootRouteImport,
+  id: '/checkout',
+  path: '/checkout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-	id: '/_dashboard-layout',
-	getParentRoute: () => rootRouteImport,
+  id: '/_dashboard-layout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-	id: '/$vanityName',
-	path: '/$vanityName',
-	getParentRoute: () => rootRouteImport,
+  id: '/$vanityName',
+  path: '/$vanityName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-	id: '/products/',
-	path: '/products/',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/',
+  path: '/products/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-	id: '/posts/',
-	path: '/posts/',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/',
+  path: '/posts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-	id: '/nostr/',
-	path: '/nostr/',
-	getParentRoute: () => rootRouteImport,
+  id: '/nostr/',
+  path: '/nostr/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-	id: '/community/',
-	path: '/community/',
-	getParentRoute: () => rootRouteImport,
+  id: '/community/',
+  path: '/community/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-	id: '/search/products',
-	path: '/search/products',
-	getParentRoute: () => rootRouteImport,
+  id: '/search/products',
+  path: '/search/products',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-	id: '/profile/$profileId',
-	path: '/profile/$profileId',
-	getParentRoute: () => rootRouteImport,
+  id: '/profile/$profileId',
+  path: '/profile/$profileId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-	id: '/products/$productId',
-	path: '/products/$productId',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/$productId',
+  path: '/products/$productId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-	id: '/posts/$postId',
-	path: '/posts/$postId',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/$postId',
+  path: '/posts/$postId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-	id: '/collection/$collectionId',
-	path: '/collection/$collectionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/collection/$collectionId',
+  path: '/collection/$collectionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
-	id: '/dashboard/',
-	path: '/dashboard/',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
-	id: '/dashboard/about',
-	path: '/dashboard/about',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
-	id: '/dashboard/sales/sales',
-	path: '/dashboard/sales/sales',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
-	id: '/dashboard/sales/messages',
-	path: '/dashboard/sales/messages',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-	id: '/dashboard/sales/circular-economy',
-	path: '/dashboard/sales/circular-economy',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-	id: '/dashboard/products/shipping-options',
-	path: '/dashboard/products/shipping-options',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
-	id: '/dashboard/products/products',
-	path: '/dashboard/products/products',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-	id: '/dashboard/products/migration-tool',
-	path: '/dashboard/products/migration-tool',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-	id: '/dashboard/products/collections',
-	path: '/dashboard/products/collections',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-	id: '/dashboard/orders/$orderId',
-	path: '/dashboard/orders/$orderId',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-	id: '/dashboard/app-settings/team',
-	path: '/dashboard/app-settings/team',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-	id: '/dashboard/app-settings/featured-items',
-	path: '/dashboard/app-settings/featured-items',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-	id: '/dashboard/app-settings/blacklists',
-	path: '/dashboard/app-settings/blacklists',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-	id: '/dashboard/app-settings/app-miscelleneous',
-	path: '/dashboard/app-settings/app-miscelleneous',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-	id: '/dashboard/account/your-purchases',
-	path: '/dashboard/account/your-purchases',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-	id: '/dashboard/account/vanity-url',
-	path: '/dashboard/account/vanity-url',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-	id: '/dashboard/account/receiving-payments',
-	path: '/dashboard/account/receiving-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
-	id: '/dashboard/account/profile',
-	path: '/dashboard/account/profile',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-	id: '/dashboard/account/preferences',
-	path: '/dashboard/account/preferences',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-	id: '/dashboard/account/nostr-address',
-	path: '/dashboard/account/nostr-address',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
-	id: '/dashboard/account/network',
-	path: '/dashboard/account/network',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-	id: '/dashboard/account/making-payments',
-	path: '/dashboard/account/making-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-	id: '/$pubkey',
-	path: '/$pubkey',
-	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-	id: '/$productId',
-	path: '/$productId',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-} as any)
+const DashboardLayoutDashboardIndexRoute =
+  DashboardLayoutDashboardIndexRouteImport.update({
+    id: '/dashboard/',
+    path: '/dashboard/',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAboutRoute =
+  DashboardLayoutDashboardAboutRouteImport.update({
+    id: '/dashboard/about',
+    path: '/dashboard/about',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesSalesRoute =
+  DashboardLayoutDashboardSalesSalesRouteImport.update({
+    id: '/dashboard/sales/sales',
+    path: '/dashboard/sales/sales',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesRoute =
+  DashboardLayoutDashboardSalesMessagesRouteImport.update({
+    id: '/dashboard/sales/messages',
+    path: '/dashboard/sales/messages',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute =
+  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+    id: '/dashboard/sales/circular-economy',
+    path: '/dashboard/sales/circular-economy',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute =
+  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+    id: '/dashboard/products/shipping-options',
+    path: '/dashboard/products/shipping-options',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsRoute =
+  DashboardLayoutDashboardProductsProductsRouteImport.update({
+    id: '/dashboard/products/products',
+    path: '/dashboard/products/products',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute =
+  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+    id: '/dashboard/products/migration-tool',
+    path: '/dashboard/products/migration-tool',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsRoute =
+  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+    id: '/dashboard/products/collections',
+    path: '/dashboard/products/collections',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute =
+  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+    id: '/dashboard/orders/$orderId',
+    path: '/dashboard/orders/$orderId',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute =
+  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+    id: '/dashboard/app-settings/team',
+    path: '/dashboard/app-settings/team',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+    id: '/dashboard/app-settings/featured-items',
+    path: '/dashboard/app-settings/featured-items',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
+  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+    id: '/dashboard/app-settings/blacklists',
+    path: '/dashboard/app-settings/blacklists',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+    id: '/dashboard/app-settings/app-miscelleneous',
+    path: '/dashboard/app-settings/app-miscelleneous',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute =
+  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+    id: '/dashboard/account/your-purchases',
+    path: '/dashboard/account/your-purchases',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute =
+  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+    id: '/dashboard/account/vanity-url',
+    path: '/dashboard/account/vanity-url',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
+  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+    id: '/dashboard/account/receiving-payments',
+    path: '/dashboard/account/receiving-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountProfileRoute =
+  DashboardLayoutDashboardAccountProfileRouteImport.update({
+    id: '/dashboard/account/profile',
+    path: '/dashboard/account/profile',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountPreferencesRoute =
+  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+    id: '/dashboard/account/preferences',
+    path: '/dashboard/account/preferences',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute =
+  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+    id: '/dashboard/account/nostr-address',
+    path: '/dashboard/account/nostr-address',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNetworkRoute =
+  DashboardLayoutDashboardAccountNetworkRouteImport.update({
+    id: '/dashboard/account/network',
+    path: '/dashboard/account/network',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute =
+  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+    id: '/dashboard/account/making-payments',
+    path: '/dashboard/account/making-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
+  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+    id: '/$pubkey',
+    path: '/$pubkey',
+    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsNewRoute =
+  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute =
+  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+    id: '/$productId',
+    path: '/$productId',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute =
+  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-		id: '/$collectionId',
-		path: '/$collectionId',
-		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-	} as any)
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+    id: '/$collectionId',
+    path: '/$collectionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/community': typeof CommunityIndexRoute
-	'/nostr': typeof NostrIndexRoute
-	'/posts': typeof PostsIndexRoute
-	'/products': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/dashboard/about'
-		| '/dashboard/'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/community'
-		| '/nostr'
-		| '/posts'
-		| '/products'
-		| '/dashboard/about'
-		| '/dashboard'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	id:
-		| '__root__'
-		| '/'
-		| '/$vanityName'
-		| '/_dashboard-layout'
-		| '/checkout'
-		| '/setup'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/_dashboard-layout/dashboard/about'
-		| '/_dashboard-layout/dashboard/'
-		| '/_dashboard-layout/dashboard/account/making-payments'
-		| '/_dashboard-layout/dashboard/account/network'
-		| '/_dashboard-layout/dashboard/account/nostr-address'
-		| '/_dashboard-layout/dashboard/account/preferences'
-		| '/_dashboard-layout/dashboard/account/profile'
-		| '/_dashboard-layout/dashboard/account/receiving-payments'
-		| '/_dashboard-layout/dashboard/account/vanity-url'
-		| '/_dashboard-layout/dashboard/account/your-purchases'
-		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-		| '/_dashboard-layout/dashboard/app-settings/blacklists'
-		| '/_dashboard-layout/dashboard/app-settings/featured-items'
-		| '/_dashboard-layout/dashboard/app-settings/team'
-		| '/_dashboard-layout/dashboard/orders/$orderId'
-		| '/_dashboard-layout/dashboard/products/collections'
-		| '/_dashboard-layout/dashboard/products/migration-tool'
-		| '/_dashboard-layout/dashboard/products/products'
-		| '/_dashboard-layout/dashboard/products/shipping-options'
-		| '/_dashboard-layout/dashboard/sales/circular-economy'
-		| '/_dashboard-layout/dashboard/sales/messages'
-		| '/_dashboard-layout/dashboard/sales/sales'
-		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
-		| '/_dashboard-layout/dashboard/products/collections/new'
-		| '/_dashboard-layout/dashboard/products/products/$productId'
-		| '/_dashboard-layout/dashboard/products/products/new'
-		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  id:
+    | '__root__'
+    | '/'
+    | '/$vanityName'
+    | '/_dashboard-layout'
+    | '/checkout'
+    | '/setup'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/_dashboard-layout/dashboard/about'
+    | '/_dashboard-layout/dashboard/'
+    | '/_dashboard-layout/dashboard/account/making-payments'
+    | '/_dashboard-layout/dashboard/account/network'
+    | '/_dashboard-layout/dashboard/account/nostr-address'
+    | '/_dashboard-layout/dashboard/account/preferences'
+    | '/_dashboard-layout/dashboard/account/profile'
+    | '/_dashboard-layout/dashboard/account/receiving-payments'
+    | '/_dashboard-layout/dashboard/account/vanity-url'
+    | '/_dashboard-layout/dashboard/account/your-purchases'
+    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+    | '/_dashboard-layout/dashboard/app-settings/blacklists'
+    | '/_dashboard-layout/dashboard/app-settings/featured-items'
+    | '/_dashboard-layout/dashboard/app-settings/team'
+    | '/_dashboard-layout/dashboard/orders/$orderId'
+    | '/_dashboard-layout/dashboard/products/collections'
+    | '/_dashboard-layout/dashboard/products/migration-tool'
+    | '/_dashboard-layout/dashboard/products/products'
+    | '/_dashboard-layout/dashboard/products/shipping-options'
+    | '/_dashboard-layout/dashboard/sales/circular-economy'
+    | '/_dashboard-layout/dashboard/sales/messages'
+    | '/_dashboard-layout/dashboard/sales/sales'
+    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
+    | '/_dashboard-layout/dashboard/products/collections/new'
+    | '/_dashboard-layout/dashboard/products/products/$productId'
+    | '/_dashboard-layout/dashboard/products/products/new'
+    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	VanityNameRoute: typeof VanityNameRoute
-	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-	CheckoutRoute: typeof CheckoutRoute
-	SetupRoute: typeof SetupRoute
-	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-	PostsPostIdRoute: typeof PostsPostIdRoute
-	ProductsProductIdRoute: typeof ProductsProductIdRoute
-	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-	SearchProductsRoute: typeof SearchProductsRoute
-	CommunityIndexRoute: typeof CommunityIndexRoute
-	NostrIndexRoute: typeof NostrIndexRoute
-	PostsIndexRoute: typeof PostsIndexRoute
-	ProductsIndexRoute: typeof ProductsIndexRoute
+  IndexRoute: typeof IndexRoute
+  VanityNameRoute: typeof VanityNameRoute
+  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+  CheckoutRoute: typeof CheckoutRoute
+  SetupRoute: typeof SetupRoute
+  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+  PostsPostIdRoute: typeof PostsPostIdRoute
+  ProductsProductIdRoute: typeof ProductsProductIdRoute
+  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+  SearchProductsRoute: typeof SearchProductsRoute
+  CommunityIndexRoute: typeof CommunityIndexRoute
+  NostrIndexRoute: typeof NostrIndexRoute
+  PostsIndexRoute: typeof PostsIndexRoute
+  ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/setup': {
-			id: '/setup'
-			path: '/setup'
-			fullPath: '/setup'
-			preLoaderRoute: typeof SetupRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/checkout': {
-			id: '/checkout'
-			path: '/checkout'
-			fullPath: '/checkout'
-			preLoaderRoute: typeof CheckoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout': {
-			id: '/_dashboard-layout'
-			path: ''
-			fullPath: '/'
-			preLoaderRoute: typeof DashboardLayoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/$vanityName': {
-			id: '/$vanityName'
-			path: '/$vanityName'
-			fullPath: '/$vanityName'
-			preLoaderRoute: typeof VanityNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/': {
-			id: '/'
-			path: '/'
-			fullPath: '/'
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/': {
-			id: '/products/'
-			path: '/products'
-			fullPath: '/products/'
-			preLoaderRoute: typeof ProductsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/': {
-			id: '/posts/'
-			path: '/posts'
-			fullPath: '/posts/'
-			preLoaderRoute: typeof PostsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/nostr/': {
-			id: '/nostr/'
-			path: '/nostr'
-			fullPath: '/nostr/'
-			preLoaderRoute: typeof NostrIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/community/': {
-			id: '/community/'
-			path: '/community'
-			fullPath: '/community/'
-			preLoaderRoute: typeof CommunityIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/search/products': {
-			id: '/search/products'
-			path: '/search/products'
-			fullPath: '/search/products'
-			preLoaderRoute: typeof SearchProductsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/profile/$profileId': {
-			id: '/profile/$profileId'
-			path: '/profile/$profileId'
-			fullPath: '/profile/$profileId'
-			preLoaderRoute: typeof ProfileProfileIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/$productId': {
-			id: '/products/$productId'
-			path: '/products/$productId'
-			fullPath: '/products/$productId'
-			preLoaderRoute: typeof ProductsProductIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/$postId': {
-			id: '/posts/$postId'
-			path: '/posts/$postId'
-			fullPath: '/posts/$postId'
-			preLoaderRoute: typeof PostsPostIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/collection/$collectionId': {
-			id: '/collection/$collectionId'
-			path: '/collection/$collectionId'
-			fullPath: '/collection/$collectionId'
-			preLoaderRoute: typeof CollectionCollectionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout/dashboard/': {
-			id: '/_dashboard-layout/dashboard/'
-			path: '/dashboard'
-			fullPath: '/dashboard/'
-			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/about': {
-			id: '/_dashboard-layout/dashboard/about'
-			path: '/dashboard/about'
-			fullPath: '/dashboard/about'
-			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/sales': {
-			id: '/_dashboard-layout/dashboard/sales/sales'
-			path: '/dashboard/sales/sales'
-			fullPath: '/dashboard/sales/sales'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages': {
-			id: '/_dashboard-layout/dashboard/sales/messages'
-			path: '/dashboard/sales/messages'
-			fullPath: '/dashboard/sales/messages'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/circular-economy': {
-			id: '/_dashboard-layout/dashboard/sales/circular-economy'
-			path: '/dashboard/sales/circular-economy'
-			fullPath: '/dashboard/sales/circular-economy'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/shipping-options': {
-			id: '/_dashboard-layout/dashboard/products/shipping-options'
-			path: '/dashboard/products/shipping-options'
-			fullPath: '/dashboard/products/shipping-options'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/products': {
-			id: '/_dashboard-layout/dashboard/products/products'
-			path: '/dashboard/products/products'
-			fullPath: '/dashboard/products/products'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/migration-tool': {
-			id: '/_dashboard-layout/dashboard/products/migration-tool'
-			path: '/dashboard/products/migration-tool'
-			fullPath: '/dashboard/products/migration-tool'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections': {
-			id: '/_dashboard-layout/dashboard/products/collections'
-			path: '/dashboard/products/collections'
-			fullPath: '/dashboard/products/collections'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/orders/$orderId': {
-			id: '/_dashboard-layout/dashboard/orders/$orderId'
-			path: '/dashboard/orders/$orderId'
-			fullPath: '/dashboard/orders/$orderId'
-			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/team': {
-			id: '/_dashboard-layout/dashboard/app-settings/team'
-			path: '/dashboard/app-settings/team'
-			fullPath: '/dashboard/app-settings/team'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/featured-items': {
-			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-			path: '/dashboard/app-settings/featured-items'
-			fullPath: '/dashboard/app-settings/featured-items'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/blacklists': {
-			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-			path: '/dashboard/app-settings/blacklists'
-			fullPath: '/dashboard/app-settings/blacklists'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-			path: '/dashboard/app-settings/app-miscelleneous'
-			fullPath: '/dashboard/app-settings/app-miscelleneous'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/your-purchases': {
-			id: '/_dashboard-layout/dashboard/account/your-purchases'
-			path: '/dashboard/account/your-purchases'
-			fullPath: '/dashboard/account/your-purchases'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/vanity-url': {
-			id: '/_dashboard-layout/dashboard/account/vanity-url'
-			path: '/dashboard/account/vanity-url'
-			fullPath: '/dashboard/account/vanity-url'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/receiving-payments': {
-			id: '/_dashboard-layout/dashboard/account/receiving-payments'
-			path: '/dashboard/account/receiving-payments'
-			fullPath: '/dashboard/account/receiving-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/profile': {
-			id: '/_dashboard-layout/dashboard/account/profile'
-			path: '/dashboard/account/profile'
-			fullPath: '/dashboard/account/profile'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/preferences': {
-			id: '/_dashboard-layout/dashboard/account/preferences'
-			path: '/dashboard/account/preferences'
-			fullPath: '/dashboard/account/preferences'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/nostr-address': {
-			id: '/_dashboard-layout/dashboard/account/nostr-address'
-			path: '/dashboard/account/nostr-address'
-			fullPath: '/dashboard/account/nostr-address'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/network': {
-			id: '/_dashboard-layout/dashboard/account/network'
-			path: '/dashboard/account/network'
-			fullPath: '/dashboard/account/network'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/making-payments': {
-			id: '/_dashboard-layout/dashboard/account/making-payments'
-			path: '/dashboard/account/making-payments'
-			fullPath: '/dashboard/account/making-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-			path: '/$pubkey'
-			fullPath: '/dashboard/sales/messages/$pubkey'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/new': {
-			id: '/_dashboard-layout/dashboard/products/products/new'
-			path: '/new'
-			fullPath: '/dashboard/products/products/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/$productId': {
-			id: '/_dashboard-layout/dashboard/products/products/$productId'
-			path: '/$productId'
-			fullPath: '/dashboard/products/products/$productId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/new': {
-			id: '/_dashboard-layout/dashboard/products/collections/new'
-			path: '/new'
-			fullPath: '/dashboard/products/collections/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
-			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-			path: '/$collectionId'
-			fullPath: '/dashboard/products/collections/$collectionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-	}
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/checkout': {
+      id: '/checkout'
+      path: '/checkout'
+      fullPath: '/checkout'
+      preLoaderRoute: typeof CheckoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout': {
+      id: '/_dashboard-layout'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof DashboardLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$vanityName': {
+      id: '/$vanityName'
+      path: '/$vanityName'
+      fullPath: '/$vanityName'
+      preLoaderRoute: typeof VanityNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/': {
+      id: '/products/'
+      path: '/products'
+      fullPath: '/products'
+      preLoaderRoute: typeof ProductsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/posts'
+      fullPath: '/posts'
+      preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nostr/': {
+      id: '/nostr/'
+      path: '/nostr'
+      fullPath: '/nostr'
+      preLoaderRoute: typeof NostrIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/community/': {
+      id: '/community/'
+      path: '/community'
+      fullPath: '/community'
+      preLoaderRoute: typeof CommunityIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search/products': {
+      id: '/search/products'
+      path: '/search/products'
+      fullPath: '/search/products'
+      preLoaderRoute: typeof SearchProductsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile/$profileId': {
+      id: '/profile/$profileId'
+      path: '/profile/$profileId'
+      fullPath: '/profile/$profileId'
+      preLoaderRoute: typeof ProfileProfileIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/$productId': {
+      id: '/products/$productId'
+      path: '/products/$productId'
+      fullPath: '/products/$productId'
+      preLoaderRoute: typeof ProductsProductIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/posts/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collection/$collectionId': {
+      id: '/collection/$collectionId'
+      path: '/collection/$collectionId'
+      fullPath: '/collection/$collectionId'
+      preLoaderRoute: typeof CollectionCollectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout/dashboard/': {
+      id: '/_dashboard-layout/dashboard/'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/about': {
+      id: '/_dashboard-layout/dashboard/about'
+      path: '/dashboard/about'
+      fullPath: '/dashboard/about'
+      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/sales': {
+      id: '/_dashboard-layout/dashboard/sales/sales'
+      path: '/dashboard/sales/sales'
+      fullPath: '/dashboard/sales/sales'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages': {
+      id: '/_dashboard-layout/dashboard/sales/messages'
+      path: '/dashboard/sales/messages'
+      fullPath: '/dashboard/sales/messages'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/circular-economy': {
+      id: '/_dashboard-layout/dashboard/sales/circular-economy'
+      path: '/dashboard/sales/circular-economy'
+      fullPath: '/dashboard/sales/circular-economy'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/shipping-options': {
+      id: '/_dashboard-layout/dashboard/products/shipping-options'
+      path: '/dashboard/products/shipping-options'
+      fullPath: '/dashboard/products/shipping-options'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/products': {
+      id: '/_dashboard-layout/dashboard/products/products'
+      path: '/dashboard/products/products'
+      fullPath: '/dashboard/products/products'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/migration-tool': {
+      id: '/_dashboard-layout/dashboard/products/migration-tool'
+      path: '/dashboard/products/migration-tool'
+      fullPath: '/dashboard/products/migration-tool'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections': {
+      id: '/_dashboard-layout/dashboard/products/collections'
+      path: '/dashboard/products/collections'
+      fullPath: '/dashboard/products/collections'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/orders/$orderId': {
+      id: '/_dashboard-layout/dashboard/orders/$orderId'
+      path: '/dashboard/orders/$orderId'
+      fullPath: '/dashboard/orders/$orderId'
+      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/team': {
+      id: '/_dashboard-layout/dashboard/app-settings/team'
+      path: '/dashboard/app-settings/team'
+      fullPath: '/dashboard/app-settings/team'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/featured-items': {
+      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+      path: '/dashboard/app-settings/featured-items'
+      fullPath: '/dashboard/app-settings/featured-items'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/blacklists': {
+      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+      path: '/dashboard/app-settings/blacklists'
+      fullPath: '/dashboard/app-settings/blacklists'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+      path: '/dashboard/app-settings/app-miscelleneous'
+      fullPath: '/dashboard/app-settings/app-miscelleneous'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/your-purchases': {
+      id: '/_dashboard-layout/dashboard/account/your-purchases'
+      path: '/dashboard/account/your-purchases'
+      fullPath: '/dashboard/account/your-purchases'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/vanity-url': {
+      id: '/_dashboard-layout/dashboard/account/vanity-url'
+      path: '/dashboard/account/vanity-url'
+      fullPath: '/dashboard/account/vanity-url'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/receiving-payments': {
+      id: '/_dashboard-layout/dashboard/account/receiving-payments'
+      path: '/dashboard/account/receiving-payments'
+      fullPath: '/dashboard/account/receiving-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/profile': {
+      id: '/_dashboard-layout/dashboard/account/profile'
+      path: '/dashboard/account/profile'
+      fullPath: '/dashboard/account/profile'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/preferences': {
+      id: '/_dashboard-layout/dashboard/account/preferences'
+      path: '/dashboard/account/preferences'
+      fullPath: '/dashboard/account/preferences'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/nostr-address': {
+      id: '/_dashboard-layout/dashboard/account/nostr-address'
+      path: '/dashboard/account/nostr-address'
+      fullPath: '/dashboard/account/nostr-address'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/network': {
+      id: '/_dashboard-layout/dashboard/account/network'
+      path: '/dashboard/account/network'
+      fullPath: '/dashboard/account/network'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/making-payments': {
+      id: '/_dashboard-layout/dashboard/account/making-payments'
+      path: '/dashboard/account/making-payments'
+      fullPath: '/dashboard/account/making-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+      path: '/$pubkey'
+      fullPath: '/dashboard/sales/messages/$pubkey'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/new': {
+      id: '/_dashboard-layout/dashboard/products/products/new'
+      path: '/new'
+      fullPath: '/dashboard/products/products/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/$productId': {
+      id: '/_dashboard-layout/dashboard/products/products/$productId'
+      path: '/$productId'
+      fullPath: '/dashboard/products/products/$productId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/new': {
+      id: '/_dashboard-layout/dashboard/products/collections/new'
+      path: '/new'
+      fullPath: '/dashboard/products/collections/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
+      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+      path: '/$collectionId'
+      fullPath: '/dashboard/products/collections/$collectionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+  }
 }
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
-}
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
+      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+    DashboardLayoutDashboardProductsCollectionsNewRoute:
+      DashboardLayoutDashboardProductsCollectionsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsCollectionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
+  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsCollectionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
-	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
-}
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsProductsProductIdRoute:
+      DashboardLayoutDashboardProductsProductsProductIdRoute,
+    DashboardLayoutDashboardProductsProductsNewRoute:
+      DashboardLayoutDashboardProductsProductsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsProductsRouteChildren,
-)
+const DashboardLayoutDashboardProductsProductsRouteWithChildren =
+  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsProductsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-}
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
+  {
+    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
+      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+  }
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-	DashboardLayoutDashboardSalesMessagesRouteChildren,
-)
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
+  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+    DashboardLayoutDashboardSalesMessagesRouteChildren,
+  )
 
 interface DashboardLayoutRouteChildren {
-	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
-	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
-	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
-	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
-	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
-	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
-	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
-	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
-	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
-	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
-	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
-	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
+  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+  DashboardLayoutDashboardAccountMakingPaymentsRoute:
+    DashboardLayoutDashboardAccountMakingPaymentsRoute,
+  DashboardLayoutDashboardAccountNetworkRoute:
+    DashboardLayoutDashboardAccountNetworkRoute,
+  DashboardLayoutDashboardAccountNostrAddressRoute:
+    DashboardLayoutDashboardAccountNostrAddressRoute,
+  DashboardLayoutDashboardAccountPreferencesRoute:
+    DashboardLayoutDashboardAccountPreferencesRoute,
+  DashboardLayoutDashboardAccountProfileRoute:
+    DashboardLayoutDashboardAccountProfileRoute,
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
+    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+  DashboardLayoutDashboardAccountVanityUrlRoute:
+    DashboardLayoutDashboardAccountVanityUrlRoute,
+  DashboardLayoutDashboardAccountYourPurchasesRoute:
+    DashboardLayoutDashboardAccountYourPurchasesRoute,
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
+    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
+    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
+    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+  DashboardLayoutDashboardAppSettingsTeamRoute:
+    DashboardLayoutDashboardAppSettingsTeamRoute,
+  DashboardLayoutDashboardOrdersOrderIdRoute:
+    DashboardLayoutDashboardOrdersOrderIdRoute,
+  DashboardLayoutDashboardProductsCollectionsRoute:
+    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+  DashboardLayoutDashboardProductsMigrationToolRoute:
+    DashboardLayoutDashboardProductsMigrationToolRoute,
+  DashboardLayoutDashboardProductsProductsRoute:
+    DashboardLayoutDashboardProductsProductsRouteWithChildren,
+  DashboardLayoutDashboardProductsShippingOptionsRoute:
+    DashboardLayoutDashboardProductsShippingOptionsRoute,
+  DashboardLayoutDashboardSalesCircularEconomyRoute:
+    DashboardLayoutDashboardSalesCircularEconomyRoute,
+  DashboardLayoutDashboardSalesMessagesRoute:
+    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+  DashboardLayoutDashboardSalesSalesRoute:
+    DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
+  DashboardLayoutRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	VanityNameRoute: VanityNameRoute,
-	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-	CheckoutRoute: CheckoutRoute,
-	SetupRoute: SetupRoute,
-	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-	PostsPostIdRoute: PostsPostIdRoute,
-	ProductsProductIdRoute: ProductsProductIdRoute,
-	ProfileProfileIdRoute: ProfileProfileIdRoute,
-	SearchProductsRoute: SearchProductsRoute,
-	CommunityIndexRoute: CommunityIndexRoute,
-	NostrIndexRoute: NostrIndexRoute,
-	PostsIndexRoute: PostsIndexRoute,
-	ProductsIndexRoute: ProductsIndexRoute,
+  IndexRoute: IndexRoute,
+  VanityNameRoute: VanityNameRoute,
+  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+  CheckoutRoute: CheckoutRoute,
+  SetupRoute: SetupRoute,
+  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+  PostsPostIdRoute: PostsPostIdRoute,
+  ProductsProductIdRoute: ProductsProductIdRoute,
+  ProfileProfileIdRoute: ProfileProfileIdRoute,
+  SearchProductsRoute: SearchProductsRoute,
+  CommunityIndexRoute: CommunityIndexRoute,
+  NostrIndexRoute: NostrIndexRoute,
+  PostsIndexRoute: PostsIndexRoute,
+  ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -52,945 +52,884 @@ import { Route as DashboardLayoutDashboardProductsCollectionsNewRouteImport } fr
 import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/collections/$collectionId'
 
 const SetupRoute = SetupRouteImport.update({
-  id: '/setup',
-  path: '/setup',
-  getParentRoute: () => rootRouteImport,
+	id: '/setup',
+	path: '/setup',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-  id: '/checkout',
-  path: '/checkout',
-  getParentRoute: () => rootRouteImport,
+	id: '/checkout',
+	path: '/checkout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-  id: '/_dashboard-layout',
-  getParentRoute: () => rootRouteImport,
+	id: '/_dashboard-layout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-  id: '/$vanityName',
-  path: '/$vanityName',
-  getParentRoute: () => rootRouteImport,
+	id: '/$vanityName',
+	path: '/$vanityName',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-  id: '/products/',
-  path: '/products/',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/',
+	path: '/products/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-  id: '/posts/',
-  path: '/posts/',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/',
+	path: '/posts/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-  id: '/nostr/',
-  path: '/nostr/',
-  getParentRoute: () => rootRouteImport,
+	id: '/nostr/',
+	path: '/nostr/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-  id: '/community/',
-  path: '/community/',
-  getParentRoute: () => rootRouteImport,
+	id: '/community/',
+	path: '/community/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-  id: '/search/products',
-  path: '/search/products',
-  getParentRoute: () => rootRouteImport,
+	id: '/search/products',
+	path: '/search/products',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-  id: '/profile/$profileId',
-  path: '/profile/$profileId',
-  getParentRoute: () => rootRouteImport,
+	id: '/profile/$profileId',
+	path: '/profile/$profileId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-  id: '/products/$productId',
-  path: '/products/$productId',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/$productId',
+	path: '/products/$productId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-  id: '/posts/$postId',
-  path: '/posts/$postId',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/$postId',
+	path: '/posts/$postId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-  id: '/collection/$collectionId',
-  path: '/collection/$collectionId',
-  getParentRoute: () => rootRouteImport,
+	id: '/collection/$collectionId',
+	path: '/collection/$collectionId',
+	getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute =
-  DashboardLayoutDashboardIndexRouteImport.update({
-    id: '/dashboard/',
-    path: '/dashboard/',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAboutRoute =
-  DashboardLayoutDashboardAboutRouteImport.update({
-    id: '/dashboard/about',
-    path: '/dashboard/about',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesSalesRoute =
-  DashboardLayoutDashboardSalesSalesRouteImport.update({
-    id: '/dashboard/sales/sales',
-    path: '/dashboard/sales/sales',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesRoute =
-  DashboardLayoutDashboardSalesMessagesRouteImport.update({
-    id: '/dashboard/sales/messages',
-    path: '/dashboard/sales/messages',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute =
-  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-    id: '/dashboard/sales/circular-economy',
-    path: '/dashboard/sales/circular-economy',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute =
-  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-    id: '/dashboard/products/shipping-options',
-    path: '/dashboard/products/shipping-options',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsRoute =
-  DashboardLayoutDashboardProductsProductsRouteImport.update({
-    id: '/dashboard/products/products',
-    path: '/dashboard/products/products',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute =
-  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-    id: '/dashboard/products/migration-tool',
-    path: '/dashboard/products/migration-tool',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsRoute =
-  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-    id: '/dashboard/products/collections',
-    path: '/dashboard/products/collections',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute =
-  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-    id: '/dashboard/orders/$orderId',
-    path: '/dashboard/orders/$orderId',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute =
-  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-    id: '/dashboard/app-settings/team',
-    path: '/dashboard/app-settings/team',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-    id: '/dashboard/app-settings/featured-items',
-    path: '/dashboard/app-settings/featured-items',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
-  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-    id: '/dashboard/app-settings/blacklists',
-    path: '/dashboard/app-settings/blacklists',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-    id: '/dashboard/app-settings/app-miscelleneous',
-    path: '/dashboard/app-settings/app-miscelleneous',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute =
-  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-    id: '/dashboard/account/your-purchases',
-    path: '/dashboard/account/your-purchases',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute =
-  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-    id: '/dashboard/account/vanity-url',
-    path: '/dashboard/account/vanity-url',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
-  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-    id: '/dashboard/account/receiving-payments',
-    path: '/dashboard/account/receiving-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountProfileRoute =
-  DashboardLayoutDashboardAccountProfileRouteImport.update({
-    id: '/dashboard/account/profile',
-    path: '/dashboard/account/profile',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountPreferencesRoute =
-  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-    id: '/dashboard/account/preferences',
-    path: '/dashboard/account/preferences',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute =
-  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-    id: '/dashboard/account/nostr-address',
-    path: '/dashboard/account/nostr-address',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNetworkRoute =
-  DashboardLayoutDashboardAccountNetworkRouteImport.update({
-    id: '/dashboard/account/network',
-    path: '/dashboard/account/network',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute =
-  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-    id: '/dashboard/account/making-payments',
-    path: '/dashboard/account/making-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
-  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-    id: '/$pubkey',
-    path: '/$pubkey',
-    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsNewRoute =
-  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute =
-  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-    id: '/$productId',
-    path: '/$productId',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute =
-  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
+const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
+	id: '/dashboard/',
+	path: '/dashboard/',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
+	id: '/dashboard/about',
+	path: '/dashboard/about',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
+	id: '/dashboard/sales/sales',
+	path: '/dashboard/sales/sales',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
+	id: '/dashboard/sales/messages',
+	path: '/dashboard/sales/messages',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+	id: '/dashboard/sales/circular-economy',
+	path: '/dashboard/sales/circular-economy',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+	id: '/dashboard/products/shipping-options',
+	path: '/dashboard/products/shipping-options',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
+	id: '/dashboard/products/products',
+	path: '/dashboard/products/products',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+	id: '/dashboard/products/migration-tool',
+	path: '/dashboard/products/migration-tool',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+	id: '/dashboard/products/collections',
+	path: '/dashboard/products/collections',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+	id: '/dashboard/orders/$orderId',
+	path: '/dashboard/orders/$orderId',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+	id: '/dashboard/app-settings/team',
+	path: '/dashboard/app-settings/team',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+	id: '/dashboard/app-settings/featured-items',
+	path: '/dashboard/app-settings/featured-items',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+	id: '/dashboard/app-settings/blacklists',
+	path: '/dashboard/app-settings/blacklists',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+	id: '/dashboard/app-settings/app-miscelleneous',
+	path: '/dashboard/app-settings/app-miscelleneous',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+	id: '/dashboard/account/your-purchases',
+	path: '/dashboard/account/your-purchases',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+	id: '/dashboard/account/vanity-url',
+	path: '/dashboard/account/vanity-url',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+	id: '/dashboard/account/receiving-payments',
+	path: '/dashboard/account/receiving-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
+	id: '/dashboard/account/profile',
+	path: '/dashboard/account/profile',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+	id: '/dashboard/account/preferences',
+	path: '/dashboard/account/preferences',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+	id: '/dashboard/account/nostr-address',
+	path: '/dashboard/account/nostr-address',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
+	id: '/dashboard/account/network',
+	path: '/dashboard/account/network',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+	id: '/dashboard/account/making-payments',
+	path: '/dashboard/account/making-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+	id: '/$pubkey',
+	path: '/$pubkey',
+	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+	id: '/$productId',
+	path: '/$productId',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+} as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-    id: '/$collectionId',
-    path: '/$collectionId',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+		id: '/$collectionId',
+		path: '/$collectionId',
+		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+	} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/community': typeof CommunityIndexRoute
-  '/nostr': typeof NostrIndexRoute
-  '/posts': typeof PostsIndexRoute
-  '/products': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/community': typeof CommunityIndexRoute
+	'/nostr': typeof NostrIndexRoute
+	'/posts': typeof PostsIndexRoute
+	'/products': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/community': typeof CommunityIndexRoute
-  '/nostr': typeof NostrIndexRoute
-  '/posts': typeof PostsIndexRoute
-  '/products': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/community': typeof CommunityIndexRoute
+	'/nostr': typeof NostrIndexRoute
+	'/posts': typeof PostsIndexRoute
+	'/products': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/community/': typeof CommunityIndexRoute
-  '/nostr/': typeof NostrIndexRoute
-  '/posts/': typeof PostsIndexRoute
-  '/products/': typeof ProductsIndexRoute
-  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	__root__: typeof rootRouteImport
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/community/': typeof CommunityIndexRoute
+	'/nostr/': typeof NostrIndexRoute
+	'/posts/': typeof PostsIndexRoute
+	'/products/': typeof ProductsIndexRoute
+	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/community'
-    | '/nostr'
-    | '/posts'
-    | '/products'
-    | '/dashboard/about'
-    | '/dashboard'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/community'
-    | '/nostr'
-    | '/posts'
-    | '/products'
-    | '/dashboard/about'
-    | '/dashboard'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  id:
-    | '__root__'
-    | '/'
-    | '/$vanityName'
-    | '/_dashboard-layout'
-    | '/checkout'
-    | '/setup'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/community/'
-    | '/nostr/'
-    | '/posts/'
-    | '/products/'
-    | '/_dashboard-layout/dashboard/about'
-    | '/_dashboard-layout/dashboard/'
-    | '/_dashboard-layout/dashboard/account/making-payments'
-    | '/_dashboard-layout/dashboard/account/network'
-    | '/_dashboard-layout/dashboard/account/nostr-address'
-    | '/_dashboard-layout/dashboard/account/preferences'
-    | '/_dashboard-layout/dashboard/account/profile'
-    | '/_dashboard-layout/dashboard/account/receiving-payments'
-    | '/_dashboard-layout/dashboard/account/vanity-url'
-    | '/_dashboard-layout/dashboard/account/your-purchases'
-    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-    | '/_dashboard-layout/dashboard/app-settings/blacklists'
-    | '/_dashboard-layout/dashboard/app-settings/featured-items'
-    | '/_dashboard-layout/dashboard/app-settings/team'
-    | '/_dashboard-layout/dashboard/orders/$orderId'
-    | '/_dashboard-layout/dashboard/products/collections'
-    | '/_dashboard-layout/dashboard/products/migration-tool'
-    | '/_dashboard-layout/dashboard/products/products'
-    | '/_dashboard-layout/dashboard/products/shipping-options'
-    | '/_dashboard-layout/dashboard/sales/circular-economy'
-    | '/_dashboard-layout/dashboard/sales/messages'
-    | '/_dashboard-layout/dashboard/sales/sales'
-    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
-    | '/_dashboard-layout/dashboard/products/collections/new'
-    | '/_dashboard-layout/dashboard/products/products/$productId'
-    | '/_dashboard-layout/dashboard/products/products/new'
-    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath
+	fullPaths:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/community'
+		| '/nostr'
+		| '/posts'
+		| '/products'
+		| '/dashboard/about'
+		| '/dashboard'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	fileRoutesByTo: FileRoutesByTo
+	to:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/community'
+		| '/nostr'
+		| '/posts'
+		| '/products'
+		| '/dashboard/about'
+		| '/dashboard'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	id:
+		| '__root__'
+		| '/'
+		| '/$vanityName'
+		| '/_dashboard-layout'
+		| '/checkout'
+		| '/setup'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/community/'
+		| '/nostr/'
+		| '/posts/'
+		| '/products/'
+		| '/_dashboard-layout/dashboard/about'
+		| '/_dashboard-layout/dashboard/'
+		| '/_dashboard-layout/dashboard/account/making-payments'
+		| '/_dashboard-layout/dashboard/account/network'
+		| '/_dashboard-layout/dashboard/account/nostr-address'
+		| '/_dashboard-layout/dashboard/account/preferences'
+		| '/_dashboard-layout/dashboard/account/profile'
+		| '/_dashboard-layout/dashboard/account/receiving-payments'
+		| '/_dashboard-layout/dashboard/account/vanity-url'
+		| '/_dashboard-layout/dashboard/account/your-purchases'
+		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+		| '/_dashboard-layout/dashboard/app-settings/blacklists'
+		| '/_dashboard-layout/dashboard/app-settings/featured-items'
+		| '/_dashboard-layout/dashboard/app-settings/team'
+		| '/_dashboard-layout/dashboard/orders/$orderId'
+		| '/_dashboard-layout/dashboard/products/collections'
+		| '/_dashboard-layout/dashboard/products/migration-tool'
+		| '/_dashboard-layout/dashboard/products/products'
+		| '/_dashboard-layout/dashboard/products/shipping-options'
+		| '/_dashboard-layout/dashboard/sales/circular-economy'
+		| '/_dashboard-layout/dashboard/sales/messages'
+		| '/_dashboard-layout/dashboard/sales/sales'
+		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
+		| '/_dashboard-layout/dashboard/products/collections/new'
+		| '/_dashboard-layout/dashboard/products/products/$productId'
+		| '/_dashboard-layout/dashboard/products/products/new'
+		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+	fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  VanityNameRoute: typeof VanityNameRoute
-  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-  CheckoutRoute: typeof CheckoutRoute
-  SetupRoute: typeof SetupRoute
-  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-  PostsPostIdRoute: typeof PostsPostIdRoute
-  ProductsProductIdRoute: typeof ProductsProductIdRoute
-  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-  SearchProductsRoute: typeof SearchProductsRoute
-  CommunityIndexRoute: typeof CommunityIndexRoute
-  NostrIndexRoute: typeof NostrIndexRoute
-  PostsIndexRoute: typeof PostsIndexRoute
-  ProductsIndexRoute: typeof ProductsIndexRoute
+	IndexRoute: typeof IndexRoute
+	VanityNameRoute: typeof VanityNameRoute
+	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+	CheckoutRoute: typeof CheckoutRoute
+	SetupRoute: typeof SetupRoute
+	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+	PostsPostIdRoute: typeof PostsPostIdRoute
+	ProductsProductIdRoute: typeof ProductsProductIdRoute
+	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+	SearchProductsRoute: typeof SearchProductsRoute
+	CommunityIndexRoute: typeof CommunityIndexRoute
+	NostrIndexRoute: typeof NostrIndexRoute
+	PostsIndexRoute: typeof PostsIndexRoute
+	ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/setup': {
-      id: '/setup'
-      path: '/setup'
-      fullPath: '/setup'
-      preLoaderRoute: typeof SetupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/checkout': {
-      id: '/checkout'
-      path: '/checkout'
-      fullPath: '/checkout'
-      preLoaderRoute: typeof CheckoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout': {
-      id: '/_dashboard-layout'
-      path: ''
-      fullPath: ''
-      preLoaderRoute: typeof DashboardLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/$vanityName': {
-      id: '/$vanityName'
-      path: '/$vanityName'
-      fullPath: '/$vanityName'
-      preLoaderRoute: typeof VanityNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/': {
-      id: '/products/'
-      path: '/products'
-      fullPath: '/products'
-      preLoaderRoute: typeof ProductsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/': {
-      id: '/posts/'
-      path: '/posts'
-      fullPath: '/posts'
-      preLoaderRoute: typeof PostsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/nostr/': {
-      id: '/nostr/'
-      path: '/nostr'
-      fullPath: '/nostr'
-      preLoaderRoute: typeof NostrIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/community/': {
-      id: '/community/'
-      path: '/community'
-      fullPath: '/community'
-      preLoaderRoute: typeof CommunityIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/search/products': {
-      id: '/search/products'
-      path: '/search/products'
-      fullPath: '/search/products'
-      preLoaderRoute: typeof SearchProductsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/profile/$profileId': {
-      id: '/profile/$profileId'
-      path: '/profile/$profileId'
-      fullPath: '/profile/$profileId'
-      preLoaderRoute: typeof ProfileProfileIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/$productId': {
-      id: '/products/$productId'
-      path: '/products/$productId'
-      fullPath: '/products/$productId'
-      preLoaderRoute: typeof ProductsProductIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/$postId': {
-      id: '/posts/$postId'
-      path: '/posts/$postId'
-      fullPath: '/posts/$postId'
-      preLoaderRoute: typeof PostsPostIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/collection/$collectionId': {
-      id: '/collection/$collectionId'
-      path: '/collection/$collectionId'
-      fullPath: '/collection/$collectionId'
-      preLoaderRoute: typeof CollectionCollectionIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout/dashboard/': {
-      id: '/_dashboard-layout/dashboard/'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/about': {
-      id: '/_dashboard-layout/dashboard/about'
-      path: '/dashboard/about'
-      fullPath: '/dashboard/about'
-      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/sales': {
-      id: '/_dashboard-layout/dashboard/sales/sales'
-      path: '/dashboard/sales/sales'
-      fullPath: '/dashboard/sales/sales'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages': {
-      id: '/_dashboard-layout/dashboard/sales/messages'
-      path: '/dashboard/sales/messages'
-      fullPath: '/dashboard/sales/messages'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/circular-economy': {
-      id: '/_dashboard-layout/dashboard/sales/circular-economy'
-      path: '/dashboard/sales/circular-economy'
-      fullPath: '/dashboard/sales/circular-economy'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/shipping-options': {
-      id: '/_dashboard-layout/dashboard/products/shipping-options'
-      path: '/dashboard/products/shipping-options'
-      fullPath: '/dashboard/products/shipping-options'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/products': {
-      id: '/_dashboard-layout/dashboard/products/products'
-      path: '/dashboard/products/products'
-      fullPath: '/dashboard/products/products'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/migration-tool': {
-      id: '/_dashboard-layout/dashboard/products/migration-tool'
-      path: '/dashboard/products/migration-tool'
-      fullPath: '/dashboard/products/migration-tool'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections': {
-      id: '/_dashboard-layout/dashboard/products/collections'
-      path: '/dashboard/products/collections'
-      fullPath: '/dashboard/products/collections'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/orders/$orderId': {
-      id: '/_dashboard-layout/dashboard/orders/$orderId'
-      path: '/dashboard/orders/$orderId'
-      fullPath: '/dashboard/orders/$orderId'
-      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/team': {
-      id: '/_dashboard-layout/dashboard/app-settings/team'
-      path: '/dashboard/app-settings/team'
-      fullPath: '/dashboard/app-settings/team'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/featured-items': {
-      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-      path: '/dashboard/app-settings/featured-items'
-      fullPath: '/dashboard/app-settings/featured-items'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/blacklists': {
-      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-      path: '/dashboard/app-settings/blacklists'
-      fullPath: '/dashboard/app-settings/blacklists'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-      path: '/dashboard/app-settings/app-miscelleneous'
-      fullPath: '/dashboard/app-settings/app-miscelleneous'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/your-purchases': {
-      id: '/_dashboard-layout/dashboard/account/your-purchases'
-      path: '/dashboard/account/your-purchases'
-      fullPath: '/dashboard/account/your-purchases'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/vanity-url': {
-      id: '/_dashboard-layout/dashboard/account/vanity-url'
-      path: '/dashboard/account/vanity-url'
-      fullPath: '/dashboard/account/vanity-url'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/receiving-payments': {
-      id: '/_dashboard-layout/dashboard/account/receiving-payments'
-      path: '/dashboard/account/receiving-payments'
-      fullPath: '/dashboard/account/receiving-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/profile': {
-      id: '/_dashboard-layout/dashboard/account/profile'
-      path: '/dashboard/account/profile'
-      fullPath: '/dashboard/account/profile'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/preferences': {
-      id: '/_dashboard-layout/dashboard/account/preferences'
-      path: '/dashboard/account/preferences'
-      fullPath: '/dashboard/account/preferences'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/nostr-address': {
-      id: '/_dashboard-layout/dashboard/account/nostr-address'
-      path: '/dashboard/account/nostr-address'
-      fullPath: '/dashboard/account/nostr-address'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/network': {
-      id: '/_dashboard-layout/dashboard/account/network'
-      path: '/dashboard/account/network'
-      fullPath: '/dashboard/account/network'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/making-payments': {
-      id: '/_dashboard-layout/dashboard/account/making-payments'
-      path: '/dashboard/account/making-payments'
-      fullPath: '/dashboard/account/making-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-      path: '/$pubkey'
-      fullPath: '/dashboard/sales/messages/$pubkey'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/new': {
-      id: '/_dashboard-layout/dashboard/products/products/new'
-      path: '/new'
-      fullPath: '/dashboard/products/products/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/$productId': {
-      id: '/_dashboard-layout/dashboard/products/products/$productId'
-      path: '/$productId'
-      fullPath: '/dashboard/products/products/$productId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/new': {
-      id: '/_dashboard-layout/dashboard/products/collections/new'
-      path: '/new'
-      fullPath: '/dashboard/products/collections/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
-      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-      path: '/$collectionId'
-      fullPath: '/dashboard/products/collections/$collectionId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-  }
+	interface FileRoutesByPath {
+		'/setup': {
+			id: '/setup'
+			path: '/setup'
+			fullPath: '/setup'
+			preLoaderRoute: typeof SetupRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/checkout': {
+			id: '/checkout'
+			path: '/checkout'
+			fullPath: '/checkout'
+			preLoaderRoute: typeof CheckoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout': {
+			id: '/_dashboard-layout'
+			path: ''
+			fullPath: ''
+			preLoaderRoute: typeof DashboardLayoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/$vanityName': {
+			id: '/$vanityName'
+			path: '/$vanityName'
+			fullPath: '/$vanityName'
+			preLoaderRoute: typeof VanityNameRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/': {
+			id: '/'
+			path: '/'
+			fullPath: '/'
+			preLoaderRoute: typeof IndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/': {
+			id: '/products/'
+			path: '/products'
+			fullPath: '/products'
+			preLoaderRoute: typeof ProductsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/': {
+			id: '/posts/'
+			path: '/posts'
+			fullPath: '/posts'
+			preLoaderRoute: typeof PostsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/nostr/': {
+			id: '/nostr/'
+			path: '/nostr'
+			fullPath: '/nostr'
+			preLoaderRoute: typeof NostrIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/community/': {
+			id: '/community/'
+			path: '/community'
+			fullPath: '/community'
+			preLoaderRoute: typeof CommunityIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/search/products': {
+			id: '/search/products'
+			path: '/search/products'
+			fullPath: '/search/products'
+			preLoaderRoute: typeof SearchProductsRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/profile/$profileId': {
+			id: '/profile/$profileId'
+			path: '/profile/$profileId'
+			fullPath: '/profile/$profileId'
+			preLoaderRoute: typeof ProfileProfileIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/$productId': {
+			id: '/products/$productId'
+			path: '/products/$productId'
+			fullPath: '/products/$productId'
+			preLoaderRoute: typeof ProductsProductIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/$postId': {
+			id: '/posts/$postId'
+			path: '/posts/$postId'
+			fullPath: '/posts/$postId'
+			preLoaderRoute: typeof PostsPostIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/collection/$collectionId': {
+			id: '/collection/$collectionId'
+			path: '/collection/$collectionId'
+			fullPath: '/collection/$collectionId'
+			preLoaderRoute: typeof CollectionCollectionIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout/dashboard/': {
+			id: '/_dashboard-layout/dashboard/'
+			path: '/dashboard'
+			fullPath: '/dashboard'
+			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/about': {
+			id: '/_dashboard-layout/dashboard/about'
+			path: '/dashboard/about'
+			fullPath: '/dashboard/about'
+			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/sales': {
+			id: '/_dashboard-layout/dashboard/sales/sales'
+			path: '/dashboard/sales/sales'
+			fullPath: '/dashboard/sales/sales'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages': {
+			id: '/_dashboard-layout/dashboard/sales/messages'
+			path: '/dashboard/sales/messages'
+			fullPath: '/dashboard/sales/messages'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/circular-economy': {
+			id: '/_dashboard-layout/dashboard/sales/circular-economy'
+			path: '/dashboard/sales/circular-economy'
+			fullPath: '/dashboard/sales/circular-economy'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/shipping-options': {
+			id: '/_dashboard-layout/dashboard/products/shipping-options'
+			path: '/dashboard/products/shipping-options'
+			fullPath: '/dashboard/products/shipping-options'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/products': {
+			id: '/_dashboard-layout/dashboard/products/products'
+			path: '/dashboard/products/products'
+			fullPath: '/dashboard/products/products'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/migration-tool': {
+			id: '/_dashboard-layout/dashboard/products/migration-tool'
+			path: '/dashboard/products/migration-tool'
+			fullPath: '/dashboard/products/migration-tool'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections': {
+			id: '/_dashboard-layout/dashboard/products/collections'
+			path: '/dashboard/products/collections'
+			fullPath: '/dashboard/products/collections'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/orders/$orderId': {
+			id: '/_dashboard-layout/dashboard/orders/$orderId'
+			path: '/dashboard/orders/$orderId'
+			fullPath: '/dashboard/orders/$orderId'
+			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/team': {
+			id: '/_dashboard-layout/dashboard/app-settings/team'
+			path: '/dashboard/app-settings/team'
+			fullPath: '/dashboard/app-settings/team'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/featured-items': {
+			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+			path: '/dashboard/app-settings/featured-items'
+			fullPath: '/dashboard/app-settings/featured-items'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/blacklists': {
+			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+			path: '/dashboard/app-settings/blacklists'
+			fullPath: '/dashboard/app-settings/blacklists'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+			path: '/dashboard/app-settings/app-miscelleneous'
+			fullPath: '/dashboard/app-settings/app-miscelleneous'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/your-purchases': {
+			id: '/_dashboard-layout/dashboard/account/your-purchases'
+			path: '/dashboard/account/your-purchases'
+			fullPath: '/dashboard/account/your-purchases'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/vanity-url': {
+			id: '/_dashboard-layout/dashboard/account/vanity-url'
+			path: '/dashboard/account/vanity-url'
+			fullPath: '/dashboard/account/vanity-url'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/receiving-payments': {
+			id: '/_dashboard-layout/dashboard/account/receiving-payments'
+			path: '/dashboard/account/receiving-payments'
+			fullPath: '/dashboard/account/receiving-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/profile': {
+			id: '/_dashboard-layout/dashboard/account/profile'
+			path: '/dashboard/account/profile'
+			fullPath: '/dashboard/account/profile'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/preferences': {
+			id: '/_dashboard-layout/dashboard/account/preferences'
+			path: '/dashboard/account/preferences'
+			fullPath: '/dashboard/account/preferences'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/nostr-address': {
+			id: '/_dashboard-layout/dashboard/account/nostr-address'
+			path: '/dashboard/account/nostr-address'
+			fullPath: '/dashboard/account/nostr-address'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/network': {
+			id: '/_dashboard-layout/dashboard/account/network'
+			path: '/dashboard/account/network'
+			fullPath: '/dashboard/account/network'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/making-payments': {
+			id: '/_dashboard-layout/dashboard/account/making-payments'
+			path: '/dashboard/account/making-payments'
+			fullPath: '/dashboard/account/making-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+			path: '/$pubkey'
+			fullPath: '/dashboard/sales/messages/$pubkey'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/new': {
+			id: '/_dashboard-layout/dashboard/products/products/new'
+			path: '/new'
+			fullPath: '/dashboard/products/products/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/$productId': {
+			id: '/_dashboard-layout/dashboard/products/products/$productId'
+			path: '/$productId'
+			fullPath: '/dashboard/products/products/$productId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/new': {
+			id: '/_dashboard-layout/dashboard/products/collections/new'
+			path: '/new'
+			fullPath: '/dashboard/products/collections/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
+			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+			path: '/$collectionId'
+			fullPath: '/dashboard/products/collections/$collectionId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+	}
 }
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
-      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-    DashboardLayoutDashboardProductsCollectionsNewRoute:
-      DashboardLayoutDashboardProductsCollectionsNewRoute,
-  }
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
-  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsCollectionsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsCollectionsRouteChildren,
+)
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsProductsProductIdRoute:
-      DashboardLayoutDashboardProductsProductsProductIdRoute,
-    DashboardLayoutDashboardProductsProductsNewRoute:
-      DashboardLayoutDashboardProductsProductsNewRoute,
-  }
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
+	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
+	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren =
-  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsProductsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsProductsRouteChildren,
+)
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
-  {
-    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
-      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-  }
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+}
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
-  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-    DashboardLayoutDashboardSalesMessagesRouteChildren,
-  )
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+	DashboardLayoutDashboardSalesMessagesRouteChildren,
+)
 
 interface DashboardLayoutRouteChildren {
-  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-  DashboardLayoutDashboardAccountMakingPaymentsRoute:
-    DashboardLayoutDashboardAccountMakingPaymentsRoute,
-  DashboardLayoutDashboardAccountNetworkRoute:
-    DashboardLayoutDashboardAccountNetworkRoute,
-  DashboardLayoutDashboardAccountNostrAddressRoute:
-    DashboardLayoutDashboardAccountNostrAddressRoute,
-  DashboardLayoutDashboardAccountPreferencesRoute:
-    DashboardLayoutDashboardAccountPreferencesRoute,
-  DashboardLayoutDashboardAccountProfileRoute:
-    DashboardLayoutDashboardAccountProfileRoute,
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
-    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-  DashboardLayoutDashboardAccountVanityUrlRoute:
-    DashboardLayoutDashboardAccountVanityUrlRoute,
-  DashboardLayoutDashboardAccountYourPurchasesRoute:
-    DashboardLayoutDashboardAccountYourPurchasesRoute,
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
-    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
-    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
-    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-  DashboardLayoutDashboardAppSettingsTeamRoute:
-    DashboardLayoutDashboardAppSettingsTeamRoute,
-  DashboardLayoutDashboardOrdersOrderIdRoute:
-    DashboardLayoutDashboardOrdersOrderIdRoute,
-  DashboardLayoutDashboardProductsCollectionsRoute:
-    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-  DashboardLayoutDashboardProductsMigrationToolRoute:
-    DashboardLayoutDashboardProductsMigrationToolRoute,
-  DashboardLayoutDashboardProductsProductsRoute:
-    DashboardLayoutDashboardProductsProductsRouteWithChildren,
-  DashboardLayoutDashboardProductsShippingOptionsRoute:
-    DashboardLayoutDashboardProductsShippingOptionsRoute,
-  DashboardLayoutDashboardSalesCircularEconomyRoute:
-    DashboardLayoutDashboardSalesCircularEconomyRoute,
-  DashboardLayoutDashboardSalesMessagesRoute:
-    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-  DashboardLayoutDashboardSalesSalesRoute:
-    DashboardLayoutDashboardSalesSalesRoute,
+	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
+	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
+	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
+	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
+	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
+	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
+	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
+	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
+	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
+	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
+	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
+	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
-  DashboardLayoutRouteChildren,
-)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  VanityNameRoute: VanityNameRoute,
-  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-  CheckoutRoute: CheckoutRoute,
-  SetupRoute: SetupRoute,
-  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-  PostsPostIdRoute: PostsPostIdRoute,
-  ProductsProductIdRoute: ProductsProductIdRoute,
-  ProfileProfileIdRoute: ProfileProfileIdRoute,
-  SearchProductsRoute: SearchProductsRoute,
-  CommunityIndexRoute: CommunityIndexRoute,
-  NostrIndexRoute: NostrIndexRoute,
-  PostsIndexRoute: PostsIndexRoute,
-  ProductsIndexRoute: ProductsIndexRoute,
+	IndexRoute: IndexRoute,
+	VanityNameRoute: VanityNameRoute,
+	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+	CheckoutRoute: CheckoutRoute,
+	SetupRoute: SetupRoute,
+	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+	PostsPostIdRoute: PostsPostIdRoute,
+	ProductsProductIdRoute: ProductsProductIdRoute,
+	ProfileProfileIdRoute: ProfileProfileIdRoute,
+	SearchProductsRoute: SearchProductsRoute,
+	CommunityIndexRoute: CommunityIndexRoute,
+	NostrIndexRoute: NostrIndexRoute,
+	PostsIndexRoute: PostsIndexRoute,
+	ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { useBlacklistSync } from '@/hooks/useBlacklistSync'
 import { useVanitySync } from '@/hooks/useVanitySync'
 import { useNip05Sync } from '@/hooks/useNip05Sync'
 import { useStore } from '@tanstack/react-store'
+import { TooltipProvider } from '@/components/ui/tooltip'
 
 export const Route = createRootRoute({
 	component: RootComponent,
@@ -66,20 +67,22 @@ function RootLayout() {
 	}
 
 	return (
-		<div className="relative flex flex-col min-h-screen">
-			<Header />
+		<TooltipProvider>
+			<div className="relative flex flex-col min-h-screen">
+				<Header />
 
-			<main className="flex-grow flex flex-col">
-				<Outlet />
-			</main>
-			<Pattern pattern="page" />
-			{!isDashboardPage && !isCheckoutPage && <Footer />}
-			{/* Having some build error with this rn */}
-			{/* <TanStackRouterDevtools /> */}
-			<DecryptPasswordDialog />
-			<SheetRegistry />
-			<DialogRegistry />
-			<Toaster />
-		</div>
+				<main className="flex flex-col flex-grow">
+					<Outlet />
+				</main>
+				<Pattern pattern="page" />
+				{!isDashboardPage && !isCheckoutPage && <Footer />}
+				{/* Having some build error with this rn */}
+				{/* <TanStackRouterDevtools /> */}
+				<DecryptPasswordDialog />
+				<SheetRegistry />
+				<DialogRegistry />
+				<Toaster />
+			</div>
+		</TooltipProvider>
 	)
 }

--- a/src/routes/_dashboard-layout.tsx
+++ b/src/routes/_dashboard-layout.tsx
@@ -127,10 +127,10 @@ function LoginPrompt() {
 	}
 
 	return (
-		<div className="flex items-center justify-center h-full">
+		<div className="flex justify-center items-center h-full">
 			<div className="flex flex-col items-center space-y-4">
-				<p className="text-lg text-muted-foreground">Please log in to view</p>
-				<Button variant="primary" onClick={handleLoginClick}>
+				<p className="text-muted-foreground text-lg">Please log in to view</p>
+				<Button variant="default" onClick={handleLoginClick}>
 					Login
 				</Button>
 			</div>
@@ -258,21 +258,21 @@ function DashboardLayout() {
 	return (
 		<div className="lg:flex lg:flex-col lg:h-[calc(100vh-5rem)]">
 			{/* Header - responsive for mobile/desktop */}
-			<div className="lg:hidden sticky top-[8.5rem] z-10">
-				<h1 className="font-heading p-4 bg-secondary-black text-secondary flex items-center gap-2 justify-center text-center relative">
+			<div className="lg:hidden top-[8.5rem] z-10 sticky">
+				<h1 className="relative flex justify-center items-center gap-2 bg-secondary-black p-4 font-heading text-secondary text-center">
 					{/* Mobile back button - only visible on small screens when not showing sidebar */}
 					{!showSidebar && isMobile && (
 						<button
 							onClick={handleBackToSidebar}
-							className="flex items-center justify-center text-secondary focus:outline-none absolute left-2 sm:left-3 md:left-4 top-1/2 -translate-y-1/2 w-12 h-12 z-20 cursor-pointer"
+							className="top-1/2 left-2 sm:left-3 md:left-4 z-20 absolute flex justify-center items-center focus:outline-none w-12 h-12 text-secondary -translate-y-1/2 cursor-pointer"
 							aria-label="Back to sidebar"
 						>
-							<span className="i-back w-6 h-6" />
+							<span className="w-6 h-6 i-back" />
 						</button>
 					)}
 
 					{/* Title */}
-					<span className="w-full truncate px-8 sm:px-12 md:px-16 text-3xl flex items-center justify-center gap-2 min-w-0">
+					<span className="flex justify-center items-center gap-2 px-8 sm:px-12 md:px-16 w-full min-w-0 text-3xl truncate">
 						{showSidebar || !isMobile ? (
 							'Dashboard'
 						) : (
@@ -282,7 +282,7 @@ function DashboardLayout() {
 								) : (
 									<>
 										{dashboardEmoji && <span className="text-2xl">{dashboardEmoji}</span>}
-										<span className="truncate min-w-0 flex-1 text-center">{dashboardTitleWithoutEmoji}</span>
+										<span className="flex-1 min-w-0 text-center truncate">{dashboardTitleWithoutEmoji}</span>
 									</>
 								)}
 							</>
@@ -291,7 +291,7 @@ function DashboardLayout() {
 
 					{/* Mobile emoji - only visible on small screens when not showing sidebar */}
 					{!showSidebar && emoji && isMobile && !dashboardEmoji && (
-						<span className="absolute right-2 sm:right-3 md:right-4 top-1/2 -translate-y-1/2 text-2xl select-none w-12 h-12 flex items-center justify-center z-20">
+						<span className="top-1/2 right-2 sm:right-3 md:right-4 z-20 absolute flex justify-center items-center w-12 h-12 text-2xl -translate-y-1/2 select-none">
 							{emoji}
 						</span>
 					)}
@@ -299,22 +299,22 @@ function DashboardLayout() {
 			</div>
 
 			<div className="hidden lg:block">
-				<h1 className="font-heading py-2 px-4 bg-secondary-black text-secondary flex items-center gap-2 justify-center text-center lg:justify-start relative">
+				<h1 className="relative flex justify-center lg:justify-start items-center gap-2 bg-secondary-black px-4 py-2 font-heading text-secondary text-center">
 					Dashboard
 				</h1>
 			</div>
 
 			{/* Main container - responsive layout */}
-			<div className="lg:flex lg:pt-6 lg:px-6 lg:pb-4 lg:gap-6 lg:flex-1 lg:overflow-hidden lg:max-w-none lg:min-h-0">
-				<div ref={parent} className="lg:flex lg:w-full lg:gap-6">
+			<div className="lg:flex lg:flex-1 lg:gap-6 lg:px-6 lg:pt-6 lg:pb-4 lg:max-w-none lg:min-h-0 lg:overflow-hidden">
+				<div ref={parent} className="lg:flex lg:gap-6 lg:w-full">
 					{/* Sidebar - responsive behavior */}
 					{(showSidebar || !isMobile) && (
-						<aside className="w-full lg:w-80 lg:overflow-y-auto lg:border lg:border-black lg:rounded lg:max-h-full lg:bg-white lg:flex-shrink-0">
+						<aside className="lg:flex-shrink-0 lg:bg-white lg:border lg:border-black lg:rounded w-full lg:w-80 lg:max-h-full lg:overflow-y-auto">
 							<div className="lg:space-y-2">
 								{filteredNavigation.map((section) => (
 									<div key={section.title}>
-										<h3 className="font-heading bg-tertiary-black text-white px-4 py-2 mb-0 lg:mb-2">{section.title}</h3>
-										<nav className="space-y-2 p-4 lg:p-0 text-xl lg:text-base">
+										<h3 className="bg-tertiary-black mb-0 lg:mb-2 px-4 py-2 font-heading text-white">{section.title}</h3>
+										<nav className="space-y-2 p-4 lg:p-0 lg:text-base text-xl">
 											{section.items.map((item) => {
 												const isActive = matchRoute({ to: item.path, fuzzy: true })
 												const notificationCount = getNotificationCount(item.path, unseenOrders, unseenMessages, unseenPurchases)
@@ -322,14 +322,14 @@ function DashboardLayout() {
 													<Link
 														key={item.path}
 														to={item.path}
-														className="block p-4 lg:px-6 lg:py-2 transition-colors font-bold border border-black bg-white rounded lg:border-0 lg:bg-transparent lg:rounded-none data-[status=active]:bg-secondary data-[status=active]:text-white data-[status=active]:border-secondary hover:text-pink-500 relative"
+														className="block relative bg-white data-[status=active]:bg-secondary lg:bg-transparent p-4 lg:px-6 lg:py-2 border border-black data-[status=active]:border-secondary lg:border-0 rounded lg:rounded-none font-bold data-[status=active]:text-white hover:text-pink-500 transition-colors"
 														onClick={handleSidebarItemClick}
 														data-status={isActive ? 'active' : 'inactive'}
 													>
-														<span className="flex items-center justify-between">
+														<span className="flex justify-between items-center">
 															<span>{item.title}</span>
 															{notificationCount > 0 && (
-																<span className="inline-flex items-center justify-center min-w-[1.5rem] h-6 px-2 text-xs font-bold text-white bg-pink-500 rounded-full ml-2">
+																<span className="inline-flex justify-center items-center bg-pink-500 ml-2 px-2 rounded-full min-w-[1.5rem] h-6 font-bold text-white text-xs">
 																	{notificationCount > 99 ? '99+' : notificationCount}
 																</span>
 															)}
@@ -353,20 +353,20 @@ function DashboardLayout() {
 						>
 							{/* Desktop back button and title - fixed to top of container */}
 							{needsBackButton && (
-								<div className="sticky top-0 z-10 bg-white border-b border-gray-200 pb-4 mb-0 p-4 lg:p-8 flex-shrink-0 flex items-center relative">
+								<div className="top-0 z-10 relative sticky flex flex-shrink-0 items-center bg-white mb-0 p-4 lg:p-8 pb-4 border-gray-200 border-b">
 									<button
 										onClick={handleBackToParent}
 										className="flex items-center gap-2 text-gray-600 hover:text-gray-800 transition-colors cursor-pointer"
 										aria-label={backButtonInfo?.parentPath ? `Back to ${backButtonInfo?.parentTitle}` : 'Go back'}
 									>
-										<span className="i-back w-5 h-5" />
-										<span className="text-sm font-medium">
+										<span className="w-5 h-5 i-back" />
+										<span className="font-medium text-sm">
 											{backButtonInfo?.parentPath ? `Back to ${backButtonInfo?.parentTitle}` : 'Back'}
 										</span>
 									</button>
 
 									{!isMobile && (
-										<h1 className="absolute left-1/2 -translate-x-1/2 text-[1.6rem] font-bold flex items-center gap-2">
+										<h1 className="left-1/2 absolute flex items-center gap-2 font-bold text-[1.6rem] -translate-x-1/2">
 											{isMessageDetailView && chatProfile?.user?.pubkey ? (
 												<UserCard pubkey={chatProfile?.user?.pubkey} size="md" />
 											) : (
@@ -379,7 +379,7 @@ function DashboardLayout() {
 									{dashboardHeaderAction && (
 										<button
 											onClick={dashboardHeaderAction.onClick}
-											className="absolute right-4 lg:right-8 top-1/2 -translate-y-1/2 px-3 py-1 text-sm font-medium bg-pink-500 text-white rounded hover:bg-pink-600 transition-colors"
+											className="top-1/2 right-4 lg:right-8 absolute bg-pink-500 hover:bg-pink-600 px-3 py-1 rounded font-medium text-white text-sm transition-colors -translate-y-1/2"
 										>
 											{dashboardHeaderAction.label}
 										</button>
@@ -394,7 +394,7 @@ function DashboardLayout() {
 									<div className="h-full">
 										<div
 											className={cn(
-												'p-4 bg-white lg:p-8 lg:bg-transparent h-full',
+												'bg-white lg:bg-transparent p-4 lg:p-8 h-full',
 												location.pathname === '/dashboard/sales/sales' && 'p-0 lg:p-0',
 												location.pathname.startsWith('/dashboard/sales/messages') && 'p-0 lg:p-0',
 												location.pathname === '/dashboard/sales/circular-economy' && 'p-0 lg:p-0',
@@ -443,7 +443,7 @@ function DashboardLayout() {
 												location.pathname !== '/dashboard/account/preferences' &&
 												location.pathname !== '/dashboard/account/vanity-url' &&
 												location.pathname !== '/dashboard/account/nostr-address' && (
-													<h1 className="text-[1.6rem] font-bold mb-4">{dashboardTitle}</h1>
+													<h1 className="mb-4 font-bold text-[1.6rem]">{dashboardTitle}</h1>
 												)}
 											{!isAuthenticated ? (
 												<LoginPrompt />
@@ -473,7 +473,7 @@ function DashboardLayout() {
 														location.pathname !== '/dashboard/account/preferences' &&
 														location.pathname !== '/dashboard/account/vanity-url' &&
 														location.pathname !== '/dashboard/account/nostr-address' && (
-															<h1 className="text-[1.6rem] font-bold mb-4">{dashboardTitle}</h1>
+															<h1 className="mb-4 font-bold text-[1.6rem]">{dashboardTitle}</h1>
 														)}
 													<Outlet />
 												</>

--- a/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
+++ b/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
@@ -129,12 +129,12 @@ function AppMiscelleneousComponent() {
 
 	return (
 		<div>
-			<div className="hidden lg:flex sticky top-0 z-10 bg-white border-b py-4 px-4 lg:px-6 items-center justify-between">
-				<h1 className="text-2xl font-bold">App Settings</h1>
+			<div className="hidden top-0 z-10 sticky lg:flex justify-between items-center bg-white px-4 lg:px-6 py-4 border-b">
+				<h1 className="font-bold text-2xl">App Settings</h1>
 				<form.Subscribe
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 					children={([canSubmit, isSubmitting]) => (
-						<Button type="button" disabled={isSubmitting || !canSubmit} onClick={() => form.handleSubmit()} variant="primary">
+						<Button type="button" disabled={isSubmitting || !canSubmit} onClick={() => form.handleSubmit()}>
 							{isSubmitting ? 'Saving...' : 'Save Settings'}
 						</Button>
 					)}
@@ -150,8 +150,8 @@ function AppMiscelleneousComponent() {
 				className="space-y-6 p-4 lg:p-6"
 			>
 				{/* Identity Section */}
-				<div className="border rounded-lg p-4 space-y-4">
-					<h3 className="text-lg font-semibold">Identity</h3>
+				<div className="space-y-4 p-4 border rounded-lg">
+					<h3 className="font-semibold text-lg">Identity</h3>
 
 					<OwnerField ownerPk={appSettings?.ownerPk} />
 
@@ -167,19 +167,19 @@ function AppMiscelleneousComponent() {
 						{(field) => (
 							<div>
 								<Label className="font-medium" htmlFor={field.name}>
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Instance name</span>
+									<span className="after:ml-0.5 after:text-red-500 after:content-['*']">Instance name</span>
 								</Label>
 								<Input
 									id={field.name}
 									required
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="Instance name"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 							</div>
 						)}
@@ -197,19 +197,19 @@ function AppMiscelleneousComponent() {
 						{(field) => (
 							<div>
 								<Label className="font-medium" htmlFor={field.name}>
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Display name</span>
+									<span className="after:ml-0.5 after:text-red-500 after:content-['*']">Display name</span>
 								</Label>
 								<Input
 									id={field.name}
 									required
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="Display name"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 							</div>
 						)}
@@ -233,7 +233,7 @@ function AppMiscelleneousComponent() {
 								</Label>
 								<Input
 									id={field.name}
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
@@ -241,7 +241,7 @@ function AppMiscelleneousComponent() {
 									type="email"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 							</div>
 						)}
@@ -249,8 +249,8 @@ function AppMiscelleneousComponent() {
 				</div>
 
 				{/* Branding Section */}
-				<div className="border rounded-lg p-4 space-y-4">
-					<h3 className="text-lg font-semibold">Branding</h3>
+				<div className="space-y-4 p-4 border rounded-lg">
+					<h3 className="font-semibold text-lg">Branding</h3>
 
 					<form.Field
 						name="picture"
@@ -269,21 +269,21 @@ function AppMiscelleneousComponent() {
 						{(field) => (
 							<div>
 								<Label className="font-medium" htmlFor={field.name}>
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Logo URL</span>
+									<span className="after:ml-0.5 after:text-red-500 after:content-['*']">Logo URL</span>
 								</Label>
 								<Input
 									id={field.name}
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="https://example.com/logo.png"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 								{field.state.value && !field.state.meta.errors?.length && (
-									<div className="mt-2 flex justify-center">
+									<div className="flex justify-center mt-2">
 										<img
 											className="max-w-28 max-h-28 object-contain"
 											src={field.state.value}
@@ -322,23 +322,23 @@ function AppMiscelleneousComponent() {
 						{(field) => (
 							<div>
 								<Label className="font-medium" htmlFor={field.name}>
-									<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Banner URL</span>
+									<span className="after:ml-0.5 after:text-red-500 after:content-['*']">Banner URL</span>
 								</Label>
 								<Input
 									id={field.name}
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="https://example.com/banner.png"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 								{field.state.value && !field.state.meta.errors?.length && (
 									<div className="mt-2">
 										<img
-											className="max-h-32 w-full object-cover rounded"
+											className="rounded w-full max-h-32 object-cover"
 											src={field.state.value}
 											alt="Banner preview"
 											onError={(e) => {
@@ -360,8 +360,8 @@ function AppMiscelleneousComponent() {
 				</div>
 
 				{/* General Settings Section */}
-				<div className="border rounded-lg p-4 space-y-4">
-					<h3 className="text-lg font-semibold">General</h3>
+				<div className="space-y-4 p-4 border rounded-lg">
+					<h3 className="font-semibold text-lg">General</h3>
 
 					<form.Field name="defaultCurrency">
 						{(field) => (
@@ -370,7 +370,7 @@ function AppMiscelleneousComponent() {
 									Default currency
 								</Label>
 								<Select onValueChange={(value) => field.handleChange(value)} value={field.state.value}>
-									<SelectTrigger className="border-2 mt-1">
+									<SelectTrigger className="mt-1 border-2">
 										<SelectValue placeholder="Currency" />
 									</SelectTrigger>
 									<SelectContent>
@@ -397,7 +397,7 @@ function AppMiscelleneousComponent() {
 									<Label htmlFor={field.name} className="font-medium cursor-pointer">
 										Allow registration
 									</Label>
-									<p className="text-sm text-muted-foreground">When enabled, new users can register on this instance.</p>
+									<p className="text-muted-foreground text-sm">When enabled, new users can register on this instance.</p>
 								</div>
 							</div>
 						)}
@@ -415,7 +415,7 @@ function AppMiscelleneousComponent() {
 									<Label htmlFor={field.name} className="font-medium cursor-pointer">
 										Show Nostr link in navigation
 									</Label>
-									<p className="text-sm text-muted-foreground">When enabled, a "Nostr" link will appear in the main navigation menu.</p>
+									<p className="text-muted-foreground text-sm">When enabled, a "Nostr" link will appear in the main navigation menu.</p>
 								</div>
 							</div>
 						)}
@@ -423,9 +423,9 @@ function AppMiscelleneousComponent() {
 				</div>
 
 				{/* Servers Section */}
-				<div className="border rounded-lg p-4 space-y-4">
-					<h3 className="text-lg font-semibold">Servers</h3>
-					<p className="text-sm text-muted-foreground">Configure file storage servers. Leave empty to use defaults.</p>
+				<div className="space-y-4 p-4 border rounded-lg">
+					<h3 className="font-semibold text-lg">Servers</h3>
+					<p className="text-muted-foreground text-sm">Configure file storage servers. Leave empty to use defaults.</p>
 
 					<form.Field
 						name="blossom_server"
@@ -449,14 +449,14 @@ function AppMiscelleneousComponent() {
 								</Label>
 								<Input
 									id={field.name}
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="https://blossom.example.com"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 							</div>
 						)}
@@ -484,14 +484,14 @@ function AppMiscelleneousComponent() {
 								</Label>
 								<Input
 									id={field.name}
-									className="border-2 mt-1"
+									className="mt-1 border-2"
 									value={field.state.value}
 									onChange={(e) => field.handleChange(e.target.value)}
 									onBlur={field.handleBlur}
 									placeholder="https://nip96.example.com"
 								/>
 								{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-									<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+									<div className="mt-1 text-red-500 text-sm">{field.state.meta.errors.join(', ')}</div>
 								)}
 							</div>
 						)}
@@ -508,7 +508,7 @@ function AppMiscelleneousComponent() {
 				<form.Subscribe
 					selector={(state) => [state.canSubmit, state.isSubmitting]}
 					children={([canSubmit, isSubmitting]) => (
-						<Button type="submit" className="w-full lg:hidden" disabled={isSubmitting || !canSubmit} variant="primary">
+						<Button type="submit" className="lg:hidden w-full" disabled={isSubmitting || !canSubmit}>
 							{isSubmitting ? 'Saving...' : 'Save Settings'}
 						</Button>
 					)}
@@ -545,12 +545,12 @@ function OwnerField({ ownerPk }: { ownerPk?: string }) {
 				{ownerPk ? <UserCard pubkey={ownerPk} size="md" onPress="none" /> : <span className="text-muted-foreground">Unknown</span>}
 			</div>
 			<div className="flex items-center gap-2">
-				<Input value={ownerNpub} disabled className="border-2 bg-gray-50 text-muted-foreground" />
+				<Input value={ownerNpub} disabled className="bg-gray-50 border-2 text-muted-foreground" />
 				<Button type="button" variant="outline" size="icon" className="shrink-0" onClick={handleCopy}>
-					{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+					{copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
 				</Button>
 			</div>
-			<p className="text-xs text-muted-foreground mt-1">Owner public key cannot be changed.</p>
+			<p className="mt-1 text-muted-foreground text-xs">Owner public key cannot be changed.</p>
 		</div>
 	)
 }

--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -21,6 +21,7 @@ import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tans
 import { useStore } from '@tanstack/react-store'
 import { PackageIcon, Trash, EyeOff, Clock, Eye } from 'lucide-react'
 import { useState, useMemo } from 'react'
+import { TooltipButton } from '@/components/shared/TooltipButton'
 
 // Component to show basic product information
 function ProductBasicInfo({ product }: { product: NDKEvent }) {
@@ -38,26 +39,26 @@ function ProductBasicInfo({ product }: { product: NDKEvent }) {
 		<Link
 			to={`/products/${product.id}`}
 			onClick={() => queryClient.setQueryData(productQueryOptions(product.id).queryKey, product)}
-			className="block p-4 bg-gray-50 border-t hover:bg-gray-100 transition-colors cursor-pointer"
+			className="block bg-gray-50 hover:bg-gray-100 p-4 border-t transition-colors cursor-pointer"
 		>
 			<div className="space-y-3">
 				{images.length > 0 && (
-					<div className="w-full h-32 bg-gray-200 rounded-md overflow-hidden">
+					<div className="bg-gray-200 rounded-md w-full h-32 overflow-hidden">
 						<img src={images[0][1]} alt="Product image" className="w-full h-full object-cover" />
 					</div>
 				)}
 				<div>
-					<p className="text-sm text-gray-600 mb-1">Description:</p>
+					<p className="mb-1 text-gray-600 text-sm">Description:</p>
 					<p className="text-sm">{description}</p>
 				</div>
 				<div className="flex justify-between">
 					<div>
-						<p className="text-sm text-gray-600">
+						<p className="text-gray-600 text-sm">
 							Price: <span className="font-medium">{price}</span>
 						</p>
 					</div>
 					<div>
-						<p className="text-sm text-gray-600">
+						<p className="text-gray-600 text-sm">
 							Visibility:{' '}
 							<span
 								className={`font-medium capitalize ${visibility === 'hidden' ? 'text-gray-500' : visibility === 'pre-order' ? 'text-blue-600' : 'text-green-600'}`}
@@ -69,12 +70,12 @@ function ProductBasicInfo({ product }: { product: NDKEvent }) {
 				</div>
 				{stock && (
 					<div>
-						<p className="text-sm text-gray-600">
+						<p className="text-gray-600 text-sm">
 							Stock: <span className="font-medium">{stock} in stock</span>
 						</p>
 					</div>
 				)}
-				<p className="text-xs text-gray-400 text-right">Click to view product page →</p>
+				<p className="text-gray-400 text-xs text-right">Click to view product page →</p>
 			</div>
 		</Link>
 	)
@@ -118,9 +119,9 @@ function ProductListItem({
 	const triggerContent = (
 		<div className="flex items-center gap-3">
 			{thumbnailUrl ? (
-				<img src={thumbnailUrl} alt="" className="w-10 h-10 rounded object-cover shrink-0" />
+				<img src={thumbnailUrl} alt="" className="rounded w-10 h-10 object-cover shrink-0" />
 			) : (
-				<div className="w-10 h-10 rounded bg-gray-100 flex items-center justify-center shrink-0">
+				<div className="flex justify-center items-center bg-gray-100 rounded w-10 h-10 shrink-0">
 					<PackageIcon className="w-5 h-5 text-gray-400" />
 				</div>
 			)}
@@ -133,7 +134,7 @@ function ProductListItem({
 
 	const actions = (
 		<>
-			<Button
+			<TooltipButton
 				variant="ghost"
 				size="sm"
 				tooltip="Edit"
@@ -143,9 +144,9 @@ function ProductListItem({
 				}}
 				aria-label={`Edit ${getProductTitle(product)}`}
 			>
-				<span className="i-edit w-5 h-5" />
-			</Button>
-			<Button
+				<span className="w-5 h-5 i-edit" />
+			</TooltipButton>
+			<TooltipButton
 				variant="ghost"
 				size="sm"
 				tooltip="Share"
@@ -155,9 +156,9 @@ function ProductListItem({
 				}}
 				aria-label={`Share ${getProductTitle(product)}`}
 			>
-				<span className="i-sharing w-4 h-4" />
-			</Button>
-			<Button
+				<span className="w-4 h-4 i-sharing" />
+			</TooltipButton>
+			<TooltipButton
 				variant="ghost"
 				size="sm"
 				tooltip="Delete"
@@ -169,11 +170,11 @@ function ProductListItem({
 				disabled={isDeleting}
 			>
 				{isDeleting ? (
-					<div className="animate-spin h-4 w-4 border-2 border-destructive border-t-transparent rounded-full" />
+					<div className="border-2 border-destructive border-t-transparent rounded-full w-4 h-4 animate-spin" />
 				) : (
 					<Trash className="w-4 h-4 text-destructive" />
 				)}
-			</Button>
+			</TooltipButton>
 		</>
 	)
 
@@ -309,8 +310,8 @@ function ProductsOverviewComponent() {
 
 	return (
 		<div>
-			<div className="hidden lg:flex sticky top-0 z-10 bg-white border-b py-4 px-4 lg:px-6 items-center justify-between">
-				<h1 className="text-2xl font-bold">Products</h1>
+			<div className="hidden top-0 z-10 sticky lg:flex justify-between items-center bg-white px-4 lg:px-6 py-4 border-b">
+				<h1 className="font-bold text-2xl">Products</h1>
 				<div className="flex items-center gap-4">
 					<Select value={orderBy} onValueChange={setOrderBy}>
 						<SelectTrigger className="w-56">
@@ -328,9 +329,9 @@ function ProductsOverviewComponent() {
 					<Button
 						onClick={handleAddProductClick}
 						data-testid="add-product-button"
-						className="bg-neutral-800 hover:bg-neutral-700 text-white flex items-center gap-2 px-4 py-2 text-sm font-semibold"
+						className="flex items-center gap-2 bg-neutral-800 hover:bg-neutral-700 px-4 py-2 font-semibold text-white text-sm"
 					>
-						<span className="i-product w-5 h-5" /> Add A Product
+						<span className="w-5 h-5 i-product" /> Add A Product
 					</Button>
 				</div>
 			</div>
@@ -352,15 +353,15 @@ function ProductsOverviewComponent() {
 					<Button
 						onClick={handleAddProductClick}
 						data-testid="add-product-button-mobile"
-						className="w-full bg-neutral-800 hover:bg-neutral-700 text-white flex items-center justify-center gap-2 py-3 text-base font-semibold rounded-t-md rounded-b-none border-b border-neutral-600"
+						className="flex justify-center items-center gap-2 bg-neutral-800 hover:bg-neutral-700 py-3 border-neutral-600 border-b rounded-t-md rounded-b-none w-full font-semibold text-white text-base"
 					>
-						<span className="i-product w-5 h-5" /> Add A Product
+						<span className="w-5 h-5 i-product" /> Add A Product
 					</Button>
 				</div>
 
 				<div>
-					{isLoading && <div className="p-6 text-center text-gray-500 mt-4">Loading your products...</div>}
-					{error && <div className="p-6 text-center text-red-600 mt-4">Failed to load products: {error.message}</div>}
+					{isLoading && <div className="mt-4 p-6 text-gray-500 text-center">Loading your products...</div>}
+					{error && <div className="mt-4 p-6 text-red-600 text-center">Failed to load products: {error.message}</div>}
 
 					{!isLoading && !error && (
 						<>
@@ -381,9 +382,9 @@ function ProductsOverviewComponent() {
 									))}
 								</ul>
 							) : (
-								<div className="text-center text-gray-500 py-10 px-6">
-									<span className="i-product w-5 h-5" />
-									<h3 className="mt-2 text-lg font-semibold text-gray-700">No products yet</h3>
+								<div className="px-6 py-10 text-gray-500 text-center">
+									<span className="w-5 h-5 i-product" />
+									<h3 className="mt-2 font-semibold text-gray-700 text-lg">No products yet</h3>
 									<p className="mt-1 text-sm">Click the "Add A Product" button to create your first one.</p>
 								</div>
 							)}

--- a/src/routes/collection.$collectionId.tsx
+++ b/src/routes/collection.$collectionId.tsx
@@ -186,6 +186,12 @@ function RouteComponent() {
 			navigate({ to: '/community' })
 		}
 	}
+	// Handle message button
+	const handleMessageClick = () => {
+		if (user?.pubkey) {
+			uiActions.openConversation(user.pubkey)
+		}
+	}
 
 	return (
 		<div className="flex flex-col gap-4">

--- a/src/routes/collection.$collectionId.tsx
+++ b/src/routes/collection.$collectionId.tsx
@@ -31,6 +31,7 @@ import { useStore } from '@tanstack/react-store'
 import { ArrowLeft, Edit, MessageCircle, Share2 } from 'lucide-react'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
+import { TooltipButton } from '@/components/shared/TooltipButton'
 
 // Hook to inject dynamic CSS for background image
 function useHeroBackground(imageUrl: string, className: string) {
@@ -73,8 +74,8 @@ function RouteComponent() {
 
 	if (!collection) {
 		return (
-			<div className="flex h-[50vh] flex-col items-center justify-center gap-4">
-				<h1 className="text-2xl font-bold">Collection Not Found</h1>
+			<div className="flex flex-col justify-center items-center gap-4 h-[50vh]">
+				<h1 className="font-bold text-2xl">Collection Not Found</h1>
 				<p className="text-gray-600">The collection you're looking for doesn't exist.</p>
 			</div>
 		)
@@ -188,43 +189,49 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="relative z-10">
+			<div className="z-10 relative">
 				{!mobileMenuOpen && (
 					<Button variant="ghost" onClick={handleBackClick} className="back-button">
-						<ArrowLeft className="h-8 w-8 lg:h-4 lg:w-4" />
+						<ArrowLeft className="w-8 lg:w-4 h-8 lg:h-4" />
 						<span className="hidden sm:inline">Back to Community</span>
 					</Button>
 				)}
 				<div className={`relative hero-container-small ${marketBackgroundImageUrl ? `bg-hero-image ${marketHeroClassName}` : 'bg-black'}`}>
 					<div className="hero-overlays">
-						<div className="absolute inset-0 bg-radial-overlay z-10" />
-						<div className="absolute inset-0 opacity-30 bg-dots-overlay z-10" />
+						<div className="z-10 absolute inset-0 bg-radial-overlay" />
+						<div className="z-10 absolute inset-0 bg-dots-overlay opacity-30" />
 					</div>
 
 					<div className="hero-content">
-						<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-16 lg:mt-0">
-							<h1 className="text-2xl font-heading text-center sm:text-left">{title}</h1>
-							<div className="flex flex-col items-center justify-center lg:col-span-2 text-md text-white text-center font-medium">
+						<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-16 lg:mt-0 text-white text-center">
+							<h1 className="font-heading text-2xl sm:text-left text-center">{title}</h1>
+							<div className="flex flex-col justify-center items-center lg:col-span-2 font-medium text-md text-white text-center">
 								{summary}
 							</div>
 						</div>
 					</div>
 				</div>
-				<div className="flex flex-row justify-between px-4 py-2 bg-black items-center">
+				<div className="flex flex-row justify-between items-center bg-black px-4 py-2">
 					<UserCard pubkey={pubkey} size="md" className="[&>h2]:text-white" />
 					{!isSmallScreen && (
 						<div className="flex gap-2">
 							{user && <ZapButton event={user} />}
-							<Button variant="focus" size="icon">
-								<MessageCircle className="w-5 h-5" />
-							</Button>
+							<TooltipButton
+								variant="outline"
+								size="icon"
+								tooltip="Message"
+								onClick={handleMessageClick}
+								className="bg-transparent hover:bg-background border-2 border-background rounded text-background hover:text-foreground"
+							>
+								<MessageCircle className="size-5" />
+							</TooltipButton>
 							<Button variant="secondary" size="icon">
 								<Share2 className="w-5 h-5" />
 							</Button>
 							{/* Edit button for owner */}
 							{permissions.canEdit && (
 								<Button variant="secondary" onClick={handleEdit} className="flex items-center gap-2">
-									<Edit className="h-5 w-5" />
+									<Edit className="w-5 h-5" />
 									<span className="hidden md:inline">Edit Collection</span>
 								</Button>
 							)}
@@ -248,15 +255,15 @@ function RouteComponent() {
 
 				<div className="p-4">
 					{productsLoading ? (
-						<div className="flex flex-col items-center justify-center h-full">
+						<div className="flex flex-col justify-center items-center h-full">
 							<span className="text-xl">Loading products...</span>
 						</div>
 					) : products && products.length > 0 ? (
 						<ItemGrid
 						// title={
-						// 	<div className="flex flex-col sm:flex-row sm:items-center sm:gap-2 text-center sm:text-left">
-						// 		<span className="text-2xl font-heading">Products in collection</span>
-						// 		{/*<ProfileName pubkey={user?.pubkey || ''} className="text-2xl font-heading" />*/}
+						// 	<div className="flex sm:flex-row flex-col sm:items-center sm:gap-2 sm:text-left text-center">
+						// 		<span className="font-heading text-2xl">Products in collection</span>
+						// 		{/*<ProfileName pubkey={user?.pubkey || ''} className="font-heading text-2xl" />*/}
 						// 	</div>
 						// }
 						>
@@ -265,8 +272,8 @@ function RouteComponent() {
 							))}
 						</ItemGrid>
 					) : (
-						<div className="flex flex-col items-center justify-center h-full">
-							<span className="text-2xl font-heading">No products found</span>
+						<div className="flex flex-col justify-center items-center h-full">
+							<span className="font-heading text-2xl">No products found</span>
 						</div>
 					)}
 				</div>

--- a/src/routes/community.index.tsx
+++ b/src/routes/community.index.tsx
@@ -68,9 +68,9 @@ function useFeaturedCollectionEvents(featuredCollections: string[] | undefined) 
 export const Route = createFileRoute('/community/')({
 	component: CommunityRoute,
 	errorComponent: ({ error }) => (
-		<div className="flex flex-col items-center justify-center min-h-[50vh] gap-4 px-4 text-center">
-			<h2 className="text-xl font-semibold">Unable to load collections</h2>
-			<p className="text-muted-foreground max-w-md">
+		<div className="flex flex-col justify-center items-center gap-4 px-4 min-h-[50vh] text-center">
+			<h2 className="font-semibold text-xl">Unable to load collections</h2>
+			<p className="max-w-md text-muted-foreground">
 				{error instanceof Error ? error.message : 'There was a problem connecting to relays. Please try again.'}
 			</p>
 			<Button variant="secondary" onClick={() => window.location.reload()}>
@@ -205,15 +205,15 @@ function CommunityRoute() {
 
 	// Render homepage hero content
 	const renderHomepageHero = () => (
-		<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-16 lg:mt-0">
-			<div className="flex items-center justify-center h-24 lg:h-32">
-				<h1 className="text-4xl lg:text-5xl font-theylive transition-opacity duration-500">Browse Collections</h1>
+		<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-16 lg:mt-0 text-white text-center">
+			<div className="flex justify-center items-center h-24 lg:h-32">
+				<h1 className="font-theylive text-4xl lg:text-5xl transition-opacity duration-500">Browse Collections</h1>
 			</div>
 
 			<div className="flex flex-col gap-6">
-				<Button variant="focus" size="lg" onClick={handleStartSelling}>
+				<Button variant="secondary" size="lg" onClick={handleStartSelling}>
 					<span className="flex items-center gap-2">
-						<span className="i-nostr w-6 h-6"></span>Start Selling
+						<span className="size-6 i-nostr"></span>Start Selling
 					</span>
 				</Button>
 
@@ -238,9 +238,9 @@ function CommunityRoute() {
 
 	// Render collections hero content
 	const renderCollectionsHero = () => (
-		<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-16 lg:mt-0">
-			<div className="flex items-center justify-center h-24 lg:h-32">
-				<h1 className="text-4xl lg:text-5xl font-theylive transition-opacity duration-500">{displayTitle || 'Loading...'}</h1>
+		<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-16 lg:mt-0 text-white text-center">
+			<div className="flex justify-center items-center h-24 lg:h-32">
+				<h1 className="font-theylive text-4xl lg:text-5xl transition-opacity duration-500">{displayTitle || 'Loading...'}</h1>
 			</div>
 
 			<div className="flex flex-col gap-6">
@@ -280,8 +280,8 @@ function CommunityRoute() {
 					onTouchEnd={handleTouchEnd}
 				>
 					<div className="hero-overlays">
-						<div className="absolute inset-0 bg-radial-overlay z-10 opacity-40" />
-						<div className="absolute inset-0 opacity-20 bg-dots-overlay z-10" />
+						<div className="z-10 absolute inset-0 bg-radial-overlay opacity-40" />
+						<div className="z-10 absolute inset-0 bg-dots-overlay opacity-20" />
 					</div>
 
 					<div className="hero-content">{renderHomepageHero()}</div>
@@ -295,15 +295,15 @@ function CommunityRoute() {
 					onTouchEnd={handleTouchEnd}
 				>
 					<div className="hero-overlays">
-						<div className="absolute inset-0 bg-radial-overlay z-10 opacity-40" />
-						<div className="absolute inset-0 opacity-20 bg-dots-overlay z-10" />
+						<div className="z-10 absolute inset-0 bg-radial-overlay opacity-40" />
+						<div className="z-10 absolute inset-0 bg-dots-overlay opacity-20" />
 					</div>
 
 					<div className="hero-content">{renderCollectionsHero()}</div>
 				</div>
 			)}
 
-			<div className="px-4 py-4 flex flex-col gap-12">
+			<div className="flex flex-col gap-12 px-4 py-4">
 				<ItemGrid title="Collections">
 					{collections.map((collection) => (
 						<CollectionCard key={collection.id} collection={collection} />
@@ -311,9 +311,9 @@ function CommunityRoute() {
 				</ItemGrid>
 				<ItemGrid title="Merchants" cols={2} smCols={2} lgCols={2} xlCols={3} gap={16}>
 					{isLoadingMerchants ? (
-						<div className="col-span-full text-center py-8 text-gray-500">Loading merchants...</div>
+						<div className="col-span-full py-8 text-gray-500 text-center">Loading merchants...</div>
 					) : filteredMerchantPubkeys.length === 0 ? (
-						<div className="col-span-full text-center py-8 text-gray-500">No merchants found</div>
+						<div className="col-span-full py-8 text-gray-500 text-center">No merchants found</div>
 					) : (
 						filteredMerchantPubkeys.map((pubkey) => <FeaturedUserCard key={pubkey} userPubkey={pubkey} />)
 					)}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -103,20 +103,20 @@ function Index() {
 			{/* Hero Section */}
 			<div className={`relative hero-container ${marketBackgroundImageUrl ? `bg-hero-image ${marketHeroClassName}` : 'bg-gray-700'}`}>
 				<div className="hero-overlays">
-					<div className="absolute inset-0 bg-radial-overlay z-10 opacity-40" />
-					<div className="absolute inset-0 opacity-20 bg-dots-overlay z-10" />
+					<div className="z-10 absolute inset-0 bg-radial-overlay opacity-40" />
+					<div className="z-10 absolute inset-0 bg-dots-overlay opacity-20" />
 				</div>
 
 				<div className="hero-content">
-					<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-16 lg:mt-0">
-						<div className="flex items-center justify-center h-24 lg:h-32">
-							<h1 className="text-4xl lg:text-5xl font-theylive transition-opacity duration-500">Buy & Sell Stuff with sats</h1>
+					<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-16 lg:mt-0 text-white text-center">
+						<div className="flex justify-center items-center h-24 lg:h-32">
+							<h1 className="font-theylive text-4xl lg:text-5xl transition-opacity duration-500">Buy & Sell Stuff with sats</h1>
 						</div>
 
 						<div className="flex flex-col gap-6">
-							<Button variant="focus" size="lg" onClick={handleStartSelling}>
+							<Button variant="secondary" size="lg" onClick={handleStartSelling}>
 								<span className="flex items-center gap-2">
-									<span className="i-nostr w-6 h-6"></span>Start Selling
+									<span className="size-6 i-nostr"></span>Start Selling
 								</span>
 							</Button>
 						</div>
@@ -125,17 +125,17 @@ function Index() {
 			</div>
 			{/* Tag Filter Bar */}
 			{defaultTags.length > 0 && (
-				<div className="sticky top-0 z-20 bg-off-black border-b shadow-sm">
+				<div className="top-0 z-20 sticky bg-off-black shadow-sm border-b">
 					<div className="px-4 py-3 overflow-x-auto">
 						<div className="flex items-center gap-2 min-w-max">
-							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="cursor-pointer transition-colors" onClick={handleClearFilter}>
+							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="transition-colors cursor-pointer" onClick={handleClearFilter}>
 								All
 							</Badge>
 							{defaultTags.map((tagName) => (
 								<Badge
 									key={tagName}
 									variant={tag === tagName ? 'primaryActive' : 'primary'}
-									className="cursor-pointer transition-colors"
+									className="transition-colors cursor-pointer"
 									onClick={() => handleTagClick(tagName)}
 								>
 									{tagName}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { useQuery } from '@tanstack/react-query'
 import { productsQueryOptions } from '@/queries/products'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { z } from 'zod'
+import { SelectableBadge } from '@/components/shared/SelectableBadge'
 
 // Hook to inject dynamic CSS for background image
 function useHeroBackground(imageUrl: string, className: string) {
@@ -128,18 +129,13 @@ function Index() {
 				<div className="top-0 z-20 sticky bg-off-black shadow-sm border-b">
 					<div className="px-4 py-3 overflow-x-auto">
 						<div className="flex items-center gap-2 min-w-max">
-							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="transition-colors cursor-pointer" onClick={handleClearFilter}>
+							<SelectableBadge isSelected className="transition-colors cursor-pointer" onClick={handleClearFilter}>
 								All
-							</Badge>
+							</SelectableBadge>
 							{defaultTags.map((tagName) => (
-								<Badge
-									key={tagName}
-									variant={tag === tagName ? 'primaryActive' : 'primary'}
-									className="transition-colors cursor-pointer"
-									onClick={() => handleTagClick(tagName)}
-								>
+								<SelectableBadge key={tagName} className="transition-colors cursor-pointer" onClick={() => handleTagClick(tagName)}>
 									{tagName}
-								</Badge>
+								</SelectableBadge>
 							))}
 						</div>
 					</div>

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -101,7 +101,7 @@ enum TabProductPage {
 const getIsTabDisabled = (tab: TabProductPage) => tab === TabProductPage.reviews
 
 const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView: boolean) => {
-	const wrapContent = (content: ReactNode) => <div className="rounded-lg bg-white p-6 shadow-md">{content}</div>
+	const wrapContent = (content: ReactNode) => <div className="bg-white shadow-md p-6 rounded-lg">{content}</div>
 
 	const summary = getProductSummary(eventProduct)
 	const description = getProductDescription(eventProduct)
@@ -114,8 +114,8 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 		case TabProductPage.description:
 			return wrapContent(
 				<>
-					{summary && <p className="text-gray-600 italic mb-4 pb-4 border-b border-gray-200">{summary}</p>}
-					<p className="whitespace-pre-wrap break-words text-gray-700">{description}</p>
+					{summary && <p className="mb-4 pb-4 border-gray-200 border-b text-gray-600 italic">{summary}</p>}
+					<p className="text-gray-700 break-words whitespace-pre-wrap">{description}</p>
 				</>,
 			)
 		case TabProductPage.spec:
@@ -124,16 +124,16 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 				<div className={className}>
 					{weightTag && (
 						<div className="flex flex-col">
-							<span className="text-base font-medium text-gray-500">Weight</span>
-							<span className="text-base text-gray-900">
+							<span className="font-medium text-gray-500 text-base">Weight</span>
+							<span className="text-gray-900 text-base">
 								{weightTag[1]} {weightTag[2]}
 							</span>
 						</div>
 					)}
 					{dimensionsTag && (
 						<div className="flex flex-col">
-							<span className="text-base font-medium text-gray-500">Dimensions (L×W×H)</span>
-							<span className="text-base text-gray-900 break-all">
+							<span className="font-medium text-gray-500 text-base">Dimensions (L×W×H)</span>
+							<span className="text-gray-900 text-base break-all">
 								{dimensionsTag[1]
 									.split('x')
 									.map((num) => parseFloat(num).toFixed(1))
@@ -144,24 +144,24 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 					)}
 					{specs.map((spec, index) => (
 						<div key={index} className="flex flex-col">
-							<span className="text-base font-medium text-gray-500 capitalize">{spec[1]}</span>
-							<span className="text-base text-gray-900 break-all">{spec[2]}</span>
+							<span className="font-medium text-gray-500 text-base capitalize">{spec[1]}</span>
+							<span className="text-gray-900 text-base break-all">{spec[2]}</span>
 						</div>
 					))}
-					{specs.length === 0 && !weightTag && !dimensionsTag && <p className="text-gray-700 col-span-2">No specifications available</p>}
+					{specs.length === 0 && !weightTag && !dimensionsTag && <p className="col-span-2 text-gray-700">No specifications available</p>}
 				</div>,
 			)
 		case TabProductPage.shipping:
 			return wrapContent(
 				<div className="flex flex-col gap-6">
 					<div className="flex items-center gap-3">
-						<Truck className="h-6 w-6 text-gray-500" />
-						<h3 className="text-lg font-medium">Shipping Options</h3>
+						<Truck className="w-6 h-6 text-gray-500" />
+						<h3 className="font-medium text-lg">Shipping Options</h3>
 					</div>
 
 					<div className="flex flex-wrap md:flex-nowrap gap-6">
 						<div className="w-full md:w-1/2 min-w-0">
-							<p className="text-sm text-gray-500 mb-4">Select a shipping method to see estimated costs and delivery times.</p>
+							<p className="mb-4 text-gray-500 text-sm">Select a shipping method to see estimated costs and delivery times.</p>
 
 							<div className="w-full">
 								<ShippingSelector
@@ -174,17 +174,17 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 							</div>
 
 							<div className="mt-4">
-								<p className="text-sm text-gray-500">Shipping costs will be added to the final price in the cart.</p>
+								<p className="text-gray-500 text-sm">Shipping costs will be added to the final price in the cart.</p>
 							</div>
 						</div>
 
-						<div className="w-full md:w-1/2 min-w-0 bg-gray-50 p-4 rounded-md">
-							<h4 className="font-medium mb-2">Shipping Information</h4>
+						<div className="bg-gray-50 p-4 rounded-md w-full md:w-1/2 min-w-0">
+							<h4 className="mb-2 font-medium">Shipping Information</h4>
 
 							{weightTag && (
 								<div className="flex flex-col mb-2">
-									<span className="text-base font-medium text-gray-500">Weight:</span>
-									<span className="text-base text-gray-900">
+									<span className="font-medium text-gray-500 text-base">Weight:</span>
+									<span className="text-gray-900 text-base">
 										{weightTag[1]} {weightTag[2]}
 									</span>
 								</div>
@@ -192,8 +192,8 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 
 							{dimensionsTag && (
 								<div className="flex flex-col mb-2">
-									<span className="text-base font-medium text-gray-500">Dimensions:</span>
-									<span className="text-base text-gray-900">
+									<span className="font-medium text-gray-500 text-base">Dimensions:</span>
+									<span className="text-gray-900 text-base">
 										<span className="break-all">{dimensionsTag[1]}</span> {dimensionsTag[2]}
 									</span>
 								</div>
@@ -201,12 +201,12 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 
 							{location && (
 								<div className="flex flex-col mb-2">
-									<span className="text-base font-medium text-gray-500">Ships from:</span>
-									<span className="text-base text-gray-900">{location}</span>
+									<span className="font-medium text-gray-500 text-base">Ships from:</span>
+									<span className="text-gray-900 text-base">{location}</span>
 								</div>
 							)}
 
-							<div className="mt-3 text-sm text-gray-500">Delivery times are estimates and may vary based on your location.</div>
+							<div className="mt-3 text-gray-500 text-sm">Delivery times are estimates and may vary based on your location.</div>
 						</div>
 					</div>
 				</div>,
@@ -321,8 +321,8 @@ function RouteComponent() {
 	// Keep this route resilient during relay warmup: don't error-boundary the whole page for transient misses.
 	if (!product && (productQuery.isLoading || productQuery.isFetching)) {
 		return (
-			<div className="flex h-[50vh] flex-col items-center justify-center gap-3 px-4 text-center">
-				<div className="animate-spin w-8 h-8 border-4 border-primary border-t-transparent rounded-full" />
+			<div className="flex flex-col justify-center items-center gap-3 px-4 h-[50vh] text-center">
+				<div className="border-4 border-primary border-t-transparent rounded-full w-8 h-8 animate-spin" />
 				<p className="text-muted-foreground">Loading product…</p>
 			</div>
 		)
@@ -330,10 +330,10 @@ function RouteComponent() {
 
 	if (!product && productQuery.isError) {
 		return (
-			<div className="flex h-[50vh] flex-col items-center justify-center gap-4 px-4 text-center">
-				<h1 className="text-2xl font-bold">Still loading product</h1>
+			<div className="flex flex-col justify-center items-center gap-4 px-4 h-[50vh] text-center">
+				<h1 className="font-bold text-2xl">Still loading product</h1>
 				<p className="text-gray-600">{productQuery.error instanceof Error ? productQuery.error.message : 'Please try again.'}</p>
-				<div className="flex flex-wrap items-center justify-center gap-2">
+				<div className="flex flex-wrap justify-center items-center gap-2">
 					<Button
 						variant="secondary"
 						onClick={() => {
@@ -352,8 +352,8 @@ function RouteComponent() {
 
 	if (!product) {
 		return (
-			<div className="flex h-[50vh] flex-col items-center justify-center gap-4 px-4 text-center">
-				<h1 className="text-2xl font-bold">Product Not Found</h1>
+			<div className="flex flex-col justify-center items-center gap-4 px-4 h-[50vh] text-center">
+				<h1 className="font-bold text-2xl">Product Not Found</h1>
 				<p className="text-gray-600">The product you're looking for doesn't exist (or hasn't propagated to relays yet).</p>
 				<Link to="/products" className="inline-flex">
 					<Button variant="outline">Back to products</Button>
@@ -366,17 +366,17 @@ function RouteComponent() {
 	const productIsNSFW = isNSFWProduct(product)
 	if (productIsNSFW && !showNSFWContent) {
 		return (
-			<div className="flex h-[50vh] flex-col items-center justify-center gap-4 px-4 text-center">
+			<div className="flex flex-col justify-center items-center gap-4 px-4 h-[50vh] text-center">
 				<AlertTriangle className="w-16 h-16 text-amber-500" />
-				<h1 className="text-2xl font-bold">Adult Content</h1>
-				<p className="text-gray-600 max-w-md">
+				<h1 className="font-bold text-2xl">Adult Content</h1>
+				<p className="max-w-md text-gray-600">
 					This product contains adult or sensitive content. To view it, you need to enable adult content viewing in your settings.
 				</p>
 				<div className="flex gap-3">
 					<Link to="/products" className="inline-flex">
 						<Button variant="outline">Back to products</Button>
 					</Link>
-					<Button variant="primary" onClick={() => uiActions.openNSFWConfirmation()} className="bg-amber-600 hover:bg-amber-700">
+					<Button onClick={() => uiActions.openNSFWConfirmation()} className="bg-amber-600 hover:bg-amber-700">
 						Enable adult content
 					</Button>
 				</div>
@@ -490,17 +490,17 @@ function RouteComponent() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="relative z-10">
+			<div className="z-10 relative">
 				<div className={`relative hero-container-product ${backgroundImageUrl ? `bg-hero-image ${heroClassName}` : 'bg-black'}`}>
 					<div className="hero-overlays">
 						<div className="absolute inset-0 bg-radial-overlay" />
-						<div className="absolute inset-0 opacity-30 bg-dots-overlay" />
+						<div className="absolute inset-0 bg-dots-overlay opacity-30" />
 					</div>
 
 					<div className="hero-content-product">
 						{!mobileMenuOpen && (
-							<button onClick={handleBackClick} className="back-button col-span-full">
-								<ArrowLeft className="h-4 w-6" />
+							<button onClick={handleBackClick} className="col-span-full back-button">
+								<ArrowLeft className="w-6 h-4" />
 								<span>Back to results</span>
 							</button>
 						)}
@@ -509,9 +509,9 @@ function RouteComponent() {
 							<ImageCarousel images={formattedImages} title={title} onImageClick={handleImageClick} />
 						</div>
 
-						<div className="flex flex-col gap-2 text-white w-full max-w-[600px] mx-auto lg:max-w-none">
-							<div className="flex items-center justify-between">
-								<h1 className="text-3xl font-semibold lg:pl-0">{title}</h1>
+						<div className="flex flex-col gap-2 mx-auto w-full max-w-[600px] lg:max-w-none text-white">
+							<div className="flex justify-between items-center">
+								<h1 className="lg:pl-0 font-semibold text-3xl">{title}</h1>
 								<div className="flex items-center gap-2">
 									{/* Entity Actions Menu for admins/editors/owners */}
 									<EntityActionsMenu
@@ -540,11 +540,9 @@ function RouteComponent() {
 							/>
 
 							{visibility === 'pre-order' ? (
-								<Badge variant="primary" className="bg-blue-500">
-									Pre-order
-								</Badge>
+								<Badge className="bg-blue-500">Pre-order</Badge>
 							) : (
-								<Badge variant="primary">{stock !== undefined ? `${stock} in stock` : 'Out of stock'}</Badge>
+								<Badge>{stock !== undefined ? `${stock} in stock` : 'Out of stock'}</Badge>
 							)}
 
 							{(() => {
@@ -572,18 +570,19 @@ function RouteComponent() {
 								<div className="flex items-center gap-4">
 									{/* Show cart controls for non-owners */}
 									{permissions.canAddToCart && (
-										<div className="flex items-center gap-2 flex-wrap">
-											<div className="flex items-center gap-2 flex-shrink-0">
+										<div className="flex flex-wrap items-center gap-2">
+											<div className="flex flex-shrink-0 items-center gap-2">
 												<Button
-													variant="tertiary"
+													variant="outline"
+													className="text-foreground"
 													size="icon"
 													onClick={() => setQuantity(Math.max(1, quantity - 1))}
 													disabled={quantity <= 1}
 												>
-													<Minus className="h-6 w-6" />
+													<Minus className="w-6 h-6" />
 												</Button>
 												<Input
-													className="w-12 text-center font-medium bg-white text-black"
+													className="bg-white w-12 font-medium text-black text-center"
 													value={quantity}
 													onChange={(e) => {
 														const value = parseInt(e.target.value)
@@ -596,12 +595,13 @@ function RouteComponent() {
 													type="number"
 												/>
 												<Button
-													variant="tertiary"
+													variant="outline"
+													className="text-foreground"
 													size="icon"
 													onClick={() => setQuantity(Math.min(stock || quantity + 1, quantity + 1))}
 													disabled={quantity >= (stock || quantity)}
 												>
-													<Plus className="h-6 w-6" />
+													<Plus className="w-6 h-6" />
 												</Button>
 											</div>
 											<Button variant="secondary" onClick={handleAddToCartClick} disabled={isOutOfStock || visibility === 'hidden'}>
@@ -618,7 +618,7 @@ function RouteComponent() {
 									{/* Show edit button for owners */}
 									{permissions.canEdit && (
 										<Button variant="secondary" onClick={handleEdit} className="flex items-center gap-2">
-											<Edit className="h-5 w-5" />
+											<Edit className="w-5 h-5" />
 											<span>Edit Product</span>
 										</Button>
 									)}
@@ -632,14 +632,14 @@ function RouteComponent() {
 						</div>
 					</div>
 				</div>
-				<div className="relative z-20 mx-auto max-w-7xl px-4 py-6 -mt-12">
+				<div className="z-20 relative mx-auto -mt-12 px-4 py-6 max-w-7xl">
 					{isMobileOrTablet ? (
 						<div className="flex flex-col gap-6">
 							{Object.values(TabProductPage).map(
 								(tab) =>
 									!getIsTabDisabled(tab) && (
 										<div>
-											<div className="bg-secondary text-white px-4 py-2 text-sm font-medium rounded-t-md">{tab}</div>
+											<div className="bg-secondary px-4 py-2 rounded-t-md font-medium text-white text-sm">{tab}</div>
 											{getTabContent(tab, product, true)}
 										</div>
 									),
@@ -647,12 +647,12 @@ function RouteComponent() {
 						</div>
 					) : (
 						<Tabs defaultValue={TabProductPage.description} value={currentTab} className="w-full">
-							<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-2 justify-start">
+							<TabsList className="flex flex-wrap justify-start gap-2 bg-transparent p-0 h-auto">
 								{Object.values(TabProductPage).map((tab) => (
 									<TabsTrigger
 										value={tab}
 										onClick={() => setCurrentTab(tab)}
-										className="px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+										className="data-[state=active]:bg-secondary data-[state=inactive]:bg-gray-100 px-4 py-2 rounded-none font-medium data-[state=active]:text-white data-[state=inactive]:text-black text-sm"
 										disabled={getIsTabDisabled(tab)}
 									>
 										{tab}
@@ -661,7 +661,7 @@ function RouteComponent() {
 							</TabsList>
 
 							{Object.values(TabProductPage).map((tab) => (
-								<TabsContent value={tab} className="mt-4 border-t-3 border-secondary bg-tertiary">
+								<TabsContent value={tab} className="bg-tertiary mt-4 border-secondary border-t-3">
 									{getTabContent(tab, product, false)}
 								</TabsContent>
 							))}
@@ -673,7 +673,7 @@ function RouteComponent() {
 			{/* More from this seller */}
 			{sellerProducts.filter((p) => p.id !== productId).length > 0 && (
 				<div className="flex flex-col gap-4 p-4">
-					<h2 className="font-heading text-2xl text-center lg:text-left">More from this seller</h2>
+					<h2 className="font-heading text-2xl lg:text-left text-center">More from this seller</h2>
 					<ItemGrid className="gap-4 sm:gap-8">
 						{sellerProducts
 							.filter((p) => p.id !== productId)

--- a/src/routes/products.index.tsx
+++ b/src/routes/products.index.tsx
@@ -222,18 +222,18 @@ function ProductsRoute() {
 
 	// Render homepage hero content
 	const renderHomepageHero = () => (
-		<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-4 lg:mt-0">
+		<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-4 lg:mt-0 text-white text-center">
 			{/* Button in same position as product image */}
-			<div className="mb-2 h-40 lg:h-48 flex items-center justify-center">
-				<Button variant="focus" size="lg" onClick={handleStartSelling}>
+			<div className="flex justify-center items-center mb-2 h-40 lg:h-48">
+				<Button variant="secondary" size="lg" onClick={handleStartSelling}>
 					<span className="flex items-center gap-2">
-						<span className="i-nostr w-6 h-6"></span>Start Selling
+						<span className="size-6 i-nostr"></span>Start Selling
 					</span>
 				</Button>
 			</div>
 
-			<div className="flex items-center justify-center h-16 lg:h-20">
-				<h1 className="text-2xl lg:text-4xl font-theylive transition-opacity duration-500">Browse Products</h1>
+			<div className="flex justify-center items-center h-16 lg:h-20">
+				<h1 className="font-theylive text-2xl lg:text-4xl transition-opacity duration-500">Browse Products</h1>
 			</div>
 
 			<div className="flex flex-col gap-4">
@@ -258,12 +258,12 @@ function ProductsRoute() {
 
 	// Render product hero content
 	const renderProductHero = () => (
-		<div className="flex flex-col items-center justify-center text-white text-center lg:col-span-2 relative z-20 mt-4 lg:mt-0">
+		<div className="z-20 relative flex flex-col justify-center items-center lg:col-span-2 mt-4 lg:mt-0 text-white text-center">
 			{/* Featured Product Image - Fixed size container */}
-			<div className="mb-2 w-40 h-40 lg:w-48 lg:h-48">
+			<div className="mb-2 w-40 lg:w-48 h-40 lg:h-48">
 				{backgroundImageUrl && (
 					<Link to={`/products/${currentProductId}`} className="block w-full h-full">
-						<div className="relative w-full h-full overflow-hidden rounded-lg shadow-xl ring-2 ring-white/20 hover:ring-secondary transition-all">
+						<div className="relative shadow-xl rounded-lg ring-2 ring-white/20 hover:ring-secondary w-full h-full overflow-hidden transition-all">
 							<img
 								src={backgroundImageUrl}
 								alt={displayTitle || 'Featured product'}
@@ -274,8 +274,8 @@ function ProductsRoute() {
 				)}
 			</div>
 
-			<div className="flex items-center justify-center h-16 lg:h-20">
-				<h1 className="text-2xl lg:text-4xl font-theylive transition-opacity duration-500">{displayTitle || 'Loading...'}</h1>
+			<div className="flex justify-center items-center h-16 lg:h-20">
+				<h1 className="font-theylive text-2xl lg:text-4xl transition-opacity duration-500">{displayTitle || 'Loading...'}</h1>
 			</div>
 
 			<div className="flex flex-col gap-4">
@@ -309,8 +309,8 @@ function ProductsRoute() {
 					onTouchEnd={handleTouchEnd}
 				>
 					<div className="hero-overlays">
-						<div className="absolute inset-0 bg-radial-overlay z-10 opacity-40" />
-						<div className="absolute inset-0 opacity-20 bg-dots-overlay z-10" />
+						<div className="z-10 absolute inset-0 bg-radial-overlay opacity-40" />
+						<div className="z-10 absolute inset-0 bg-dots-overlay opacity-20" />
 					</div>
 
 					<div className="hero-content">{renderHomepageHero()}</div>
@@ -324,26 +324,26 @@ function ProductsRoute() {
 					onTouchEnd={handleTouchEnd}
 				>
 					<div className="hero-overlays">
-						<div className="absolute inset-0 bg-radial-overlay z-10 opacity-40" />
-						<div className="absolute inset-0 opacity-20 bg-dots-overlay z-10" />
+						<div className="z-10 absolute inset-0 bg-radial-overlay opacity-40" />
+						<div className="z-10 absolute inset-0 bg-dots-overlay opacity-20" />
 					</div>
 
 					<div className="hero-content">{renderProductHero()}</div>
 				</div>
 			)}
 			{/* Tag Filter Bar */}
-			<div className="sticky top-0 z-20 bg-off-black border-b shadow-sm">
-				<div className="px-4 py-3 flex items-center justify-between gap-4">
-					<div className="overflow-x-auto flex-1">
+			<div className="top-0 z-20 sticky bg-off-black shadow-sm border-b">
+				<div className="flex justify-between items-center gap-4 px-4 py-3">
+					<div className="flex-1 overflow-x-auto">
 						<div className="flex items-center gap-2 min-w-max">
-							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="cursor-pointer transition-colors" onClick={handleClearFilter}>
+							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="transition-colors cursor-pointer" onClick={handleClearFilter}>
 								All
 							</Badge>
 							{defaultTags.map((tagName) => (
 								<Badge
 									key={tagName}
 									variant={tag === tagName ? 'primaryActive' : 'primary'}
-									className="cursor-pointer transition-colors"
+									className="transition-colors cursor-pointer"
 									onClick={() => handleTagClick(tagName)}
 								>
 									{tagName}

--- a/src/routes/products.index.tsx
+++ b/src/routes/products.index.tsx
@@ -22,6 +22,7 @@ import {
 } from '../queries/products'
 import { useConfigQuery } from '@/queries/config'
 import { useFeaturedProducts } from '@/queries/featured'
+import { SelectableBadge } from '@/components/shared/SelectableBadge'
 
 // Hook to inject dynamic CSS for background image
 function useHeroBackground(imageUrl: string, className: string) {
@@ -336,18 +337,18 @@ function ProductsRoute() {
 				<div className="flex justify-between items-center gap-4 px-4 py-3">
 					<div className="flex-1 overflow-x-auto">
 						<div className="flex items-center gap-2 min-w-max">
-							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="transition-colors cursor-pointer" onClick={handleClearFilter}>
+							<SelectableBadge isSelected={!tag} className="transition-colors cursor-pointer" onClick={handleClearFilter}>
 								All
-							</Badge>
+							</SelectableBadge>
 							{defaultTags.map((tagName) => (
-								<Badge
+								<SelectableBadge
 									key={tagName}
-									variant={tag === tagName ? 'primaryActive' : 'primary'}
+									isSelected={tag === tagName}
 									className="transition-colors cursor-pointer"
 									onClick={() => handleTagClick(tagName)}
 								>
 									{tagName}
-								</Badge>
+								</SelectableBadge>
 							))}
 						</div>
 					</div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -467,6 +467,58 @@ button {
 		overflow: hidden; /* Required alongside min-height: 0 for aspect-ratio in grid */
 	}
 
+	/* Components e.g. buttons */
+
+	button {
+  		cursor: pointer;
+	}
+
+	.btn-border-highlight {
+		background-color: var(--primary);
+		color: var(--primary-foreground);
+		
+		/* Border */
+		border: 2px solid var(--primary-border);
+		border-radius: 0.25rem; 
+		
+		/* Padding */
+		padding: 0.5rem; /* Matches 'p-2' (0.5rem) */
+		
+		/* Positioning */
+		position: relative;
+
+		& svg {
+			pointer-events: none;
+			flex-shrink: 0; /* Prevents shrinking */
+			/* If the icon doesn't have a size class, force it to 1rem (size-4) */
+			width: 1.5rem; /* Force w-6 (24px) if not set */
+			height: 1.5rem; /* Force h-6 (24px) if not set */
+			stroke-width: 2; /* Ensures "thicker" lines (Lucide default is usually 2) */
+		}
+		
+		/* Hover States */
+		&:hover {
+			background-color: transparent;
+			color: var(--primary-foreground-hover);
+			border-color: var(--primary-border-hover);
+			
+			/* Nested selector for span inside */
+			& > span {
+				color: var(--secondary);
+			}
+		}
+	}
+
+	.btn-border-highlight.btn-active {
+		background-color: var(--secondary);
+		color: var(--secondary-foreground);
+
+		&:hover {
+			background-color: var(--secondary);
+			color: var(--secondary-foreground);
+		}
+	}
+
 	/* Custom utility classes */
 	.bg-off-black {
 		background-color: var(--off-black);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -467,7 +467,7 @@ button {
 		overflow: hidden; /* Required alongside min-height: 0 for aspect-ratio in grid */
 	}
 
-	/* Components e.g. buttons */
+	/* Components e.g. buttons, input */
 
 	button {
   		cursor: pointer;
@@ -517,6 +517,22 @@ button {
 			background-color: var(--secondary);
 			color: var(--secondary-foreground);
 		}
+	}
+
+	/* Override focus ring for all inputs and form elements */
+	*:focus-visible {
+		outline: none !important;
+		box-shadow: none !important;
+		border: 1px solid var(--ring) !important;
+	}
+
+	/* Specifically for inputs, textareas, selects */
+	input:focus-visible,
+	textarea:focus-visible,
+	select:focus-visible {
+		outline: none !important;
+		box-shadow: none !important;
+		border: 2px solid var(--ring) !important;
 	}
 
 	/* Custom utility classes */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -470,20 +470,20 @@ button {
 	/* Components e.g. buttons, input */
 
 	button {
-  		cursor: pointer;
+		cursor: pointer;
 	}
 
 	.btn-border-highlight {
 		background-color: var(--primary);
 		color: var(--primary-foreground);
-		
+
 		/* Border */
 		border: 2px solid var(--primary-border);
-		border-radius: 0.25rem; 
-		
+		border-radius: 0.25rem;
+
 		/* Padding */
 		padding: 0.5rem; /* Matches 'p-2' (0.5rem) */
-		
+
 		/* Positioning */
 		position: relative;
 
@@ -495,13 +495,13 @@ button {
 			height: 1.5rem; /* Force h-6 (24px) if not set */
 			stroke-width: 2; /* Ensures "thicker" lines (Lucide default is usually 2) */
 		}
-		
+
 		/* Hover States */
 		&:hover {
 			background-color: transparent;
 			color: var(--primary-foreground-hover);
 			border-color: var(--primary-border-hover);
-			
+
 			/* Nested selector for span inside */
 			& > span {
 				color: var(--secondary);


### PR DESCRIPTION
- Reset the components that are part of the shadcn library in `components/ui`. 
- Added a script `shadcn_pull_components.sh` to update components
- Turned existing customization into wrappers, like `TooltipButton` and `SelectableBadge`, as well as css classes and manual definitions when applying to only specific files.