### PR TITLE
auctions: fix tie-break winner ordering

### DIFF
--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -92,7 +92,7 @@ describe('auctionSettlement helpers', () => {
 		expect(bobChain?.chain.map((bid) => bid.id)).toEqual(['bob-1'])
 	})
 
-	test('compareAuctionBidChainPriority prefers higher amount, then later timestamp, then lexicographic id', () => {
+	test('compareAuctionBidChainPriority prefers higher amount, then earlier timestamp, then lexicographic id', () => {
 		const lower = {
 			bidderPubkey: 'alice',
 			latestBid: makeBid({ id: 'a', pubkey: 'alice', amount: 1000, createdAt: 10 }),
@@ -103,15 +103,32 @@ describe('auctionSettlement helpers', () => {
 			latestBid: makeBid({ id: 'b', pubkey: 'bob', amount: 1200, createdAt: 5 }),
 			chain: [],
 		}
-		const laterTie = {
+		const earlierTie = {
 			bidderPubkey: 'carol',
-			latestBid: makeBid({ id: 'c', pubkey: 'carol', amount: 1200, createdAt: 6 }),
+			latestBid: makeBid({ id: 'c', pubkey: 'carol', amount: 1200, createdAt: 4 }),
 			chain: [],
 		}
 
-		const sorted = [lower, higher, laterTie].sort(compareAuctionBidChainPriority)
+		const sorted = [lower, higher, earlierTie].sort(compareAuctionBidChainPriority)
 
 		expect(sorted.map((entry) => entry.latestBid.id)).toEqual(['c', 'b', 'a'])
+	})
+
+	test('compareAuctionBidChainPriority prefers smaller event id when amount and created_at match', () => {
+		const smallerId = {
+			bidderPubkey: 'alice',
+			latestBid: makeBid({ id: 'aaa', pubkey: 'alice', amount: 1200, createdAt: 5 }),
+			chain: [],
+		}
+		const largerId = {
+			bidderPubkey: 'bob',
+			latestBid: makeBid({ id: 'bbb', pubkey: 'bob', amount: 1200, createdAt: 5 }),
+			chain: [],
+		}
+
+		const sorted = [largerId, smallerId].sort(compareAuctionBidChainPriority)
+
+		expect(sorted.map((entry) => entry.latestBid.id)).toEqual(['aaa', 'bbb'])
 	})
 
 	test('resolveAuctionVersionSet pins the first publish as root and ignores immutable changes', () => {

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -287,8 +287,8 @@ export const compareAuctionBidChainPriority = (left: AuctionBidChainGroup, right
 	const amountDelta = getAuctionBidAmount(right.latestBid) - getAuctionBidAmount(left.latestBid)
 	if (amountDelta !== 0) return amountDelta
 
-	const createdAtDelta = (right.latestBid.created_at || 0) - (left.latestBid.created_at || 0)
+	const createdAtDelta = (left.latestBid.created_at || 0) - (right.latestBid.created_at || 0)
 	if (createdAtDelta !== 0) return createdAtDelta
 
-	return right.latestBid.id.localeCompare(left.latestBid.id)
+	return left.latestBid.id.localeCompare(right.latestBid.id)
 }


### PR DESCRIPTION
## Summary

This is a narrow correctness fix against the auctions branch behind PR #815.

It aligns `compareAuctionBidChainPriority` with the documented winner-selection semantics:

1. higher amount wins
2. if equal amount, earlier `created_at` wins
3. if same `created_at`, lexicographically smaller bid event ID wins

## Changes

- flipped the timestamp tie-break direction in `src/lib/auctionSettlement.ts`
- flipped the final event-id tie-break direction in `src/lib/auctionSettlement.ts`
- updated the existing settlement ordering test to match the intended rule
- added a regression test for exact timestamp ties where smaller event ID should win

## Scope

Intentionally narrow.

Touched only:

- `src/lib/auctionSettlement.ts`
- `src/lib/__tests__/auctionSettlement.test.ts`

No wallet, oracle, publish flow, UI, or dependency changes.

## Why

The previous comparator preferred the opposite ordering on ties, which could select the wrong winner relative to the documented auction rule.

## Validation

Ran:

- `bun test src/lib/__tests__/auctionSettlement.test.ts`

Result:

- 5 pass
- 0 fail