### PR TITLE
test: stabilize collections edit visibility assertion

### DIFF
--- a/e2e-new/tests/collections.spec.ts
+++ b/e2e-new/tests/collections.spec.ts
@@ -155,8 +155,6 @@ test.describe('Collection Management', () => {
 		await fillCollectionInfo(merchantPage, updated)
 		await submitCollection(merchantPage, 'Update Collection')
 
-		await expectCollectionVisible(merchantPage, updated.name)
-
 		await revisitCollectionsAndAssert(merchantPage, async () => {
 			await expectCollectionVisible(merchantPage, updated.name)
 			await expectCollectionAbsent(merchantPage, original.name)


### PR DESCRIPTION
## Summary

This PR stabilizes the collections edit E2E by reusing the existing revisit-and-retry helper for the post-update visibility check in `e2e-new/tests/collections.spec.ts`.

## Why

The collections edit failure was caused by asserting the updated title too eagerly on the first post-submit collections view, before the refreshed list reliably reflected the updated event.

This was an async visibility/refresh race in the E2E, not a proven collections product bug.

## Scope

Test-only:

* `e2e-new/tests/collections.spec.ts`

No application code changes.

## What changed

After `Update Collection`, the test now verifies the updated collection title through the existing `revisitCollectionsAndAssert(...)` helper instead of expecting the updated list entry immediately on the first returned view.

## Verification

* `bun test:e2e-new -- collections.spec.ts`
* 4 passed