### PR TITLE
test: stabilize product-page social interaction e2e selectors

### DIFF
--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -96,6 +96,10 @@ const getShareButton = (page: Page): Locator => {
 	return getProductHero(page).getByTestId('share-button')
 }
 
+const getPopoverContent = (page: Page): Locator => {
+	return page.locator('[data-slot="popover-content"]')
+}
+
 /**
  * Verifies the reaction button is in the "filled" (active) state.
  */
@@ -466,12 +470,15 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		// Hover to open popover
 		await reactionBtn.hover()
 
+		const popover = getPopoverContent(buyerPage)
+		await expect(popover).toBeVisible({ timeout: 5000 })
+
 		// Verify emojis appear
-		await expect(buyerPage.getByText('❤️')).toBeVisible({ timeout: 5000 })
-		await expect(buyerPage.getByText('😂')).toBeVisible()
-		await expect(buyerPage.getByText('🔥')).toBeVisible()
-		await expect(buyerPage.getByText('💰')).toBeVisible()
-		await expect(buyerPage.getByText('👀')).toBeVisible()
+		await expect(popover.getByRole('button', { name: '❤️' })).toBeVisible()
+		await expect(popover.getByRole('button', { name: '😂' })).toBeVisible()
+		await expect(popover.getByRole('button', { name: '🔥' })).toBeVisible()
+		await expect(popover.getByRole('button', { name: '💰' })).toBeVisible()
+		await expect(popover.getByRole('button', { name: '👀' })).toBeVisible()
 	})
 
 	test('can add a reaction by selecting an emoji', async ({ buyerPage }) => {
@@ -564,13 +571,23 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		await commentReactionBtn.hover()
 
 		// Select emoji
-		await buyerPage.getByText('❤️').click()
+		const popover = getPopoverContent(buyerPage)
+		await expect(popover).toBeVisible({ timeout: 5000 })
+		await popover.getByRole('button', { name: '❤️' }).click()
 
 		// Verify reaction was added - check for filled state
 		await expect(commentReactionBtn).toHaveClass(/bg-neo-purple/)
 
+<<<<<<< HEAD
 		// Verify the emoji appears with count
 		const commentContainer = buyerPage.getByTestId('product-comments')
 		await expect(commentContainer.getByText('❤️')).toBeVisible()
+=======
+		// Verify the reaction chip appears on the same comment with count 1
+		const commentReactionsList = commentSocialInteractions.getByTestId('reactions-list').first()
+		const reactionChip = commentReactionsList.getByRole('button', { name: /❤️/ })
+		await expect(reactionChip).toBeVisible()
+		await expect(reactionChip).toContainText('1')
+>>>>>>> 8e20ef62 (test: stabilize product-page social interaction selectors)
 	})
 })

