### PR TITLE
fix: centralize product workflow step resolution

### DIFF
--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
 import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
-import { useV4VConfiguration } from '@/queries/v4v'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -16,18 +16,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { NameTab } from './NameTab'
 import { CategoryTab, DetailTab, ImagesTab, ShippingTab, SpecTab } from './tabs'
-import { shouldRequireV4VSetup } from './v4vSetup'
 
 export function ProductFormContent({
 	className = '',
 	showFooter = true,
 	productDTag,
 	productEventId,
+	workflow,
 }: {
 	className?: string
 	showFooter?: boolean
 	productDTag?: string | null
 	productEventId?: string | null
+	workflow?: ProductWorkflowResolution
 }) {
 	const [isPublishing, setIsPublishing] = useState(false)
 	const [hasDraft, setHasDraft] = useState(false)
@@ -36,7 +37,14 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { activeTab, editingProductId, isDirty, shippings, formSessionId, name, description, images } = formState
+	const { activeTab, editingProductId, isDirty, shippings, name, description, images } = formState
+	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
+		mode: editingProductId ? 'edit' : 'create',
+		isBootstrapReady: true,
+		initialTab: activeTab,
+		shouldStartAtShipping: false,
+		requiresV4VSetup: false,
+	}
 
 	// Compute validation states
 	const hasValidName = name.trim().length > 0
