### PR TITLE
E2E: reduce flakiness

### DIFF
--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -69,6 +69,8 @@ export async function resetRemoteCartForUser(skHex: string): Promise<void> {
 	} finally {
 		relay.close()
 	}
+
+	console.log('    Reset remote cart for user.')
 }
 
 // --- Seeding functions ---

--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -518,27 +518,49 @@ export async function resetAppBlacklist() {
 	console.log(`    Reset app Blacklist.`)
 }
 
+/**
+ * @param addressItem Address of the item to be featured (e.g. 30402:<pubkey>:<dtag>)
+ * @param kindList kind of the "featured" list, either: 30405 (products), 30003 (collections) or 30000 (users)
+ * @param dTagList d-tag of the "featured" list, one of: product, user, or collection
+ */
+export async function seedAppFeaturedItem(
+	addressItem: string,
+	kindList: number,
+	dTagList: 'featured_products' | 'featured_collections' | 'featured_users',
+) {
+	const relay = await Relay.connect(RELAY_URL)
+
+	await publish(relay, TEST_APP_PRIVATE_KEY, {
+		kind: kindList,
+		created_at: Math.floor(Date.now() / 1000),
+		content: '',
+		tags: [
+			['d', dTagList],
+			['a', addressItem],
+		],
+	})
+}
+
 export async function resetAppFeaturedList() {
 	const relay = await Relay.connect(RELAY_URL)
-	const skAdmin = devUser1.sk
 
 	await Promise.all([
 		// Products
-		publish(relay, skAdmin, {
+		publish(relay, TEST_APP_PRIVATE_KEY, {
 			kind: 30405,
 			created_at: Math.floor(Date.now() / 1000),
 			content: '',
 			tags: [['d', 'featured_products']],
 		}),
 		// Collections
-		publish(relay, skAdmin, {
+		publish(relay, TEST_APP_PRIVATE_KEY, {
 			kind: 30003,
 			created_at: Math.floor(Date.now() / 1000),
 			content: '',
 			tags: [['d', 'featured_collections']],
 		}),
 		// Users
-		publish(relay, skAdmin, {
+		publish(relay, TEST_APP_PRIVATE_KEY, {
 			kind: 30000,
 			created_at: Math.floor(Date.now() / 1000),
 			content: '',

--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -5,9 +5,6 @@ import WebSocket from 'ws'
 import { devUser1, devUser2, WALLETED_USER_LUD16 } from '../../src/lib/fixtures'
 import { RELAY_URL, TEST_APP_PRIVATE_KEY, TEST_APP_PUBLIC_KEY } from '../test-config'
 import { isAddressableKind } from 'nostr-tools/kinds'
-import { SimplePool } from 'nostr-tools/pool'
-import type { Filter } from 'nostr-tools'
-import type { NostrEvent } from '@nostr-dev-kit/ndk'
 
 useWebSocketImplementation(WebSocket)
 
@@ -55,19 +52,6 @@ async function publish(relay: Relay, skHex: string, template: EventTemplate) {
 	return event
 }
 
-async function fetch(relay: Relay, filter: Filter): Promise<NostrEvent[]> {
-	const pool = new SimplePool()
-	const relays = [relay.url]
-
-	// One-time fetch using querySync (returns an array of events once received)
-	const events = await pool.querySync(relays, filter)
-
-	// Close the pool after fetching
-	pool.close(relays)
-
-	return events
-}
-
 export async function resetRemoteCartForUser(skHex: string): Promise<void> {
 	const relay = await Relay.connect(RELAY_URL)
 
@@ -87,33 +71,6 @@ export async function resetRemoteCartForUser(skHex: string): Promise<void> {
 	}
 
 	console.log('    Reset remote cart for user.')
-}
-
-export async function resetCollectionsByUser(skHex: string, pkHex: string): Promise<void> {
-	// Fetch all collections by user
-	const relay = await Relay.connect(RELAY_URL)
-
-	const events = await fetch(relay, { kinds: [30405], authors: [pkHex] })
-
-	if (events.length === 0) {
-		console.log('    No collections from user to delete, skipping.')
-		return
-	}
-
-	// Delete all collections by this user, simply by using id
-
-	const deletion: EventTemplate = {
-		kind: 5,
-		created_at: Math.floor(Date.now() / 1000),
-		content: '',
-		tags: [],
-	}
-
-	events.forEach((e) => deletion.tags.push(['e', e.id ?? '']))
-
-	await publish(relay, skHex, deletion)
-
-	console.log('    Deleted ' + events.length + ' collections from user.')
 }
 
 // --- Seeding functions ---
@@ -407,33 +364,6 @@ export async function seedProduct(
 
 	console.log(`    Published product: ${opts.title}`)
 	return event
-}
-
-export async function seedCollection(
-	skHex: string,
-	opts: {
-		name: string
-		description: string
-		summary: string
-	},
-) {
-	const relay = await Relay.connect(RELAY_URL)
-
-	const id = crypto.randomUUID()
-	const event: EventTemplate = {
-		kind: 30405,
-		content: opts.description,
-		created_at: Math.floor(Date.now() / 1000),
-		tags: [
-			['d', id],
-			['title', opts.name],
-			['summary', opts.summary],
-		],
-	}
-
-	await publish(relay, skHex, event)
-
-	console.log('    Created collection with ID: ' + id)
 }
 
 export async function seedComment(

--- a/e2e-new/scenarios/index.ts
+++ b/e2e-new/scenarios/index.ts
@@ -5,6 +5,9 @@ import WebSocket from 'ws'
 import { devUser1, devUser2, WALLETED_USER_LUD16 } from '../../src/lib/fixtures'
 import { RELAY_URL, TEST_APP_PRIVATE_KEY, TEST_APP_PUBLIC_KEY } from '../test-config'
 import { isAddressableKind } from 'nostr-tools/kinds'
+import { SimplePool } from 'nostr-tools/pool'
+import type { Filter } from 'nostr-tools'
+import type { NostrEvent } from '@nostr-dev-kit/ndk'
 
 useWebSocketImplementation(WebSocket)
 
@@ -52,6 +55,19 @@ async function publish(relay: Relay, skHex: string, template: EventTemplate) {
 	return event
 }
 
+async function fetch(relay: Relay, filter: Filter): Promise<NostrEvent[]> {
+	const pool = new SimplePool()
+	const relays = [relay.url]
+
+	// One-time fetch using querySync (returns an array of events once received)
+	const events = await pool.querySync(relays, filter)
+
+	// Close the pool after fetching
+	pool.close(relays)
+
+	return events
+}
+
 export async function resetRemoteCartForUser(skHex: string): Promise<void> {
 	const relay = await Relay.connect(RELAY_URL)
 
@@ -71,6 +87,33 @@ export async function resetRemoteCartForUser(skHex: string): Promise<void> {
 	}
 
 	console.log('    Reset remote cart for user.')
+}
+
+export async function resetCollectionsByUser(skHex: string, pkHex: string): Promise<void> {
+	// Fetch all collections by user
+	const relay = await Relay.connect(RELAY_URL)
+
+	const events = await fetch(relay, { kinds: [30405], authors: [pkHex] })
+
+	if (events.length === 0) {
+		console.log('    No collections from user to delete, skipping.')
+		return
+	}
+
+	// Delete all collections by this user, simply by using id
+
+	const deletion: EventTemplate = {
+		kind: 5,
+		created_at: Math.floor(Date.now() / 1000),
+		content: '',
+		tags: [],
+	}
+
+	events.forEach((e) => deletion.tags.push(['e', e.id ?? '']))
+
+	await publish(relay, skHex, deletion)
+
+	console.log('    Deleted ' + events.length + ' collections from user.')
 }
 
 // --- Seeding functions ---
@@ -364,6 +407,33 @@ export async function seedProduct(
 
 	console.log(`    Published product: ${opts.title}`)
 	return event
+}
+
+export async function seedCollection(
+	skHex: string,
+	opts: {
+		name: string
+		description: string
+		summary: string
+	},
+) {
+	const relay = await Relay.connect(RELAY_URL)
+
+	const id = crypto.randomUUID()
+	const event: EventTemplate = {
+		kind: 30405,
+		content: opts.description,
+		created_at: Math.floor(Date.now() / 1000),
+		tags: [
+			['d', id],
+			['title', opts.name],
+			['summary', opts.summary],
+		],
+	}
+
+	await publish(relay, skHex, event)
+
+	console.log('    Created collection with ID: ' + id)
 }
 
 export async function seedComment(

--- a/e2e-new/tests/app-settings.spec.ts
+++ b/e2e-new/tests/app-settings.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures'
 import { devUser1, devUser2, devUser3 } from '../../src/lib/fixtures'
 import { nip19 } from 'nostr-tools'
-import { resetAppBlacklist, resetAppFeaturedList } from 'e2e-new/scenarios'
+import { resetAppBlacklist, resetAppFeaturedList, seedAppFeaturedItem } from 'e2e-new/scenarios'
 import { npubEncode } from 'nostr-tools/nip19'
 import type { Page } from '@playwright/test'
 
@@ -143,14 +143,18 @@ test.describe('Featured Items', () => {
 	})
 
 	test('can remove a product from featured list', async ({ merchantPage }) => {
+		const dTag = `e2e-remove-${Date.now()}`
+		const productCoords = `30402:${devUser1.pk}:${dTag}`
+
+		await seedAppFeaturedItem(productCoords, 30405, 'featured_products')
+
 		await gotoAdminRoute(merchantPage, '/dashboard/app-settings/featured-items')
 		await expectPageHeading(merchantPage, 'Featured Items')
 
 		// Add a uniquely identifiable coordinate so the remove assertion targets the exact row
-		const dTag = `e2e-remove-${Date.now()}`
-		const productCoords = `30402:${devUser1.pk}:${dTag}`
-		await fillAndAdd(merchantPage, 'newProduct', productCoords)
-		await expectInputCleared(merchantPage, 'newProduct')
+		// await fillAndAdd(merchantPage, 'newProduct', productCoords)
+		// await expectInputCleared(merchantPage, 'newProduct')
+
 		await clickDestructiveButtonForText(merchantPage, `ID: ${dTag}`)
 	})
 

--- a/e2e-new/tests/app-settings.spec.ts
+++ b/e2e-new/tests/app-settings.spec.ts
@@ -151,10 +151,6 @@ test.describe('Featured Items', () => {
 		await gotoAdminRoute(merchantPage, '/dashboard/app-settings/featured-items')
 		await expectPageHeading(merchantPage, 'Featured Items')
 
-		// Add a uniquely identifiable coordinate so the remove assertion targets the exact row
-		// await fillAndAdd(merchantPage, 'newProduct', productCoords)
-		// await expectInputCleared(merchantPage, 'newProduct')
-
 		await clickDestructiveButtonForText(merchantPage, `ID: ${dTag}`)
 	})
 

--- a/e2e-new/tests/cart.spec.ts
+++ b/e2e-new/tests/cart.spec.ts
@@ -38,6 +38,18 @@ async function safeGoto(page: Page, url: string): Promise<void> {
 	await page.goto(url)
 }
 
+async function resetLocalStorageCart(page: Page): Promise<void> {
+	// Reset the browser/localstorage cart
+	await page.evaluate(() =>
+		window.sessionStorage.setItem(
+			'cart',
+			`{"version":1,"updatedAt":${Math.floor(Date.now() / 1000)},"cart":{"sellers":{},"products":{},"orders":{},"invoices":{}}}`,
+		),
+	)
+
+	console.log('    Cleared current cart in localstorage.')
+}
+
 /** Open the cart drawer via the basket icon in the header. */
 async function openCart(page: Page): Promise<void> {
 	await page
@@ -172,6 +184,8 @@ test.describe('Cart - Change Quantity', () => {
 	})
 
 	test('can decrement product quantity using the minus button', async ({ newUserPage }) => {
+		await resetLocalStorageCart(newUserPage)
+
 		await safeGoto(newUserPage, '/products')
 		await waitForProducts(newUserPage)
 

--- a/e2e-new/tests/collections.spec.ts
+++ b/e2e-new/tests/collections.spec.ts
@@ -1,7 +1,5 @@
 import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
-import { devUser1 } from '@/lib/fixtures'
-import { resetCollectionsByUser, seedCollection } from 'e2e-new/scenarios'
 
 test.use({ scenario: 'merchant' })
 
@@ -115,10 +113,6 @@ async function createCollection(
 	await expectCollectionVisible(page, fields.name)
 }
 
-test.beforeEach(async () => {
-	await resetCollectionsByUser(devUser1.sk, devUser1.pk)
-})
-
 test.describe('Collection Management', () => {
 	test('collections list page is accessible', async ({ merchantPage }) => {
 		await gotoCollections(merchantPage)
@@ -149,8 +143,7 @@ test.describe('Collection Management', () => {
 			summary: 'Updated summary',
 		}
 
-		// Seed pre-existing collection
-		await seedCollection(devUser1.sk, original)
+		await createCollection(merchantPage, original)
 
 		await gotoCollections(merchantPage)
 		await collectionEditButton(merchantPage, original.name).click()
@@ -159,12 +152,10 @@ test.describe('Collection Management', () => {
 		await expect(merchantPage.getByTestId('collection-description-input')).toHaveValue(original.description)
 		await expect(merchantPage.getByTestId('collection-summary-input')).toHaveValue(original.summary)
 
-		// Fill & submit updated info
-
 		await fillCollectionInfo(merchantPage, updated)
 		await submitCollection(merchantPage, 'Update Collection')
 
-		// Re-visit collections page to check contents
+		await expectCollectionVisible(merchantPage, updated.name)
 
 		await revisitCollectionsAndAssert(merchantPage, async () => {
 			await expectCollectionVisible(merchantPage, updated.name)

--- a/e2e-new/tests/collections.spec.ts
+++ b/e2e-new/tests/collections.spec.ts
@@ -1,5 +1,7 @@
 import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
+import { devUser1 } from '@/lib/fixtures'
+import { resetCollectionsByUser, seedCollection } from 'e2e-new/scenarios'
 
 test.use({ scenario: 'merchant' })
 
@@ -113,6 +115,10 @@ async function createCollection(
 	await expectCollectionVisible(page, fields.name)
 }
 
+test.beforeEach(async () => {
+	await resetCollectionsByUser(devUser1.sk, devUser1.pk)
+})
+
 test.describe('Collection Management', () => {
 	test('collections list page is accessible', async ({ merchantPage }) => {
 		await gotoCollections(merchantPage)
@@ -143,7 +149,8 @@ test.describe('Collection Management', () => {
 			summary: 'Updated summary',
 		}
 
-		await createCollection(merchantPage, original)
+		// Seed pre-existing collection
+		await seedCollection(devUser1.sk, original)
 
 		await gotoCollections(merchantPage)
 		await collectionEditButton(merchantPage, original.name).click()
@@ -152,10 +159,12 @@ test.describe('Collection Management', () => {
 		await expect(merchantPage.getByTestId('collection-description-input')).toHaveValue(original.description)
 		await expect(merchantPage.getByTestId('collection-summary-input')).toHaveValue(original.summary)
 
+		// Fill & submit updated info
+
 		await fillCollectionInfo(merchantPage, updated)
 		await submitCollection(merchantPage, 'Update Collection')
 
-		await expectCollectionVisible(merchantPage, updated.name)
+		// Re-visit collections page to check contents
 
 		await revisitCollectionsAndAssert(merchantPage, async () => {
 			await expectCollectionVisible(merchantPage, updated.name)

--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -569,7 +569,6 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 
 		// Verify the emoji appears with count
 		const commentContainer = buyerPage.getByTestId('product-comments')
-		await expect(commentContainer.getByText('❤️')).toBeVisible()
-		await expect(commentContainer.getByText('1')).toBeVisible()
+		await expect(commentContainer.getByText('❤️1', { exact: true })).toBeVisible()
 	})
 })

--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -74,23 +74,23 @@ const getCommentSubmitButtonReply = (comment: Locator) => comment.getByRole('but
 /**
  * Helper to get the reaction button locator
  */
-const getReactionButton = (page: Page): Locator => {
+const getReactionButton = (page: Page | Locator): Locator => {
 	return page.getByTestId('reaction-button')
 }
 
-const getReactionsList = (page: Page): Locator => {
+const getReactionsList = (page: Page | Locator): Locator => {
 	return page.getByTestId('reactions-list')
 }
 
-const getZapButton = (page: Page): Locator => {
+const getZapButton = (page: Page | Locator): Locator => {
 	return page.getByTestId('zap-button')
 }
 
-const getCommentButton = (page: Page): Locator => {
+const getCommentButton = (page: Page | Locator): Locator => {
 	return page.getByTestId('comment-button')
 }
 
-const getShareButton = (page: Page): Locator => {
+const getShareButton = (page: Page | Locator): Locator => {
 	return page.getByTestId('share-button')
 }
 
@@ -240,25 +240,27 @@ test.describe('Product Page - View Only (Unauthenticated)', () => {
 		if (!currentProductId) throw new Error('Product not seeded')
 		await unauthenticatedPage.goto(`/products/${currentProductId}`)
 
+		const headerContent = unauthenticatedPage.locator('.hero-content-product')
+
 		// Verify ReactionButton is visible
-		await expect(getReactionButton(unauthenticatedPage)).toBeVisible()
+		await expect(getReactionButton(headerContent)).toBeVisible()
 
 		// Verify ZapButton is visible
-		await expect(getZapButton(unauthenticatedPage)).toBeVisible()
+		await expect(getZapButton(headerContent)).toBeVisible()
 
 		// Verify CommentButton is visible
-		await expect(getCommentButton(unauthenticatedPage)).toBeVisible()
+		await expect(getCommentButton(headerContent)).toBeVisible()
 
 		// Verify ShareButton is visible
-		await expect(getShareButton(unauthenticatedPage)).toBeVisible()
+		await expect(getShareButton(headerContent)).toBeVisible()
 	})
 
-	test('should display ReactionsList for product reactions', async ({ buyerPage }) => {
+	test('should display ReactionsList for product reactions', async ({ unauthenticatedPage }) => {
 		if (!currentProductId) throw new Error('Product not seeded')
-		await buyerPage.goto(`/products/${currentProductId}`)
+		await unauthenticatedPage.goto(`/products/${currentProductId}`)
 
 		// Verify ReactionsList container exists (even if empty)
-		const reactionsList = getReactionsList(buyerPage)
+		const reactionsList = getReactionsList(unauthenticatedPage)
 		await expect(reactionsList).toBeAttached() // Use beAttached instead of beVisible since it might be empty
 	})
 
@@ -558,14 +560,11 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		const commentSocialInteractions = buyerPage.locator('[data-testid="product-comments"] .comment-social-interactions')
 		const commentReactionBtn = commentSocialInteractions.locator('[data-testid="reaction-button"]').first()
 
-		// Hover to open popover
-		await commentReactionBtn.hover()
+		// Click reaction button to select default reaction
+		await commentReactionBtn.click()
 
-		// Select emoji
-		await buyerPage.getByText('❤️').click()
-
-		// Verify reaction was added - check for filled state
-		await expect(commentReactionBtn).toHaveClass(/bg-neo-purple/)
+		// Check for reaction button to update to filled state (icon version/ghost variant)
+		await expect(commentReactionBtn.locator('.i-heart-fill')).toBeVisible()
 
 		// Verify the emoji appears with count
 		const commentContainer = buyerPage.getByTestId('product-comments')


### PR DESCRIPTION
Not a complete fix for tests, but an improvement for specific tests to be less flaky by hardening setup or UI actions.

Specifically targeted these tests:

- Featured Items > can remove a product from featured list
  - Seed item in setup instead of manually creating
- Cart - Change quantity > can decrement product quantity using the minus button
  - Reset local storage for cart
- ~~Collection Management > can edit a collection~~
  - ~~Seed collection instead of manually creating~~
- Product Page - Interactions & Social (Authenticated) > should allow adding reaction to a comment
  - Fixed error-prone locator
- Product Page - View Only (Unauthenticated) > should display SocialInteractions component at product level
  - Fixed error-prone locator
- Product Page - Interactions & Social (Authenticated) > should allow adding reaction to a comment
  - Click button instead of hover + click interaction

Test results [**master** vs. **this branch**] - 10 each:

- can remove a product from featured list - **3 failed** (master) - **no failures** (this)
- can decrement product quantity using the minus button - **no failures** (master) - **no failures** (this)
- ~~can edit a collection - **1 failed** (master) - **3 failed** (this)~~
- should display SocialInteractions component at product level - **10 failed** (master) -  **no failures** (this)
- should allow adding reaction to a comment: **10 failed** (master) - **2 failed** (this)

*Note: For practicality, the collections test is performing better with the manual creation instead of seeding. Thus I'll be keeping the old version and not changing the execution.*