### PR TITLE
style: product tags horizontal scroll bar

### DIFF
--- a/src/routes/auctions.index.tsx
+++ b/src/routes/auctions.index.tsx
@@ -324,7 +324,7 @@ function AuctionsRoute() {
 
 			<div className="sticky top-0 z-20 bg-off-black border-b shadow-sm">
 				<div className="px-4 py-3 flex items-center justify-between gap-4">
-					<div className="overflow-x-auto flex-1">
+					<div className="hide-scrollbar overflow-x-auto flex-1">
 						<div className="flex items-center gap-2 min-w-max">
 							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="cursor-pointer transition-colors" onClick={handleClearFilter}>
 								All

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -126,7 +126,7 @@ function Index() {
 			{/* Tag Filter Bar */}
 			{defaultTags.length > 0 && (
 				<div className="sticky top-0 z-20 bg-off-black border-b shadow-sm">
-					<div className="px-4 py-3 overflow-x-auto">
+					<div className="hide-scrollbar overflow-x-auto px-4 py-3">
 						<div className="flex items-center gap-2 min-w-max">
 							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="cursor-pointer transition-colors" onClick={handleClearFilter}>
 								All

--- a/src/routes/products.index.tsx
+++ b/src/routes/products.index.tsx
@@ -334,7 +334,7 @@ function ProductsRoute() {
 			{/* Tag Filter Bar */}
 			<div className="sticky top-0 z-20 bg-off-black border-b shadow-sm">
 				<div className="px-4 py-3 flex items-center justify-between gap-4">
-					<div className="overflow-x-auto flex-1">
+					<div className="hide-scrollbar overflow-x-auto flex-1">
 						<div className="flex items-center gap-2 min-w-max">
 							<Badge variant={!tag ? 'primaryActive' : 'primary'} className="cursor-pointer transition-colors" onClick={handleClearFilter}>
 								All

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -78,6 +78,15 @@
 	font-synthesis: none;
 }
 
+.hide-scrollbar {
+	-ms-overflow-style: none;
+	scrollbar-width: none;
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+	display: none;
+}
+
 /* Add specific sizes for different heading levels */
 h1.font-heading {
 	font-size: 2.4rem;


### PR DESCRIPTION
This change removes the custom tag scroller approach and keeps the implementation simple by using the existing horizontal overflow behavior with hidden scrollbars for the homepage, products, and auctions tag bars.

https://github.com/user-attachments/assets/647a4e29-30cf-44d6-8faa-40cdaf81b8ea

closes #775