--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -51,6 +51,12 @@ const getTabsList = (page: Page) => getTabsContainer(page).locator('[role="tabli
  */
 const getTabsPanels = (page: Page) => getTabsContainer(page).locator('[role="tabpanel"]')
 
+const getProductHero = (page: Page) => page.locator('.hero-content-product')
+
+const getProductLevelSocialInteractions = (page: Page): Locator => {
+	return getProductHero(page).getByTestId('social-interactions')
+}
+
 /**
  * Returns the comment input locator
  */
@@ -246,7 +252,11 @@ test.describe('Product Page - View Only (Unauthenticated)', () => {
 		if (!currentProductId) throw new Error('Product not seeded')
 		await unauthenticatedPage.goto(`/products/${currentProductId}`)
 
+		const productSocialInteractions = getProductLevelSocialInteractions(unauthenticatedPage)
+		await expect(productSocialInteractions).toBeVisible()
+
 		// Verify ReactionButton is visible
+<<<<<<< HEAD
 		await expect(getReactionButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
 
 		// Verify ZapButton is visible
@@ -257,6 +267,18 @@ test.describe('Product Page - View Only (Unauthenticated)', () => {
 
 		// Verify ShareButton is visible
 		await expect(getShareButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
+=======
+		await expect(productSocialInteractions.getByTestId('reaction-button')).toBeVisible()
+
+		// Verify ZapButton is visible
+		await expect(productSocialInteractions.getByTestId('zap-button')).toBeVisible()
+
+		// Verify CommentButton is visible
+		await expect(productSocialInteractions.getByTestId('comment-button')).toBeVisible()
+
+		// Verify ShareButton is visible
+		await expect(productSocialInteractions.getByTestId('share-button')).toBeVisible()
+>>>>>>> ca74b20b (test: align comment reaction assertion with rendered UI contract)
 	})
 
 	test('should display ReactionsList for product reactions', async ({ buyerPage }) => {
@@ -563,9 +585,12 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		// Wait for comment to load
 		await buyerPage.getByText('Existing seeded comment for testing.').waitFor()
 
-		// Find comment's reaction button
-		const commentSocialInteractions = buyerPage.locator('[data-testid="product-comments"] .comment-social-interactions')
-		const commentReactionBtn = commentSocialInteractions.locator('[data-testid="reaction-button"]').first()
+		const commentContainer = buyerPage.getByTestId('product-comments')
+		const commentItem = commentContainer.locator('div.relative.border-b.border-gray-200', {
+			has: buyerPage.getByText('Existing seeded comment for testing.'),
+		})
+		const commentSocialInteractions = commentItem.locator('.comment-social-interactions')
+		const commentReactionBtn = commentSocialInteractions.getByTestId('reaction-button')
 
 		// Hover to open popover
 		await commentReactionBtn.hover()
@@ -579,6 +604,7 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		await expect(commentReactionBtn).toHaveClass(/bg-neo-purple/)
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 		// Verify the emoji appears with count
 		const commentContainer = buyerPage.getByTestId('product-comments')
 		await expect(commentContainer.getByText('❤️')).toBeVisible()
@@ -589,5 +615,12 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 		await expect(reactionChip).toBeVisible()
 		await expect(reactionChip).toContainText('1')
 >>>>>>> 8e20ef62 (test: stabilize product-page social interaction selectors)
+=======
+		// Comment rows combine zaps and reactions as children, so there is no
+		// standalone `reactions-list` wrapper here. Assert against the combined
+		// post-action surface within this specific comment row instead.
+		const commentPostActionSurface = commentSocialInteractions.locator('div.flex.flex-wrap.gap-2')
+		await expect(commentPostActionSurface).toContainText(/❤️\s*1/)
+>>>>>>> ca74b20b (test: align comment reaction assertion with rendered UI contract)
 	})
 })

--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -80,7 +80,6 @@ const getCommentSubmitButtonReply = (comment: Locator) => comment.getByRole('but
 /**
  * Helper to get the reaction button locator
  */
-const getProductHero = (page: Page): Locator => page.locator('.hero-content-product')
 
 const getReactionButton = (page: Page): Locator => {
 	return getProductHero(page).getByTestId('reaction-button')
@@ -256,18 +255,6 @@ test.describe('Product Page - View Only (Unauthenticated)', () => {
 		await expect(productSocialInteractions).toBeVisible()
 
 		// Verify ReactionButton is visible
-<<<<<<< HEAD
-		await expect(getReactionButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
-
-		// Verify ZapButton is visible
-		await expect(getZapButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
-
-		// Verify CommentButton is visible
-		await expect(getCommentButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
-
-		// Verify ShareButton is visible
-		await expect(getShareButton(unauthenticatedPage)).toBeVisible({ timeout: 15000 })
-=======
 		await expect(productSocialInteractions.getByTestId('reaction-button')).toBeVisible()
 
 		// Verify ZapButton is visible
@@ -278,7 +265,6 @@ test.describe('Product Page - View Only (Unauthenticated)', () => {
 
 		// Verify ShareButton is visible
 		await expect(productSocialInteractions.getByTestId('share-button')).toBeVisible()
->>>>>>> ca74b20b (test: align comment reaction assertion with rendered UI contract)
 	})
 
 	test('should display ReactionsList for product reactions', async ({ buyerPage }) => {
@@ -602,25 +588,10 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 
 		// Verify reaction was added - check for filled state
 		await expect(commentReactionBtn).toHaveClass(/bg-neo-purple/)
-
-<<<<<<< HEAD
-<<<<<<< HEAD
-		// Verify the emoji appears with count
-		const commentContainer = buyerPage.getByTestId('product-comments')
-		await expect(commentContainer.getByText('❤️')).toBeVisible()
-=======
 		// Verify the reaction chip appears on the same comment with count 1
 		const commentReactionsList = commentSocialInteractions.getByTestId('reactions-list').first()
 		const reactionChip = commentReactionsList.getByRole('button', { name: /❤️/ })
 		await expect(reactionChip).toBeVisible()
 		await expect(reactionChip).toContainText('1')
->>>>>>> 8e20ef62 (test: stabilize product-page social interaction selectors)
-=======
-		// Comment rows combine zaps and reactions as children, so there is no
-		// standalone `reactions-list` wrapper here. Assert against the combined
-		// post-action surface within this specific comment row instead.
-		const commentPostActionSurface = commentSocialInteractions.locator('div.flex.flex-wrap.gap-2')
-		await expect(commentPostActionSurface).toContainText(/❤️\s*1/)
->>>>>>> ca74b20b (test: align comment reaction assertion with rendered UI contract)
 	})
 })


### PR DESCRIPTION
## Summary

This PR stabilizes product-page social interaction E2E coverage by tightening selectors and assertions to match the actual rendered UI contract.

## What changed

- scoped product-level social interaction button locators to the hero product interaction container
- tightened the comment-reaction assertion to the specific comment’s own interaction region
- avoided arbitrary sleeps and did not change application code

## Files changed

- `e2e-new/tests/product-page.spec.ts`

## Why

The previous test helpers were too broad:

- the zap-button locator matched multiple social interaction regions under Playwright strict mode
- the comment-reaction assertion was scoped to the overall comments container rather than the specific rendered comment interaction block

This patch keeps the stabilization narrowly focused on product-page E2E selectors.