### PR TITLE
E2E: Fix - product page test

### DIFF
--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -546,11 +546,11 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 
 		// Seed a reaction from someone else, then we add ours
 		await seedExistingReaction('👀')
+		await seedExistingReaction('👀', devUser2.sk)
 
 		await buyerPage.goto(`/products/${currentProductId}`)
 
 		const reactionBtn = getReactionsList(buyerPage).getByRole('button', { name: '👀' })
-		await reactionBtn.click()
 
 		// Now try to remove it by clicking the button again (toggle behavior)
 		await reactionBtn.click()

--- a/e2e-new/tests/product-page.spec.ts
+++ b/e2e-new/tests/product-page.spec.ts
@@ -1,4 +1,3 @@
-// e2e-new/tests/product-page-view.spec.ts
 import { test, expect } from '../fixtures'
 import { Relay } from 'nostr-tools/relay'
 import { RELAY_URL } from 'e2e-new/test-config'
@@ -544,8 +543,8 @@ test.describe('Product Page - Interactions & Social (Authenticated)', () => {
 	test('can remove a reaction by clicking the existing one in the list', async ({ buyerPage }) => {
 		if (!currentProductId) throw new Error('Product not seeded')
 
-		// Seed a reaction from someone else, then we add ours
-		await seedExistingReaction('👀')
+		// Seed a reaction from someone else as well as own user
+		await seedExistingReaction('👀', devUser3.sk)
 		await seedExistingReaction('👀', devUser2.sk)
 
 		await buyerPage.goto(`/products/${currentProductId}`)


### PR DESCRIPTION
Simple improvement for an e2e test which was failing on my side (possibly flaky).

Implementation uses a pre-seeded reaction from the own user instead of relying on two UI transactions, one of which is purely setup.