@@ -57,19 +65,10 @@ export function ProductFormContent({
 	const authState = useStore(authStore)
 	const userPubkey = authState.user?.pubkey || ''
 
-	// Check semantic V4V setup state for new products.
-	const { data: v4vConfiguration, isLoading: isLoadingV4V } = useV4VConfiguration(userPubkey)
-	const needsV4VSetup = shouldRequireV4VSetup({
-		editingProductId,
-		isLoadingV4V,
-		v4vConfigurationState: v4vConfiguration?.state ?? 'unknown',
-	})
-
 	// Check if user has any shipping options configured (for tab ordering)
 	// Query is only enabled when userPubkey is available
 	const {
 		data: userShippingOptions,
-		isLoading: isLoadingUserShipping,
 		isFetched: isShippingFetched,
 	} = useShippingOptionsByPubkey(userPubkey)
 
@@ -90,66 +89,16 @@ export function ProductFormContent({
 		)
 	}, [userShippingOptions])
 
-	// Determine if we should show shipping tab first (user has no shipping options)
-	const shouldShowShippingFirst = useMemo(() => {
-		// Don't redirect if editing an existing product
-		if (editingProductId) return false
-		// Don't redirect if pubkey not loaded yet (query is disabled)
-		if (!userPubkey) return false
-		// Don't redirect if we haven't fetched shipping data yet
-		if (!isShippingFetched) return false
-		// Don't redirect while loading
-		if (isLoadingUserShipping) return false
-		// Check if user has any non-deleted shipping options
-		// (query data might be cached and include deleted items)
-		if (!userShippingOptions || userShippingOptions.length === 0) return true
-		// Filter out any deleted shipping options from cached data
-		const activeShippingOptions = userShippingOptions.filter((event) => {
-			const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
-			return dTag ? !isShippingDeleted(dTag) : true
-		})
-		return activeShippingOptions.length === 0
-	}, [editingProductId, userShippingOptions, isLoadingUserShipping, userPubkey, isShippingFetched])
-
 	const hasValidShipping = useMemo(() => {
 		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
 	}, [shippings, isShippingFetched, resolvedShippingRefs])
 
-	// Set initial tab to Shipping when user has no shipping options
-	// Track which formSessionId we've handled to avoid re-triggering on same session
-	const handledSessionIdRef = useRef<number | null>(null)
-
-	useEffect(() => {
-		// Only auto-switch to shipping tab if:
-		// 1. We haven't handled this session yet
-		// 2. User should see shipping first (no shipping options)
-		// 3. We're NOT already on the shipping tab
-		if (handledSessionIdRef.current !== formSessionId && shouldShowShippingFirst && activeTab !== 'shipping') {
-			productFormActions.setActiveTab('shipping')
-			handledSessionIdRef.current = formSessionId
-		}
-	}, [shouldShowShippingFirst, activeTab, formSessionId])
-
-	// Track if we started with shipping first (no shipping options)
-	// This is used to determine if we should auto-navigate to name tab after first shipping is added
-	const startedWithShippingFirstRef = useRef<boolean>(false)
-
-	// Track if we've started with shipping first in this session
-	useEffect(() => {
-		if (shouldShowShippingFirst && activeTab === 'shipping') {
-			startedWithShippingFirstRef.current = true
-		}
-	}, [shouldShowShippingFirst, activeTab])
-
 	// Auto-navigate to 'name' tab after first shipping option is added when we started with shipping first
 	useEffect(() => {
-		if (startedWithShippingFirstRef.current && hasValidShipping && activeTab === 'shipping') {
-			// First shipping option added, navigate to name tab
+		if (resolvedWorkflow.shouldStartAtShipping && hasValidShipping && activeTab === 'shipping') {
 			productFormActions.setActiveTab('name')
-			// Reset the flag so we don't auto-navigate again
-			startedWithShippingFirstRef.current = false
 		}
-	}, [hasValidShipping, activeTab])
+	}, [resolvedWorkflow.shouldStartAtShipping, hasValidShipping, activeTab])
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {
@@ -385,8 +334,8 @@ export function ProductFormContent({
 							</Button>
 						)}
 
-						{/* Show 'Next' button when shipping tab is shown first and user is on shipping tab */}
-						{shouldShowShippingFirst && activeTab === 'shipping' && !hasValidShipping ? (
+						{/* Show 'Next' button when shipping tab is the resolved first step and user is still onboarding shipping */}
+						{resolvedWorkflow.shouldStartAtShipping && activeTab === 'shipping' && !hasValidShipping ? (
 							<Button
 								type="button"
 								variant="secondary"
@@ -401,7 +350,7 @@ export function ProductFormContent({
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
 								children={([canSubmit, isSubmitting]) => {
 									// Check if we need V4V setup for new products
-									if (needsV4VSetup && !editingProductId) {
+									if (resolvedWorkflow.requiresV4VSetup && !editingProductId) {
 										return (
 											<TooltipProvider>
 												<Tooltip>

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -86,16 +86,21 @@ export function ProductFormContent({
 		)
 	}, [userShippingOptions])
 
+	const hasSelectedShipping = useMemo(() => {
+		return shippings.some((ship) => !!ship.shippingRef)
+	}, [shippings])
+
 	const hasValidShipping = useMemo(() => {
 		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
 	}, [shippings, isShippingFetched, resolvedShippingRefs])
 
-	// Auto-navigate to 'name' tab after first shipping option is added when we started with shipping first
+	// Once the draft has a shipping reference, move out of the shipping-first bootstrap step
+	// without waiting for query cache propagation to catch up.
 	useEffect(() => {
-		if (resolvedWorkflow.shouldStartAtShipping && hasValidShipping && activeTab === 'shipping') {
+		if (resolvedWorkflow.shouldStartAtShipping && hasSelectedShipping && activeTab === 'shipping') {
 			productFormActions.setActiveTab('name')
 		}
-	}, [resolvedWorkflow.shouldStartAtShipping, hasValidShipping, activeTab])
+	}, [resolvedWorkflow.shouldStartAtShipping, hasSelectedShipping, activeTab])
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -67,10 +67,7 @@ export function ProductFormContent({
 
 	// Check if user has any shipping options configured (for tab ordering)
 	// Query is only enabled when userPubkey is available
-	const {
-		data: userShippingOptions,
-		isFetched: isShippingFetched,
-	} = useShippingOptionsByPubkey(userPubkey)
+	const { data: userShippingOptions, isFetched: isShippingFetched } = useShippingOptionsByPubkey(userPubkey)
 
 	const resolvedShippingRefs = useMemo(() => {
 		if (!userShippingOptions) return new Set<string>()

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -130,6 +130,25 @@ const cancelPendingSave = () => {
 	}
 }
 
+const createResetState = (
+	state: ProductFormState,
+	options?: {
+		activeTab?: ProductFormTab
+		editingProductId?: string | null
+	},
+): ProductFormState => {
+	const selectedCurrency = uiStore.state.selectedCurrency
+
+	return {
+		...DEFAULT_FORM_STATE,
+		formSessionId: state.formSessionId + 1,
+		activeTab: options?.activeTab ?? DEFAULT_FORM_STATE.activeTab,
+		editingProductId: options?.editingProductId ?? null,
+		currency: selectedCurrency === 'BTC' ? 'SATS' : selectedCurrency,
+		currencyMode: ['BTC', 'SATS'].includes(selectedCurrency) ? 'sats' : 'fiat',
+	}
+}
+
 const debouncedSave = () => {
 	cancelPendingSave()
 
@@ -307,10 +326,18 @@ export const productFormActions = {
 		})
 	},
 
+<<<<<<< HEAD
 	// Legacy compatibility alias.
 	// Prefer startCreateProductSession() for explicit create-mode initialization.
 	reset: () => {
 		productFormActions.startCreateProductSession()
+=======
+	reset: (options?: { activeTab?: ProductFormTab; editingProductId?: string | null }) => {
+		// Cancel any pending auto-save to prevent stale data from being written
+		cancelPendingSave()
+
+		productFormStore.setState((state) => createResetState(state, options))
+>>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 	},
 
 	updateValues: (values: Partial<ProductFormState>) => {
@@ -356,7 +383,7 @@ export const productFormActions = {
 		debouncedSave()
 	},
 
-	loadDraftForProduct: async (productId: string): Promise<boolean> => {
+	loadDraftForProduct: async (productId: string, options?: { activeTab?: ProductFormTab }): Promise<boolean> => {
 		try {
 			const draft = await getProductFormDraft(productId)
 			if (draft) {
@@ -368,6 +395,7 @@ export const productFormActions = {
 					...draftValues
 				} = draft
 
+<<<<<<< HEAD
 				const normalizedShippings = normalizeProductShippingSelections((draftValues.shippings as ProductShippingForm[] | undefined) ?? [])
 
 				productFormStore.setState((state) =>
@@ -379,6 +407,19 @@ export const productFormActions = {
 						isDirty: true,
 					}),
 				)
+=======
+				productFormStore.setState((state) => ({
+					...createResetState(state, {
+						activeTab: options?.activeTab ?? 'name',
+						editingProductId: draft.editingProductId ?? productId,
+					}),
+					...draft,
+					shippings: normalizedShippings,
+					activeTab: options?.activeTab ?? 'name',
+					// Mark as dirty since we're loading unsaved changes
+					isDirty: true,
+				}))
+>>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 				return true
 			}
 			return false

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -326,18 +326,11 @@ export const productFormActions = {
 		})
 	},
 
-<<<<<<< HEAD
-	// Legacy compatibility alias.
-	// Prefer startCreateProductSession() for explicit create-mode initialization.
-	reset: () => {
-		productFormActions.startCreateProductSession()
-=======
 	reset: (options?: { activeTab?: ProductFormTab; editingProductId?: string | null }) => {
 		// Cancel any pending auto-save to prevent stale data from being written
 		cancelPendingSave()
 
 		productFormStore.setState((state) => createResetState(state, options))
->>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 	},
 
 	updateValues: (values: Partial<ProductFormState>) => {
@@ -395,19 +388,8 @@ export const productFormActions = {
 					...draftValues
 				} = draft
 
-<<<<<<< HEAD
 				const normalizedShippings = normalizeProductShippingSelections((draftValues.shippings as ProductShippingForm[] | undefined) ?? [])
 
-				productFormStore.setState((state) =>
-					getFreshSessionState(state, {
-						...draftValues,
-						shippings: normalizedShippings,
-						editingProductId: productId,
-						activeTab: 'name',
-						isDirty: true,
-					}),
-				)
-=======
 				productFormStore.setState((state) => ({
 					...createResetState(state, {
 						activeTab: options?.activeTab ?? 'name',
@@ -419,7 +401,6 @@ export const productFormActions = {
 					// Mark as dirty since we're loading unsaved changes
 					isDirty: true,
 				}))
->>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 				return true
 			}
 			return false

--- a/src/lib/workflow/productWorkflowResolver.test.ts
+++ b/src/lib/workflow/productWorkflowResolver.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
+
+describe('resolveProductWorkflow', () => {
+	test('keeps edit sessions independent from create-only setup rules', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'edit',
+			editingProductId: 'product-123',
+			shippingState: 'empty',
+			v4vConfigurationState: 'never-configured',
+		})
+
+		expect(resolution).toEqual({
+			mode: 'edit',
+			isBootstrapReady: true,
+			initialTab: 'name',
+			shouldStartAtShipping: false,
+			requiresV4VSetup: false,
+		})
+	})
+
+	test('routes new sessions to shipping first when setup truth says shipping is empty', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'empty',
+			v4vConfigurationState: 'configured-zero',
+		})
+
+		expect(resolution.initialTab).toBe('shipping')
+		expect(resolution.shouldStartAtShipping).toBe(true)
+		expect(resolution.requiresV4VSetup).toBe(false)
+	})
+
+	test('waits for loading shipping truth before choosing an initial create step', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'loading',
+			v4vConfigurationState: 'loading',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(false)
+		expect(resolution.initialTab).toBe('name')
+	})
+
+	test('falls back to name when setup truth is unknown but keeps the result deterministic', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'unknown',
+			v4vConfigurationState: 'unknown',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(true)
+		expect(resolution.initialTab).toBe('name')
+	})
+
+	test('does not allow requestedTab to bypass shipping-first bootstrap in create flow', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'empty',
+			v4vConfigurationState: 'never-configured',
+			requestedTab: 'images',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(true)
+		expect(resolution.initialTab).toBe('shipping')
+		expect(resolution.requiresV4VSetup).toBe(true)
+	})
+
+	test('may honor requestedTab for create flow only when bootstrap policy is not forcing shipping', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'ready',
+			v4vConfigurationState: 'configured-zero',
+			requestedTab: 'images',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(true)
+		expect(resolution.initialTab).toBe('images')
+		expect(resolution.shouldStartAtShipping).toBe(false)
+	})
+
+	test('may honor requestedTab more freely in edit flow', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'edit',
+			editingProductId: 'product-123',
+			shippingState: 'empty',
+			v4vConfigurationState: 'never-configured',
+			requestedTab: 'images',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(true)
+		expect(resolution.initialTab).toBe('images')
+		expect(resolution.shouldStartAtShipping).toBe(false)
+		expect(resolution.requiresV4VSetup).toBe(false)
+	})
+})

--- a/src/lib/workflow/productWorkflowResolver.ts
+++ b/src/lib/workflow/productWorkflowResolver.ts
@@ -1,0 +1,51 @@
+import type { ProductFormTab } from '@/lib/stores/product'
+
+export type ProductWorkflowMode = 'create' | 'edit'
+
+export type ShippingSetupState = 'unknown' | 'loading' | 'empty' | 'ready'
+
+export type V4VSetupState = 'unknown' | 'loading' | 'never-configured' | 'configured-zero' | 'configured-nonzero'
+
+export type ProductWorkflowResolverInput = {
+	mode: ProductWorkflowMode
+	editingProductId?: string | null
+	shippingState: ShippingSetupState
+	v4vConfigurationState: V4VSetupState
+	requestedTab?: ProductFormTab | null
+}
+
+export type ProductWorkflowResolution = {
+	mode: ProductWorkflowMode
+	isBootstrapReady: boolean
+	initialTab: ProductFormTab
+	shouldStartAtShipping: boolean
+	requiresV4VSetup: boolean
+}
+
+export function resolveProductWorkflow(input: ProductWorkflowResolverInput): ProductWorkflowResolution {
+	const mode = input.mode === 'edit' || input.editingProductId ? 'edit' : 'create'
+	const requestedTab = input.requestedTab ?? null
+
+	if (mode === 'edit') {
+		const initialTab: ProductFormTab = requestedTab ?? 'name'
+
+		return {
+			mode,
+			isBootstrapReady: true,
+			initialTab,
+			shouldStartAtShipping: false,
+			requiresV4VSetup: false,
+		}
+	}
+
+	const shouldStartAtShipping = input.shippingState === 'empty'
+	const initialTab: ProductFormTab = shouldStartAtShipping ? 'shipping' : requestedTab ?? 'name'
+
+	return {
+		mode,
+		isBootstrapReady: input.shippingState !== 'loading',
+		initialTab,
+		shouldStartAtShipping,
+		requiresV4VSetup: input.v4vConfigurationState === 'never-configured',
+	}
+}

--- a/src/lib/workflow/productWorkflowResolver.ts
+++ b/src/lib/workflow/productWorkflowResolver.ts
@@ -39,7 +39,7 @@ export function resolveProductWorkflow(input: ProductWorkflowResolverInput): Pro
 	}
 
 	const shouldStartAtShipping = input.shippingState === 'empty'
-	const initialTab: ProductFormTab = shouldStartAtShipping ? 'shipping' : requestedTab ?? 'name'
+	const initialTab: ProductFormTab = shouldStartAtShipping ? 'shipping' : (requestedTab ?? 'name')
 
 	return {
 		mode,

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -1,6 +1,7 @@
 import { ProductFormContent } from '@/components/sheet-contents/NewProductContent'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
 import { authStore } from '@/lib/stores/auth'
 import { productFormActions } from '@/lib/stores/product'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
@@ -39,6 +40,12 @@ function EditProductComponent() {
 
 	// Get the d tag value - this is what we use for draft storage (consistent with editingProductId)
 	const productDTag = product ? getProductId(product) : null
+	const workflow = resolveProductWorkflow({
+		mode: 'edit',
+		editingProductId: productDTag,
+		shippingState: 'unknown',
+		v4vConfigurationState: 'unknown',
+	})
 
 	const initializeForm = useCallback(async () => {
 		if (!productDTag) return
@@ -47,6 +54,10 @@ function EditProductComponent() {
 
 		try {
 			setInitState('checking')
+			productFormActions.reset({
+				activeTab: workflow.initialTab,
+				editingProductId: productDTag,
+			})
 
 			// Use productDTag for draft lookup (same key used for saving)
 			const hasDraft = await hasProductFormDraft(productDTag)
@@ -54,17 +65,29 @@ function EditProductComponent() {
 			if (hasDraft) {
 				// Auto-load the draft instead of prompting
 				setInitState('loading-draft')
+<<<<<<< HEAD
 				await productFormActions.loadDraftForProduct(productDTag)
 				setInitState('ready')
 			} else {
 				setInitState('loading-product')
 				await productFormActions.loadProductForEdit(productId)
+=======
+				await productFormActions.loadDraftForProduct(productDTag, {
+					activeTab: workflow.initialTab,
+				})
+				setInitState('ready')
+			} else {
+				setInitState('loading-product')
+				await productFormActions.loadProductForEdit(productId, {
+					preserveTabState: { activeTab: workflow.initialTab },
+				})
+>>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 				setInitState('ready')
 			}
 		} finally {
 			lockRef.current = false
 		}
-	}, [productId, productDTag])
+	}, [productId, productDTag, workflow.initialTab])
 
 	// Effect to reset state when productId changes
 	useEffect(() => {
@@ -123,5 +146,5 @@ function EditProductComponent() {
 	}
 
 	// Ready to show the form - pass productDTag for draft checking and productId for reloading
-	return <ProductFormContent showFooter={true} productDTag={productDTag} productEventId={productId} />
+	return <ProductFormContent showFooter={true} productDTag={productDTag} productEventId={productId} workflow={workflow} />
 }

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -65,13 +65,6 @@ function EditProductComponent() {
 			if (hasDraft) {
 				// Auto-load the draft instead of prompting
 				setInitState('loading-draft')
-<<<<<<< HEAD
-				await productFormActions.loadDraftForProduct(productDTag)
-				setInitState('ready')
-			} else {
-				setInitState('loading-product')
-				await productFormActions.loadProductForEdit(productId)
-=======
 				await productFormActions.loadDraftForProduct(productDTag, {
 					activeTab: workflow.initialTab,
 				})
@@ -81,7 +74,6 @@ function EditProductComponent() {
 				await productFormActions.loadProductForEdit(productId, {
 					preserveTabState: { activeTab: workflow.initialTab },
 				})
->>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 				setInitState('ready')
 			}
 		} finally {

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -64,10 +64,6 @@ function NewProductComponent() {
 	)
 
 	useEffect(() => {
-<<<<<<< HEAD
-		productFormActions.startCreateProductSession()
-	}, [])
-=======
 		hasBootstrappedRef.current = false
 		setIsBootstrapped(false)
 	}, [userPubkey])
@@ -97,7 +93,6 @@ function NewProductComponent() {
 			</Card>
 		)
 	}
->>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 
 	return (
 		<div className="space-y-6">

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -1,8 +1,19 @@
 import { ProductFormContent } from '@/components/sheet-contents/NewProductContent'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { authStore } from '@/lib/stores/auth'
+import {
+	resolveProductWorkflow,
+	type ShippingSetupState,
+	type V4VSetupState,
+} from '@/lib/workflow/productWorkflowResolver'
 import { productFormActions } from '@/lib/stores/product'
+import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { useV4VConfiguration } from '@/queries/v4v'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { createFileRoute } from '@tanstack/react-router'
-import { useEffect } from 'react'
+import { useStore } from '@tanstack/react-store'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/products/products/new')({
 	component: NewProductComponent,
@@ -11,13 +22,90 @@ export const Route = createFileRoute('/_dashboard-layout/dashboard/products/prod
 function NewProductComponent() {
 	useDashboardTitle('Add a Product')
 
+	const { user } = useStore(authStore)
+	const userPubkey = user?.pubkey ?? ''
+	const [isBootstrapped, setIsBootstrapped] = useState(false)
+	const hasBootstrappedRef = useRef(false)
+
+	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
+	const v4vQuery = useV4VConfiguration(userPubkey)
+
+	const shippingState = useMemo<ShippingSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
+
+		const activeShippingRefs = new Set(
+			(shippingQuery.data ?? [])
+				.filter((event) => {
+					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
+					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+				})
+				.map((event) => {
+					const info = getShippingInfo(event)
+					return info ? createShippingReference(event.pubkey, info.id) : null
+				})
+				.filter((shippingRef): shippingRef is string => !!shippingRef),
+		)
+
+		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
+	}, [userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
+
+	const v4vState = useMemo<V4VSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (v4vQuery.isLoading) return 'loading'
+
+		return v4vQuery.data?.state ?? 'unknown'
+	}, [userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
+
+	const workflow = useMemo(
+		() =>
+			resolveProductWorkflow({
+				mode: 'create',
+				shippingState,
+				v4vConfigurationState: v4vState,
+			}),
+		[shippingState, v4vState],
+	)
+
 	useEffect(() => {
+<<<<<<< HEAD
 		productFormActions.startCreateProductSession()
 	}, [])
+=======
+		hasBootstrappedRef.current = false
+		setIsBootstrapped(false)
+	}, [userPubkey])
+
+	useEffect(() => {
+		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
+
+		productFormActions.reset({
+			activeTab: workflow.initialTab,
+			editingProductId: null,
+		})
+
+		hasBootstrappedRef.current = true
+		setIsBootstrapped(true)
+	}, [workflow.initialTab, workflow.isBootstrapReady])
+
+	if (!workflow.isBootstrapReady || !isBootstrapped) {
+		return (
+			<Card>
+				<CardContent className="p-8">
+					<div className="space-y-4">
+						<Skeleton className="h-8 w-48" />
+						<Skeleton className="h-4 w-full" />
+						<Skeleton className="h-4 w-3/4" />
+					</div>
+				</CardContent>
+			</Card>
+		)
+	}
+>>>>>>> 43565027 (Centralize product workflow bootstrap resolution)
 
 	return (
 		<div className="space-y-6">
-			<ProductFormContent showFooter={true} />
+			<ProductFormContent showFooter={true} workflow={workflow} />
 		</div>
 	)
 }

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -2,11 +2,7 @@ import { ProductFormContent } from '@/components/sheet-contents/NewProductConten
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { authStore } from '@/lib/stores/auth'
-import {
-	resolveProductWorkflow,
-	type ShippingSetupState,
-	type V4VSetupState,
-} from '@/lib/workflow/productWorkflowResolver'
+import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
 import { productFormActions } from '@/lib/stores/product'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useV4VConfiguration } from '@/queries/v4v'


### PR DESCRIPTION
Implements PR 6 of the #724 workstream.

## Summary

This PR implements PR 6 of the Add Product stabilization roadmap by introducing an explicit workflow resolver for create/edit bootstrap and initial step determination.

The goal is to move the Add Product flow from reactive correction to deterministic resolution.

## What this changes

- introduces a pure workflow resolver for Add Product bootstrap decisions
- centralizes create vs edit workflow mode handling
- centralizes initial tab/step determination
- centralizes shipping-first and create-only V4V setup gating decisions
- reduces effect-driven workflow correction inside `ProductFormContent`
- adds focused unit coverage for workflow bootstrap resolution

## Why

PRs 1–5 cleaned up key truth boundaries:

- create/edit session boundaries
- navigation vs draft mutation
- canonical shipping refs
- quick-create shipping identity
- semantic V4V state

But workflow bootstrap policy was still too distributed across component logic and async effect timing.

This PR makes the workflow decision engine explicit, centralized, and testable.

## What this PR intentionally does NOT do

This PR does **not**:

- redesign visible tab order
- redesign final V4V UX
- redesign publish validation/readiness
- change shipping truth model
- change V4V semantic truth model
- introduce a full workflow state machine

## Review focus

Please review this PR primarily for:

- purity and clarity of the resolver
- explicit create vs edit behavior
- deterministic initial-step resolution
- reduction of workflow policy in `ProductFormContent`
- preservation of prior PR 1–5 truth-boundary fixes

## Verification

Focused tests run:

- `bun test src/lib/workflow/productWorkflowResolver.test.ts src/lib/stores/product-navigation.test.ts src/components/sheet-contents/products/v4vSetup.test.ts`
- 15 passed