### PR TITLE
Fix/authentication issues

### DIFF
--- a/src/components/auth/DecryptPasswordDialog.tsx
+++ b/src/components/auth/DecryptPasswordDialog.tsx
@@ -1,9 +1,11 @@
+// components/dialogs/DecryptPasswordDialog.tsx
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useAuth } from '@/lib/stores/auth'
 import { Loader2 } from 'lucide-react'
+import { decrypt } from 'nostr-tools/nip49'
 import { useState } from 'react'
 
 export function DecryptPasswordDialog() {
@@ -21,9 +23,11 @@ export function DecryptPasswordDialog() {
 		try {
 			setIsLoading(true)
 			setError('')
+
+			// Login with the decrypted key
 			await decryptAndLogin(password)
 		} catch (error) {
-			setError(error instanceof Error ? error.message : 'Failed to decrypt key')
+			setError('Failed to decrypt key. Please check your password.')
 		} finally {
 			setIsLoading(false)
 		}

--- a/src/components/auth/DecryptPasswordDialog.tsx
+++ b/src/components/auth/DecryptPasswordDialog.tsx
@@ -3,16 +3,16 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { useAuth } from '@/lib/stores/auth'
-import { Loader2 } from 'lucide-react'
-import { decrypt } from 'nostr-tools/nip49'
+import { useAuth, authActions } from '@/lib/stores/auth'
+import { Loader2, LogOut } from 'lucide-react'
 import { useState } from 'react'
 
 export function DecryptPasswordDialog() {
-	const { needsDecryptionPassword, decryptAndLogin } = useAuth()
+	const { needsDecryptionPassword } = useAuth()
 	const [password, setPassword] = useState('')
 	const [error, setError] = useState('')
 	const [isLoading, setIsLoading] = useState(false)
+	const [isLoggingOut, setIsLoggingOut] = useState(false)
 
 	const handleSubmit = async () => {
 		if (!password) {
@@ -23,9 +23,7 @@ export function DecryptPasswordDialog() {
 		try {
 			setIsLoading(true)
 			setError('')
-
-			// Login with the decrypted key
-			await decryptAndLogin(password)
+			await authActions.decryptAndLogin(password)
 		} catch (error) {
 			setError('Failed to decrypt key. Please check your password.')
 		} finally {
@@ -33,13 +31,28 @@ export function DecryptPasswordDialog() {
 		}
 	}
 
+	const handleLogout = async () => {
+		try {
+			setIsLoggingOut(true)
+			setError('')
+			// This clears localStorage keys and resets the auth store state
+			await authActions.logout()
+			// The dialog will close automatically because needsDecryptionPassword becomes false
+		} catch (error) {
+			setError('Failed to clear stored key.')
+		} finally {
+			setIsLoggingOut(false)
+		}
+	}
+
 	return (
 		<Dialog open={needsDecryptionPassword}>
-			<DialogContent className="sm:max-w-[425px]" data-testid="decrypt-password-dialog">
+			<DialogContent className="sm:max-w-[425px]" data-testid="decrypt-password-dialog" showCloseButton={false}>
 				<DialogHeader>
 					<DialogTitle>Decrypt Private Key</DialogTitle>
 					<DialogDescription>Enter your password to decrypt your stored private key.</DialogDescription>
 				</DialogHeader>
+
 				<div className="space-y-4 py-4">
 					<div className="space-y-2">
 						<Label htmlFor="password">Password</Label>
@@ -58,9 +71,31 @@ export function DecryptPasswordDialog() {
 						/>
 						{error && <p className="text-sm text-red-500">{error}</p>}
 					</div>
-					<Button onClick={handleSubmit} disabled={isLoading} className="w-full" data-testid="decrypt-login-button">
+
+					<Button onClick={handleSubmit} disabled={isLoading || isLoggingOut} className="w-full" data-testid="decrypt-login-button">
 						{isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Decrypt & Login'}
 					</Button>
+
+					<div className="relative flex items-center py-2">
+						<div className="flex-grow border-t border-muted"></div>
+						<span className="flex-shrink-0 mx-4 text-xs text-muted-foreground">OR</span>
+						<div className="flex-grow border-t border-muted"></div>
+					</div>
+
+					<Button
+						onClick={handleLogout}
+						variant="outline"
+						disabled={isLoading || isLoggingOut}
+						className="w-full text-destructive hover:text-destructive"
+						data-testid="logout-clear-key-button"
+					>
+						{isLoggingOut ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <LogOut className="h-4 w-4 mr-2" />}
+						Remove Stored Key & Logout
+					</Button>
+
+					<p className="text-xs text-muted-foreground text-center mt-2">
+						This will delete your encrypted private key from this device. You will need your password or a new key to log in again.
+					</p>
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/src/components/auth/PrivateKeyLogin.tsx
+++ b/src/components/auth/PrivateKeyLogin.tsx
@@ -5,6 +5,7 @@ import { authActions, NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY } from '@/lib/stores/auth
 import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools'
 import { useEffect, useRef, useState } from 'react'
 import { Copy, Eye, EyeOff, Loader2 } from 'lucide-react'
+import { decrypt, encrypt } from 'nostr-tools/nip49'
 
 interface PrivateKeyLoginProps {
 	onError?: (error: string) => void
@@ -31,6 +32,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		if (storedKey) {
 			setHasStoredKey(true)
 			try {
+				// Extract pubkey from stored key format: "pubkey:ncryptsec..."
 				const [pubkey] = storedKey.split(':')
 				setStoredPubkey(pubkey)
 			} catch (e) {
@@ -73,17 +75,23 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		return trimmedKey
 	}
 
+	// Encrypt and store key using nostr-tools encrypt function
 	const encryptAndStoreKey = async (key: string, password: string) => {
 		try {
 			const normalizedKey = normalizePrivateKey(key)
-			const secretKeyBytes = nip19.decode(normalizedKey).data as Uint8Array
+			const { data: secretKeyBytes } = nip19.decode(normalizedKey) as { data: Uint8Array }
 			const pubkey = getPublicKey(secretKeyBytes)
-			const encryptedKey = `${pubkey}:${normalizedKey}`
-			localStorage.setItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, encryptedKey)
+
+			// Use nostr-tools encrypt function
+			const encryptedKey = encrypt(secretKeyBytes, password) // Encrypt with default parameters (logN = 16, ksb = 2)
+
+			// Store in format: "pubkey:ncryptsec..."
+			const storedFormat = `${pubkey}:${encryptedKey}`
+			localStorage.setItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, storedFormat)
 			setHasStoredKey(true)
 			setStoredPubkey(pubkey)
 		} catch (error) {
-			throw new Error('Failed to encrypt and store key')
+			throw new Error(`Failed to encrypt and store key: ${error instanceof Error ? error.message : 'Unknown error'}`)
 		}
 	}
 
@@ -129,12 +137,18 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 			return
 		}
 
+		if (process.env.NODE_ENV === 'production' && encryptionPassword.length < 8) {
+			setPasswordError('Password must be at least 8 characters long')
+			return
+		}
+
 		try {
 			setIsLoading(true)
+			setPasswordError('')
 			await encryptAndStoreKey(privateKey, encryptionPassword)
 			await handleValidatePrivateKey()
 		} catch (error) {
-			setPasswordError(error instanceof Error ? error.message : 'Failed to encrypt and store key')
+			setPasswordError('Failed to encrypt and store key')
 		} finally {
 			setIsLoading(false)
 		}
@@ -148,16 +162,28 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 
 		try {
 			setIsLoading(true)
+			setPasswordError('')
+
 			const storedKey = localStorage.getItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)
 			if (!storedKey) {
 				throw new Error('No stored key found')
 			}
 
-			const [, key] = storedKey.split(':')
-			await authActions.loginWithPrivateKey(key)
+			// Extract the ncryptsec part (format: "pubkey:ncryptsec...")
+			const [, encryptedKey] = storedKey.split(':')
+
+			// Use nostr-tools decrypt function
+			const decryptedBytes = decrypt(encryptedKey, encryptionPassword)
+
+			// Convert Uint8Array to hex string
+			const privateKeyHex = Array.from(decryptedBytes)
+				.map((byte) => byte.toString(16).padStart(2, '0'))
+				.join('')
+
+			await authActions.loginWithPrivateKey(privateKeyHex)
 			onSuccess?.()
 		} catch (error) {
-			setPasswordError(error instanceof Error ? error.message : 'Failed to decrypt key')
+			setPasswordError('Failed to decrypt key. Please check your password.')
 		} finally {
 			setIsLoading(false)
 		}

--- a/src/components/auth/PrivateKeyLogin.tsx
+++ b/src/components/auth/PrivateKeyLogin.tsx
@@ -17,6 +17,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 	const [encryptionPassword, setEncryptionPassword] = useState('')
 	const [confirmPassword, setConfirmPassword] = useState('')
 	const [passwordError, setPasswordError] = useState('')
+	const [keyError, setKeyError] = useState<string | null>(null) // New state for key validation
 	const [isLoading, setIsLoading] = useState(false)
 	const [hasStoredKey, setHasStoredKey] = useState(false)
 	const [storedPubkey, setStoredPubkey] = useState<string | null>(null)
@@ -32,7 +33,6 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		if (storedKey) {
 			setHasStoredKey(true)
 			try {
-				// Extract pubkey from stored key format: "pubkey:ncryptsec..."
 				const [pubkey] = storedKey.split(':')
 				setStoredPubkey(pubkey)
 			} catch (e) {
@@ -57,33 +57,67 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		}
 	}, [showPrivateKey])
 
-	// Normalize private key input - accept both nsec and 64-char hex format
+	/**
+	 * Validates and normalizes the private key input.
+	 * Accepts:
+	 * 1. Valid nsec1... string
+	 * 2. Valid 64-character hex string (converts to nsec)
+	 * Returns the normalized nsec string or throws an error.
+	 */
 	const normalizePrivateKey = (key: string): string => {
 		const trimmedKey = key.trim()
 
-		// Check if it's a 64-character hex string
-		if (/^[0-9a-fA-F]{64}$/.test(trimmedKey)) {
-			// Convert hex to Uint8Array and encode as nsec
-			const hexBytes = new Uint8Array(32)
-			for (let i = 0; i < 32; i++) {
-				hexBytes[i] = parseInt(trimmedKey.slice(i * 2, i * 2 + 2), 16)
-			}
-			return nip19.nsecEncode(hexBytes)
+		if (!trimmedKey) {
+			throw new Error('Private key cannot be empty')
 		}
 
-		// Return as-is if it's already in nsec format or other format
-		return trimmedKey
+		// Case 1: Already in nsec format
+		if (trimmedKey.startsWith('nsec1')) {
+			try {
+				// Validate the bech32 encoding
+				const decoded = nip19.decode(trimmedKey)
+				if (decoded.type !== 'nsec') {
+					throw new Error('Invalid nsec format')
+				}
+				return trimmedKey
+			} catch (e) {
+				throw new Error('Invalid nsec format: Failed to decode')
+			}
+		}
+
+		// Case 2: Hex format
+		if (/^[0-9a-fA-F]{64}$/.test(trimmedKey)) {
+			try {
+				// Convert hex to Uint8Array
+				const hexBytes = new Uint8Array(32)
+				for (let i = 0; i < 32; i++) {
+					hexBytes[i] = parseInt(trimmedKey.slice(i * 2, i * 2 + 2), 16)
+				}
+				// Encode as nsec
+				return nip19.nsecEncode(hexBytes)
+			} catch (e) {
+				throw new Error('Failed to convert hex to nsec')
+			}
+		}
+
+		// Invalid format
+		if (trimmedKey.length === 64) {
+			throw new Error('Invalid hex key: Must contain only characters 0-9 and a-f')
+		}
+
+		throw new Error('Invalid format: Please enter a valid nsec1... key or a 64-character hex key')
 	}
 
 	// Encrypt and store key using nostr-tools encrypt function
 	const encryptAndStoreKey = async (key: string, password: string) => {
 		try {
+			// Ensure we have a valid nsec before proceeding
 			const normalizedKey = normalizePrivateKey(key)
 			const { data: secretKeyBytes } = nip19.decode(normalizedKey) as { data: Uint8Array }
 			const pubkey = getPublicKey(secretKeyBytes)
 
 			// Use nostr-tools encrypt function
-			const encryptedKey = encrypt(secretKeyBytes, password) // Encrypt with default parameters (logN = 16, ksb = 2)
+			const encryptedKey = encrypt(secretKeyBytes, password) // Encrypt with default parameters
 
 			// Store in format: "pubkey:ncryptsec..."
 			const storedFormat = `${pubkey}:${encryptedKey}`
@@ -98,6 +132,8 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 	const handleValidatePrivateKey = async () => {
 		try {
 			setIsLoading(true)
+			setKeyError(null)
+
 			const normalizedKey = normalizePrivateKey(privateKey)
 			await authActions.loginWithPrivateKey(normalizedKey)
 			setPrivateKey('')
@@ -112,7 +148,15 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 
 	const handleContinue = () => {
 		if (!privateKey) return
-		setShowPasswordInput(true)
+
+		// Validate before showing password input
+		try {
+			normalizePrivateKey(privateKey)
+			setKeyError(null)
+			setShowPasswordInput(true)
+		} catch (error) {
+			setKeyError(error instanceof Error ? error.message : 'Invalid key format')
+		}
 	}
 
 	const handleCopyToClipboard = async () => {
@@ -169,13 +213,9 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 				throw new Error('No stored key found')
 			}
 
-			// Extract the ncryptsec part (format: "pubkey:ncryptsec...")
 			const [, encryptedKey] = storedKey.split(':')
-
-			// Use nostr-tools decrypt function
 			const decryptedBytes = decrypt(encryptedKey, encryptionPassword)
 
-			// Convert Uint8Array to hex string
 			const privateKeyHex = Array.from(decryptedBytes)
 				.map((byte) => byte.toString(16).padStart(2, '0'))
 				.join('')
@@ -196,6 +236,18 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		setEncryptionPassword('')
 		setConfirmPassword('')
 		setPasswordError('')
+		setKeyError(null)
+	}
+
+	// Helper to check if current input is valid for enabling the button
+	const isKeyValid = () => {
+		if (!privateKey) return false
+		try {
+			normalizePrivateKey(privateKey)
+			return true
+		} catch {
+			return false
+		}
 	}
 
 	if (hasStoredKey) {
@@ -272,7 +324,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 		<div className="space-y-4 py-4 w-full max-w-full overflow-hidden">
 			<div className="space-y-2 max-w-full">
 				<div className="flex justify-between items-center gap-2 flex-wrap">
-					<Label htmlFor="private-key">Private Key (nsec)</Label>
+					<Label htmlFor="private-key">Private Key (nsec or hex)</Label>
 					<Button
 						variant="outline"
 						size="sm"
@@ -281,6 +333,7 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 							setPrivateKey(nip19.nsecEncode(newPrivateKey))
 							setShowPrivateKey(true)
 							setShowGeneratedKeyWarning(true)
+							setKeyError(null) // Clear errors on generation
 						}}
 						data-testid="generate-key-button"
 					>
@@ -291,15 +344,18 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 					<Input
 						id="private-key"
 						type={showPrivateKey ? 'text' : 'password'}
-						placeholder="nsec1..."
+						placeholder="nsec1... or 64-char hex"
 						value={privateKey}
-						onChange={(e) => setPrivateKey(e.target.value)}
+						onChange={(e) => {
+							setPrivateKey(e.target.value)
+							if (keyError) setKeyError(null) // Clear error on change
+						}}
 						onKeyDown={(e) => {
-							if (e.key === 'Enter' && privateKey) {
+							if (e.key === 'Enter') {
 								handleContinue()
 							}
 						}}
-						className={`pr-20 min-w-0 ${showPrivateKey ? 'text-red-500' : ''}`}
+						className={`pr-20 min-w-0 ${keyError ? 'border-red-500 focus-visible:ring-red-500' : ''} ${showPrivateKey ? 'text-red-500' : ''}`}
 						data-testid="private-key-input"
 					/>
 					<Button
@@ -324,6 +380,13 @@ export function PrivateKeyLogin({ onError, onSuccess }: PrivateKeyLoginProps) {
 						{showPrivateKey ? <EyeOff className="h-4 w-4 text-gray-500" /> : <Eye className="h-4 w-4 text-gray-500" />}
 					</Button>
 				</div>
+
+				{keyError && (
+					<div className="flex items-center gap-2 text-sm text-red-500">
+						<span>{keyError}</span>
+					</div>
+				)}
+
 				{showGeneratedKeyWarning && (
 					<div className="space-y-2">
 						<p className="text-sm text-red-500 font-medium">⚠️ Copy this text and save it somewhere safe, it cannot be recovered.</p>

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -5,6 +5,8 @@ import { cartActions } from './cart'
 import { fetchProductsByPubkey } from '@/queries/products'
 import { hasAcceptedTerms, TERMS_ACCEPTED_KEY } from '@/components/dialogs/TermsConditionsDialog'
 import { uiActions } from './ui'
+import { getPublicKey, nip19 } from 'nostr-tools'
+import { decrypt, encrypt } from 'nostr-tools/nip49'
 
 export const NOSTR_CONNECT_KEY = 'nostr_connect_url'
 export const NOSTR_LOCAL_SIGNER_KEY = 'nostr_local_signer_key'
@@ -57,7 +59,6 @@ export const authActions = {
 			authStore.setState((state) => ({ ...state, isAuthenticating: false }))
 		}
 	},
-
 	decryptAndLogin: async (password: string) => {
 		try {
 			authStore.setState((state) => ({ ...state, isAuthenticating: true }))
@@ -66,10 +67,52 @@ export const authActions = {
 				throw new Error('No encrypted key found')
 			}
 
-			const [, key] = encryptedPrivateKey.split(':')
-			await authActions.loginWithPrivateKey(key)
+			// Extract the ncryptsec part (format: "pubkey:ncryptsec...")
+			const [, encryptedKey] = encryptedPrivateKey.split(':')
+
+			// Use nostr-tools decrypt function
+			const decryptedBytes = decrypt(encryptedKey, password)
+
+			// Convert Uint8Array to hex string
+			const privateKeyHex = Array.from(decryptedBytes)
+				.map((byte) => byte.toString(16).padStart(2, '0'))
+				.join('')
+
+			// Login with the decrypted key
+			await authActions.loginWithPrivateKey(privateKeyHex)
 			authStore.setState((state) => ({ ...state, needsDecryptionPassword: false }))
 			authActions.checkAndShowTermsDialog()
+		} catch (error) {
+			throw error
+		} finally {
+			authStore.setState((state) => ({ ...state, isAuthenticating: false }))
+		}
+	},
+
+	// New method to encrypt and save private key using nostr-tools
+	encryptAndSavePrivateKey: async (privateKey: string, password: string, logN: number = 18) => {
+		try {
+			authStore.setState((state) => ({ ...state, isAuthenticating: true }))
+
+			// Normalize the private key
+			const normalizedKey = privateKey.startsWith('nsec1') ? privateKey : nip19.nsecEncode(new Uint8Array(32).fill(0)) // This would need proper conversion
+
+			const { data: secretKeyBytes } = nip19.decode(normalizedKey) as { data: Uint8Array }
+			const pubkey = getPublicKey(secretKeyBytes)
+
+			// Use nostr-tools encrypt function
+			const encryptedKey = encrypt(secretKeyBytes, password, logN, 1)
+
+			// Save encrypted key in format: "pubkey:ncryptsec..."
+			localStorage.setItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY, `${pubkey}:${encryptedKey}`)
+
+			// Remove unencrypted key
+			localStorage.removeItem(NOSTR_LOCAL_SIGNER_KEY)
+
+			// Enable auto-login
+			localStorage.setItem(NOSTR_AUTO_LOGIN, 'true')
+
+			return true
 		} catch (error) {
 			throw error
 		} finally {


### PR DESCRIPTION
Fixed some core authentication issues alongside UI/UX improvements.

The main issue is that private keys (nsec) are help unecrypted in localstorage, and the password input is useless. This fixes that issue by adding NIP-49 local encryption to the key.

- Added encryption following NIP-49 to store secret key as ncryptsec using user password. Handled both encryption/decryption
- UI to handle invalid passwords
- Fix being able to input invalid private keys/nsec into the first step of "Private Key" Login Option. Now the user is stopped before being able to proceed to setting a password.
- Fixed Auto-login modal to not show "X" (close dialog) (since the behavior was blocked anyway) and instead present a Logout option.