### PR TITLE
Fixed homepage alternate color handling

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -3,8 +3,9 @@ import { getCollectionId, getCollectionImages, getCollectionSummary, getCollecti
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { Link, useLocation } from '@tanstack/react-router'
 import { UserCard } from './UserCard'
+import { cn } from '@/lib/utils'
 
-export function CollectionCard({ collection }: { collection: NDKEvent }) {
+export function CollectionCard({ collection, className }: { collection: NDKEvent } & React.HTMLAttributes<'div'>) {
 	const title = getCollectionTitle(collection)
 	const collectionId = getCollectionId(collection)
 	const pubkey = collection.pubkey
@@ -18,7 +19,7 @@ export function CollectionCard({ collection }: { collection: NDKEvent }) {
 		uiActions.setCollectionSourcePath(location.pathname)
 	}
 	return (
-		<div className="border border-zinc-800 rounded-lg bg-white shadow-sm flex flex-col" data-testid="product-card">
+		<div className={cn('border border-zinc-800 rounded-lg bg-white shadow-sm flex flex-col', className)} data-testid="product-card">
 			{/* Square aspect ratio container for image */}
 			<Link
 				to={`/collection/${collectionId}`}

--- a/src/components/FeaturedSections.tsx
+++ b/src/components/FeaturedSections.tsx
@@ -18,7 +18,7 @@ interface FeaturedSectionsProps {
 }
 
 // Component for displaying a featured product
-function FeaturedProductItem({ productCoords }: { productCoords: string }) {
+function FeaturedProductItem({ productCoords, ...props }: { productCoords: string } & React.HTMLAttributes<HTMLDivElement>) {
 	// Extract pubkey and dTag from coordinates (format: kind:pubkey:dtag)
 	const [, pubkey, dTag] = productCoords.split(':')
 
@@ -39,11 +39,11 @@ function FeaturedProductItem({ productCoords }: { productCoords: string }) {
 
 	if (!product) return null
 
-	return <ProductCard product={product} />
+	return <ProductCard product={product} {...props} />
 }
 
 // Component for displaying a featured collection
-function FeaturedCollectionItem({ collectionCoords }: { collectionCoords: string }) {
+function FeaturedCollectionItem({ collectionCoords, ...props }: { collectionCoords: string } & React.HTMLAttributes<'div'>) {
 	// Extract pubkey and dTag from coordinates (format: kind:pubkey:dtag)
 	const coordsParts = collectionCoords.split(':')
 	const pubkey = coordsParts[1] || ''
@@ -66,7 +66,7 @@ function FeaturedCollectionItem({ collectionCoords }: { collectionCoords: string
 
 	if (!collection) return null
 
-	return <CollectionCard collection={collection} />
+	return <CollectionCard collection={collection} {...props} />
 }
 
 // FeaturedUserItem has been replaced with FeaturedUserCard component
@@ -85,21 +85,23 @@ export function FeaturedSections({ className, maxItemsPerSection = 5 }: Featured
 
 	// Track section index for alternating backgrounds
 	let sectionIndex = 0
+	let classNameDark = 'bg-foreground text-background color-background'
+	let classNameLight = 'bg-background text-foreground color-foreground'
 
 	return (
 		<div className={cn('w-full max-w-full overflow-hidden', className)}>
 			{/* Featured Products */}
 			{displayProducts.length > 0 && (
-				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ % 2 === 0 ? 'bg-transparent' : 'bg-off-black')}>
+				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ /* Increment section index */)}>
 					<div className="px-4 sm:px-8 max-w-full">
 						<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-2">
 							<div className="flex items-center gap-3">
-								<Package className="w-6 h-6 text-primary shrink-0" />
+								<Package className="w-6 h-6 shrink-0" />
 								<h2 className="text-xl sm:text-2xl font-heading">Featured Products</h2>
 							</div>
 							{featuredProducts?.featuredProducts && featuredProducts.featuredProducts.length > maxItemsPerSection && (
 								<div className="w-full sm:w-auto flex justify-end">
-									<Link to="/products" className="flex items-center gap-2 text-primary hover:underline">
+									<Link to="/products" className="flex items-center gap-2 hover:underline">
 										<Button variant="ghost" size="sm" className="gap-2">
 											View All <ArrowRight className="w-4 h-4" />
 										</Button>
@@ -118,16 +120,16 @@ export function FeaturedSections({ className, maxItemsPerSection = 5 }: Featured
 
 			{/* Featured Collections */}
 			{displayCollections.length > 0 && (
-				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ % 2 === 0 ? 'bg-transparent' : 'bg-off-black')}>
+				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ % 2 === 0 ? 'bg-transparent' : classNameDark)}>
 					<div className="px-4 sm:px-8 max-w-full">
 						<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-2">
 							<div className="flex items-center gap-3">
-								<FolderOpen className="w-6 h-6 text-primary text-white shrink-0" />
-								<h2 className="text-xl sm:text-2xl font-heading text-white">Featured Collections</h2>
+								<FolderOpen className="w-6 h-6 shrink-0" />
+								<h2 className="text-xl sm:text-2xl font-heading">Featured Collections</h2>
 							</div>
 							{featuredCollections?.featuredCollections && featuredCollections.featuredCollections.length > maxItemsPerSection && (
 								<div className="w-full sm:w-auto flex justify-end">
-									<Link to="/collections" className="flex items-center gap-2 text-primary hover:underline">
+									<Link to="/collections" className="flex items-center gap-2 hover:underline">
 										<Button variant="ghost" size="sm" className="gap-2">
 											View All <ArrowRight className="w-4 h-4" />
 										</Button>
@@ -137,7 +139,7 @@ export function FeaturedSections({ className, maxItemsPerSection = 5 }: Featured
 						</div>
 						<ItemGrid className="gap-4 sm:gap-8">
 							{displayCollections.map((collectionCoords: string) => (
-								<FeaturedCollectionItem key={collectionCoords} collectionCoords={collectionCoords} />
+								<FeaturedCollectionItem key={collectionCoords} collectionCoords={collectionCoords} className={classNameLight} />
 							))}
 						</ItemGrid>
 					</div>
@@ -146,17 +148,17 @@ export function FeaturedSections({ className, maxItemsPerSection = 5 }: Featured
 
 			{/* Featured Users */}
 			{displayUsers.length > 0 && (
-				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ % 2 === 0 ? 'bg-transparent' : 'bg-off-black')}>
+				<section className={cn('w-full max-w-full py-12 overflow-hidden', sectionIndex++ % 2 === 0 ? 'bg-transparent' : classNameDark)}>
 					<div className="px-4 sm:px-8 max-w-full">
 						<div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-2">
 							<div className="flex items-center gap-3">
-								<Users className="w-6 h-6 text-primary shrink-0" />
+								<Users className="w-6 h-6 shrink-0" />
 								<h2 className="text-xl sm:text-2xl font-heading">Featured Sellers</h2>
 							</div>
 						</div>
 						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
 							{displayUsers.map((userPubkey: string) => (
-								<FeaturedUserCard key={userPubkey} userPubkey={userPubkey} />
+								<FeaturedUserCard key={userPubkey} userPubkey={userPubkey} className={classNameLight} />
 							))}
 						</div>
 					</div>

--- a/src/components/FeaturedUserCard.tsx
+++ b/src/components/FeaturedUserCard.tsx
@@ -11,61 +11,8 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { nip19 } from 'nostr-tools'
 
-interface FeaturedUserCardProps {
+interface FeaturedUserCardProps extends React.HTMLAttributes<'div'> {
 	userPubkey: string
-}
-
-// Mini product card component for displaying user's products
-function MiniProductCard({ productCoords }: { productCoords: string }) {
-	// Extract pubkey and dTag from coordinates (format: kind:pubkey:dtag)
-	const [, pubkey, dTag] = productCoords.split(':')
-
-	const { data: product, isLoading } = useQuery({
-		...productByATagQueryOptions(pubkey, dTag),
-		enabled: !!(pubkey && dTag),
-	})
-
-	if (isLoading) {
-		return (
-			<div className="animate-pulse">
-				<div className="bg-gray-200 aspect-square rounded-lg mb-1"></div>
-				<div className="bg-gray-200 h-3 rounded"></div>
-			</div>
-		)
-	}
-
-	if (!product) return null
-
-	const title = getProductTitle(product)
-	const images = getProductImages(product)
-	const priceTag = getProductPrice(product)
-
-	// Extract price amount and currency from tuple: ['price', amount, currency]
-	const priceAmount = priceTag?.[1]
-	const priceCurrency = priceTag?.[2]
-	const priceDisplay = priceAmount && priceCurrency ? `${priceAmount} ${priceCurrency}` : 'Price not set'
-
-	return (
-		<Link to="/product/$productId" params={{ productId: product.id }} className="block">
-			<div className="group cursor-pointer">
-				<div className="aspect-square rounded-lg overflow-hidden mb-2 bg-gray-100">
-					{images && images.length > 0 ? (
-						<img
-							src={images[0][1]}
-							alt={title}
-							className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
-						/>
-					) : (
-						<div className="w-full h-full bg-gray-200 flex items-center justify-center">
-							<span className="text-gray-400 text-xs">No Image</span>
-						</div>
-					)}
-				</div>
-				<h4 className="text-xs font-medium truncate">{title}</h4>
-				<p className="text-xs text-gray-600">{priceDisplay}</p>
-			</div>
-		</Link>
-	)
 }
 
 export function FeaturedUserCard({ userPubkey }: FeaturedUserCardProps) {
@@ -93,10 +40,10 @@ export function FeaturedUserCard({ userPubkey }: FeaturedUserCardProps) {
 	const picture = profile?.picture
 
 	return (
-		<Card className="hover:shadow-lg h-[200px] transition-shadow bg-white overflow-hidden">
+		<Card className="hover:shadow-lg h-50 transition-shadow bg-background overflow-hidden py-0">
 			<div className="flex h-full">
 				{/* Avatar on the left */}
-				<div className="flex-shrink-0 w-[200px] h-full">
+				<div className="shrink-0 w-50 h-full">
 					<Link to="/profile/$profileId" params={{ profileId: pubkeyString }}>
 						<img
 							src={picture || `https://robohash.org/${pubkeyString}?set=set4&size=200x200`}
@@ -107,22 +54,22 @@ export function FeaturedUserCard({ userPubkey }: FeaturedUserCardProps) {
 				</div>
 
 				{/* User info and products */}
-				<div className="flex flex-col justify-between flex-1 p-4 min-w-0">
+				<div className="flex flex-col justify-between  p-4 min-w-0">
 					{/* User info */}
 					<div className="flex-1 min-w-0">
 						<Link to="/profile/$profileId" params={{ profileId: pubkeyString }} className="block">
-							<h3 className="font-semibold text-gray-900 truncate hover:text-blue-600 transition-colors">{displayName}</h3>
-							{about && <p className="text-sm text-gray-600 line-clamp-2 mt-1">{about}</p>}
-							<p className="text-xs text-gray-500 mt-1">{userProducts.length} products</p>
+							<h3 className="font-semibold text-foreground/90 truncate hover:text-blue-600 transition-colors">{displayName}</h3>
+							{about && <p className="text-sm text-foreground/80 line-clamp-2 mt-1">{about}</p>}
+							<p className="text-xs text-foreground/70 mt-1">{userProducts.length} products</p>
 						</Link>
 					</div>
 
 					{/* Product grid at the bottom */}
-					<div className="flex-shrink-0 mt-2">
+					<div className="shrink-0 mt-2">
 						{isLoadingProducts ? (
 							<div className="flex flex-row gap-1">
 								{Array.from({ length: 4 }).map((_, index) => (
-									<div key={index} className="bg-gray-200 rounded animate-pulse w-12 h-12"></div>
+									<div key={index} className="bg-background/80 rounded animate-pulse w-12 h-12"></div>
 								))}
 							</div>
 						) : (
@@ -142,8 +89,8 @@ export function FeaturedUserCard({ userPubkey }: FeaturedUserCardProps) {
 										)
 									} else {
 										return (
-											<div key={index} className="w-12 h-12 bg-gray-100 rounded flex items-center justify-center">
-												<span className="text-gray-400 text-xs">•</span>
+											<div key={index} className="w-12 h-12 bg-background/90 rounded flex items-center justify-center">
+												<span className="text-foreground/70 text-xs">•</span>
 											</div>
 										)
 									}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -19,12 +19,13 @@ import { PriceDisplay } from './PriceDisplay'
 import { Button } from './ui/button'
 import { authStore, useAuth } from '@/lib/stores/auth'
 import { ZapButton } from './social/ZapButton'
+import { cn } from '@/lib/utils'
 
-export interface ProductCardProps {
+export interface ProductCardProps extends React.HTMLAttributes<HTMLDivElement> {
 	product: NDKEvent
 }
 
-export function ProductCard({ product }: ProductCardProps) {
+export function ProductCard({ product, className }: ProductCardProps) {
 	const title = getProductTitle(product)
 	const images = getProductImages(product)
 	const price = getProductPrice(product)
@@ -83,7 +84,10 @@ export function ProductCard({ product }: ProductCardProps) {
 		<Link
 			to={`/products/${product.id}`}
 			onClick={handleProductClick}
-			className="border border-zinc-800 rounded-lg bg-white shadow-sm flex flex-col w-full max-w-full overflow-hidden hover:shadow-md transition-shadow duration-200 cursor-pointer"
+			className={cn(
+				'border border-zinc-800 rounded-lg bg-white shadow-sm flex flex-col w-full max-w-full overflow-hidden hover:shadow-md transition-shadow duration-200 cursor-pointer',
+				className,
+			)}
 			data-testid="product-card"
 		>
 			{/* Square aspect ratio container for image */}


### PR DESCRIPTION
Quick fix ensuring colors are handled correctly in the home page when alternating light/dark backgrounds. Also did some small clean-up in the featured component files, notably Featured Sellers, since the seller images weren't laid out correctly.

<img width="1728" height="408" src="https://github.com/user-attachments/assets/c7a83463-b153-458e-b8e4-ff575f70f192" alt="Screenshot 2026-04-23 at 17 38 17">

<img width="1728" height="728" src="https://github.com/user-attachments/assets/4cfecf67-b89b-45b6-9767-1caac00977a6" alt="Screenshot 2026-04-23 at 17 37 40">

<img width="391" height="685" src="https://github.com/user-attachments/assets/625a276e-60da-44a7-a0eb-569a13aeb408" alt="Screenshot 2026-04-23 at 17 37 51">

<img width="387" height="689" src="https://github.com/user-attachments/assets/3772061e-ec1e-455a-955d-f1f5b4cef648" alt="Screenshot 2026-04-23 at 17 38 27">
