### PR TITLE
fix(workflow): unify product create bootstrap and V4V gating across entrypoints

### DIFF
--- a/docs/adr/ADR-stage-based-product-authoring.md
+++ b/docs/adr/ADR-stage-based-product-authoring.md
@@ -1,0 +1,69 @@
+# ADR: Make stage-based product authoring the canonical workflow model
+
+## Status
+
+Proposed
+
+## Context
+
+The Add Product workflow historically treated tabs as both UI navigation and workflow truth. That made small UI details responsible for policy decisions such as where create starts, whether delivery is complete, and when publishing is allowed.
+
+This is brittle because tabs are a presentation affordance. They can be rearranged, hidden, grouped, or temporarily retained during migration without changing the underlying authoring lifecycle. Workflow policy needs a stable model that is independent of those rendering details.
+
+The current stabilization stack already separates seller readiness and draft validation into explicit sources. The remaining issue is that progression still depends on tab conditionals in the form.
+
+In particular, Publish must not be an alias for Delivery or Shipping. Delivery collects fulfillment information; Publish is the final readiness and action gate.
+
+## Decision
+
+Product authoring workflow truth will be stage-based.
+
+The canonical stages are:
+
+1. Basics
+2. Pricing & Inventory
+3. Media
+4. Delivery
+5. Publish
+
+Tabs may remain temporarily as a rendering affordance, but they are not the workflow source. Product authoring policy resolves against stages and uses tab mapping only to render existing form sections.
+
+Publish is a real workflow stage. It does not require a legacy tab and must not be collapsed into Delivery or Shipping.
+
+## Non-goals
+
+This ADR does not redesign shipping UX, public product-page shipping behavior, route names, V4V semantics, or unrelated marketplace flows.
+
+## Boundaries
+
+Seller readiness remains query-derived state owned by `useProductCreateReadiness`.
+
+Draft validity remains pure product-state validation owned by `validateProductDraft`.
+
+Stage progression is derived from seller readiness, draft validation, and the current form section mapping.
+
+Publish gating is the final stage gate and must use stage state rather than ad hoc tab checks.
+
+## Consequences
+
+Stage order is explicit and deterministic.
+
+ProductCreateShell remains the shared create orchestration owner and computes stage truth for create entrypoints.
+
+ProductFormContent consumes stage truth and may continue rendering legacy form sections while the UI migrates incrementally.
+
+The Publish stage can represent prerequisite blockers such as V4V setup without changing the underlying V4V policy in this PR.
+
+## Migration Approach
+
+This PR introduces the stage model and stage progression truth immediately.
+
+Legacy form sections remain as presentational sections for reviewability. They are mapped into stages:
+
+- Basics: name and category sections
+- Pricing & Inventory: detail and spec sections
+- Media: images section
+- Delivery: shipping section
+- Publish: final readiness, V4V, and publish CTA surface with no legacy tab
+
+Later PRs may remove or redesign the legacy section presentation, but that is intentionally out of scope here.

--- a/src/components/product-authoring/ProductAuthoringStageNavigator.tsx
+++ b/src/components/product-authoring/ProductAuthoringStageNavigator.tsx
@@ -1,0 +1,38 @@
+import { Button } from '@/components/ui/button'
+import type { ProductAuthoringStage, ProductAuthoringStageResolution } from '@/lib/workflow/productAuthoringStages'
+import { CheckIcon } from 'lucide-react'
+
+export function ProductAuthoringStageNavigator({
+	resolution,
+	onStageSelect,
+}: {
+	resolution: ProductAuthoringStageResolution
+	onStageSelect: (stage: ProductAuthoringStage) => void
+}) {
+	return (
+		<div className="flex flex-wrap gap-2" aria-label="Product authoring stages">
+			{resolution.stages.map((stageState, index) => {
+				const isAttentionStage = stageState.isFirstIncomplete && !stageState.isComplete
+
+				return (
+					<Button
+						key={stageState.stage}
+						type="button"
+						variant={stageState.isSelected ? 'secondary' : 'outline'}
+						className="h-auto flex-1 min-w-[8rem] justify-start gap-2 px-3 py-2 text-left normal-case"
+						onClick={() => onStageSelect(stageState.stage)}
+						aria-current={stageState.isSelected ? 'step' : undefined}
+					>
+						<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs">
+							{stageState.isComplete ? <CheckIcon className="h-3.5 w-3.5" /> : index + 1}
+						</span>
+						<span className="flex min-w-0 flex-col">
+							<span className="truncate text-xs font-semibold">{stageState.label}</span>
+							{isAttentionStage ? <span className="text-[10px] text-red-600">Needs attention</span> : null}
+						</span>
+					</Button>
+				)
+			})}
+		</div>
+	)
+}

--- a/src/components/product-authoring/ProductAuthoringStageNavigator.tsx
+++ b/src/components/product-authoring/ProductAuthoringStageNavigator.tsx
@@ -21,6 +21,7 @@ export function ProductAuthoringStageNavigator({
 						variant={stageState.isSelected ? 'secondary' : 'outline'}
 						className="h-auto flex-1 min-w-[8rem] justify-start gap-2 px-3 py-2 text-left normal-case"
 						onClick={() => onStageSelect(stageState.stage)}
+						disabled={!stageState.canSelect}
 						aria-current={stageState.isSelected ? 'step' : undefined}
 					>
 						<span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs">

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -16,8 +16,8 @@ type ProductCreateShellProps = {
 
 let lastCreateShellBootstrapIdentity: string | null = null
 
-function hasStartedProductFormOrIsEditing(state: ProductFormState) {
-	if (state.editingProductId) return true
+function hasStartedCreateDraft(state: ProductFormState) {
+	if (state.editingProductId) return false
 	if (state.isDirty) return true
 
 	return (
@@ -61,7 +61,7 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 	const readiness = useProductCreateReadiness(normalizedUserPubkey)
 	const [isBootstrapped, setIsBootstrapped] = useState(false)
 	const hasBootstrappedRef = useRef(false)
-	const hasStartedCreateFormOrIsEditing = hasStartedProductFormOrIsEditing(formState)
+	const hasStartedCreateDraftState = hasStartedCreateDraft(formState)
 
 	const workflow = useMemo(
 		() =>
@@ -83,10 +83,9 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 
 		const hasKnownDifferentBootstrapIdentity =
 			lastCreateShellBootstrapIdentity !== null && lastCreateShellBootstrapIdentity !== normalizedUserPubkey
-		const shouldResumeExistingSession =
-			Boolean(formState.editingProductId) || (hasStartedCreateFormOrIsEditing && !hasKnownDifferentBootstrapIdentity)
+		const shouldResumeCreateDraft = hasStartedCreateDraftState && !hasKnownDifferentBootstrapIdentity
 
-		if (!shouldResumeExistingSession) {
+		if (!shouldResumeCreateDraft) {
 			productFormActions.startCreateProductSession()
 			productFormActions.setActiveTab(workflow.initialTab)
 		}
@@ -94,7 +93,7 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 		lastCreateShellBootstrapIdentity = normalizedUserPubkey
 		hasBootstrappedRef.current = true
 		setIsBootstrapped(true)
-	}, [formState.editingProductId, hasStartedCreateFormOrIsEditing, normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
+	}, [hasStartedCreateDraftState, normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
 
 	const content =
 		!workflow.isBootstrapReady || !isBootstrapped ? (

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -2,10 +2,19 @@ import { ProductFormContent } from '@/components/sheet-contents/products/Product
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore, type ProductFormState } from '@/lib/stores/product'
+import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
+import {
+	getNextProductAuthoringStage,
+	getPreviousProductAuthoringStage,
+	getPrimaryProductAuthoringTabForStage,
+	getProductAuthoringStageForTab,
+	resolveProductAuthoringStages,
+	type ProductAuthoringStage,
+} from '@/lib/workflow/productAuthoringStages'
 import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
 import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 type ProductCreateShellProps = {
 	userPubkey?: string | null
@@ -61,6 +70,7 @@ export function ProductCreateShell({ userPubkey, entrypoint, className = '', for
 	const formState = useStore(productFormStore)
 	const readiness = useProductCreateReadiness(normalizedUserPubkey)
 	const [isBootstrapped, setIsBootstrapped] = useState(false)
+	const [selectedStage, setSelectedStage] = useState<ProductAuthoringStage>('basics')
 	const hasBootstrappedRef = useRef(false)
 	const hasStartedCreateDraftState = hasStartedCreateDraft(formState)
 
@@ -74,9 +84,48 @@ export function ProductCreateShell({ userPubkey, entrypoint, className = '', for
 		[readiness.shippingState, readiness.v4vConfigurationState],
 	)
 
+	const resolvedShippingRefs = useMemo(() => new Set(readiness.savedShippingRefs), [readiness.savedShippingRefs])
+	const isShippingFetched = readiness.shippingState !== 'loading'
+	const draftValidation = useMemo(
+		() =>
+			validateProductDraft({
+				state: formState,
+				resolvedShippingRefs,
+				isShippingFetched,
+			}),
+		[formState, isShippingFetched, resolvedShippingRefs],
+	)
+	const stageResolution = useMemo(
+		() =>
+			resolveProductAuthoringStages({
+				selectedStage,
+				validation: draftValidation,
+				workflow,
+			}),
+		[draftValidation, selectedStage, workflow],
+	)
+	const selectStage = useCallback((stage: ProductAuthoringStage) => {
+		setSelectedStage(stage)
+
+		// Legacy tabs remain a rendering bridge only. Publish intentionally has no tab to sync.
+		const primaryTab = getPrimaryProductAuthoringTabForStage(stage)
+		if (primaryTab) {
+			productFormActions.setActiveTab(primaryTab)
+		}
+	}, [])
+	const selectPreviousStage = useCallback(() => {
+		const previousStage = getPreviousProductAuthoringStage(selectedStage)
+		if (previousStage) selectStage(previousStage)
+	}, [selectStage, selectedStage])
+	const selectNextStage = useCallback(() => {
+		const nextStage = getNextProductAuthoringStage(selectedStage)
+		if (nextStage) selectStage(nextStage)
+	}, [selectStage, selectedStage])
+
 	useEffect(() => {
 		hasBootstrappedRef.current = false
 		setIsBootstrapped(false)
+		setSelectedStage('basics')
 	}, [normalizedUserPubkey])
 
 	useEffect(() => {
@@ -89,6 +138,9 @@ export function ProductCreateShell({ userPubkey, entrypoint, className = '', for
 		if (!shouldResumeCreateDraft) {
 			productFormActions.startCreateProductSession()
 			productFormActions.setActiveTab(workflow.initialTab)
+			setSelectedStage(getProductAuthoringStageForTab(workflow.initialTab))
+		} else {
+			setSelectedStage(getProductAuthoringStageForTab(productFormStore.state.activeTab))
 		}
 
 		lastCreateShellBootstrapIdentity = normalizedUserPubkey
@@ -100,7 +152,15 @@ export function ProductCreateShell({ userPubkey, entrypoint, className = '', for
 		!workflow.isBootstrapReady || !isBootstrapped ? (
 			<ProductCreateLoadingState />
 		) : (
-			<ProductFormContent className={formClassName} showFooter={showFooter} workflow={workflow} />
+			<ProductFormContent
+				className={formClassName}
+				showFooter={showFooter}
+				workflow={workflow}
+				stageResolution={stageResolution}
+				onStageSelect={selectStage}
+				onStageBack={selectPreviousStage}
+				onStageNext={selectNextStage}
+			/>
 		)
 
 	return className ? <div className={className}>{content}</div> : content

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 type ProductCreateShellProps = {
 	userPubkey?: string | null
+	entrypoint: 'dashboard' | 'homepage-sheet'
 	className?: string
 	formClassName?: string
 	showFooter?: boolean
@@ -55,7 +56,7 @@ function ProductCreateLoadingState() {
 	)
 }
 
-export function ProductCreateShell({ userPubkey, className = '', formClassName, showFooter = true }: ProductCreateShellProps) {
+export function ProductCreateShell({ userPubkey, entrypoint, className = '', formClassName, showFooter = true }: ProductCreateShellProps) {
 	const normalizedUserPubkey = userPubkey ?? ''
 	const formState = useStore(productFormStore)
 	const readiness = useProductCreateReadiness(normalizedUserPubkey)
@@ -83,7 +84,7 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 
 		const hasKnownDifferentBootstrapIdentity =
 			lastCreateShellBootstrapIdentity !== null && lastCreateShellBootstrapIdentity !== normalizedUserPubkey
-		const shouldResumeCreateDraft = hasStartedCreateDraftState && !hasKnownDifferentBootstrapIdentity
+		const shouldResumeCreateDraft = entrypoint === 'homepage-sheet' && hasStartedCreateDraftState && !hasKnownDifferentBootstrapIdentity
 
 		if (!shouldResumeCreateDraft) {
 			productFormActions.startCreateProductSession()
@@ -93,7 +94,7 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 		lastCreateShellBootstrapIdentity = normalizedUserPubkey
 		hasBootstrappedRef.current = true
 		setIsBootstrapped(true)
-	}, [hasStartedCreateDraftState, normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
+	}, [entrypoint, hasStartedCreateDraftState, normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
 
 	const content =
 		!workflow.isBootstrapReady || !isBootstrapped ? (

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -56,7 +56,7 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 
 		hasBootstrappedRef.current = true
 		setIsBootstrapped(true)
-	}, [workflow.initialTab, workflow.isBootstrapReady])
+	}, [normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
 
 	const content =
 		!workflow.isBootstrapReady || !isBootstrapped ? (

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -1,9 +1,10 @@
 import { ProductFormContent } from '@/components/sheet-contents/products/ProductFormContent'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
-import { productFormActions } from '@/lib/stores/product'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore, type ProductFormState } from '@/lib/stores/product'
 import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
 import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
+import { useStore } from '@tanstack/react-store'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 type ProductCreateShellProps = {
@@ -11,6 +12,33 @@ type ProductCreateShellProps = {
 	className?: string
 	formClassName?: string
 	showFooter?: boolean
+}
+
+let lastCreateShellBootstrapIdentity: string | null = null
+
+function hasStartedProductFormOrIsEditing(state: ProductFormState) {
+	if (state.editingProductId) return true
+	if (state.isDirty) return true
+
+	return (
+		state.name !== DEFAULT_FORM_STATE.name ||
+		state.summary !== DEFAULT_FORM_STATE.summary ||
+		state.description !== DEFAULT_FORM_STATE.description ||
+		state.price !== DEFAULT_FORM_STATE.price ||
+		state.fiatPrice !== DEFAULT_FORM_STATE.fiatPrice ||
+		state.quantity !== DEFAULT_FORM_STATE.quantity ||
+		state.status !== DEFAULT_FORM_STATE.status ||
+		state.productType !== DEFAULT_FORM_STATE.productType ||
+		state.mainCategory !== DEFAULT_FORM_STATE.mainCategory ||
+		state.selectedCollection !== DEFAULT_FORM_STATE.selectedCollection ||
+		state.specs.length > 0 ||
+		state.categories.length > 0 ||
+		state.images.length > 0 ||
+		state.shippings.length > 0 ||
+		state.weight !== DEFAULT_FORM_STATE.weight ||
+		state.dimensions !== DEFAULT_FORM_STATE.dimensions ||
+		state.isNSFW !== DEFAULT_FORM_STATE.isNSFW
+	)
 }
 
 function ProductCreateLoadingState() {
@@ -29,9 +57,11 @@ function ProductCreateLoadingState() {
 
 export function ProductCreateShell({ userPubkey, className = '', formClassName, showFooter = true }: ProductCreateShellProps) {
 	const normalizedUserPubkey = userPubkey ?? ''
+	const formState = useStore(productFormStore)
 	const readiness = useProductCreateReadiness(normalizedUserPubkey)
 	const [isBootstrapped, setIsBootstrapped] = useState(false)
 	const hasBootstrappedRef = useRef(false)
+	const hasStartedCreateFormOrIsEditing = hasStartedProductFormOrIsEditing(formState)
 
 	const workflow = useMemo(
 		() =>
@@ -51,12 +81,20 @@ export function ProductCreateShell({ userPubkey, className = '', formClassName, 
 	useEffect(() => {
 		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
 
-		productFormActions.startCreateProductSession()
-		productFormActions.setActiveTab(workflow.initialTab)
+		const hasKnownDifferentBootstrapIdentity =
+			lastCreateShellBootstrapIdentity !== null && lastCreateShellBootstrapIdentity !== normalizedUserPubkey
+		const shouldResumeExistingSession =
+			Boolean(formState.editingProductId) || (hasStartedCreateFormOrIsEditing && !hasKnownDifferentBootstrapIdentity)
 
+		if (!shouldResumeExistingSession) {
+			productFormActions.startCreateProductSession()
+			productFormActions.setActiveTab(workflow.initialTab)
+		}
+
+		lastCreateShellBootstrapIdentity = normalizedUserPubkey
 		hasBootstrappedRef.current = true
 		setIsBootstrapped(true)
-	}, [normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
+	}, [formState.editingProductId, hasStartedCreateFormOrIsEditing, normalizedUserPubkey, workflow.initialTab, workflow.isBootstrapReady])
 
 	const content =
 		!workflow.isBootstrapReady || !isBootstrapped ? (

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore, type ProductFormState } from '@/lib/stores/product'
 import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
 import {
+	canSelectProductAuthoringStage,
 	getNextProductAuthoringStage,
 	getPreviousProductAuthoringStage,
 	getPrimaryProductAuthoringTabForStage,
@@ -104,23 +105,29 @@ export function ProductCreateShell({ userPubkey, entrypoint, className = '', for
 			}),
 		[draftValidation, selectedStage, workflow],
 	)
-	const selectStage = useCallback((stage: ProductAuthoringStage) => {
-		setSelectedStage(stage)
+	const selectStage = useCallback(
+		(stage: ProductAuthoringStage) => {
+			if (!canSelectProductAuthoringStage(stage, stageResolution)) return
 
-		// Legacy tabs remain a rendering bridge only. Publish intentionally has no tab to sync.
-		const primaryTab = getPrimaryProductAuthoringTabForStage(stage)
-		if (primaryTab) {
-			productFormActions.setActiveTab(primaryTab)
-		}
-	}, [])
+			setSelectedStage(stage)
+
+			// Legacy tabs remain a rendering bridge only. Publish intentionally has no tab to sync.
+			const primaryTab = getPrimaryProductAuthoringTabForStage(stage)
+			if (primaryTab) {
+				productFormActions.setActiveTab(primaryTab)
+			}
+		},
+		[stageResolution],
+	)
 	const selectPreviousStage = useCallback(() => {
 		const previousStage = getPreviousProductAuthoringStage(selectedStage)
 		if (previousStage) selectStage(previousStage)
 	}, [selectStage, selectedStage])
 	const selectNextStage = useCallback(() => {
 		const nextStage = getNextProductAuthoringStage(selectedStage)
+		if (!stageResolution.canAdvanceToNextStage) return
 		if (nextStage) selectStage(nextStage)
-	}, [selectStage, selectedStage])
+	}, [selectStage, selectedStage, stageResolution.canAdvanceToNextStage])
 
 	useEffect(() => {
 		hasBootstrappedRef.current = false

--- a/src/components/product-authoring/ProductCreateShell.tsx
+++ b/src/components/product-authoring/ProductCreateShell.tsx
@@ -1,0 +1,69 @@
+import { ProductFormContent } from '@/components/sheet-contents/products/ProductFormContent'
+import { Card, CardContent } from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import { productFormActions } from '@/lib/stores/product'
+import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
+import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+type ProductCreateShellProps = {
+	userPubkey?: string | null
+	className?: string
+	formClassName?: string
+	showFooter?: boolean
+}
+
+function ProductCreateLoadingState() {
+	return (
+		<Card>
+			<CardContent className="p-8">
+				<div className="space-y-4">
+					<Skeleton className="h-8 w-48" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-3/4" />
+				</div>
+			</CardContent>
+		</Card>
+	)
+}
+
+export function ProductCreateShell({ userPubkey, className = '', formClassName, showFooter = true }: ProductCreateShellProps) {
+	const normalizedUserPubkey = userPubkey ?? ''
+	const readiness = useProductCreateReadiness(normalizedUserPubkey)
+	const [isBootstrapped, setIsBootstrapped] = useState(false)
+	const hasBootstrappedRef = useRef(false)
+
+	const workflow = useMemo(
+		() =>
+			resolveProductWorkflow({
+				mode: 'create',
+				shippingState: readiness.shippingState,
+				v4vConfigurationState: readiness.v4vConfigurationState,
+			}),
+		[readiness.shippingState, readiness.v4vConfigurationState],
+	)
+
+	useEffect(() => {
+		hasBootstrappedRef.current = false
+		setIsBootstrapped(false)
+	}, [normalizedUserPubkey])
+
+	useEffect(() => {
+		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
+
+		productFormActions.startCreateProductSession()
+		productFormActions.setActiveTab(workflow.initialTab)
+
+		hasBootstrappedRef.current = true
+		setIsBootstrapped(true)
+	}, [workflow.initialTab, workflow.isBootstrapReady])
+
+	const content =
+		!workflow.isBootstrapReady || !isBootstrapped ? (
+			<ProductCreateLoadingState />
+		) : (
+			<ProductFormContent className={formClassName} showFooter={showFooter} workflow={workflow} />
+		)
+
+	return className ? <div className={className}>{content}</div> : content
+}

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -7,6 +7,7 @@ import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
+import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
 import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
@@ -37,7 +38,7 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { activeTab, editingProductId, isDirty, shippings, name, description, images } = formState
+	const { activeTab, editingProductId, isDirty, shippings } = formState
 	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
 		mode: editingProductId ? 'edit' : 'create',
 		isBootstrapReady: true,
@@ -53,21 +54,6 @@ export function ProductFormContent({
 			)
 		}
 	}, [workflow, editingProductId, resolvedWorkflow.mode])
-
-	// Compute validation states
-	const hasValidName = name.trim().length > 0
-	const hasValidDescription = description.trim().length > 0
-	const hasValidImages = images.length > 0
-
-	// Compute validation message for tooltip
-	const getValidationMessage = () => {
-		const issues: string[] = []
-		if (!hasValidName) issues.push('Product name is required')
-		if (!hasValidDescription) issues.push('Description is required')
-		if (!hasValidImages) issues.push('At least one image is required')
-		if (!hasValidShipping) issues.push('At least one shipping option is required')
-		return issues
-	}
 
 	// Get user pubkey from auth store directly to avoid timing issues
 	const authState = useStore(authStore)
@@ -94,13 +80,19 @@ export function ProductFormContent({
 		)
 	}, [userShippingOptions])
 
+	const draftValidation = useMemo(
+		() =>
+			validateProductDraft({
+				state: formState,
+				resolvedShippingRefs,
+				isShippingFetched,
+			}),
+		[formState, isShippingFetched, resolvedShippingRefs],
+	)
+
 	const hasSelectedShipping = useMemo(() => {
 		return shippings.some((ship) => !!ship.shippingRef)
 	}, [shippings])
-
-	const hasValidShipping = useMemo(() => {
-		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
-	}, [shippings, isShippingFetched, resolvedShippingRefs])
 
 	// Once the draft has a shipping reference, move out of the shipping-first bootstrap step
 	// without waiting for query cache propagation to catch up.
@@ -259,7 +251,7 @@ export function ProductFormContent({
 							data-testid="product-tab-name"
 						>
 							Name
-							{(!hasValidName || !hasValidDescription) && <span className="ml-1 text-red-500">*</span>}
+							{draftValidation.issuesByTab.name?.length ? <span className="ml-1 text-red-500">*</span> : null}
 						</TabsTrigger>
 						<TabsTrigger
 							value="detail"
@@ -288,7 +280,7 @@ export function ProductFormContent({
 							data-testid="product-tab-images"
 						>
 							Images
-							{!hasValidImages && <span className="ml-1 text-red-500">*</span>}
+							{draftValidation.issuesByTab.images?.length ? <span className="ml-1 text-red-500">*</span> : null}
 						</TabsTrigger>
 						<TabsTrigger
 							value="shipping"
@@ -296,7 +288,7 @@ export function ProductFormContent({
 							data-testid="product-tab-shipping"
 						>
 							Shipping
-							{!hasValidShipping && <span className="ml-1 text-red-500">*</span>}
+							{draftValidation.issuesByTab.shipping?.length ? <span className="ml-1 text-red-500">*</span> : null}
 						</TabsTrigger>
 					</TabsList>
 
@@ -345,7 +337,7 @@ export function ProductFormContent({
 						)}
 
 						{/* Show 'Next' button when shipping tab is the resolved first step and user is still onboarding shipping */}
-						{resolvedWorkflow.shouldStartAtShipping && activeTab === 'shipping' && !hasValidShipping ? (
+						{resolvedWorkflow.shouldStartAtShipping && activeTab === 'shipping' && !draftValidation.hasValidShipping ? (
 							<Button
 								type="button"
 								variant="secondary"
@@ -389,8 +381,8 @@ export function ProductFormContent({
 										)
 									}
 
-									const validationIssues = getValidationMessage()
-									const hasValidationErrors = validationIssues.length > 0
+									const validationIssues = draftValidation.issues
+									const hasValidationErrors = !draftValidation.allRequiredFieldsValid
 									const isDisabled = isSubmitting || isPublishing || hasValidationErrors
 
 									return (

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -1,12 +1,23 @@
+import { ProductAuthoringStageNavigator } from '@/components/product-authoring/ProductAuthoringStageNavigator'
 import { Button } from '@/components/ui/button'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
-import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
+import { productFormActions, productFormStore } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
+import {
+	getNextProductAuthoringStage,
+	getPreviousProductAuthoringStage,
+	getPrimaryProductAuthoringTabForStage,
+	getProductAuthoringStageForTab,
+	getProductAuthoringTabsForStage,
+	PRODUCT_AUTHORING_V4V_SETUP_ISSUE,
+	resolveProductAuthoringStages,
+	type ProductAuthoringStage,
+	type ProductAuthoringStageResolution,
+} from '@/lib/workflow/productAuthoringStages'
 import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
 import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
 import { useForm } from '@tanstack/react-form'
@@ -24,12 +35,20 @@ export function ProductFormContent({
 	productDTag,
 	productEventId,
 	workflow,
+	stageResolution,
+	onStageSelect,
+	onStageBack,
+	onStageNext,
 }: {
 	className?: string
 	showFooter?: boolean
 	productDTag?: string | null
 	productEventId?: string | null
 	workflow?: ProductWorkflowResolution
+	stageResolution?: ProductAuthoringStageResolution
+	onStageSelect?: (stage: ProductAuthoringStage) => void
+	onStageBack?: () => void
+	onStageNext?: () => void
 }) {
 	const [isPublishing, setIsPublishing] = useState(false)
 	const [hasDraft, setHasDraft] = useState(false)
@@ -38,7 +57,10 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { activeTab, editingProductId, isDirty, shippings } = formState
+	const { activeTab, editingProductId, isDirty } = formState
+	const [editCompatibilityStage, setEditCompatibilityStage] = useState<ProductAuthoringStage>(() =>
+		getProductAuthoringStageForTab(activeTab),
+	)
 	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
 		mode: editingProductId ? 'edit' : 'create',
 		isBootstrapReady: true,
@@ -59,8 +81,8 @@ export function ProductFormContent({
 	const authState = useStore(authStore)
 	const userPubkey = authState.user?.pubkey || ''
 
-	// Check if user has any shipping options configured (for tab ordering)
-	// Query is only enabled when userPubkey is available
+	// Resolve seller shipping references for draft validation.
+	// Query is only enabled when userPubkey is available.
 	const { data: userShippingOptions, isFetched: isShippingFetched } = useShippingOptionsByPubkey(userPubkey)
 
 	const resolvedShippingRefs = useMemo(() => {
@@ -89,18 +111,60 @@ export function ProductFormContent({
 			}),
 		[formState, isShippingFetched, resolvedShippingRefs],
 	)
+	const editCompatibilityStageResolution = useMemo(() => {
+		if (stageResolution || resolvedWorkflow.mode !== 'edit') return null
 
-	const hasSelectedShipping = useMemo(() => {
-		return shippings.some((ship) => !!ship.shippingRef)
-	}, [shippings])
+		return resolveProductAuthoringStages({
+			selectedStage: editCompatibilityStage,
+			validation: draftValidation,
+			workflow: resolvedWorkflow,
+		})
+	}, [draftValidation, editCompatibilityStage, resolvedWorkflow, stageResolution])
+	const isMissingShellStageResolution = !stageResolution && !editCompatibilityStageResolution
+	const resolvedStageResolution =
+		stageResolution ??
+		editCompatibilityStageResolution ??
+		resolveProductAuthoringStages({
+			selectedStage: 'basics',
+			validation: draftValidation,
+			workflow: resolvedWorkflow,
+		})
 
-	// Once the draft has a shipping reference, move out of the shipping-first bootstrap step
-	// without waiting for query cache propagation to catch up.
-	useEffect(() => {
-		if (resolvedWorkflow.shouldStartAtShipping && hasSelectedShipping && activeTab === 'shipping') {
-			productFormActions.setActiveTab('name')
+	const selectedStage = resolvedStageResolution.selectedStage
+	const renderedTabs = getProductAuthoringTabsForStage(selectedStage)
+	const previousStage = getPreviousProductAuthoringStage(selectedStage)
+	const nextStage = getNextProductAuthoringStage(selectedStage)
+	const selectStage = useCallback(
+		(stage: ProductAuthoringStage) => {
+			if (onStageSelect) {
+				onStageSelect(stage)
+				return
+			}
+
+			setEditCompatibilityStage(stage)
+			const primaryTab = getPrimaryProductAuthoringTabForStage(stage)
+			if (primaryTab) {
+				productFormActions.setActiveTab(primaryTab)
+			}
+		},
+		[onStageSelect],
+	)
+	const handleBack = useCallback(() => {
+		if (onStageBack) {
+			onStageBack()
+			return
 		}
-	}, [resolvedWorkflow.shouldStartAtShipping, hasSelectedShipping, activeTab])
+
+		if (previousStage) selectStage(previousStage)
+	}, [onStageBack, previousStage, selectStage])
+	const handleNext = useCallback(() => {
+		if (onStageNext) {
+			onStageNext()
+			return
+		}
+
+		if (nextStage) selectStage(nextStage)
+	}, [nextStage, onStageNext, selectStage])
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {
@@ -226,6 +290,40 @@ export function ProductFormContent({
 		},
 	})
 
+	const selectedStageContent =
+		selectedStage === 'publish' ? (
+			<div className="mt-4 space-y-4 rounded-lg border bg-gray-50 p-4">
+				<div>
+					<h3 className="text-sm font-semibold">Ready to publish</h3>
+					<p className="text-sm text-muted-foreground">
+						Review the required checks below, then publish when the draft and seller setup are ready.
+					</p>
+				</div>
+				{resolvedStageResolution.publishIssues.length > 0 ? (
+					<ul className="list-disc list-inside space-y-1 text-sm text-red-600">
+						{resolvedStageResolution.publishIssues.map((issue) => (
+							<li key={issue}>{issue}</li>
+						))}
+					</ul>
+				) : (
+					<p className="text-sm text-green-700">All required product details and seller setup checks are complete.</p>
+				)}
+			</div>
+		) : (
+			<div className="mt-4 space-y-6">
+				{renderedTabs.includes('name') ? <NameTab /> : null}
+				{renderedTabs.includes('detail') ? <DetailTab /> : null}
+				{renderedTabs.includes('spec') ? <SpecTab /> : null}
+				{renderedTabs.includes('category') ? <CategoryTab /> : null}
+				{renderedTabs.includes('images') ? <ImagesTab /> : null}
+				{renderedTabs.includes('shipping') ? <ShippingTab /> : null}
+			</div>
+		)
+
+	if (isMissingShellStageResolution) {
+		throw new Error('ProductFormContent requires shell-owned stageResolution in create mode')
+	}
+
 	return (
 		<form
 			onSubmit={(e) => {
@@ -238,97 +336,20 @@ export function ProductFormContent({
 			data-shipping-loaded={isShippingFetched || !!editingProductId}
 		>
 			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
-				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
-				<Tabs
-					value={activeTab}
-					onValueChange={(value) => productFormActions.setActiveTab(value as ProductFormTab)}
-					className="w-full flex flex-col flex-1 min-h-0 overflow-hidden"
-				>
-					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
-						<TabsTrigger
-							value="name"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-name"
-						>
-							Name
-							{draftValidation.issuesByTab.name?.length ? <span className="ml-1 text-red-500">*</span> : null}
-						</TabsTrigger>
-						<TabsTrigger
-							value="detail"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-detail"
-						>
-							Detail
-						</TabsTrigger>
-						<TabsTrigger
-							value="spec"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-spec"
-						>
-							Spec
-						</TabsTrigger>
-						<TabsTrigger
-							value="category"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-category"
-						>
-							Category
-						</TabsTrigger>
-						<TabsTrigger
-							value="images"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-images"
-						>
-							Images
-							{draftValidation.issuesByTab.images?.length ? <span className="ml-1 text-red-500">*</span> : null}
-						</TabsTrigger>
-						<TabsTrigger
-							value="shipping"
-							className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
-							data-testid="product-tab-shipping"
-						>
-							Shipping
-							{draftValidation.issuesByTab.shipping?.length ? <span className="ml-1 text-red-500">*</span> : null}
-						</TabsTrigger>
-					</TabsList>
+				<ProductAuthoringStageNavigator resolution={resolvedStageResolution} onStageSelect={selectStage} />
 
-					<div className="flex-1 overflow-y-auto min-h-0">
-						<TabsContent value="name" className="mt-4">
-							<NameTab />
-						</TabsContent>
-
-						<TabsContent value="detail" className="mt-4">
-							<DetailTab />
-						</TabsContent>
-
-						<TabsContent value="spec" className="mt-4">
-							<SpecTab />
-						</TabsContent>
-
-						<TabsContent value="category" className="mt-4">
-							<CategoryTab />
-						</TabsContent>
-
-						<TabsContent value="images" className="mt-4">
-							<ImagesTab />
-						</TabsContent>
-
-						<TabsContent value="shipping" className="mt-4">
-							<ShippingTab />
-						</TabsContent>
-					</div>
-				</Tabs>
+				<div className="flex-1 overflow-y-auto min-h-0">{selectedStageContent}</div>
 			</div>
 
 			{showFooter && (
 				<div className="bg-white border-t pt-4 pb-4 mt-4">
 					<div className="flex gap-2 w-full">
-						{activeTab !== 'name' && (
+						{previousStage && (
 							<Button
 								type="button"
 								variant="outline"
 								className="flex-1 gap-2 uppercase"
-								onClick={productFormActions.previousTab}
+								onClick={handleBack}
 								data-testid="product-back-button"
 							>
 								<span className="i-back w-6 h-6"></span>
@@ -336,23 +357,16 @@ export function ProductFormContent({
 							</Button>
 						)}
 
-						{/* Show 'Next' button when shipping tab is the resolved first step and user is still onboarding shipping */}
-						{resolvedWorkflow.shouldStartAtShipping && activeTab === 'shipping' && !draftValidation.hasValidShipping ? (
-							<Button
-								type="button"
-								variant="secondary"
-								className="flex-1 uppercase"
-								onClick={() => productFormActions.setActiveTab('name')}
-								data-testid="product-next-button"
-							>
-								Next
-							</Button>
-						) : activeTab === 'shipping' || editingProductId ? (
+						{selectedStage === 'publish' ? (
 							<form.Subscribe
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
-								children={([canSubmit, isSubmitting]) => {
-									// Check if we need V4V setup for new products
-									if (resolvedWorkflow.requiresV4VSetup && !editingProductId) {
+								children={([, isSubmitting]) => {
+									const validationIssues = resolvedStageResolution.publishIssues
+									const hasValidationErrors = !resolvedStageResolution.canPublish
+									const hasV4VSetupBlocker = validationIssues.includes(PRODUCT_AUTHORING_V4V_SETUP_ISSUE)
+									const hasNonV4VBlockers = validationIssues.some((issue) => issue !== PRODUCT_AUTHORING_V4V_SETUP_ISSUE)
+
+									if (hasV4VSetupBlocker && !hasNonV4VBlockers && !editingProductId) {
 										return (
 											<TooltipProvider>
 												<Tooltip>
@@ -381,8 +395,6 @@ export function ProductFormContent({
 										)
 									}
 
-									const validationIssues = draftValidation.issues
-									const hasValidationErrors = !draftValidation.allRequiredFieldsValid
 									const isDisabled = isSubmitting || isPublishing || hasValidationErrors
 
 									return (
@@ -426,7 +438,8 @@ export function ProductFormContent({
 								type="button"
 								variant="secondary"
 								className="flex-1 uppercase"
-								onClick={productFormActions.nextTab}
+								onClick={handleNext}
+								disabled={!nextStage}
 								data-testid="product-next-button"
 							>
 								Next

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -68,9 +68,8 @@ export function ProductFormContent({
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
 	const { activeTab, editingProductId, isDirty } = formState
-	const [editCompatibilityStage, setEditCompatibilityStage] = useState<ProductAuthoringStage>(() =>
-		getProductAuthoringStageForTab(activeTab),
-	)
+	const nextCompatibilityStage = getProductAuthoringStageForTab(activeTab)
+	const [editCompatibilityStage, setEditCompatibilityStage] = useState<ProductAuthoringStage>(() => nextCompatibilityStage)
 	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
 		mode: editingProductId ? 'edit' : 'create',
 		isBootstrapReady: true,
@@ -86,6 +85,13 @@ export function ProductFormContent({
 			)
 		}
 	}, [workflow, editingProductId, resolvedWorkflow.mode])
+
+	useEffect(() => {
+		if (stageResolution || resolvedWorkflow.mode !== 'edit') return
+		if (nextCompatibilityStage === editCompatibilityStage) return
+
+		setEditCompatibilityStage(nextCompatibilityStage)
+	}, [editCompatibilityStage, nextCompatibilityStage, resolvedWorkflow.mode, stageResolution])
 
 	// Get user pubkey from auth store directly to avoid timing issues
 	const authState = useStore(authStore)

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -9,6 +9,7 @@ import { productFormActions, productFormStore, type ProductFormTab } from '@/lib
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
 import {
+	canSelectProductAuthoringStage,
 	getNextProductAuthoringStage,
 	getPreviousProductAuthoringStage,
 	getPrimaryProductAuthoringTabForStage,
@@ -154,11 +155,16 @@ export function ProductFormContent({
 	const selectedStage = resolvedStageResolution.selectedStage
 	const stageValidation = resolvedStageResolution.validation
 	const shouldHideLegacyTabs = resolvedWorkflow.mode === 'create'
+	const forwardBlocker = resolvedStageResolution.forwardBlocker
+	const forwardIssues = forwardBlocker?.issues ?? []
 	const renderedTabs = getProductAuthoringTabsForStage(selectedStage)
 	const previousStage = getPreviousProductAuthoringStage(selectedStage)
 	const nextStage = getNextProductAuthoringStage(selectedStage)
+	const isNextDisabled = !nextStage || !resolvedStageResolution.canAdvanceToNextStage
 	const selectStage = useCallback(
 		(stage: ProductAuthoringStage) => {
+			if (!canSelectProductAuthoringStage(stage, resolvedStageResolution)) return
+
 			if (onStageSelect) {
 				onStageSelect(stage)
 				return
@@ -170,16 +176,18 @@ export function ProductFormContent({
 				productFormActions.setActiveTab(primaryTab)
 			}
 		},
-		[onStageSelect],
+		[onStageSelect, resolvedStageResolution],
 	)
 	const handleLegacyTabSelect = useCallback(
 		(tab: string) => {
 			const legacyTab = tab as ProductFormTab
+			const legacyStage = getProductAuthoringStageForTab(legacyTab)
+			if (!canSelectProductAuthoringStage(legacyStage, resolvedStageResolution)) return
 
-			selectStage(getProductAuthoringStageForTab(legacyTab))
+			selectStage(legacyStage)
 			productFormActions.setActiveTab(legacyTab)
 		},
-		[selectStage],
+		[resolvedStageResolution, selectStage],
 	)
 	const handleBack = useCallback(() => {
 		if (onStageBack) {
@@ -190,13 +198,15 @@ export function ProductFormContent({
 		if (previousStage) selectStage(previousStage)
 	}, [onStageBack, previousStage, selectStage])
 	const handleNext = useCallback(() => {
+		if (!nextStage || !resolvedStageResolution.canAdvanceToNextStage) return
+
 		if (onStageNext) {
 			onStageNext()
 			return
 		}
 
-		if (nextStage) selectStage(nextStage)
-	}, [nextStage, onStageNext, selectStage])
+		selectStage(nextStage)
+	}, [nextStage, onStageNext, resolvedStageResolution.canAdvanceToNextStage, selectStage])
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {
@@ -481,16 +491,37 @@ export function ProductFormContent({
 								}}
 							/>
 						) : (
-							<Button
-								type="button"
-								variant="secondary"
-								className="flex-1 uppercase"
-								onClick={handleNext}
-								disabled={!nextStage}
-								data-testid="product-next-button"
-							>
-								Next
-							</Button>
+							<TooltipProvider>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span className="flex-1">
+											<Button
+												type="button"
+												variant="secondary"
+												className="w-full uppercase"
+												onClick={handleNext}
+												disabled={isNextDisabled}
+												data-testid="product-next-button"
+											>
+												Next
+											</Button>
+										</span>
+									</TooltipTrigger>
+									{isNextDisabled && nextStage && (
+										<TooltipContent>
+											{forwardIssues.length > 0 ? (
+												<ul className="list-disc list-inside space-y-1">
+													{forwardIssues.map((issue, i) => (
+														<li key={i}>{issue}</li>
+													))}
+												</ul>
+											) : (
+												<p>Complete the current stage before continuing.</p>
+											)}
+										</TooltipContent>
+									)}
+								</Tooltip>
+							</TooltipProvider>
 						)}
 					</div>
 				</div>

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -1,10 +1,11 @@
 import { ProductAuthoringStageNavigator } from '@/components/product-authoring/ProductAuthoringStageNavigator'
 import { Button } from '@/components/ui/button'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
 import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
-import { productFormActions, productFormStore } from '@/lib/stores/product'
+import { productFormActions, productFormStore, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
 import {
@@ -28,6 +29,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { NameTab } from './NameTab'
 import { CategoryTab, DetailTab, ImagesTab, ShippingTab, SpecTab } from './tabs'
+
+const LEGACY_PRODUCT_FORM_TABS: Array<{ tab: ProductFormTab; label: string; testId: string }> = [
+	{ tab: 'name', label: 'Name', testId: 'product-tab-name' },
+	{ tab: 'detail', label: 'Detail', testId: 'product-tab-detail' },
+	{ tab: 'spec', label: 'Spec', testId: 'product-tab-spec' },
+	{ tab: 'category', label: 'Category', testId: 'product-tab-category' },
+	{ tab: 'images', label: 'Images', testId: 'product-tab-images' },
+	{ tab: 'shipping', label: 'Shipping', testId: 'product-tab-shipping' },
+]
 
 export function ProductFormContent({
 	className = '',
@@ -131,6 +141,7 @@ export function ProductFormContent({
 		})
 
 	const selectedStage = resolvedStageResolution.selectedStage
+	const stageValidation = resolvedStageResolution.validation
 	const renderedTabs = getProductAuthoringTabsForStage(selectedStage)
 	const previousStage = getPreviousProductAuthoringStage(selectedStage)
 	const nextStage = getNextProductAuthoringStage(selectedStage)
@@ -148,6 +159,15 @@ export function ProductFormContent({
 			}
 		},
 		[onStageSelect],
+	)
+	const handleLegacyTabSelect = useCallback(
+		(tab: string) => {
+			const legacyTab = tab as ProductFormTab
+
+			selectStage(getProductAuthoringStageForTab(legacyTab))
+			productFormActions.setActiveTab(legacyTab)
+		},
+		[selectStage],
 	)
 	const handleBack = useCallback(() => {
 		if (onStageBack) {
@@ -337,6 +357,21 @@ export function ProductFormContent({
 		>
 			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
 				<ProductAuthoringStageNavigator resolution={resolvedStageResolution} onStageSelect={selectStage} />
+				<Tabs value={activeTab} onValueChange={handleLegacyTabSelect} className="w-full">
+					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
+						{LEGACY_PRODUCT_FORM_TABS.map(({ tab, label, testId }) => (
+							<TabsTrigger
+								key={tab}
+								value={tab}
+								className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+								data-testid={testId}
+							>
+								{label}
+								{stageValidation.issuesByTab[tab]?.length ? <span className="ml-1 text-red-500">*</span> : null}
+							</TabsTrigger>
+						))}
+					</TabsList>
+				</Tabs>
 
 				<div className="flex-1 overflow-y-auto min-h-0">{selectedStageContent}</div>
 			</div>

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -70,6 +70,7 @@ export function ProductFormContent({
 	const { activeTab, editingProductId, isDirty } = formState
 	const nextCompatibilityStage = getProductAuthoringStageForTab(activeTab)
 	const [editCompatibilityStage, setEditCompatibilityStage] = useState<ProductAuthoringStage>(() => nextCompatibilityStage)
+	const previousActiveTabRef = useRef(activeTab)
 	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
 		mode: editingProductId ? 'edit' : 'create',
 		isBootstrapReady: true,
@@ -87,11 +88,15 @@ export function ProductFormContent({
 	}, [workflow, editingProductId, resolvedWorkflow.mode])
 
 	useEffect(() => {
+		const previousActiveTab = previousActiveTabRef.current
+		previousActiveTabRef.current = activeTab
+
 		if (stageResolution || resolvedWorkflow.mode !== 'edit') return
+		if (previousActiveTab === activeTab) return
 		if (nextCompatibilityStage === editCompatibilityStage) return
 
 		setEditCompatibilityStage(nextCompatibilityStage)
-	}, [editCompatibilityStage, nextCompatibilityStage, resolvedWorkflow.mode, stageResolution])
+	}, [activeTab, editCompatibilityStage, nextCompatibilityStage, resolvedWorkflow.mode, stageResolution])
 
 	// Get user pubkey from auth store directly to avoid timing issues
 	const authState = useStore(authStore)
@@ -148,6 +153,7 @@ export function ProductFormContent({
 
 	const selectedStage = resolvedStageResolution.selectedStage
 	const stageValidation = resolvedStageResolution.validation
+	const shouldHideLegacyTabs = resolvedWorkflow.mode === 'create'
 	const renderedTabs = getProductAuthoringTabsForStage(selectedStage)
 	const previousStage = getPreviousProductAuthoringStage(selectedStage)
 	const nextStage = getNextProductAuthoringStage(selectedStage)
@@ -363,7 +369,7 @@ export function ProductFormContent({
 		>
 			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
 				<ProductAuthoringStageNavigator resolution={resolvedStageResolution} onStageSelect={selectStage} />
-				<Tabs value={activeTab} onValueChange={handleLegacyTabSelect} className="w-full">
+				<Tabs value={activeTab} onValueChange={handleLegacyTabSelect} className={shouldHideLegacyTabs ? 'sr-only' : 'w-full'}>
 					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
 						{LEGACY_PRODUCT_FORM_TABS.map(({ tab, label, testId }) => (
 							<TabsTrigger

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -46,6 +46,14 @@ export function ProductFormContent({
 		requiresV4VSetup: false,
 	}
 
+	useEffect(() => {
+		if (process.env.NODE_ENV === 'development' && !workflow && !editingProductId && resolvedWorkflow.mode === 'create') {
+			console.warn(
+				'ProductFormContent mounted in create mode without a canonical workflow prop. This fallback is temporary and unsupported.',
+			)
+		}
+	}, [workflow, editingProductId, resolvedWorkflow.mode])
+
 	// Compute validation states
 	const hasValidName = name.trim().length > 0
 	const hasValidDescription = description.trim().length > 0

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -2,9 +2,8 @@ import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/compo
 import { authActions, authStore } from '@/lib/stores/auth'
 import type { ProductFormState } from '@/lib/stores/product'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
-import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
-import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
-import { useV4VConfiguration } from '@/queries/v4v'
+import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
+import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
 import { useStore } from '@tanstack/react-store'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
@@ -29,9 +28,7 @@ export function NewProductContent({
 	const { user, isAuthenticated } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
 	const hasBootstrappedRef = useRef(false)
-
-	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
-	const v4vQuery = useV4VConfiguration(userPubkey)
+	const readiness = useProductCreateReadiness(userPubkey)
 
 	// Function to check if the form has been modified from its default state
 	const isFormModified = (currentState: ProductFormState) => {
@@ -57,42 +54,15 @@ export function NewProductContent({
 
 	const [showForm, setShowForm] = useState(hasStartedFormOrIsEditing)
 
-	const shippingState = useMemo<ShippingSetupState>(() => {
-		if (!userPubkey) return 'loading'
-		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
-
-		const activeShippingRefs = new Set(
-			(shippingQuery.data ?? [])
-				.filter((event) => {
-					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-
-		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
-	}, [userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
-
-	const v4vState = useMemo<V4VSetupState>(() => {
-		if (!userPubkey) return 'loading'
-		if (v4vQuery.isLoading) return 'loading'
-
-		return v4vQuery.data?.state ?? 'unknown'
-	}, [userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
-
 	const workflow = useMemo(
 		() =>
 			resolveProductWorkflow({
 				mode: editingProductId ? 'edit' : 'create',
 				editingProductId,
-				shippingState,
-				v4vConfigurationState: v4vState,
+				shippingState: readiness.shippingState,
+				v4vConfigurationState: readiness.v4vConfigurationState,
 			}),
-		[editingProductId, shippingState, v4vState],
+		[editingProductId, readiness.shippingState, readiness.v4vConfigurationState],
 	)
 
 	// Check if user has products when component mounts or user changes

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -99,7 +99,7 @@ export function NewProductContent({
 				<SheetDescription className="hidden">{description || defaultDescription}</SheetDescription>
 			</SheetHeader>
 
-			{editingProductId ? <ProductFormContent /> : <ProductCreateShell userPubkey={userPubkey} />}
+			{editingProductId ? <ProductFormContent /> : <ProductCreateShell userPubkey={userPubkey} entrypoint="homepage-sheet" />}
 		</SheetContent>
 	)
 }

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -1,11 +1,10 @@
+import { ProductCreateShell } from '@/components/product-authoring/ProductCreateShell'
 import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { authActions, authStore } from '@/lib/stores/auth'
 import type { ProductFormState } from '@/lib/stores/product'
-import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
-import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
-import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
+import { DEFAULT_FORM_STATE, productFormStore } from '@/lib/stores/product'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
 import { ProductWelcomeScreen } from './ProductWelcomeScreen'
 
@@ -27,8 +26,6 @@ export function NewProductContent({
 	// Get user and authentication status from auth store
 	const { user, isAuthenticated } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
-	const hasBootstrappedRef = useRef(false)
-	const readiness = useProductCreateReadiness(userPubkey)
 
 	// Function to check if the form has been modified from its default state
 	const isFormModified = (currentState: ProductFormState) => {
@@ -54,17 +51,6 @@ export function NewProductContent({
 
 	const [showForm, setShowForm] = useState(hasStartedFormOrIsEditing)
 
-	const workflow = useMemo(
-		() =>
-			resolveProductWorkflow({
-				mode: editingProductId ? 'edit' : 'create',
-				editingProductId,
-				shippingState: readiness.shippingState,
-				v4vConfigurationState: readiness.v4vConfigurationState,
-			}),
-		[editingProductId, readiness.shippingState, readiness.v4vConfigurationState],
-	)
-
 	// Check if user has products when component mounts or user changes
 	useEffect(() => {
 		const checkUserProducts = async () => {
@@ -85,19 +71,6 @@ export function NewProductContent({
 			setShowForm(true)
 		}
 	}, [hasStartedFormOrIsEditing, hasProducts, showForm, editingProductId])
-
-	useEffect(() => {
-		if (!showForm || editingProductId) {
-			hasBootstrappedRef.current = false
-			return
-		}
-
-		if (!workflow.isBootstrapReady || hasStartedFormOrIsEditing || hasBootstrappedRef.current) return
-
-		productFormActions.startCreateProductSession()
-		productFormActions.setActiveTab(workflow.initialTab)
-		hasBootstrappedRef.current = true
-	}, [showForm, editingProductId, workflow.isBootstrapReady, workflow.initialTab, hasStartedFormOrIsEditing])
 
 	// Default titles
 	const defaultTitle = editingProductId ? 'Edit Product' : 'Add A Product'
@@ -126,7 +99,7 @@ export function NewProductContent({
 				<SheetDescription className="hidden">{description || defaultDescription}</SheetDescription>
 			</SheetHeader>
 
-			<ProductFormContent workflow={workflow} />
+			{editingProductId ? <ProductFormContent /> : <ProductCreateShell userPubkey={userPubkey} />}
 		</SheetContent>
 	)
 }

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -1,9 +1,12 @@
 import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
 import { authActions, authStore } from '@/lib/stores/auth'
 import type { ProductFormState } from '@/lib/stores/product'
-import { DEFAULT_FORM_STATE, productFormStore } from '@/lib/stores/product'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
+import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
+import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { useV4VConfiguration } from '@/queries/v4v'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
 import { ProductWelcomeScreen } from './ProductWelcomeScreen'
 
@@ -24,6 +27,11 @@ export function NewProductContent({
 
 	// Get user and authentication status from auth store
 	const { user, isAuthenticated } = useStore(authStore)
+	const userPubkey = user?.pubkey ?? ''
+	const hasBootstrappedRef = useRef(false)
+
+	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
+	const v4vQuery = useV4VConfiguration(userPubkey)
 
 	// Function to check if the form has been modified from its default state
 	const isFormModified = (currentState: ProductFormState) => {
@@ -49,6 +57,44 @@ export function NewProductContent({
 
 	const [showForm, setShowForm] = useState(hasStartedFormOrIsEditing)
 
+	const shippingState = useMemo<ShippingSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
+
+		const activeShippingRefs = new Set(
+			(shippingQuery.data ?? [])
+				.filter((event) => {
+					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
+					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+				})
+				.map((event) => {
+					const info = getShippingInfo(event)
+					return info ? createShippingReference(event.pubkey, info.id) : null
+				})
+				.filter((shippingRef): shippingRef is string => !!shippingRef),
+		)
+
+		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
+	}, [userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
+
+	const v4vState = useMemo<V4VSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (v4vQuery.isLoading) return 'loading'
+
+		return v4vQuery.data?.state ?? 'unknown'
+	}, [userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
+
+	const workflow = useMemo(
+		() =>
+			resolveProductWorkflow({
+				mode: editingProductId ? 'edit' : 'create',
+				editingProductId,
+				shippingState,
+				v4vConfigurationState: v4vState,
+			}),
+		[editingProductId, shippingState, v4vState],
+	)
+
 	// Check if user has products when component mounts or user changes
 	useEffect(() => {
 		const checkUserProducts = async () => {
@@ -69,6 +115,19 @@ export function NewProductContent({
 			setShowForm(true)
 		}
 	}, [hasStartedFormOrIsEditing, hasProducts, showForm, editingProductId])
+
+	useEffect(() => {
+		if (!showForm || editingProductId) {
+			hasBootstrappedRef.current = false
+			return
+		}
+
+		if (!workflow.isBootstrapReady || hasStartedFormOrIsEditing || hasBootstrappedRef.current) return
+
+		productFormActions.startCreateProductSession()
+		productFormActions.setActiveTab(workflow.initialTab)
+		hasBootstrappedRef.current = true
+	}, [showForm, editingProductId, workflow.isBootstrapReady, workflow.initialTab, hasStartedFormOrIsEditing])
 
 	// Default titles
 	const defaultTitle = editingProductId ? 'Edit Product' : 'Add A Product'
@@ -97,7 +156,7 @@ export function NewProductContent({
 				<SheetDescription className="hidden">{description || defaultDescription}</SheetDescription>
 			</SheetHeader>
 
-			<ProductFormContent />
+			<ProductFormContent workflow={workflow} />
 		</SheetContent>
 	)
 }

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -688,10 +688,12 @@ export function ShippingTab() {
 	}, [getUser])
 
 	const shippingOptionsQuery = useShippingOptionsByPubkey(user?.pubkey || '')
+	const hasResolvedSellerShippingState = shippingOptionsQuery.isSuccess || shippingOptionsQuery.data !== undefined
+	const sellerShippingStateIsUnresolvedError = !hasResolvedSellerShippingState && shippingOptionsQuery.isError
 
 	// Quick-create a shipping option from template
 	const handleQuickCreate = async (template: (typeof QUICK_SHIPPING_TEMPLATES)[number]) => {
-		if (isCreatingShipping || !user?.pubkey) return
+		if (isCreatingShipping || !user?.pubkey || !hasResolvedSellerShippingState) return
 
 		// For pickup, show the address form instead of creating immediately
 		if (template.service === 'pickup') {
@@ -727,7 +729,7 @@ export function ShippingTab() {
 
 	// Handle pickup address form submission
 	const handlePickupSubmit = async () => {
-		if (!user?.pubkey) return
+		if (!user?.pubkey || !hasResolvedSellerShippingState) return
 
 		// Validate required fields
 		if (!pickupAddress.street.trim()) {
@@ -791,6 +793,8 @@ export function ShippingTab() {
 	}, [shippingOptionsQuery.data, user?.pubkey])
 
 	const addShippingOption = (option: RichShippingInfo) => {
+		if (!hasResolvedSellerShippingState) return
+
 		const nextShippings = attachShippingOptionByRef(productFormStore.state.shippings, option.id)
 
 		if (nextShippings === productFormStore.state.shippings) {
@@ -943,7 +947,9 @@ export function ShippingTab() {
 					<h3 className="font-medium">Saved Merchant Shipping Options</h3>
 					<p className="text-sm text-gray-500">Reusable seller-level shipping options that can be attached to this product.</p>
 				</div>
-				{shippingOptionsQuery.isLoading ? (
+				{!hasResolvedSellerShippingState && sellerShippingStateIsUnresolvedError ? (
+					<div className="p-4 border rounded-md text-sm text-amber-600">Saved merchant shipping options are unavailable right now.</div>
+				) : !hasResolvedSellerShippingState ? (
 					<div className="flex items-center justify-center p-8">
 						<Loader2 className="w-6 h-6 animate-spin" />
 						<span className="ml-2">Loading shipping options...</span>
@@ -985,7 +991,16 @@ export function ShippingTab() {
 					<p className="text-sm text-gray-500">Common merchant-level templates that have not been saved for this seller yet.</p>
 				</div>
 
-				{showPickupForm ? (
+				{!hasResolvedSellerShippingState && sellerShippingStateIsUnresolvedError ? (
+					<div className="p-4 border rounded-md text-sm text-amber-600">
+						Quick-create templates are unavailable until seller shipping options resolve.
+					</div>
+				) : !hasResolvedSellerShippingState ? (
+					<div className="flex items-center justify-center p-8">
+						<Loader2 className="w-6 h-6 animate-spin" />
+						<span className="ml-2">Loading quick-create templates...</span>
+					</div>
+				) : showPickupForm ? (
 					<div className="border rounded-md p-4 space-y-4 bg-gray-50">
 						<div className="flex items-center gap-2">
 							<PackageIcon className="w-5 h-5 text-green-500" />

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { CURRENCIES, PRODUCT_CATEGORIES } from '@/lib/constants'
 import type { RichShippingInfo } from '@/lib/stores/cart'
 import { useNDK } from '@/lib/stores/ndk'
-import { productFormActions, productFormStore, type ProductShippingForm } from '@/lib/stores/product'
+import { productFormActions, productFormStore } from '@/lib/stores/product'
 import { uiStore } from '@/lib/stores/ui'
 import { attachShippingOptionByRef } from '@/lib/utils/productShippingQuickCreate'
 import { resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
@@ -628,11 +628,23 @@ export function ImagesTab() {
 	)
 }
 
+type QuickShippingTemplateService = Extract<ShippingFormData['service'], 'digital' | 'standard' | 'pickup'>
+
+const normalizeQuickShippingTemplateService = (service: string | null | undefined): QuickShippingTemplateService | null => {
+	const normalizedService = service?.trim().toLowerCase()
+
+	if (normalizedService === 'digital' || normalizedService === 'standard' || normalizedService === 'pickup') {
+		return normalizedService
+	}
+
+	return null
+}
+
 // Quick-create shipping templates for new users
 const QUICK_SHIPPING_TEMPLATES: Array<{
 	name: string
 	description: string
-	service: ShippingFormData['service']
+	service: QuickShippingTemplateService
 	icon: 'digital' | 'worldwide' | 'pickup'
 }> = [
 	{
@@ -779,20 +791,15 @@ export function ShippingTab() {
 	}, [shippingOptionsQuery.data, user?.pubkey])
 
 	const addShippingOption = (option: RichShippingInfo) => {
-		// Check if shipping option is already added
-		const isAlreadyAdded = shippings.some((s) => s.shippingRef === option.id)
-		if (isAlreadyAdded) {
+		const nextShippings = attachShippingOptionByRef(productFormStore.state.shippings, option.id)
+
+		if (nextShippings === productFormStore.state.shippings) {
 			toast.error('This shipping option is already added')
 			return
 		}
 
-		const newShipping: ProductShippingForm = {
-			shippingRef: option.id,
-			extraCost: '',
-		}
-
 		productFormActions.updateValues({
-			shippings: [...shippings, newShipping],
+			shippings: nextShippings,
 		})
 	}
 
@@ -830,6 +837,31 @@ export function ShippingTab() {
 		[shippings, availableShippingOptions],
 	)
 
+	const selectedShippingRefs = useMemo(
+		() => new Set(shippings.map((shipping) => shipping.shippingRef).filter((shippingRef): shippingRef is string => !!shippingRef)),
+		[shippings],
+	)
+
+	const availableMerchantShippingOptions = useMemo(
+		() => availableShippingOptions.filter((option) => !selectedShippingRefs.has(option.id)),
+		[availableShippingOptions, selectedShippingRefs],
+	)
+
+	const savedMerchantQuickTemplateServices = useMemo(
+		() =>
+			new Set(
+				availableShippingOptions
+					.map((option) => normalizeQuickShippingTemplateService(option.service))
+					.filter((service): service is QuickShippingTemplateService => !!service),
+			),
+		[availableShippingOptions],
+	)
+
+	const remainingQuickShippingTemplates = useMemo(
+		() => QUICK_SHIPPING_TEMPLATES.filter((template) => !savedMerchantQuickTemplateServices.has(template.service)),
+		[savedMerchantQuickTemplateServices],
+	)
+
 	const hasValidShipping = shippingOptionsQuery.isFetched
 		? resolvedSelectedShippings.some((shipping) => shipping.isResolved)
 		: shippings.some((shipping) => !!shipping.shippingRef)
@@ -846,9 +878,12 @@ export function ShippingTab() {
 			</div>
 
 			{/* Selected Shipping Options */}
-			{shippings.length > 0 && (
-				<div className="space-y-4">
+			<div className="space-y-4">
+				<div>
 					<h3 className="font-medium">Selected Shipping Options</h3>
+					<p className="text-sm text-gray-500">Shipping options attached to this product draft.</p>
+				</div>
+				{shippings.length > 0 ? (
 					<div className="space-y-3">
 						{resolvedSelectedShippings.map((shipping, index) => {
 							const option = shipping.option
@@ -897,173 +932,188 @@ export function ShippingTab() {
 							)
 						})}
 					</div>
-				</div>
-			)}
+				) : (
+					<div className="p-4 border rounded-md text-sm text-gray-500">No shipping options selected for this product yet.</div>
+				)}
+			</div>
 
-			{/* Available Shipping Options */}
+			{/* Saved Merchant Shipping Options */}
 			<div className="space-y-4">
-				<h3 className="font-medium">Available Shipping Options</h3>
+				<div>
+					<h3 className="font-medium">Saved Merchant Shipping Options</h3>
+					<p className="text-sm text-gray-500">Reusable seller-level shipping options that can be attached to this product.</p>
+				</div>
 				{shippingOptionsQuery.isLoading ? (
 					<div className="flex items-center justify-center p-8">
 						<Loader2 className="w-6 h-6 animate-spin" />
 						<span className="ml-2">Loading shipping options...</span>
 					</div>
 				) : availableShippingOptions.length === 0 ? (
-					<div className="space-y-4">
-						<div className="text-center p-4 text-gray-500">
-							<p>No shipping options available.</p>
-							<p className="text-sm mt-2">Quick-create a shipping option to get started:</p>
-						</div>
-						{showPickupForm ? (
-							<div className="border rounded-md p-4 space-y-4 bg-gray-50">
-								<div className="flex items-center gap-2">
-									<PackageIcon className="w-5 h-5 text-green-500" />
-									<h4 className="font-medium">Local Pickup Address</h4>
-								</div>
-								<p className="text-sm text-gray-500">Enter the address where customers can pick up their orders:</p>
-								<div className="space-y-3">
-									<div>
-										<Label htmlFor="pickup-street" className="text-sm">
-											Street Address <span className="text-red-500">*</span>
-										</Label>
-										<Input
-											id="pickup-street"
-											value={pickupAddress.street}
-											onChange={(e) => setPickupAddress((prev) => ({ ...prev, street: e.target.value }))}
-											placeholder="123 Main Street"
-											className="mt-1"
-										/>
-									</div>
-									<div className="grid grid-cols-2 gap-3">
-										<div>
-											<Label htmlFor="pickup-city" className="text-sm">
-												City <span className="text-red-500">*</span>
-											</Label>
-											<Input
-												id="pickup-city"
-												value={pickupAddress.city}
-												onChange={(e) => setPickupAddress((prev) => ({ ...prev, city: e.target.value }))}
-												placeholder="New York"
-												className="mt-1"
-											/>
-										</div>
-										<div>
-											<Label htmlFor="pickup-state" className="text-sm">
-												State/Province
-											</Label>
-											<Input
-												id="pickup-state"
-												value={pickupAddress.state}
-												onChange={(e) => setPickupAddress((prev) => ({ ...prev, state: e.target.value }))}
-												placeholder="NY"
-												className="mt-1"
-											/>
-										</div>
-									</div>
-									<div className="grid grid-cols-2 gap-3">
-										<div>
-											<Label htmlFor="pickup-postal" className="text-sm">
-												Postal Code
-											</Label>
-											<Input
-												id="pickup-postal"
-												value={pickupAddress.postalCode}
-												onChange={(e) => setPickupAddress((prev) => ({ ...prev, postalCode: e.target.value }))}
-												placeholder="10001"
-												className="mt-1"
-											/>
-										</div>
-										<div>
-											<Label htmlFor="pickup-country" className="text-sm">
-												Country
-											</Label>
-											<Input
-												id="pickup-country"
-												value={pickupAddress.country}
-												onChange={(e) => setPickupAddress((prev) => ({ ...prev, country: e.target.value }))}
-												placeholder="USA"
-												className="mt-1"
-											/>
-										</div>
-									</div>
-								</div>
-								<div className="flex gap-2 pt-2">
-									<Button
-										type="button"
-										variant="outline"
-										onClick={() => {
-											setShowPickupForm(false)
-											setPickupAddress({ street: '', city: '', state: '', postalCode: '', country: '' })
-										}}
-										disabled={isCreatingShipping}
-										className="flex-1"
-									>
-										Cancel
-									</Button>
-									<Button type="button" onClick={handlePickupSubmit} disabled={isCreatingShipping} className="flex-1">
-										{isCreatingShipping ? (
-											<>
-												<Loader2 className="w-4 h-4 animate-spin mr-2" />
-												Creating...
-											</>
-										) : (
-											'Create Pickup Option'
-										)}
-									</Button>
-								</div>
-							</div>
-						) : (
-							<div className="grid gap-3">
-								{QUICK_SHIPPING_TEMPLATES.map((template) => (
-									<button
-										key={template.name}
-										type="button"
-										onClick={() => handleQuickCreate(template)}
-										disabled={isCreatingShipping}
-										className="flex items-center gap-3 p-4 border rounded-md hover:bg-gray-50 text-left transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-									>
-										{template.icon === 'digital' && <DownloadIcon className="w-5 h-5 text-purple-500 flex-shrink-0" />}
-										{template.icon === 'worldwide' && <TruckIcon className="w-5 h-5 text-blue-500 flex-shrink-0" />}
-										{template.icon === 'pickup' && <PackageIcon className="w-5 h-5 text-green-500 flex-shrink-0" />}
-										<div className="flex-1 min-w-0">
-											<div className="font-medium">{template.name}</div>
-											<div className="text-sm text-gray-500">{template.description}</div>
-										</div>
-										{isCreatingShipping ? (
-											<Loader2 className="w-5 h-5 animate-spin text-gray-400" />
-										) : (
-											<PlusIcon className="w-5 h-5 text-gray-400" />
-										)}
-									</button>
-								))}
-							</div>
-						)}
-						<p className="text-xs text-gray-400 text-center">You can customize these options later in Dashboard → Shipping Options</p>
+					<div className="p-4 border rounded-md text-sm text-gray-500">No saved merchant shipping options yet.</div>
+				) : availableMerchantShippingOptions.length === 0 ? (
+					<div className="p-4 border rounded-md text-sm text-gray-500">
+						All saved merchant shipping options are already selected for this product.
 					</div>
 				) : (
 					<div className="grid gap-3">
-						{availableShippingOptions
-							.filter((option) => !shippings.some((s) => s.shippingRef === option.id))
-							.map((option) => (
-								<div key={option.id} className="flex items-center gap-3 p-3 border rounded-md hover:bg-gray-50">
-									{option.service && <ServiceIcon service={option.service} />}
-									<div className="flex-1">
-										<div className="font-medium">{option.name}</div>
-										<div className="text-sm text-gray-500">
-											{option.cost} {option.currency} •{' '}
-											{option.countries && option.countries.length > 1
-												? `${option.countries.length} countries`
-												: option.countries?.[0] || 'Worldwide'}{' '}
-											• {option.service || 'Unknown service'}
-										</div>
+						{availableMerchantShippingOptions.map((option) => (
+							<div key={option.id} className="flex items-center gap-3 p-3 border rounded-md hover:bg-gray-50">
+								{option.service && <ServiceIcon service={option.service} />}
+								<div className="flex-1">
+									<div className="font-medium">{option.name}</div>
+									<div className="text-sm text-gray-500">
+										{option.cost} {option.currency} •{' '}
+										{option.countries && option.countries.length > 1
+											? `${option.countries.length} countries`
+											: option.countries?.[0] || 'Worldwide'}{' '}
+										• {option.service || 'Unknown service'}
 									</div>
-									<Button type="button" variant="outline" size="sm" onClick={() => addShippingOption(option)}>
-										Add
-									</Button>
 								</div>
-							))}
+								<Button type="button" variant="outline" size="sm" onClick={() => addShippingOption(option)}>
+									Add
+								</Button>
+							</div>
+						))}
 					</div>
 				)}
+			</div>
+
+			{/* Quick-create Delivery Templates */}
+			<div className="space-y-4">
+				<div>
+					<h3 className="font-medium">Quick-create Delivery Templates</h3>
+					<p className="text-sm text-gray-500">Common merchant-level templates that have not been saved for this seller yet.</p>
+				</div>
+
+				{showPickupForm ? (
+					<div className="border rounded-md p-4 space-y-4 bg-gray-50">
+						<div className="flex items-center gap-2">
+							<PackageIcon className="w-5 h-5 text-green-500" />
+							<h4 className="font-medium">Local Pickup Address</h4>
+						</div>
+						<p className="text-sm text-gray-500">Enter the address where customers can pick up their orders:</p>
+						<div className="space-y-3">
+							<div>
+								<Label htmlFor="pickup-street" className="text-sm">
+									Street Address <span className="text-red-500">*</span>
+								</Label>
+								<Input
+									id="pickup-street"
+									value={pickupAddress.street}
+									onChange={(e) => setPickupAddress((prev) => ({ ...prev, street: e.target.value }))}
+									placeholder="123 Main Street"
+									className="mt-1"
+								/>
+							</div>
+							<div className="grid grid-cols-2 gap-3">
+								<div>
+									<Label htmlFor="pickup-city" className="text-sm">
+										City <span className="text-red-500">*</span>
+									</Label>
+									<Input
+										id="pickup-city"
+										value={pickupAddress.city}
+										onChange={(e) => setPickupAddress((prev) => ({ ...prev, city: e.target.value }))}
+										placeholder="New York"
+										className="mt-1"
+									/>
+								</div>
+								<div>
+									<Label htmlFor="pickup-state" className="text-sm">
+										State/Province
+									</Label>
+									<Input
+										id="pickup-state"
+										value={pickupAddress.state}
+										onChange={(e) => setPickupAddress((prev) => ({ ...prev, state: e.target.value }))}
+										placeholder="NY"
+										className="mt-1"
+									/>
+								</div>
+							</div>
+							<div className="grid grid-cols-2 gap-3">
+								<div>
+									<Label htmlFor="pickup-postal" className="text-sm">
+										Postal Code
+									</Label>
+									<Input
+										id="pickup-postal"
+										value={pickupAddress.postalCode}
+										onChange={(e) => setPickupAddress((prev) => ({ ...prev, postalCode: e.target.value }))}
+										placeholder="10001"
+										className="mt-1"
+									/>
+								</div>
+								<div>
+									<Label htmlFor="pickup-country" className="text-sm">
+										Country
+									</Label>
+									<Input
+										id="pickup-country"
+										value={pickupAddress.country}
+										onChange={(e) => setPickupAddress((prev) => ({ ...prev, country: e.target.value }))}
+										placeholder="USA"
+										className="mt-1"
+									/>
+								</div>
+							</div>
+						</div>
+						<div className="flex gap-2 pt-2">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => {
+									setShowPickupForm(false)
+									setPickupAddress({ street: '', city: '', state: '', postalCode: '', country: '' })
+								}}
+								disabled={isCreatingShipping}
+								className="flex-1"
+							>
+								Cancel
+							</Button>
+							<Button type="button" onClick={handlePickupSubmit} disabled={isCreatingShipping} className="flex-1">
+								{isCreatingShipping ? (
+									<>
+										<Loader2 className="w-4 h-4 animate-spin mr-2" />
+										Creating...
+									</>
+								) : (
+									'Create Pickup Option'
+								)}
+							</Button>
+						</div>
+					</div>
+				) : remainingQuickShippingTemplates.length > 0 ? (
+					<div className="grid gap-3">
+						{remainingQuickShippingTemplates.map((template) => (
+							<button
+								key={template.service}
+								type="button"
+								onClick={() => handleQuickCreate(template)}
+								disabled={isCreatingShipping}
+								className="flex items-center gap-3 p-4 border rounded-md hover:bg-gray-50 text-left transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+							>
+								{template.icon === 'digital' && <DownloadIcon className="w-5 h-5 text-purple-500 flex-shrink-0" />}
+								{template.icon === 'worldwide' && <TruckIcon className="w-5 h-5 text-blue-500 flex-shrink-0" />}
+								{template.icon === 'pickup' && <PackageIcon className="w-5 h-5 text-green-500 flex-shrink-0" />}
+								<div className="flex-1 min-w-0">
+									<div className="font-medium">{template.name}</div>
+									<div className="text-sm text-gray-500">{template.description}</div>
+								</div>
+								{isCreatingShipping ? (
+									<Loader2 className="w-5 h-5 animate-spin text-gray-400" />
+								) : (
+									<PlusIcon className="w-5 h-5 text-gray-400" />
+								)}
+							</button>
+						))}
+					</div>
+				) : (
+					<div className="p-4 border rounded-md text-sm text-gray-500">
+						All common quick-create templates already exist for this seller.
+					</div>
+				)}
+				<p className="text-xs text-gray-400 text-center">You can customize these options later in Dashboard → Shipping Options</p>
 			</div>
 		</div>
 	)

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -10,6 +10,12 @@ import type { RichShippingInfo } from '@/lib/stores/cart'
 import { useNDK } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore } from '@/lib/stores/product'
 import { uiStore } from '@/lib/stores/ui'
+import {
+	getProductDeliveryModeLabel,
+	productDeliveryModeAllowsProductExtraCost,
+	resolveProductDeliveryMode,
+	type ProductDeliveryMode,
+} from '@/lib/workflow/productDeliveryModes'
 import { attachShippingOptionByRef } from '@/lib/utils/productShippingQuickCreate'
 import {
 	normalizeProductShippingExtraCost,
@@ -19,10 +25,10 @@ import {
 import { MempoolService } from '@/lib/utils/mempool'
 import { useBtcExchangeRates, type SupportedCurrency } from '@/queries/external'
 import { usePublishShippingOptionMutation, type ShippingFormData } from '@/publish/shipping'
-import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { createShippingReference, getShippingInfo, getShippingPickupAddress, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useForm } from '@tanstack/react-form'
 import { useStore } from '@tanstack/react-store'
-import { Info, ArrowRightLeft, DownloadIcon, Loader2, PackageIcon, PlusIcon, TruckIcon, X, AlertTriangle } from 'lucide-react'
+import { ArrowRightLeft, DownloadIcon, Loader2, PackageIcon, PlusIcon, TruckIcon, X, AlertTriangle } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -671,6 +677,47 @@ const QUICK_SHIPPING_TEMPLATES: Array<{
 	},
 ]
 
+const formatPickupAddress = (address: RichShippingInfo['pickupAddress']): string | null => {
+	if (!address || typeof address !== 'object') return null
+
+	const parts = [address.street, address.city, address.state, address.postalCode, address.country].filter(
+		(part): part is string => typeof part === 'string' && part.trim().length > 0,
+	)
+
+	return parts.length ? parts.join(', ') : null
+}
+
+const formatCoverageSummary = (countries: string[] | undefined): string => {
+	if (!countries || countries.length === 0) return 'Worldwide'
+	if (countries.length === 1) return countries[0]
+	return `${countries.length} countries`
+}
+
+const getSelectedShippingSummary = (option: RichShippingInfo, deliveryMode: ProductDeliveryMode): string => {
+	if (deliveryMode === 'pickup') {
+		return formatPickupAddress(option.pickupAddress) || option.location || 'Pickup location configured by seller'
+	}
+
+	if (deliveryMode === 'digital') {
+		return option.description || 'Delivered digitally after purchase'
+	}
+
+	return `${option.cost ?? 0} ${option.currency || ''} • ${formatCoverageSummary(option.countries)} • ${option.service || 'Physical shipping'}`
+}
+
+const getProductDeliveryModeNote = (deliveryMode: ProductDeliveryMode, option: RichShippingInfo | null): string => {
+	if (deliveryMode === 'pickup') {
+		const address = formatPickupAddress(option?.pickupAddress)
+		return address ? `Pickup at ${address}` : 'Pickup instructions come from the seller shipping option'
+	}
+
+	if (deliveryMode === 'digital') {
+		return 'Delivered digitally after purchase. No shipping cost.'
+	}
+
+	return 'Optional product-specific extra shipping cost'
+}
+
 export function ShippingTab() {
 	const { shippings } = useStore(productFormStore)
 	const { getUser } = useNDK()
@@ -794,11 +841,14 @@ export function ShippingTab() {
 				return {
 					id,
 					name: info.title,
+					description: info.description,
 					cost: parseFloat(info.price.amount),
 					currency: info.price.currency,
 					countries: info.countries || [],
 					service: info.service || '',
 					carrier: info.carrier || '',
+					location: info.location || '',
+					pickupAddress: getShippingPickupAddress(event),
 				}
 			})
 			.filter(Boolean) as RichShippingInfo[]
@@ -858,14 +908,15 @@ export function ShippingTab() {
 	}
 
 	const ServiceIcon = ({ service }: { service: string }) => {
-		switch (service) {
-			case 'express':
-			case 'overnight':
-				return <TruckIcon className="w-4 h-4 text-orange-500" />
+		const deliveryMode = resolveProductDeliveryMode(service)
+
+		switch (deliveryMode) {
+			case 'digital':
+				return <DownloadIcon className="w-4 h-4 text-purple-500" />
 			case 'pickup':
 				return <PackageIcon className="w-4 h-4 text-blue-500" />
-			default:
-				return <TruckIcon className="w-4 h-4" />
+			case 'physical':
+				return <TruckIcon className={`w-4 h-4 ${service === 'express' || service === 'overnight' ? 'text-orange-500' : ''}`} />
 		}
 	}
 
@@ -944,6 +995,9 @@ export function ShippingTab() {
 					<div className="space-y-3">
 						{resolvedSelectedShippings.map((shipping, index) => {
 							const option = shipping.option
+							const deliveryMode = resolveProductDeliveryMode(option?.service || shipping.service)
+							const allowsProductExtraCost = productDeliveryModeAllowsProductExtraCost(deliveryMode)
+
 							return (
 								<div key={index} className="flex items-center gap-3 p-3 border rounded-md bg-gray-50">
 									{option?.service ? <ServiceIcon service={option.service} /> : <AlertTriangle className="w-4 h-4 text-amber-500" />}
@@ -953,11 +1007,7 @@ export function ShippingTab() {
 										</div>
 										{option ? (
 											<div className="text-sm text-gray-500">
-												{option.cost} {option.currency} •{' '}
-												{option.countries && option.countries.length > 1
-													? `${option.countries.length} countries`
-													: option.countries?.[0] || 'No countries'}{' '}
-												• {option.service || 'Unknown service'}
+												{getProductDeliveryModeLabel(deliveryMode)} • {getSelectedShippingSummary(option, deliveryMode)}
 											</div>
 										) : shippingOptionsQuery.isFetched ? (
 											<div className="text-sm text-amber-600">This shipping reference is no longer available: {shipping.shippingRef}</div>
@@ -966,9 +1016,7 @@ export function ShippingTab() {
 										)}
 									</div>
 									<div className="flex items-center gap-2">
-										{option?.service === 'digital' || option?.service === 'pickup' ? (
-											<div className="w-40 sm:w-56 md:w-76 text-sm text-gray-500">No product-specific extra cost</div>
-										) : (
+										{allowsProductExtraCost ? (
 											<Input
 												type="number"
 												inputMode="decimal"
@@ -980,6 +1028,8 @@ export function ShippingTab() {
 												placeholder="Add cost specific to this product"
 												className="w-40 sm:w-56 md:w-76 text-sm"
 											/>
+										) : (
+											<div className="w-40 sm:w-56 md:w-76 text-sm text-gray-500">{getProductDeliveryModeNote(deliveryMode, option)}</div>
 										)}
 										<Button
 											type="button"
@@ -1021,24 +1071,24 @@ export function ShippingTab() {
 					</div>
 				) : (
 					<div className="grid gap-3">
-						{availableMerchantShippingOptions.map((option) => (
-							<div key={option.id} className="flex items-center gap-3 p-3 border rounded-md hover:bg-gray-50">
-								{option.service && <ServiceIcon service={option.service} />}
-								<div className="flex-1">
-									<div className="font-medium">{option.name}</div>
-									<div className="text-sm text-gray-500">
-										{option.cost} {option.currency} •{' '}
-										{option.countries && option.countries.length > 1
-											? `${option.countries.length} countries`
-											: option.countries?.[0] || 'Worldwide'}{' '}
-										• {option.service || 'Unknown service'}
+						{availableMerchantShippingOptions.map((option) => {
+							const deliveryMode = resolveProductDeliveryMode(option.service)
+
+							return (
+								<div key={option.id} className="flex items-center gap-3 p-3 border rounded-md hover:bg-gray-50">
+									{option.service && <ServiceIcon service={option.service} />}
+									<div className="flex-1">
+										<div className="font-medium">{option.name}</div>
+										<div className="text-sm text-gray-500">
+											{getProductDeliveryModeLabel(deliveryMode)} • {getSelectedShippingSummary(option, deliveryMode)}
+										</div>
 									</div>
+									<Button type="button" variant="outline" size="sm" onClick={() => addShippingOption(option)}>
+										Add
+									</Button>
 								</div>
-								<Button type="button" variant="outline" size="sm" onClick={() => addShippingOption(option)}>
-									Add
-								</Button>
-							</div>
-						))}
+							)
+						})}
 					</div>
 				)}
 			</div>

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -719,7 +719,11 @@ export function ShippingTab() {
 			const publishedShipping = await publishShippingMutation.mutateAsync(formData)
 
 			productFormActions.updateValues({
-				shippings: attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef),
+				shippings: [
+					...attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef).map((shipping) =>
+						shipping.shippingRef === publishedShipping.shippingRef ? { ...shipping, service: template.service } : shipping,
+					),
+				],
 			})
 
 			toast.success(`${template.name} shipping option created and added!`)
@@ -760,7 +764,11 @@ export function ShippingTab() {
 			const publishedShipping = await publishShippingMutation.mutateAsync(formData)
 
 			productFormActions.updateValues({
-				shippings: attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef),
+				shippings: [
+					...attachShippingOptionByRef(productFormStore.state.shippings, publishedShipping.shippingRef).map((shipping) =>
+						shipping.shippingRef === publishedShipping.shippingRef ? { ...shipping, service: 'pickup' } : shipping,
+					),
+				],
 			})
 
 			toast.success('Local Pickup shipping option created and added!')
@@ -799,12 +807,16 @@ export function ShippingTab() {
 	const addShippingOption = (option: RichShippingInfo) => {
 		if (!hasResolvedSellerShippingState) return
 
-		const nextShippings = attachShippingOptionByRef(productFormStore.state.shippings, option.id)
+		const attachedShippings = attachShippingOptionByRef(productFormStore.state.shippings, option.id)
 
-		if (nextShippings === productFormStore.state.shippings) {
+		if (attachedShippings === productFormStore.state.shippings) {
 			toast.error('This shipping option is already added')
 			return
 		}
+
+		const nextShippings = attachedShippings.map((shipping) =>
+			shipping.shippingRef === option.id ? { ...shipping, service: option.service } : shipping,
+		)
 
 		productFormActions.updateValues({
 			shippings: nextShippings,
@@ -861,6 +873,26 @@ export function ShippingTab() {
 		() => resolveProductShippingSelections(shippings, availableShippingOptions),
 		[shippings, availableShippingOptions],
 	)
+
+	useEffect(() => {
+		const normalizedShippings = resolvedSelectedShippings.map(({ option: _option, isResolved: _isResolved, ...shipping }) => shipping)
+		const hasChanged =
+			normalizedShippings.length !== shippings.length ||
+			normalizedShippings.some((shipping, index) => {
+				const current = shippings[index]
+				return (
+					shipping.shippingRef !== current?.shippingRef ||
+					shipping.extraCost !== current?.extraCost ||
+					shipping.service !== current?.service
+				)
+			})
+
+		if (!hasChanged) return
+
+		productFormActions.updateValues({
+			shippings: normalizedShippings,
+		})
+	}, [resolvedSelectedShippings, shippings])
 
 	const selectedShippingRefs = useMemo(
 		() => new Set(shippings.map((shipping) => shipping.shippingRef).filter((shippingRef): shippingRef is string => !!shippingRef)),

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -11,7 +11,11 @@ import { useNDK } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore } from '@/lib/stores/product'
 import { uiStore } from '@/lib/stores/ui'
 import { attachShippingOptionByRef } from '@/lib/utils/productShippingQuickCreate'
-import { resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
+import {
+	normalizeProductShippingExtraCost,
+	resolveProductShippingSelections,
+	sanitizeProductShippingExtraCostInput,
+} from '@/lib/utils/productShippingSelections'
 import { MempoolService } from '@/lib/utils/mempool'
 import { useBtcExchangeRates, type SupportedCurrency } from '@/queries/external'
 import { usePublishShippingOptionMutation, type ShippingFormData } from '@/publish/shipping'
@@ -814,10 +818,27 @@ export function ShippingTab() {
 	}
 
 	const updateExtraCost = (index: number, extraCost: string) => {
+		const sanitizedExtraCost = sanitizeProductShippingExtraCostInput(extraCost)
+		if (sanitizedExtraCost === null) return
+
 		const updatedShippings = [...shippings]
 		updatedShippings[index] = {
 			...updatedShippings[index],
-			extraCost,
+			extraCost: sanitizedExtraCost,
+		}
+		productFormActions.updateValues({
+			shippings: updatedShippings,
+		})
+	}
+
+	const normalizeExtraCost = (index: number) => {
+		const normalizedExtraCost = normalizeProductShippingExtraCost(shippings[index]?.extraCost)
+		if (normalizedExtraCost === shippings[index]?.extraCost) return
+
+		const updatedShippings = [...shippings]
+		updatedShippings[index] = {
+			...updatedShippings[index],
+			extraCost: normalizedExtraCost,
 		}
 		productFormActions.updateValues({
 			shippings: updatedShippings,
@@ -913,15 +934,21 @@ export function ShippingTab() {
 										)}
 									</div>
 									<div className="flex items-center gap-2">
-										<Input
-											type="number"
-											step="0.01"
-											min="0"
-											value={shipping.extraCost}
-											onChange={(e) => updateExtraCost(index, e.target.value)}
-											placeholder="Add cost specific to this product"
-											className="w-40 sm:w-56 md:w-76 text-sm"
-										/>
+										{option?.service === 'digital' || option?.service === 'pickup' ? (
+											<div className="w-40 sm:w-56 md:w-76 text-sm text-gray-500">No product-specific extra cost</div>
+										) : (
+											<Input
+												type="number"
+												inputMode="decimal"
+												step="0.01"
+												min="0"
+												value={shipping.extraCost}
+												onChange={(e) => updateExtraCost(index, e.target.value)}
+												onBlur={() => normalizeExtraCost(index)}
+												placeholder="Add cost specific to this product"
+												className="w-40 sm:w-56 md:w-76 text-sm"
+											/>
+										)}
 										<Button
 											type="button"
 											variant="outline"

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -22,6 +22,7 @@ import {
 import { productKeys } from '@/queries/queryKeyFactory'
 import { clearProductFormDraft, getProductFormDraft, saveProductFormDraft } from '@/lib/utils/productFormStorage'
 import { normalizeProductShippingSelections, type ProductShippingSelection } from '@/lib/utils/productShippingSelections'
+import { getProductFormPublishValidationInput, validateProductPublishDraft } from '@/lib/workflow/productDraftValidation'
 import { uiActions, uiStore } from '@/lib/stores/ui'
 import NDK, { type NDKSigner } from '@nostr-dev-kit/ndk'
 import { QueryClient } from '@tanstack/react-query'
@@ -423,6 +424,11 @@ export const productFormActions = {
 
 	continuePublishing: async (signer: NDKSigner, ndk: NDK, queryClient?: QueryClient): Promise<boolean | string> => {
 		const state = productFormStore.state
+		const publishValidation = validateProductPublishDraft(getProductFormPublishValidationInput(state))
+		if (!publishValidation.isValid) {
+			console.error('Product draft validation failed:', publishValidation.issues)
+			return false
+		}
 
 		// Apply currency conversion logic before publishing
 		let finalPrice = state.price

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -49,6 +49,60 @@ describe('product shipping selection normalization', () => {
 		])
 	})
 
+	test('stale product-specific extra cost is stripped from digital selections', () => {
+		expect(
+			normalizeProductShippingSelections([
+				{
+					shippingRef: '30406:merchant:digital',
+					service: 'digital',
+					extraCost: '12.50',
+				},
+			]),
+		).toEqual([
+			{
+				shippingRef: '30406:merchant:digital',
+				service: 'digital',
+				extraCost: '',
+			},
+		])
+	})
+
+	test('stale product-specific extra cost is stripped from pickup selections', () => {
+		expect(
+			normalizeProductShippingSelections([
+				{
+					shippingRef: '30406:merchant:pickup',
+					service: 'pickup',
+					extraCost: '7',
+				},
+			]),
+		).toEqual([
+			{
+				shippingRef: '30406:merchant:pickup',
+				service: 'pickup',
+				extraCost: '',
+			},
+		])
+	})
+
+	test('physical shipping extra cost is preserved and normalized', () => {
+		expect(
+			normalizeProductShippingSelections([
+				{
+					shippingRef: '30406:merchant:standard',
+					service: 'standard',
+					extraCost: '4.567',
+				},
+			]),
+		).toEqual([
+			{
+				shippingRef: '30406:merchant:standard',
+				service: 'standard',
+				extraCost: '4.56',
+			},
+		])
+	})
+
 	test('unresolved shipping refs are surfaced as unavailable', () => {
 		const resolvedSelections = resolveProductShippingSelections(
 			[
@@ -67,6 +121,36 @@ describe('product shipping selection normalization', () => {
 				option: null,
 				isResolved: false,
 			},
+		])
+	})
+
+	test('resolved digital and pickup services strip stale extra cost', () => {
+		const resolvedSelections = resolveProductShippingSelections(
+			[
+				{
+					shippingRef: '30406:merchant:digital',
+					extraCost: '9.99',
+				},
+				{
+					shippingRef: '30406:merchant:pickup',
+					extraCost: '3',
+				},
+				{
+					shippingRef: '30406:merchant:standard',
+					extraCost: '2.125',
+				},
+			],
+			[
+				{ id: '30406:merchant:digital', service: 'digital' },
+				{ id: '30406:merchant:pickup', service: 'pickup' },
+				{ id: '30406:merchant:standard', service: 'standard' },
+			],
+		)
+
+		expect(resolvedSelections.map(({ shippingRef, extraCost, service }) => ({ shippingRef, extraCost, service }))).toEqual([
+			{ shippingRef: '30406:merchant:digital', extraCost: '', service: 'digital' },
+			{ shippingRef: '30406:merchant:pickup', extraCost: '', service: 'pickup' },
+			{ shippingRef: '30406:merchant:standard', extraCost: '2.12', service: 'standard' },
 		])
 	})
 

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
-import { normalizeProductShippingSelections, resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
+import {
+	normalizeProductShippingExtraCost,
+	normalizeProductShippingSelections,
+	resolveProductShippingSelections,
+	sanitizeProductShippingExtraCostInput,
+} from '@/lib/utils/productShippingSelections'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
 
 describe('product shipping selection normalization', () => {
@@ -63,5 +68,18 @@ describe('product shipping selection normalization', () => {
 				isResolved: false,
 			},
 		])
+	})
+
+	test('shipping extra cost normalization rejects garbage and dashed strings', () => {
+		expect(normalizeProductShippingExtraCost('15.213123-212-1')).toBe('')
+		expect(normalizeProductShippingExtraCost('-1')).toBe('')
+		expect(normalizeProductShippingExtraCost('abc')).toBe('')
+	})
+
+	test('shipping extra cost input keeps non-negative two-decimal precision', () => {
+		expect(sanitizeProductShippingExtraCostInput('15.213')).toBe('15.21')
+		expect(sanitizeProductShippingExtraCostInput('15.2')).toBe('15.2')
+		expect(sanitizeProductShippingExtraCostInput('0')).toBe('0')
+		expect(sanitizeProductShippingExtraCostInput('15-2')).toBeNull()
 	})
 })

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -54,14 +54,14 @@ describe('product shipping selection normalization', () => {
 			normalizeProductShippingSelections([
 				{
 					shippingRef: '30406:merchant:digital',
-					service: 'digital',
+					service: 'digital-delivery',
 					extraCost: '12.50',
 				},
 			]),
 		).toEqual([
 			{
 				shippingRef: '30406:merchant:digital',
-				service: 'digital',
+				service: 'digital-delivery',
 				extraCost: '',
 			},
 		])
@@ -90,14 +90,14 @@ describe('product shipping selection normalization', () => {
 			normalizeProductShippingSelections([
 				{
 					shippingRef: '30406:merchant:standard',
-					service: 'standard',
+					service: 'worldwide-standard',
 					extraCost: '4.567',
 				},
 			]),
 		).toEqual([
 			{
 				shippingRef: '30406:merchant:standard',
-				service: 'standard',
+				service: 'worldwide-standard',
 				extraCost: '4.56',
 			},
 		])

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -18,6 +18,25 @@ export type ResolvedProductShippingSelection = ProductShippingSelection & {
 	isResolved: boolean
 }
 
+export const sanitizeProductShippingExtraCostInput = (input: string): string | null => {
+	const value = input.trim()
+	if (!value) return ''
+	if (!/^\d*(?:\.\d*)?$/.test(value)) return null
+
+	const [whole = '', decimal = ''] = value.split('.')
+	if (value.includes('.') && decimal.length > 2) {
+		return `${whole || '0'}.${decimal.slice(0, 2)}`
+	}
+
+	return value
+}
+
+export const normalizeProductShippingExtraCost = (input: string | null | undefined): string => {
+	const sanitized = sanitizeProductShippingExtraCostInput(input ?? '')
+	if (!sanitized || sanitized === '.') return ''
+	return sanitized.endsWith('.') ? sanitized.slice(0, -1) : sanitized
+}
+
 export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {
 	const shippingRef =
 		(typeof input.shippingRef === 'string' && input.shippingRef.trim()) ||
@@ -28,7 +47,7 @@ export const normalizeProductShippingSelection = (input: ProductShippingSelectio
 
 	return {
 		shippingRef,
-		extraCost: typeof input.extraCost === 'string' ? input.extraCost : '',
+		extraCost: normalizeProductShippingExtraCost(input.extraCost),
 	}
 }
 

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -3,12 +3,14 @@ import type { RichShippingInfo } from '@/lib/stores/cart'
 export type ProductShippingSelection = {
 	shippingRef: string
 	extraCost: string
+	service?: string
 }
 
 export type LegacyProductShippingSelection = {
 	shippingRef?: string | null
-	shipping?: Pick<RichShippingInfo, 'id' | 'name'> | null
+	shipping?: Pick<RichShippingInfo, 'id' | 'name' | 'service'> | null
 	extraCost?: string | null
+	service?: string | null
 }
 
 export type ProductShippingSelectionInput = ProductShippingSelection | LegacyProductShippingSelection
@@ -37,17 +39,26 @@ export const normalizeProductShippingExtraCost = (input: string | null | undefin
 	return sanitized.endsWith('.') ? sanitized.slice(0, -1) : sanitized
 }
 
+export const shippingServiceDisallowsProductExtraCost = (service: string | null | undefined): boolean => {
+	return service === 'digital' || service === 'pickup'
+}
+
 export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {
 	const shippingRef =
 		(typeof input.shippingRef === 'string' && input.shippingRef.trim()) ||
 		(typeof input.shipping?.id === 'string' && input.shipping.id.trim()) ||
 		''
+	const service =
+		(typeof input.service === 'string' && input.service.trim()) ||
+		(typeof input.shipping?.service === 'string' && input.shipping.service.trim()) ||
+		undefined
 
 	if (!shippingRef) return null
 
 	return {
 		shippingRef,
-		extraCost: normalizeProductShippingExtraCost(input.extraCost),
+		extraCost: shippingServiceDisallowsProductExtraCost(service) ? '' : normalizeProductShippingExtraCost(input.extraCost),
+		...(service ? { service } : {}),
 	}
 }
 
@@ -67,9 +78,13 @@ export const resolveProductShippingSelections = (
 ): ResolvedProductShippingSelection[] => {
 	return selections.map((selection) => {
 		const option = availableOptions.find((availableOption) => availableOption.id === selection.shippingRef) ?? null
+		const service = option?.service || selection.service
+		const extraCost = shippingServiceDisallowsProductExtraCost(service) ? '' : normalizeProductShippingExtraCost(selection.extraCost)
 
 		return {
 			...selection,
+			extraCost,
+			...(service ? { service } : {}),
 			option,
 			isResolved: option !== null,
 		}

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -1,4 +1,5 @@
 import type { RichShippingInfo } from '@/lib/stores/cart'
+import { shippingServiceDisallowsProductExtraCost } from '@/lib/workflow/productDeliveryModes'
 
 export type ProductShippingSelection = {
 	shippingRef: string
@@ -37,10 +38,6 @@ export const normalizeProductShippingExtraCost = (input: string | null | undefin
 	const sanitized = sanitizeProductShippingExtraCostInput(input ?? '')
 	if (!sanitized || sanitized === '.') return ''
 	return sanitized.endsWith('.') ? sanitized.slice(0, -1) : sanitized
-}
-
-export const shippingServiceDisallowsProductExtraCost = (service: string | null | undefined): boolean => {
-	return service === 'digital' || service === 'pickup'
 }
 
 export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {

--- a/src/lib/workflow/productAuthoringStages.test.ts
+++ b/src/lib/workflow/productAuthoringStages.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_FORM_STATE, type ProductFormState } from '@/lib/stores/product'
+import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
+import {
+	getPrimaryProductAuthoringTabForStage,
+	getNextProductAuthoringStage,
+	getProductAuthoringStageForTab,
+	getProductAuthoringTabsForStage,
+	PRODUCT_AUTHORING_STAGES,
+	resolveProductAuthoringStages,
+} from '@/lib/workflow/productAuthoringStages'
+import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
+
+const READY_WORKFLOW: ProductWorkflowResolution = {
+	mode: 'create',
+	isBootstrapReady: true,
+	initialTab: 'name',
+	shouldStartAtShipping: false,
+	requiresV4VSetup: false,
+}
+
+const makeState = (overrides: Partial<ProductFormState> = {}): ProductFormState => ({
+	...DEFAULT_FORM_STATE,
+	...overrides,
+})
+
+const validate = (state: ProductFormState, resolvedShippingRefs = new Set<string>(['seller:standard'])) =>
+	validateProductDraft({
+		state,
+		resolvedShippingRefs,
+		isShippingFetched: true,
+	})
+
+const validDraft = makeState({
+	name: 'Valid product',
+	description: 'Valid description',
+	price: '1000',
+	quantity: '1',
+	images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
+	shippings: [{ shippingRef: 'seller:standard', extraCost: '' }],
+})
+
+describe('product authoring stages', () => {
+	test('stage order is deterministic', () => {
+		expect(PRODUCT_AUTHORING_STAGES).toEqual(['basics', 'pricing_inventory', 'media', 'delivery', 'publish'])
+	})
+
+	test('missing media blocks at the Media stage', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'media',
+			validation: validate(makeState({ ...validDraft, images: [] })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('media')
+		expect(resolution.canPublish).toBe(false)
+	})
+
+	test('missing delivery blocks at the Delivery stage', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'delivery',
+			validation: validate(makeState({ ...validDraft, shippings: [] })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('delivery')
+		expect(resolution.canPublish).toBe(false)
+	})
+
+	test('valid draft with ready seller state reaches Publish', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(validDraft),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBeNull()
+		expect(resolution.selectedStage).toBe('publish')
+		expect(resolution.canPublish).toBe(true)
+	})
+
+	test('never-configured V4V blocks at the Publish stage', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(validDraft),
+			workflow: {
+				...READY_WORKFLOW,
+				requiresV4VSetup: true,
+			},
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('publish')
+		expect(resolution.canPublish).toBe(false)
+		expect(resolution.publishIssues).toContain('Value for Value (V4V) settings must be configured before publishing your first product')
+	})
+
+	test('draft blockers stay on their mapped stage before Publish blockers', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(makeState({ ...validDraft, images: [] })),
+			workflow: {
+				...READY_WORKFLOW,
+				requiresV4VSetup: true,
+			},
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('media')
+		expect(resolution.canPublish).toBe(false)
+		expect(resolution.publishIssues).toContain('At least one image is required')
+		expect(resolution.publishIssues).toContain('Value for Value (V4V) settings must be configured before publishing your first product')
+	})
+
+	test('unresolved seller readiness blocks at the Publish stage', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(validDraft),
+			workflow: {
+				...READY_WORKFLOW,
+				isBootstrapReady: false,
+			},
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('publish')
+		expect(resolution.canPublish).toBe(false)
+		expect(resolution.publishIssues).toContain('Seller readiness is still loading')
+	})
+
+	test('delivery advances to a real Publish stage without requiring a publish tab', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(validDraft),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(getNextProductAuthoringStage('delivery')).toBe('publish')
+		expect(resolution.selectedStage).toBe('publish')
+		expect(getProductAuthoringTabsForStage('publish')).toEqual([])
+		expect(getPrimaryProductAuthoringTabForStage('publish')).toBeNull()
+		expect(resolution.stages.find((stage) => stage.stage === 'publish')?.primaryTab).toBeNull()
+	})
+
+	test('shipping tab maps to Delivery, not Publish', () => {
+		expect(getProductAuthoringStageForTab('shipping')).toBe('delivery')
+	})
+})

--- a/src/lib/workflow/productAuthoringStages.test.ts
+++ b/src/lib/workflow/productAuthoringStages.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from 'bun:test'
 import { DEFAULT_FORM_STATE, type ProductFormState } from '@/lib/stores/product'
 import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
 import {
+	canSelectProductAuthoringStage,
 	getPrimaryProductAuthoringTabForStage,
 	getNextProductAuthoringStage,
+	getPreviousProductAuthoringStage,
 	getProductAuthoringStageForTab,
 	getProductAuthoringTabsForStage,
 	PRODUCT_AUTHORING_STAGES,
@@ -36,6 +38,7 @@ const validDraft = makeState({
 	description: 'Valid description',
 	price: '1000',
 	quantity: '1',
+	mainCategory: 'Bitcoin',
 	images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
 	shippings: [{ shippingRef: 'seller:standard', extraCost: '' }],
 })
@@ -43,6 +46,48 @@ const validDraft = makeState({
 describe('product authoring stages', () => {
 	test('stage order is deterministic', () => {
 		expect(PRODUCT_AUTHORING_STAGES).toEqual(['basics', 'pricing_inventory', 'media', 'delivery', 'publish'])
+	})
+
+	test('incomplete Basics cannot advance', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'basics',
+			validation: validate(makeState()),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
+		expect(resolution.currentStageGate.firstBlockingTab).toBe('name')
+		expect(resolution.canAdvanceToNextStage).toBe(false)
+		expect(resolution.forwardBlocker?.stage).toBe('basics')
+		expect(canSelectProductAuthoringStage('pricing_inventory', resolution)).toBe(false)
+	})
+
+	test('Basics cannot advance without main category', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'basics',
+			validation: validate(makeState({ ...validDraft, mainCategory: null })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('basics')
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
+		expect(resolution.currentStageGate.firstBlockingTab).toBe('category')
+		expect(resolution.currentStageGate.issues).toContain('Main category is required')
+		expect(canSelectProductAuthoringStage('pricing_inventory', resolution)).toBe(false)
+	})
+
+	test('Pricing and Inventory cannot advance without valid price', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'pricing_inventory',
+			validation: validate(makeState({ ...validDraft, price: '' })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('pricing_inventory')
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
+		expect(resolution.currentStageGate.firstBlockingTab).toBe('detail')
+		expect(resolution.currentStageGate.issues).toContain('Valid product price is required')
+		expect(canSelectProductAuthoringStage('media', resolution)).toBe(false)
 	})
 
 	test('missing media blocks at the Media stage', () => {
@@ -53,6 +98,10 @@ describe('product authoring stages', () => {
 		})
 
 		expect(resolution.firstIncompleteStage).toBe('media')
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
+		expect(resolution.currentStageGate.firstBlockingTab).toBe('images')
+		expect(resolution.canAdvanceToNextStage).toBe(false)
+		expect(canSelectProductAuthoringStage('delivery', resolution)).toBe(false)
 		expect(resolution.canPublish).toBe(false)
 	})
 
@@ -64,19 +113,63 @@ describe('product authoring stages', () => {
 		})
 
 		expect(resolution.firstIncompleteStage).toBe('delivery')
+		expect(getNextProductAuthoringStage('delivery')).toBe('publish')
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
+		expect(resolution.currentStageGate.firstBlockingTab).toBe('shipping')
+		expect(resolution.canAdvanceToNextStage).toBe(false)
+		expect(canSelectProductAuthoringStage('publish', resolution)).toBe(false)
 		expect(resolution.canPublish).toBe(false)
+	})
+
+	test('backward navigation remains allowed by the stage selection model', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'media',
+			validation: validate(makeState({ ...validDraft, images: [] })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(getPreviousProductAuthoringStage('media')).toBe('pricing_inventory')
+		expect(canSelectProductAuthoringStage('pricing_inventory', resolution)).toBe(true)
+		expect(canSelectProductAuthoringStage('basics', resolution)).toBe(true)
 	})
 
 	test('valid draft with ready seller state reaches Publish', () => {
 		const resolution = resolveProductAuthoringStages({
-			selectedStage: 'publish',
+			selectedStage: 'delivery',
 			validation: validate(validDraft),
 			workflow: READY_WORKFLOW,
 		})
 
 		expect(resolution.firstIncompleteStage).toBeNull()
-		expect(resolution.selectedStage).toBe('publish')
+		expect(resolution.selectedStage).toBe('delivery')
+		expect(resolution.currentStageGate.canAdvance).toBe(true)
+		expect(resolution.canAdvanceToNextStage).toBe(true)
+		expect(canSelectProductAuthoringStage('publish', resolution)).toBe(true)
 		expect(resolution.canPublish).toBe(true)
+	})
+
+	test('Publish cannot claim ready when price is missing', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(makeState({ ...validDraft, price: '' })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('pricing_inventory')
+		expect(resolution.canPublish).toBe(false)
+		expect(resolution.publishIssues).toContain('Valid product price is required')
+	})
+
+	test('Publish cannot claim ready when main category is missing', () => {
+		const resolution = resolveProductAuthoringStages({
+			selectedStage: 'publish',
+			validation: validate(makeState({ ...validDraft, mainCategory: null })),
+			workflow: READY_WORKFLOW,
+		})
+
+		expect(resolution.firstIncompleteStage).toBe('basics')
+		expect(resolution.canPublish).toBe(false)
+		expect(resolution.publishIssues).toContain('Main category is required')
 	})
 
 	test('never-configured V4V blocks at the Publish stage', () => {
@@ -90,6 +183,7 @@ describe('product authoring stages', () => {
 		})
 
 		expect(resolution.firstIncompleteStage).toBe('publish')
+		expect(resolution.currentStageGate.canAdvance).toBe(false)
 		expect(resolution.canPublish).toBe(false)
 		expect(resolution.publishIssues).toContain('Value for Value (V4V) settings must be configured before publishing your first product')
 	})
@@ -106,7 +200,7 @@ describe('product authoring stages', () => {
 
 		expect(resolution.firstIncompleteStage).toBe('media')
 		expect(resolution.canPublish).toBe(false)
-		expect(resolution.publishIssues).toContain('At least one image is required')
+		expect(resolution.publishIssues).toContain('At least one product image is required')
 		expect(resolution.publishIssues).toContain('Value for Value (V4V) settings must be configured before publishing your first product')
 	})
 

--- a/src/lib/workflow/productAuthoringStages.ts
+++ b/src/lib/workflow/productAuthoringStages.ts
@@ -1,0 +1,126 @@
+import type { ProductFormTab } from '@/lib/stores/product'
+import type { ProductDraftValidation } from '@/lib/workflow/productDraftValidation'
+import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
+
+export type ProductAuthoringStage = 'basics' | 'pricing_inventory' | 'media' | 'delivery' | 'publish'
+
+export const PRODUCT_AUTHORING_STAGES: ProductAuthoringStage[] = ['basics', 'pricing_inventory', 'media', 'delivery', 'publish']
+
+export const PRODUCT_AUTHORING_STAGE_LABELS: Record<ProductAuthoringStage, string> = {
+	basics: 'Basics',
+	pricing_inventory: 'Pricing & Inventory',
+	media: 'Media',
+	delivery: 'Delivery',
+	publish: 'Publish',
+}
+
+export const PRODUCT_AUTHORING_STAGE_TABS: Record<ProductAuthoringStage, ProductFormTab[]> = {
+	basics: ['name', 'category'],
+	pricing_inventory: ['detail', 'spec'],
+	media: ['images'],
+	delivery: ['shipping'],
+	// Publish is a canonical workflow stage, not a legacy tab alias.
+	publish: [],
+}
+
+export type ProductAuthoringStageState = {
+	stage: ProductAuthoringStage
+	label: string
+	tabs: ProductFormTab[]
+	primaryTab: ProductFormTab | null
+	isComplete: boolean
+	isSelected: boolean
+	isFirstIncomplete: boolean
+	issues: string[]
+}
+
+export type ProductAuthoringStageResolution = {
+	stages: ProductAuthoringStageState[]
+	selectedStage: ProductAuthoringStage
+	firstIncompleteStage: ProductAuthoringStage | null
+	canPublish: boolean
+	publishIssues: string[]
+	validation: ProductDraftValidation
+}
+
+export const PRODUCT_AUTHORING_V4V_SETUP_ISSUE = 'Value for Value (V4V) settings must be configured before publishing your first product'
+export const PRODUCT_AUTHORING_BOOTSTRAP_ISSUE = 'Seller readiness is still loading'
+
+export function isProductAuthoringStage(stage: string): stage is ProductAuthoringStage {
+	return PRODUCT_AUTHORING_STAGES.includes(stage as ProductAuthoringStage)
+}
+
+export function getProductAuthoringStageForTab(tab: ProductFormTab): ProductAuthoringStage {
+	if (tab === 'detail' || tab === 'spec') return 'pricing_inventory'
+	if (tab === 'images') return 'media'
+	if (tab === 'shipping') return 'delivery'
+
+	return 'basics'
+}
+
+export function getProductAuthoringTabsForStage(stage: ProductAuthoringStage): ProductFormTab[] {
+	return PRODUCT_AUTHORING_STAGE_TABS[stage]
+}
+
+export function getPrimaryProductAuthoringTabForStage(stage: ProductAuthoringStage): ProductFormTab | null {
+	return PRODUCT_AUTHORING_STAGE_TABS[stage][0] ?? null
+}
+
+export function getNextProductAuthoringStage(stage: ProductAuthoringStage): ProductAuthoringStage | null {
+	const index = PRODUCT_AUTHORING_STAGES.indexOf(stage)
+	return PRODUCT_AUTHORING_STAGES[index + 1] ?? null
+}
+
+export function getPreviousProductAuthoringStage(stage: ProductAuthoringStage): ProductAuthoringStage | null {
+	const index = PRODUCT_AUTHORING_STAGES.indexOf(stage)
+	return index > 0 ? PRODUCT_AUTHORING_STAGES[index - 1] : null
+}
+
+export function resolveProductAuthoringStages({
+	selectedStage,
+	validation,
+	workflow,
+}: {
+	selectedStage: ProductAuthoringStage
+	validation: ProductDraftValidation
+	workflow: ProductWorkflowResolution
+}): ProductAuthoringStageResolution {
+	const stageIssues: Record<ProductAuthoringStage, string[]> = {
+		basics: getProductAuthoringTabsForStage('basics').flatMap((tab) => validation.issuesByTab[tab] ?? []),
+		pricing_inventory: getProductAuthoringTabsForStage('pricing_inventory').flatMap((tab) => validation.issuesByTab[tab] ?? []),
+		media: getProductAuthoringTabsForStage('media').flatMap((tab) => validation.issuesByTab[tab] ?? []),
+		delivery: getProductAuthoringTabsForStage('delivery').flatMap((tab) => validation.issuesByTab[tab] ?? []),
+		publish: [],
+	}
+
+	const publishIssues = [...validation.issues]
+	if (!workflow.isBootstrapReady) publishIssues.push(PRODUCT_AUTHORING_BOOTSTRAP_ISSUE)
+	if (workflow.requiresV4VSetup) publishIssues.push(PRODUCT_AUTHORING_V4V_SETUP_ISSUE)
+
+	const canPublish = validation.allRequiredFieldsValid && workflow.isBootstrapReady && !workflow.requiresV4VSetup
+	stageIssues.publish = canPublish ? [] : publishIssues
+
+	const firstIncompleteStage =
+		PRODUCT_AUTHORING_STAGES.find((stage) => {
+			if (stage === 'publish') return !canPublish
+			return stageIssues[stage].length > 0
+		}) ?? null
+
+	return {
+		stages: PRODUCT_AUTHORING_STAGES.map((stage) => ({
+			stage,
+			label: PRODUCT_AUTHORING_STAGE_LABELS[stage],
+			tabs: PRODUCT_AUTHORING_STAGE_TABS[stage],
+			primaryTab: getPrimaryProductAuthoringTabForStage(stage),
+			isComplete: stage === 'publish' ? canPublish : stageIssues[stage].length === 0,
+			isSelected: stage === selectedStage,
+			isFirstIncomplete: stage === firstIncompleteStage,
+			issues: stageIssues[stage],
+		})),
+		selectedStage,
+		firstIncompleteStage,
+		canPublish,
+		publishIssues,
+		validation,
+	}
+}

--- a/src/lib/workflow/productAuthoringStages.ts
+++ b/src/lib/workflow/productAuthoringStages.ts
@@ -23,6 +23,13 @@ export const PRODUCT_AUTHORING_STAGE_TABS: Record<ProductAuthoringStage, Product
 	publish: [],
 }
 
+export type ProductAuthoringStageGate = {
+	stage: ProductAuthoringStage
+	canAdvance: boolean
+	issues: string[]
+	firstBlockingTab: ProductFormTab | null
+}
+
 export type ProductAuthoringStageState = {
 	stage: ProductAuthoringStage
 	label: string
@@ -31,13 +38,20 @@ export type ProductAuthoringStageState = {
 	isComplete: boolean
 	isSelected: boolean
 	isFirstIncomplete: boolean
+	canAdvance: boolean
+	canSelect: boolean
+	firstBlockingTab: ProductFormTab | null
 	issues: string[]
 }
 
 export type ProductAuthoringStageResolution = {
 	stages: ProductAuthoringStageState[]
+	stageGates: ProductAuthoringStageGate[]
 	selectedStage: ProductAuthoringStage
 	firstIncompleteStage: ProductAuthoringStage | null
+	currentStageGate: ProductAuthoringStageGate
+	forwardBlocker: ProductAuthoringStageGate | null
+	canAdvanceToNextStage: boolean
 	canPublish: boolean
 	publishIssues: string[]
 	validation: ProductDraftValidation
@@ -76,6 +90,30 @@ export function getPreviousProductAuthoringStage(stage: ProductAuthoringStage): 
 	return index > 0 ? PRODUCT_AUTHORING_STAGES[index - 1] : null
 }
 
+export function getProductAuthoringStageGate(
+	resolution: ProductAuthoringStageResolution,
+	stage: ProductAuthoringStage,
+): ProductAuthoringStageGate {
+	return resolution.stageGates.find((gate) => gate.stage === stage) ?? resolution.currentStageGate
+}
+
+export function canSelectProductAuthoringStage(targetStage: ProductAuthoringStage, resolution: ProductAuthoringStageResolution): boolean {
+	const selectedIndex = PRODUCT_AUTHORING_STAGES.indexOf(resolution.selectedStage)
+	const targetIndex = PRODUCT_AUTHORING_STAGES.indexOf(targetStage)
+	if (selectedIndex === -1 || targetIndex === -1) return false
+	if (targetIndex <= selectedIndex) return true
+
+	return PRODUCT_AUTHORING_STAGES.slice(0, targetIndex).every((stage) => getProductAuthoringStageGate(resolution, stage).canAdvance)
+}
+
+function getFirstBlockingTabForStage(stage: ProductAuthoringStage, validation: ProductDraftValidation): ProductFormTab | null {
+	if (stage === 'publish') {
+		return validation.allRequiredFieldsValid ? null : validation.firstIncompleteTab
+	}
+
+	return getProductAuthoringTabsForStage(stage).find((tab) => validation.issuesByTab[tab]?.length) ?? null
+}
+
 export function resolveProductAuthoringStages({
 	selectedStage,
 	validation,
@@ -100,25 +138,64 @@ export function resolveProductAuthoringStages({
 	const canPublish = validation.allRequiredFieldsValid && workflow.isBootstrapReady && !workflow.requiresV4VSetup
 	stageIssues.publish = canPublish ? [] : publishIssues
 
+	const stageGates: ProductAuthoringStageGate[] = PRODUCT_AUTHORING_STAGES.map((stage) => {
+		const issues = stageIssues[stage]
+		const canAdvance = stage === 'publish' ? canPublish : issues.length === 0
+
+		return {
+			stage,
+			canAdvance,
+			issues,
+			firstBlockingTab: canAdvance ? null : getFirstBlockingTabForStage(stage, validation),
+		}
+	})
+
+	const getGate = (stage: ProductAuthoringStage): ProductAuthoringStageGate =>
+		stageGates.find((gate) => gate.stage === stage) ?? stageGates[0]
+	const selectedStageIndex = PRODUCT_AUTHORING_STAGES.indexOf(selectedStage)
+	const nextStage = getNextProductAuthoringStage(selectedStage)
+	const forwardBlocker =
+		nextStage && selectedStageIndex >= 0
+			? (PRODUCT_AUTHORING_STAGES.slice(0, PRODUCT_AUTHORING_STAGES.indexOf(nextStage)).find((stage) => !getGate(stage).canAdvance) ?? null)
+			: null
+	const currentStageGate = getGate(selectedStage)
+	const canAdvanceToNextStage = !!nextStage && !forwardBlocker
+
 	const firstIncompleteStage =
 		PRODUCT_AUTHORING_STAGES.find((stage) => {
-			if (stage === 'publish') return !canPublish
-			return stageIssues[stage].length > 0
+			return !getGate(stage).canAdvance
 		}) ?? null
 
 	return {
-		stages: PRODUCT_AUTHORING_STAGES.map((stage) => ({
-			stage,
-			label: PRODUCT_AUTHORING_STAGE_LABELS[stage],
-			tabs: PRODUCT_AUTHORING_STAGE_TABS[stage],
-			primaryTab: getPrimaryProductAuthoringTabForStage(stage),
-			isComplete: stage === 'publish' ? canPublish : stageIssues[stage].length === 0,
-			isSelected: stage === selectedStage,
-			isFirstIncomplete: stage === firstIncompleteStage,
-			issues: stageIssues[stage],
-		})),
+		stages: PRODUCT_AUTHORING_STAGES.map((stage) => {
+			const gate = getGate(stage)
+
+			return {
+				stage,
+				label: PRODUCT_AUTHORING_STAGE_LABELS[stage],
+				tabs: PRODUCT_AUTHORING_STAGE_TABS[stage],
+				primaryTab: getPrimaryProductAuthoringTabForStage(stage),
+				isComplete: gate.canAdvance,
+				isSelected: stage === selectedStage,
+				isFirstIncomplete: stage === firstIncompleteStage,
+				canAdvance: gate.canAdvance,
+				canSelect:
+					selectedStageIndex >= 0 &&
+					PRODUCT_AUTHORING_STAGES.indexOf(stage) >= 0 &&
+					(PRODUCT_AUTHORING_STAGES.indexOf(stage) <= selectedStageIndex ||
+						PRODUCT_AUTHORING_STAGES.slice(0, PRODUCT_AUTHORING_STAGES.indexOf(stage)).every(
+							(previousStage) => getGate(previousStage).canAdvance,
+						)),
+				firstBlockingTab: gate.firstBlockingTab,
+				issues: gate.issues,
+			}
+		}),
+		stageGates,
 		selectedStage,
 		firstIncompleteStage,
+		currentStageGate,
+		forwardBlocker: forwardBlocker ? getGate(forwardBlocker) : null,
+		canAdvanceToNextStage,
 		canPublish,
 		publishIssues,
 		validation,

--- a/src/lib/workflow/productDeliveryModes.test.ts
+++ b/src/lib/workflow/productDeliveryModes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+	canonicalizeProductDeliveryService,
 	productDeliveryModeAllowsProductExtraCost,
 	productDeliveryModeRequiresShippingCost,
 	productDeliveryModeUsesCoverage,
@@ -46,5 +47,22 @@ describe('product delivery modes', () => {
 		expect(productDeliveryModeUsesCoverage('pickup')).toBe(false)
 		expect(productDeliveryModeUsesCoverage('digital')).toBe(false)
 		expect(productDeliveryModeUsesCoverage('physical')).toBe(true)
+	})
+
+	test('canonicalizes pickup aliases before persistence', () => {
+		expect(canonicalizeProductDeliveryService('local-pickup')).toBe('pickup')
+		expect(canonicalizeProductDeliveryService('store_collection')).toBe('pickup')
+	})
+
+	test('canonicalizes digital aliases before persistence', () => {
+		expect(canonicalizeProductDeliveryService('digital-delivery')).toBe('digital')
+		expect(canonicalizeProductDeliveryService('instant_download')).toBe('digital')
+	})
+
+	test('canonicalizes physical aliases before persistence', () => {
+		expect(canonicalizeProductDeliveryService('express-shipping')).toBe('express')
+		expect(canonicalizeProductDeliveryService('overnight-delivery')).toBe('overnight')
+		expect(canonicalizeProductDeliveryService('worldwide-standard')).toBe('standard')
+		expect(canonicalizeProductDeliveryService('carrier-rate')).toBe('standard')
 	})
 })

--- a/src/lib/workflow/productDeliveryModes.test.ts
+++ b/src/lib/workflow/productDeliveryModes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	productDeliveryModeAllowsProductExtraCost,
+	productDeliveryModeRequiresShippingCost,
+	productDeliveryModeUsesCoverage,
+	resolveProductDeliveryMode,
+	shippingServiceDisallowsProductExtraCost,
+} from '@/lib/workflow/productDeliveryModes'
+
+describe('product delivery modes', () => {
+	test('maps pickup-like services to pickup mode', () => {
+		expect(resolveProductDeliveryMode('pickup')).toBe('pickup')
+		expect(resolveProductDeliveryMode('local-pickup')).toBe('pickup')
+		expect(resolveProductDeliveryMode('Local Pickup')).toBe('pickup')
+		expect(resolveProductDeliveryMode({ service: 'store_collection' })).toBe('pickup')
+	})
+
+	test('maps digital-like services to digital mode', () => {
+		expect(resolveProductDeliveryMode('digital')).toBe('digital')
+		expect(resolveProductDeliveryMode('digital-delivery')).toBe('digital')
+		expect(resolveProductDeliveryMode('instant_download')).toBe('digital')
+		expect(resolveProductDeliveryMode({ service: 'virtual delivery' })).toBe('digital')
+	})
+
+	test('maps physical shipping services to physical mode', () => {
+		expect(resolveProductDeliveryMode('standard')).toBe('physical')
+		expect(resolveProductDeliveryMode('express')).toBe('physical')
+		expect(resolveProductDeliveryMode('overnight')).toBe('physical')
+		expect(resolveProductDeliveryMode('worldwide-standard')).toBe('physical')
+		expect(resolveProductDeliveryMode(undefined)).toBe('physical')
+	})
+
+	test('only physical mode exposes product-specific extra-cost semantics', () => {
+		expect(productDeliveryModeAllowsProductExtraCost('pickup')).toBe(false)
+		expect(productDeliveryModeAllowsProductExtraCost('digital')).toBe(false)
+		expect(productDeliveryModeAllowsProductExtraCost('physical')).toBe(true)
+		expect(shippingServiceDisallowsProductExtraCost('pickup')).toBe(true)
+		expect(shippingServiceDisallowsProductExtraCost('digital')).toBe(true)
+		expect(shippingServiceDisallowsProductExtraCost('standard')).toBe(false)
+	})
+
+	test('only physical mode uses shipping-cost and coverage controls', () => {
+		expect(productDeliveryModeRequiresShippingCost('pickup')).toBe(false)
+		expect(productDeliveryModeRequiresShippingCost('digital')).toBe(false)
+		expect(productDeliveryModeRequiresShippingCost('physical')).toBe(true)
+		expect(productDeliveryModeUsesCoverage('pickup')).toBe(false)
+		expect(productDeliveryModeUsesCoverage('digital')).toBe(false)
+		expect(productDeliveryModeUsesCoverage('physical')).toBe(true)
+	})
+})

--- a/src/lib/workflow/productDeliveryModes.ts
+++ b/src/lib/workflow/productDeliveryModes.ts
@@ -2,6 +2,8 @@ export const PRODUCT_DELIVERY_MODES = ['pickup', 'digital', 'physical'] as const
 
 export type ProductDeliveryMode = (typeof PRODUCT_DELIVERY_MODES)[number]
 
+export type CanonicalProductDeliveryService = 'standard' | 'express' | 'overnight' | 'pickup' | 'digital'
+
 export type ProductDeliveryModeInput =
 	| string
 	| null
@@ -35,6 +37,18 @@ export const resolveProductDeliveryMode = (input: ProductDeliveryModeInput): Pro
 	if (normalized.includes('pickup') || normalized.includes('pick up') || normalized.includes('collection')) return 'pickup'
 
 	return 'physical'
+}
+
+export const canonicalizeProductDeliveryService = (input: ProductDeliveryModeInput): CanonicalProductDeliveryService => {
+	const normalized = normalizeDeliveryModeInput(input)
+	const deliveryMode = resolveProductDeliveryMode(input)
+
+	if (deliveryMode === 'pickup') return 'pickup'
+	if (deliveryMode === 'digital') return 'digital'
+	if (normalized.includes('overnight')) return 'overnight'
+	if (normalized.includes('express')) return 'express'
+
+	return 'standard'
 }
 
 export const productDeliveryModeAllowsProductExtraCost = (mode: ProductDeliveryMode): boolean => mode === 'physical'

--- a/src/lib/workflow/productDeliveryModes.ts
+++ b/src/lib/workflow/productDeliveryModes.ts
@@ -1,0 +1,63 @@
+export const PRODUCT_DELIVERY_MODES = ['pickup', 'digital', 'physical'] as const
+
+export type ProductDeliveryMode = (typeof PRODUCT_DELIVERY_MODES)[number]
+
+export type ProductDeliveryModeInput =
+	| string
+	| null
+	| undefined
+	| {
+			service?: string | null
+			name?: string | null
+			title?: string | null
+	  }
+
+const normalizeDeliveryModeInput = (input: ProductDeliveryModeInput): string => {
+	const value =
+		typeof input === 'string'
+			? input
+			: typeof input?.service === 'string'
+				? input.service
+				: typeof input?.title === 'string'
+					? input.title
+					: typeof input?.name === 'string'
+						? input.name
+						: ''
+
+	return value.trim().toLowerCase().replace(/[_-]+/g, ' ')
+}
+
+export const resolveProductDeliveryMode = (input: ProductDeliveryModeInput): ProductDeliveryMode => {
+	const normalized = normalizeDeliveryModeInput(input)
+
+	if (!normalized) return 'physical'
+	if (normalized.includes('digital') || normalized.includes('download') || normalized.includes('virtual')) return 'digital'
+	if (normalized.includes('pickup') || normalized.includes('pick up') || normalized.includes('collection')) return 'pickup'
+
+	return 'physical'
+}
+
+export const productDeliveryModeAllowsProductExtraCost = (mode: ProductDeliveryMode): boolean => mode === 'physical'
+
+export const productDeliveryModeRequiresShippingCost = (mode: ProductDeliveryMode): boolean => mode === 'physical'
+
+export const productDeliveryModeUsesCoverage = (mode: ProductDeliveryMode): boolean => mode === 'physical'
+
+export const shippingServiceAllowsProductExtraCost = (service: string | null | undefined): boolean => {
+	return productDeliveryModeAllowsProductExtraCost(resolveProductDeliveryMode(service))
+}
+
+export const shippingServiceDisallowsProductExtraCost = (service: string | null | undefined): boolean => {
+	return !shippingServiceAllowsProductExtraCost(service)
+}
+
+export const getProductDeliveryModeLabel = (mode: ProductDeliveryMode): string => {
+	switch (mode) {
+		case 'pickup':
+			return 'Local pickup'
+		case 'digital':
+			return 'Digital delivery'
+		case 'physical':
+			return 'Physical shipping'
+	}
+}

--- a/src/lib/workflow/productDraftValidation.test.ts
+++ b/src/lib/workflow/productDraftValidation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_FORM_STATE, type ProductFormState } from '@/lib/stores/product'
+import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
+
+const makeState = (overrides: Partial<ProductFormState> = {}): ProductFormState => ({
+	...DEFAULT_FORM_STATE,
+	...overrides,
+})
+
+describe('validateProductDraft', () => {
+	test('returns deterministic issues and first incomplete tab for empty drafts', () => {
+		const validation = validateProductDraft({
+			state: makeState(),
+			resolvedShippingRefs: new Set(),
+			isShippingFetched: true,
+		})
+
+		expect(validation.issues).toEqual([
+			'Product name is required',
+			'Description is required',
+			'At least one image is required',
+			'At least one shipping option is required',
+		])
+		expect(validation.issuesByTab).toEqual({
+			name: ['Product name is required', 'Description is required'],
+			images: ['At least one image is required'],
+			shipping: ['At least one shipping option is required'],
+		})
+		expect(validation.firstIncompleteTab).toBe('name')
+		expect(validation.allRequiredFieldsValid).toBe(false)
+	})
+
+	test('marks required fields valid when the selected shipping ref resolves', () => {
+		const validation = validateProductDraft({
+			state: makeState({
+				name: 'Valid product',
+				description: 'Valid description',
+				images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
+				shippings: [{ shippingRef: 'seller-pubkey:standard', extraCost: '100' }],
+			}),
+			resolvedShippingRefs: new Set(['seller-pubkey:standard']),
+			isShippingFetched: true,
+		})
+
+		expect(validation.hasValidName).toBe(true)
+		expect(validation.hasValidDescription).toBe(true)
+		expect(validation.hasValidCategory).toBe(true)
+		expect(validation.hasValidImages).toBe(true)
+		expect(validation.hasValidShipping).toBe(true)
+		expect(validation.issues).toEqual([])
+		expect(validation.allRequiredFieldsValid).toBe(true)
+		expect(validation.firstIncompleteTab).toBe('shipping')
+	})
+
+	test('keeps current shipping readiness semantics before and after seller shipping fetch', () => {
+		const state = makeState({
+			name: 'Valid product',
+			description: 'Valid description',
+			images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
+			shippings: [{ shippingRef: 'seller-pubkey:standard', extraCost: '' }],
+		})
+
+		expect(
+			validateProductDraft({
+				state,
+				resolvedShippingRefs: new Set(),
+				isShippingFetched: false,
+			}).hasValidShipping,
+		).toBe(true)
+
+		expect(
+			validateProductDraft({
+				state,
+				resolvedShippingRefs: new Set(),
+				isShippingFetched: true,
+			}).hasValidShipping,
+		).toBe(false)
+
+		expect(
+			validateProductDraft({
+				state,
+				resolvedShippingRefs: new Set(['seller-pubkey:standard']),
+				isShippingFetched: true,
+			}).allRequiredFieldsValid,
+		).toBe(true)
+	})
+})

--- a/src/lib/workflow/productDraftValidation.test.ts
+++ b/src/lib/workflow/productDraftValidation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { DEFAULT_FORM_STATE, type ProductFormState } from '@/lib/stores/product'
-import { validateProductDraft } from '@/lib/workflow/productDraftValidation'
+import { validateProductDraft, validateProductPublishDraft } from '@/lib/workflow/productDraftValidation'
 
 const makeState = (overrides: Partial<ProductFormState> = {}): ProductFormState => ({
 	...DEFAULT_FORM_STATE,
@@ -17,13 +17,18 @@ describe('validateProductDraft', () => {
 
 		expect(validation.issues).toEqual([
 			'Product name is required',
-			'Description is required',
-			'At least one image is required',
+			'Product description is required',
+			'Valid product price is required',
+			'Valid product quantity is required',
+			'Main category is required',
+			'At least one product image is required',
 			'At least one shipping option is required',
 		])
 		expect(validation.issuesByTab).toEqual({
-			name: ['Product name is required', 'Description is required'],
-			images: ['At least one image is required'],
+			name: ['Product name is required', 'Product description is required'],
+			detail: ['Valid product price is required', 'Valid product quantity is required'],
+			category: ['Main category is required'],
+			images: ['At least one product image is required'],
 			shipping: ['At least one shipping option is required'],
 		})
 		expect(validation.firstIncompleteTab).toBe('name')
@@ -35,6 +40,9 @@ describe('validateProductDraft', () => {
 			state: makeState({
 				name: 'Valid product',
 				description: 'Valid description',
+				price: '1000',
+				quantity: '1',
+				mainCategory: 'Bitcoin',
 				images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
 				shippings: [{ shippingRef: 'seller-pubkey:standard', extraCost: '100' }],
 			}),
@@ -56,6 +64,9 @@ describe('validateProductDraft', () => {
 		const state = makeState({
 			name: 'Valid product',
 			description: 'Valid description',
+			price: '1000',
+			quantity: '1',
+			mainCategory: 'Bitcoin',
 			images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
 			shippings: [{ shippingRef: 'seller-pubkey:standard', extraCost: '' }],
 		})
@@ -83,5 +94,21 @@ describe('validateProductDraft', () => {
 				isShippingFetched: true,
 			}).allRequiredFieldsValid,
 		).toBe(true)
+	})
+
+	test('canonical publish validation rejects missing price and category', () => {
+		const validation = validateProductPublishDraft({
+			name: 'Valid product',
+			description: 'Valid description',
+			price: '',
+			quantity: '1',
+			mainCategory: null,
+			images: [{ imageUrl: 'https://example.com/image.png', imageOrder: 0 }],
+			shippings: [{ shippingRef: 'seller-pubkey:standard', extraCost: '' }],
+		})
+
+		expect(validation.isValid).toBe(false)
+		expect(validation.issues).toContain('Valid product price is required')
+		expect(validation.issues).toContain('Main category is required')
 	})
 })

--- a/src/lib/workflow/productDraftValidation.ts
+++ b/src/lib/workflow/productDraftValidation.ts
@@ -1,0 +1,58 @@
+import type { ProductFormState, ProductFormTab } from '@/lib/stores/product'
+
+export type ProductDraftValidation = {
+	hasValidName: boolean
+	hasValidDescription: boolean
+	hasValidCategory: boolean
+	hasValidImages: boolean
+	hasValidShipping: boolean
+	allRequiredFieldsValid: boolean
+	issues: string[]
+	issuesByTab: Partial<Record<ProductFormTab, string[]>>
+	firstIncompleteTab: ProductFormTab
+}
+
+export function validateProductDraft({
+	state,
+	resolvedShippingRefs,
+	isShippingFetched,
+}: {
+	state: ProductFormState
+	resolvedShippingRefs: Set<string>
+	isShippingFetched: boolean
+}): ProductDraftValidation {
+	const hasValidName = state.name.trim().length > 0
+	const hasValidDescription = state.description.trim().length > 0
+	const hasValidCategory = true
+	const hasValidImages = state.images.length > 0
+	const hasValidShipping = state.shippings.some(
+		(ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)),
+	)
+
+	const issuesByTab: Partial<Record<ProductFormTab, string[]>> = {}
+	const addIssue = (tab: ProductFormTab, issue: string) => {
+		issuesByTab[tab] = [...(issuesByTab[tab] ?? []), issue]
+	}
+
+	if (!hasValidName) addIssue('name', 'Product name is required')
+	if (!hasValidDescription) addIssue('name', 'Description is required')
+	if (!hasValidImages) addIssue('images', 'At least one image is required')
+	if (!hasValidShipping) addIssue('shipping', 'At least one shipping option is required')
+
+	const issues = (['name', 'detail', 'spec', 'category', 'images', 'shipping'] as ProductFormTab[]).flatMap((tab) => issuesByTab[tab] ?? [])
+	const allRequiredFieldsValid = issues.length === 0
+	const firstIncompleteTab =
+		(['name', 'detail', 'spec', 'category', 'images', 'shipping'] as ProductFormTab[]).find((tab) => issuesByTab[tab]?.length) ?? 'shipping'
+
+	return {
+		hasValidName,
+		hasValidDescription,
+		hasValidCategory,
+		hasValidImages,
+		hasValidShipping,
+		allRequiredFieldsValid,
+		issues,
+		issuesByTab,
+		firstIncompleteTab,
+	}
+}

--- a/src/lib/workflow/productDraftValidation.ts
+++ b/src/lib/workflow/productDraftValidation.ts
@@ -1,15 +1,79 @@
 import type { ProductFormState, ProductFormTab } from '@/lib/stores/product'
+import { normalizeProductShippingSelections, type ProductShippingSelectionInput } from '@/lib/utils/productShippingSelections'
+
+type ProductPublishValidationField = 'name' | 'description' | 'price' | 'quantity' | 'images' | 'mainCategory' | 'shipping'
+
+export type ProductPublishValidationInput = {
+	name: string
+	description: string
+	price: string
+	quantity: string
+	mainCategory: string | null
+	images: unknown[]
+	shippings: ProductShippingSelectionInput[]
+}
+
+export type ProductPublishValidation = {
+	isValid: boolean
+	issues: string[]
+	issuesByField: Partial<Record<ProductPublishValidationField, string[]>>
+}
 
 export type ProductDraftValidation = {
 	hasValidName: boolean
 	hasValidDescription: boolean
+	hasValidPrice: boolean
+	hasValidQuantity: boolean
 	hasValidCategory: boolean
 	hasValidImages: boolean
 	hasValidShipping: boolean
+	publishValidation: ProductPublishValidation
 	allRequiredFieldsValid: boolean
 	issues: string[]
 	issuesByTab: Partial<Record<ProductFormTab, string[]>>
 	firstIncompleteTab: ProductFormTab
+}
+
+const PRODUCT_FORM_TAB_ORDER: ProductFormTab[] = ['name', 'detail', 'spec', 'category', 'images', 'shipping']
+
+export function validateProductPublishDraft(input: ProductPublishValidationInput): ProductPublishValidation {
+	const issuesByField: Partial<Record<ProductPublishValidationField, string[]>> = {}
+	const addIssue = (field: ProductPublishValidationField, issue: string) => {
+		issuesByField[field] = [...(issuesByField[field] ?? []), issue]
+	}
+
+	if (!input.name.trim()) addIssue('name', 'Product name is required')
+	if (!input.description.trim()) addIssue('description', 'Product description is required')
+	if (!input.price.trim() || isNaN(Number(input.price))) addIssue('price', 'Valid product price is required')
+	if (!input.quantity.trim() || isNaN(Number(input.quantity))) addIssue('quantity', 'Valid product quantity is required')
+	if (input.images.length === 0) addIssue('images', 'At least one product image is required')
+	if (!input.mainCategory) addIssue('mainCategory', 'Main category is required')
+
+	const validShippings = normalizeProductShippingSelections(input.shippings).filter((ship) => ship.shippingRef)
+	if (validShippings.length === 0) addIssue('shipping', 'At least one shipping option is required')
+
+	const fieldOrder: ProductPublishValidationField[] = ['name', 'description', 'price', 'quantity', 'images', 'mainCategory', 'shipping']
+	const issues = fieldOrder.flatMap((field) => issuesByField[field] ?? [])
+
+	return {
+		isValid: issues.length === 0,
+		issues,
+		issuesByField,
+	}
+}
+
+export function getProductFormPublishValidationInput(state: ProductFormState): ProductPublishValidationInput {
+	const usesFiatPublishPrice = state.currency !== 'SATS' && state.currency !== 'BTC' && state.currencyMode === 'fiat'
+
+	return {
+		name: state.name,
+		description: state.description,
+		price: usesFiatPublishPrice ? state.fiatPrice || state.price : state.price,
+		quantity: state.quantity,
+		mainCategory: state.mainCategory,
+		images: state.images,
+		shippings: state.shippings,
+	}
 }
 
 export function validateProductDraft({
@@ -21,35 +85,46 @@ export function validateProductDraft({
 	resolvedShippingRefs: Set<string>
 	isShippingFetched: boolean
 }): ProductDraftValidation {
-	const hasValidName = state.name.trim().length > 0
-	const hasValidDescription = state.description.trim().length > 0
-	const hasValidCategory = true
-	const hasValidImages = state.images.length > 0
-	const hasValidShipping = state.shippings.some(
+	const publishValidation = validateProductPublishDraft(getProductFormPublishValidationInput(state))
+	const hasValidName = !(publishValidation.issuesByField.name?.length ?? 0)
+	const hasValidDescription = !(publishValidation.issuesByField.description?.length ?? 0)
+	const hasValidPrice = !(publishValidation.issuesByField.price?.length ?? 0)
+	const hasValidQuantity = !(publishValidation.issuesByField.quantity?.length ?? 0)
+	const hasValidCategory = !(publishValidation.issuesByField.mainCategory?.length ?? 0)
+	const hasValidImages = !(publishValidation.issuesByField.images?.length ?? 0)
+	const hasPublishValidShipping = !(publishValidation.issuesByField.shipping?.length ?? 0)
+	const hasResolvedShipping = state.shippings.some(
 		(ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)),
 	)
+	const hasValidShipping = hasPublishValidShipping && hasResolvedShipping
 
 	const issuesByTab: Partial<Record<ProductFormTab, string[]>> = {}
 	const addIssue = (tab: ProductFormTab, issue: string) => {
 		issuesByTab[tab] = [...(issuesByTab[tab] ?? []), issue]
 	}
 
-	if (!hasValidName) addIssue('name', 'Product name is required')
-	if (!hasValidDescription) addIssue('name', 'Description is required')
-	if (!hasValidImages) addIssue('images', 'At least one image is required')
-	if (!hasValidShipping) addIssue('shipping', 'At least one shipping option is required')
+	for (const issue of publishValidation.issuesByField.name ?? []) addIssue('name', issue)
+	for (const issue of publishValidation.issuesByField.description ?? []) addIssue('name', issue)
+	for (const issue of publishValidation.issuesByField.price ?? []) addIssue('detail', issue)
+	for (const issue of publishValidation.issuesByField.quantity ?? []) addIssue('detail', issue)
+	for (const issue of publishValidation.issuesByField.mainCategory ?? []) addIssue('category', issue)
+	for (const issue of publishValidation.issuesByField.images ?? []) addIssue('images', issue)
+	for (const issue of publishValidation.issuesByField.shipping ?? []) addIssue('shipping', issue)
+	if (hasPublishValidShipping && !hasResolvedShipping) addIssue('shipping', 'Selected shipping option is no longer available')
 
-	const issues = (['name', 'detail', 'spec', 'category', 'images', 'shipping'] as ProductFormTab[]).flatMap((tab) => issuesByTab[tab] ?? [])
+	const issues = PRODUCT_FORM_TAB_ORDER.flatMap((tab) => issuesByTab[tab] ?? [])
 	const allRequiredFieldsValid = issues.length === 0
-	const firstIncompleteTab =
-		(['name', 'detail', 'spec', 'category', 'images', 'shipping'] as ProductFormTab[]).find((tab) => issuesByTab[tab]?.length) ?? 'shipping'
+	const firstIncompleteTab = PRODUCT_FORM_TAB_ORDER.find((tab) => issuesByTab[tab]?.length) ?? 'shipping'
 
 	return {
 		hasValidName,
 		hasValidDescription,
+		hasValidPrice,
+		hasValidQuantity,
 		hasValidCategory,
 		hasValidImages,
 		hasValidShipping,
+		publishValidation,
 		allRequiredFieldsValid,
 		issues,
 		issuesByTab,

--- a/src/lib/workflow/productWorkflowResolver.test.ts
+++ b/src/lib/workflow/productWorkflowResolver.test.ts
@@ -19,15 +19,15 @@ describe('resolveProductWorkflow', () => {
 		})
 	})
 
-	test('routes new sessions to shipping first when setup truth says shipping is empty', () => {
+	test('does not route new sessions to shipping first when setup truth says shipping is empty', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'empty',
 			v4vConfigurationState: 'configured-zero',
 		})
 
-		expect(resolution.initialTab).toBe('shipping')
-		expect(resolution.shouldStartAtShipping).toBe(true)
+		expect(resolution.initialTab).toBe('name')
+		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(false)
 	})
 
@@ -53,7 +53,7 @@ describe('resolveProductWorkflow', () => {
 		expect(resolution.initialTab).toBe('name')
 	})
 
-	test('does not allow requestedTab to bypass shipping-first bootstrap in create flow', () => {
+	test('allows requestedTab even when shipping setup truth says shipping is empty', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'empty',
@@ -62,11 +62,12 @@ describe('resolveProductWorkflow', () => {
 		})
 
 		expect(resolution.isBootstrapReady).toBe(true)
-		expect(resolution.initialTab).toBe('shipping')
+		expect(resolution.initialTab).toBe('images')
+		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(true)
 	})
 
-	test('may honor requestedTab for create flow only when bootstrap policy is not forcing shipping', () => {
+	test('may honor requestedTab for create flow when shipping is ready', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'ready',
@@ -77,6 +78,19 @@ describe('resolveProductWorkflow', () => {
 		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('images')
 		expect(resolution.shouldStartAtShipping).toBe(false)
+	})
+
+	test('shipping emptiness affects readiness, not first-step policy', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'empty',
+			v4vConfigurationState: 'never-configured',
+		})
+
+		expect(resolution.initialTab).toBe('name')
+		expect(resolution.shouldStartAtShipping).toBe(false)
+		expect(resolution.requiresV4VSetup).toBe(true)
+		expect(resolution.isBootstrapReady).toBe(true)
 	})
 
 	test('may honor requestedTab more freely in edit flow', () => {

--- a/src/lib/workflow/productWorkflowResolver.ts
+++ b/src/lib/workflow/productWorkflowResolver.ts
@@ -38,14 +38,11 @@ export function resolveProductWorkflow(input: ProductWorkflowResolverInput): Pro
 		}
 	}
 
-	const shouldStartAtShipping = input.shippingState === 'empty'
-	const initialTab: ProductFormTab = shouldStartAtShipping ? 'shipping' : (requestedTab ?? 'name')
-
 	return {
 		mode,
 		isBootstrapReady: input.shippingState !== 'loading',
-		initialTab,
-		shouldStartAtShipping,
+		initialTab: requestedTab ?? 'name',
+		shouldStartAtShipping: false,
 		requiresV4VSetup: input.v4vConfigurationState === 'never-configured',
 	}
 }

--- a/src/lib/workflow/useProductCreateReadiness.test.ts
+++ b/src/lib/workflow/useProductCreateReadiness.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test'
+import { getRemainingQuickTemplateServices, normalizeQuickShippingTemplateService } from '@/lib/workflow/useProductCreateReadiness'
+
+describe('product create readiness helpers', () => {
+	test('normalizes quick template services by service key', () => {
+		expect(normalizeQuickShippingTemplateService(' STANDARD ')).toBe('standard')
+		expect(normalizeQuickShippingTemplateService('pickup')).toBe('pickup')
+		expect(normalizeQuickShippingTemplateService('Digital Delivery')).toBeNull()
+		expect(normalizeQuickShippingTemplateService('express')).toBeNull()
+	})
+
+	test('derives remaining quick templates from normalized saved services', () => {
+		expect(getRemainingQuickTemplateServices([])).toEqual(['digital', 'standard', 'pickup'])
+		expect(getRemainingQuickTemplateServices(['standard'])).toEqual(['digital', 'pickup'])
+		expect(getRemainingQuickTemplateServices(['standard', 'pickup'])).toEqual(['digital'])
+		expect(getRemainingQuickTemplateServices(['standard', 'pickup', 'digital'])).toEqual([])
+	})
+})

--- a/src/lib/workflow/useProductCreateReadiness.ts
+++ b/src/lib/workflow/useProductCreateReadiness.ts
@@ -1,0 +1,100 @@
+import type { RichShippingInfo } from '@/lib/stores/cart'
+import type { ShippingSetupState, V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
+import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { useV4VConfiguration } from '@/queries/v4v'
+import { useMemo } from 'react'
+
+export type QuickShippingTemplateService = 'digital' | 'standard' | 'pickup'
+
+const QUICK_SHIPPING_TEMPLATE_SERVICES: QuickShippingTemplateService[] = ['digital', 'standard', 'pickup']
+
+export type ProductCreateReadiness = {
+	shippingState: ShippingSetupState
+	v4vConfigurationState: V4VSetupState
+	hasResolvedSellerReadiness: boolean
+	isBootstrapReady: boolean
+	savedShippingOptions: RichShippingInfo[]
+	savedShippingRefs: string[]
+	remainingQuickTemplateServices: QuickShippingTemplateService[]
+}
+
+export function normalizeQuickShippingTemplateService(service: string | null | undefined): QuickShippingTemplateService | null {
+	const normalizedService = service?.trim().toLowerCase()
+
+	if (normalizedService === 'digital' || normalizedService === 'standard' || normalizedService === 'pickup') {
+		return normalizedService
+	}
+
+	return null
+}
+
+export function getRemainingQuickTemplateServices(savedServices: Array<string | null | undefined>): QuickShippingTemplateService[] {
+	const savedQuickTemplateServices = new Set(
+		savedServices
+			.map((service) => normalizeQuickShippingTemplateService(service))
+			.filter((service): service is QuickShippingTemplateService => !!service),
+	)
+
+	return QUICK_SHIPPING_TEMPLATE_SERVICES.filter((service) => !savedQuickTemplateServices.has(service))
+}
+
+export function useProductCreateReadiness(userPubkey: string): ProductCreateReadiness {
+	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
+	const v4vQuery = useV4VConfiguration(userPubkey)
+
+	const savedShippingOptions = useMemo<RichShippingInfo[]>(() => {
+		if (!shippingQuery.data || !userPubkey) return []
+
+		return shippingQuery.data
+			.filter((event) => {
+				const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
+				return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+			})
+			.map((event) => {
+				const info = getShippingInfo(event)
+				if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return null
+
+				return {
+					id: createShippingReference(event.pubkey, info.id),
+					name: info.title,
+					cost: parseFloat(info.price.amount),
+					currency: info.price.currency,
+					countries: info.countries || [],
+					service: info.service || '',
+					carrier: info.carrier || '',
+				}
+			})
+			.filter((option): option is RichShippingInfo => option !== null)
+	}, [shippingQuery.data, userPubkey])
+
+	const savedShippingRefs = useMemo(() => savedShippingOptions.map((option) => option.id), [savedShippingOptions])
+
+	const shippingState = useMemo<ShippingSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
+
+		return savedShippingRefs.length === 0 ? 'empty' : 'ready'
+	}, [userPubkey, shippingQuery.isFetched, shippingQuery.isLoading, savedShippingRefs.length])
+
+	const v4vConfigurationState = useMemo<V4VSetupState>(() => {
+		if (!userPubkey) return 'loading'
+		if (v4vQuery.isLoading) return 'loading'
+
+		return v4vQuery.data?.state ?? 'unknown'
+	}, [userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
+
+	const remainingQuickTemplateServices = useMemo(
+		() => getRemainingQuickTemplateServices(savedShippingOptions.map((option) => option.service)),
+		[savedShippingOptions],
+	)
+
+	return {
+		shippingState,
+		v4vConfigurationState,
+		hasResolvedSellerReadiness: shippingState !== 'loading' && v4vConfigurationState !== 'loading',
+		isBootstrapReady: shippingState !== 'loading',
+		savedShippingOptions,
+		savedShippingRefs,
+		remainingQuickTemplateServices,
+	}
+}

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -1,6 +1,7 @@
 import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 import { ndkActions } from '@/lib/stores/ndk'
 import { normalizeProductShippingSelections, type ProductShippingSelectionInput } from '@/lib/utils/productShippingSelections'
+import { validateProductPublishDraft } from '@/lib/workflow/productDraftValidation'
 import { productKeys } from '@/queries/queryKeyFactory'
 import { markProductAsDeleted } from '@/queries/products'
 import NDK, { NDKEvent, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
@@ -26,6 +27,13 @@ export interface ProductFormData {
 	weight: { value: string; unit: string } | null
 	dimensions: { value: string; unit: string } | null
 	isNSFW: boolean
+}
+
+const assertValidProductPublishData = (formData: ProductFormData) => {
+	const validation = validateProductPublishDraft(formData)
+	if (!validation.isValid) {
+		throw new Error(validation.issues[0])
+	}
 }
 
 /**
@@ -109,36 +117,7 @@ export const createProductEvent = (
  * Publishes a new product
  */
 export const publishProduct = async (formData: ProductFormData, signer: NDKSigner, ndk: NDK): Promise<string> => {
-	// Validation
-	if (!formData.name.trim()) {
-		throw new Error('Product name is required')
-	}
-
-	if (!formData.description.trim()) {
-		throw new Error('Product description is required')
-	}
-
-	if (!formData.price.trim() || isNaN(Number(formData.price))) {
-		throw new Error('Valid product price is required')
-	}
-
-	if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
-		throw new Error('Valid product quantity is required')
-	}
-
-	if (formData.images.length === 0) {
-		throw new Error('At least one product image is required')
-	}
-
-	if (!formData.mainCategory) {
-		throw new Error('Main category is required')
-	}
-
-	// Validate shipping options
-	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
-	if (validShippings.length === 0) {
-		throw new Error('At least one shipping option is required')
-	}
+	assertValidProductPublishData(formData)
 
 	const event = createProductEvent(formData, signer, ndk)
 
@@ -162,35 +141,7 @@ export const updateProduct = async (
 		throw new Error('Product d tag is required for updates')
 	}
 
-	if (!formData.name.trim()) {
-		throw new Error('Product name is required')
-	}
-
-	if (!formData.description.trim()) {
-		throw new Error('Product description is required')
-	}
-
-	if (!formData.price.trim() || isNaN(Number(formData.price))) {
-		throw new Error('Valid product price is required')
-	}
-
-	if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
-		throw new Error('Valid product quantity is required')
-	}
-
-	if (formData.images.length === 0) {
-		throw new Error('At least one product image is required')
-	}
-
-	if (!formData.mainCategory) {
-		throw new Error('Main category is required')
-	}
-
-	// Validate shipping options
-	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
-	if (validShippings.length === 0) {
-		throw new Error('At least one shipping option is required')
-	}
+	assertValidProductPublishData(formData)
 
 	// Create event with the same d tag to update the existing product
 	const event = createProductEvent(formData, signer, ndk, productDTag)

--- a/src/publish/shipping.test.ts
+++ b/src/publish/shipping.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, test } from 'bun:test'
-import { buildPublishedShippingOption } from '@/publish/shipping'
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { buildPublishedShippingOption, type ShippingFormData } from '@/publish/shipping'
+
+let normalizeShippingFormDataForDeliveryMode: (formData: ShippingFormData, defaultCurrency: string) => ShippingFormData
+
+beforeAll(async () => {
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: {
+			getItem: () => null,
+			setItem: () => undefined,
+			removeItem: () => undefined,
+		},
+	})
+	;({ normalizeShippingFormDataForDeliveryMode } = await import('@/routes/_dashboard-layout/dashboard/products/shipping-options'))
+})
 
 describe('published shipping option identity', () => {
 	test('derives canonical shippingRef from mutation result identity', () => {
@@ -8,5 +22,96 @@ describe('published shipping option identity', () => {
 			shippingDTag: 'shipping_abc',
 			shippingRef: '30406:merchant-pubkey:shipping_abc',
 		})
+	})
+})
+
+const physicalDraftWithMetadata = (service: ShippingFormData['service'] | string): ShippingFormData =>
+	({
+		title: 'Existing shipping option',
+		description: 'Existing instructions',
+		price: '12.50',
+		currency: 'USD',
+		countries: ['USA', 'CAN'],
+		service,
+		carrier: 'UPS',
+		location: 'Warehouse 1',
+		region: 'US-CA',
+		additionalRegions: ['US-NV'],
+		geohash: '9q8yy',
+		duration: {
+			min: '2',
+			max: '5',
+			unit: 'D',
+		},
+		weightLimits: {
+			min: { value: '1', unit: 'kg' },
+			max: { value: '10', unit: 'kg' },
+		},
+		dimensionLimits: {
+			min: { value: '10x10x10', unit: 'cm' },
+			max: { value: '100x100x100', unit: 'cm' },
+		},
+		priceCalculations: {
+			weight: { value: '1.5', unit: 'kg' },
+		},
+	}) as ShippingFormData
+
+const expectNoPhysicalMetadata = (formData: ShippingFormData) => {
+	expect(formData).not.toHaveProperty('carrier')
+	expect(formData).not.toHaveProperty('location')
+	expect(formData).not.toHaveProperty('region')
+	expect(formData).not.toHaveProperty('additionalRegions')
+	expect(formData).not.toHaveProperty('geohash')
+	expect(formData).not.toHaveProperty('duration')
+	expect(formData).not.toHaveProperty('weightLimits')
+	expect(formData).not.toHaveProperty('dimensionLimits')
+	expect(formData).not.toHaveProperty('priceCalculations')
+}
+
+describe('shipping option delivery-mode normalization', () => {
+	test('physical to digital strips hidden physical metadata before persistence', () => {
+		const normalized = normalizeShippingFormDataForDeliveryMode(physicalDraftWithMetadata('digital-delivery'), 'USD')
+
+		expect(normalized.service).toBe('digital')
+		expect(normalized.price).toBe('0')
+		expect(normalized.countries).toEqual([])
+		expect(normalized.description).toBe('Existing instructions')
+		expectNoPhysicalMetadata(normalized)
+	})
+
+	test('physical to pickup strips hidden physical metadata before persistence', () => {
+		const normalized = normalizeShippingFormDataForDeliveryMode(
+			{
+				...physicalDraftWithMetadata('local-pickup'),
+				pickupAddress: {
+					street: '123 Main St',
+					city: 'Austin',
+					state: 'TX',
+					postalCode: '78701',
+					country: 'USA',
+				},
+			},
+			'USD',
+		)
+
+		expect(normalized.service).toBe('pickup')
+		expect(normalized.price).toBe('0')
+		expect(normalized.countries).toEqual(['USA'])
+		expect(normalized.description).toBe('Existing instructions')
+		expect(normalized.pickupAddress).toEqual({
+			street: '123 Main St',
+			city: 'Austin',
+			state: 'TX',
+			postalCode: '78701',
+			country: 'USA',
+		})
+		expectNoPhysicalMetadata(normalized)
+	})
+
+	test('physical mode preserves physical metadata before persistence', () => {
+		const draft = physicalDraftWithMetadata('express')
+		const normalized = normalizeShippingFormDataForDeliveryMode(draft, 'USD')
+
+		expect(normalized).toEqual(draft)
 	})
 })

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -14,5 +14,5 @@ function NewProductComponent() {
 	const { user } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
 
-	return <ProductCreateShell userPubkey={userPubkey} className="space-y-6" />
+	return <ProductCreateShell userPubkey={userPubkey} entrypoint="dashboard" className="space-y-6" />
 }

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -2,10 +2,9 @@ import { ProductFormContent } from '@/components/sheet-contents/NewProductConten
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { authStore } from '@/lib/stores/auth'
-import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
+import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
+import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
 import { productFormActions } from '@/lib/stores/product'
-import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
-import { useV4VConfiguration } from '@/queries/v4v'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
@@ -23,44 +22,16 @@ function NewProductComponent() {
 	const [isBootstrapped, setIsBootstrapped] = useState(false)
 	const hasBootstrappedRef = useRef(false)
 
-	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
-	const v4vQuery = useV4VConfiguration(userPubkey)
-
-	const shippingState = useMemo<ShippingSetupState>(() => {
-		if (!userPubkey) return 'loading'
-		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
-
-		const activeShippingRefs = new Set(
-			(shippingQuery.data ?? [])
-				.filter((event) => {
-					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-
-		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
-	}, [userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
-
-	const v4vState = useMemo<V4VSetupState>(() => {
-		if (!userPubkey) return 'loading'
-		if (v4vQuery.isLoading) return 'loading'
-
-		return v4vQuery.data?.state ?? 'unknown'
-	}, [userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
+	const readiness = useProductCreateReadiness(userPubkey)
 
 	const workflow = useMemo(
 		() =>
 			resolveProductWorkflow({
 				mode: 'create',
-				shippingState,
-				v4vConfigurationState: v4vState,
+				shippingState: readiness.shippingState,
+				v4vConfigurationState: readiness.v4vConfigurationState,
 			}),
-		[shippingState, v4vState],
+		[readiness.shippingState, readiness.v4vConfigurationState],
 	)
 
 	useEffect(() => {

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -1,14 +1,8 @@
-import { ProductFormContent } from '@/components/sheet-contents/NewProductContent'
-import { Card, CardContent } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
+import { ProductCreateShell } from '@/components/product-authoring/ProductCreateShell'
 import { authStore } from '@/lib/stores/auth'
-import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
-import { useProductCreateReadiness } from '@/lib/workflow/useProductCreateReadiness'
-import { productFormActions } from '@/lib/stores/product'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useRef, useState } from 'react'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/products/products/new')({
 	component: NewProductComponent,
@@ -19,55 +13,6 @@ function NewProductComponent() {
 
 	const { user } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
-	const [isBootstrapped, setIsBootstrapped] = useState(false)
-	const hasBootstrappedRef = useRef(false)
 
-	const readiness = useProductCreateReadiness(userPubkey)
-
-	const workflow = useMemo(
-		() =>
-			resolveProductWorkflow({
-				mode: 'create',
-				shippingState: readiness.shippingState,
-				v4vConfigurationState: readiness.v4vConfigurationState,
-			}),
-		[readiness.shippingState, readiness.v4vConfigurationState],
-	)
-
-	useEffect(() => {
-		hasBootstrappedRef.current = false
-		setIsBootstrapped(false)
-	}, [userPubkey])
-
-	useEffect(() => {
-		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
-
-		productFormActions.reset({
-			activeTab: workflow.initialTab,
-			editingProductId: null,
-		})
-
-		hasBootstrappedRef.current = true
-		setIsBootstrapped(true)
-	}, [workflow.initialTab, workflow.isBootstrapReady])
-
-	if (!workflow.isBootstrapReady || !isBootstrapped) {
-		return (
-			<Card>
-				<CardContent className="p-8">
-					<div className="space-y-4">
-						<Skeleton className="h-8 w-48" />
-						<Skeleton className="h-4 w-full" />
-						<Skeleton className="h-4 w-3/4" />
-					</div>
-				</CardContent>
-			</Card>
-		)
-	}
-
-	return (
-		<div className="space-y-6">
-			<ProductFormContent showFooter={true} workflow={workflow} />
-		</div>
-	)
+	return <ProductCreateShell userPubkey={userPubkey} className="space-y-6" />
 }

--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -284,7 +284,6 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 		}
 
 		setIsSubmitting(true)
-		setFormData(normalizedFormData)
 
 		try {
 			if (isEditing) {
@@ -497,8 +496,17 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 									value={formData.service}
 									onValueChange={(value: any) => {
 										setFormData((prev) => {
+											const previousDeliveryMode = resolveProductDeliveryMode(prev.service)
 											const nextDeliveryMode = resolveProductDeliveryMode(value)
 											const newFormData = { ...prev, service: value }
+
+											if (previousDeliveryMode !== nextDeliveryMode) {
+												if (nextDeliveryMode === 'digital') {
+													setIsWorldwide(true)
+												} else if (nextDeliveryMode === 'physical') {
+													setIsWorldwide(false)
+												}
+											}
 
 											if (nextDeliveryMode === 'pickup') {
 												newFormData.price = '0'
@@ -510,9 +518,6 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 											} else if (nextDeliveryMode === 'digital') {
 												newFormData.price = '0'
 												newFormData.countries = []
-												setIsWorldwide(true)
-											} else {
-												setIsWorldwide(false)
 											}
 											return newFormData
 										})

--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -11,6 +11,12 @@ import { COUNTRIES_ISO, CURRENCIES, SHIPPING_TEMPLATES } from '@/lib/constants'
 import { uiStore } from '@/lib/stores/ui'
 import { useNDK } from '@/lib/stores/ndk'
 import {
+	getProductDeliveryModeLabel,
+	productDeliveryModeRequiresShippingCost,
+	productDeliveryModeUsesCoverage,
+	resolveProductDeliveryMode,
+} from '@/lib/workflow/productDeliveryModes'
+import {
 	useDeleteShippingOptionMutation,
 	usePublishShippingOptionMutation,
 	useUpdateShippingOptionMutation,
@@ -56,6 +62,32 @@ const DURATION_UNITS = [
 	{ value: 'W', label: 'Weeks' },
 	{ value: 'M', label: 'Months' },
 ] as const
+
+const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, defaultCurrency: string): ShippingFormData => {
+	const deliveryMode = resolveProductDeliveryMode(formData.service)
+
+	if (deliveryMode === 'digital') {
+		return {
+			...formData,
+			price: '0',
+			currency: formData.currency || defaultCurrency,
+			countries: [],
+		}
+	}
+
+	if (deliveryMode === 'pickup') {
+		const pickupCountry = formData.pickupAddress?.country || formData.countries[0]
+
+		return {
+			...formData,
+			price: '0',
+			currency: formData.currency || defaultCurrency,
+			countries: pickupCountry ? [pickupCountry] : formData.countries,
+		}
+	}
+
+	return formData
+}
 
 interface ShippingOptionFormProps {
 	shippingOption: NDKEvent | null
@@ -147,6 +179,9 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 			},
 		}
 	})
+	const deliveryMode = resolveProductDeliveryMode(formData.service)
+	const shouldShowShippingCost = productDeliveryModeRequiresShippingCost(deliveryMode)
+	const shouldShowCoverage = productDeliveryModeUsesCoverage(deliveryMode)
 
 	// Get user on mount
 	useEffect(() => {
@@ -175,38 +210,37 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 		setIsWorldwide(false)
 	}, [])
 
-	const validateForm = (): boolean => {
+	const validateForm = (draft: ShippingFormData = formData): boolean => {
 		const errors: Record<string, string> = {}
+		const draftDeliveryMode = resolveProductDeliveryMode(draft.service)
 
-		if (!formData.title.trim()) {
+		if (!draft.title.trim()) {
 			errors.title = 'Title is required'
 		}
-		if (!formData.description.trim()) {
+		if (!draft.description.trim()) {
 			errors.description = 'Description is required'
 		}
 
-		// Price is not required for digital delivery (always free)
-		if (formData.service !== 'digital') {
-			if (!formData.price.trim()) {
+		if (productDeliveryModeRequiresShippingCost(draftDeliveryMode)) {
+			if (!draft.price.trim()) {
 				errors.price = 'Price is required'
-			} else if (isNaN(Number(formData.price))) {
+			} else if (isNaN(Number(draft.price)) || Number(draft.price) < 0) {
 				errors.price = 'Price must be a valid number'
 			}
-			if (!formData.currency.trim()) {
+			if (!draft.currency.trim()) {
 				errors.currency = 'Currency is required'
 			}
 		}
 
-		// Countries are only required for non-pickup, non-digital, and non-worldwide services
-		if (formData.service !== 'pickup' && formData.service !== 'digital' && !isWorldwide && !formData.countries.length) {
+		if (productDeliveryModeUsesCoverage(draftDeliveryMode) && !isWorldwide && !draft.countries.length) {
 			errors.countries = 'At least one country is required'
 		}
 
-		if (formData.service === 'pickup') {
-			if (!formData.pickupAddress?.street?.trim()) {
+		if (draftDeliveryMode === 'pickup') {
+			if (!draft.pickupAddress?.street?.trim()) {
 				errors.pickupStreet = 'Street address is required for local pickup'
 			}
-			if (!formData.pickupAddress?.city?.trim()) {
+			if (!draft.pickupAddress?.city?.trim()) {
 				errors.pickupCity = 'City is required for local pickup'
 			}
 		}
@@ -218,12 +252,15 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault()
 
-		if (!validateForm()) {
+		const normalizedFormData = normalizeShippingFormDataForDeliveryMode(formData, uiStore.state.selectedCurrency)
+
+		if (!validateForm(normalizedFormData)) {
 			toast.error('Please fill in all required fields')
 			return
 		}
 
 		setIsSubmitting(true)
+		setFormData(normalizedFormData)
 
 		try {
 			if (isEditing) {
@@ -233,11 +270,11 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 				}
 				await updateMutation.mutateAsync({
 					shippingDTag: shippingId,
-					formData,
+					formData: normalizedFormData,
 				})
 				toast.success('Shipping option updated successfully')
 			} else {
-				await publishMutation.mutateAsync(formData)
+				await publishMutation.mutateAsync(normalizedFormData)
 				toast.success('Shipping option created successfully')
 			}
 
@@ -272,22 +309,16 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 	}
 
 	const ServiceIcon = ({ service }: { service: string }) => {
-		switch (service) {
-			case 'express':
-			case 'overnight':
-				return <TruckIcon className="w-5 h-5 text-orange-500" />
+		const mode = resolveProductDeliveryMode(service)
+
+		switch (mode) {
 			case 'pickup':
 				return <PackageIcon className="w-5 h-5 text-blue-500" />
 			case 'digital':
 				return <DownloadIcon className="w-5 h-5 text-purple-500" />
-			default:
-				return <TruckIcon className="w-5 h-5" />
+			case 'physical':
+				return <TruckIcon className={`w-5 h-5 ${service === 'express' || service === 'overnight' ? 'text-orange-500' : ''}`} />
 		}
-	}
-
-	const getServiceLabel = (service: string) => {
-		const serviceType = SERVICE_TYPES.find((s) => s.value === service)
-		return serviceType?.label || service
 	}
 
 	const getCountryName = (code: string) => {
@@ -295,21 +326,41 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 		return country?.name || code
 	}
 
+	const getPickupAddressSummary = () => {
+		const address = formData.pickupAddress
+		if (!address) return 'Pickup address not set'
+
+		return (
+			[address.street, address.city, address.state, address.postalCode, address.country].filter(Boolean).join(', ') ||
+			'Pickup address not set'
+		)
+	}
+
+	const getCoverageSummary = () => {
+		if (isWorldwide || formData.countries.length === 0) return 'Worldwide'
+		if (formData.countries.length === 1) return getCountryName(formData.countries[0])
+		return `${formData.countries.length} countries`
+	}
+
+	const getShippingOptionSummary = () => {
+		if (deliveryMode === 'digital') return 'Digital delivery • No shipping cost'
+		if (deliveryMode === 'pickup') return `Local pickup • ${getPickupAddressSummary()}`
+		return `${formData.price || '0'} ${formData.currency} • ${getCoverageSummary()} • Physical shipping`
+	}
+
+	const getModeDescription = () => {
+		if (deliveryMode === 'digital') return 'Digital delivery keeps shipping cost and country coverage out of this option.'
+		if (deliveryMode === 'pickup') return 'Local pickup uses pickup address and instructions. Shipping cost is not configured here.'
+		return 'Physical shipping uses base cost, coverage, and optional package constraints.'
+	}
+
 	const triggerContent = isEditing ? (
 		<div className="min-w-0 flex-1">
 			<div className="font-medium truncate">{formData.title}</div>
 			{/* Stack details vertically on mobile, inline on desktop */}
 			<div className="text-sm text-muted-foreground">
-				<div className="hidden md:block truncate">
-					{formData.price} {formData.currency} • {formData.countries.map(getCountryName).join(', ')} • {getServiceLabel(formData.service)}
-				</div>
-				<div className="md:hidden space-y-1">
-					<div className="truncate">
-						{formData.price} {formData.currency}
-					</div>
-					<div className="truncate">{formData.countries.map(getCountryName).join(', ')}</div>
-					<div className="truncate">{getServiceLabel(formData.service)}</div>
-				</div>
+				<div className="hidden md:block truncate">{getShippingOptionSummary()}</div>
+				<div className="md:hidden truncate">{getShippingOptionSummary()}</div>
 			</div>
 		</div>
 	) : (
@@ -344,9 +395,7 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 									onValueChange={(templateName) => {
 										const template = SHIPPING_TEMPLATES.find((t) => t.name === templateName)
 										if (template) {
-											// Check if template is worldwide (countries is null)
 											const isWorldwideTemplate = template.countries === null
-											setIsWorldwide(isWorldwideTemplate)
 
 											// Determine service type based on template name
 											let serviceType: 'standard' | 'express' | 'overnight' | 'pickup' | 'digital' = 'standard'
@@ -359,14 +408,16 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 											} else if (template.name.toLowerCase().includes('overnight')) {
 												serviceType = 'overnight'
 											}
+											const nextDeliveryMode = resolveProductDeliveryMode(serviceType)
 
 											setFormData((prev) => ({
 												...prev,
 												title: template.name,
-												price: template.cost,
-												countries: template.countries || [],
+												price: productDeliveryModeRequiresShippingCost(nextDeliveryMode) ? template.cost : '0',
+												countries: productDeliveryModeUsesCoverage(nextDeliveryMode) ? template.countries || [] : [],
 												service: serviceType,
 											}))
+											setIsWorldwide(nextDeliveryMode === 'digital' || (nextDeliveryMode === 'physical' && isWorldwideTemplate))
 										}
 									}}
 								>
@@ -422,23 +473,22 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 									value={formData.service}
 									onValueChange={(value: any) => {
 										setFormData((prev) => {
+											const nextDeliveryMode = resolveProductDeliveryMode(value)
 											const newFormData = { ...prev, service: value }
-											// Auto-populate country and price for pickup services
-											if (value === 'pickup') {
-												// Set price to 0 for pickup services
+
+											if (nextDeliveryMode === 'pickup') {
 												newFormData.price = '0'
-												// Auto-populate country from pickup address if available
 												if (prev.pickupAddress?.country && !prev.countries.includes(prev.pickupAddress.country)) {
 													newFormData.countries = [prev.pickupAddress.country]
 												} else if (!prev.countries.length) {
-													// Default to USA if no country is set
 													newFormData.countries = ['USA']
 												}
-											} else if (value === 'digital') {
-												// Set price to 0 and clear countries for digital delivery
+											} else if (nextDeliveryMode === 'digital') {
 												newFormData.price = '0'
 												newFormData.countries = []
 												setIsWorldwide(true)
+											} else {
+												setIsWorldwide(false)
 											}
 											return newFormData
 										})
@@ -458,15 +508,19 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 										))}
 									</SelectContent>
 								</Select>
+								<p className="text-sm text-muted-foreground">
+									{getProductDeliveryModeLabel(deliveryMode)}: {getModeDescription()}
+								</p>
 							</div>
 
-							{/* Price - Hide for digital delivery (always free) */}
-							{formData.service !== 'digital' && (
+							{shouldShowShippingCost && (
 								<div className="space-y-2">
 									<Label htmlFor="price" className="font-medium">
 										Base Cost *
 									</Label>
-									<p className="text-sm text-muted-foreground">Can be adjusted per product</p>
+									<p className="text-sm text-muted-foreground">
+										Physical shipping base cost. Product-specific extra cost is configured per product.
+									</p>
 									<div className="flex gap-2">
 										<Input
 											id="price"
@@ -517,11 +571,10 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 								</div>
 							)}
 
-							{/* Countries - Hide for pickup and digital delivery services */}
-							{formData.service !== 'pickup' && formData.service !== 'digital' && (
+							{shouldShowCoverage && (
 								<div className="space-y-2">
 									<Label htmlFor="countries" className="font-medium">
-										Countries *
+										Physical Coverage *
 									</Label>
 
 									{/* Worldwide Checkbox */}
@@ -616,7 +669,11 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 
 						<div className="space-y-2">
 							<Label htmlFor="description" className="font-medium">
-								Description *
+								{deliveryMode === 'pickup'
+									? 'Pickup Instructions *'
+									: deliveryMode === 'digital'
+										? 'Digital Fulfillment Instructions *'
+										: 'Description *'}
 							</Label>
 							<Textarea
 								id="description"
@@ -628,7 +685,13 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 										setFieldErrors((prev) => ({ ...prev, description: '' }))
 									}
 								}}
-								placeholder="Describe your shipping option..."
+								placeholder={
+									deliveryMode === 'pickup'
+										? 'Describe pickup hours, handoff details, or what the buyer should bring.'
+										: deliveryMode === 'digital'
+											? 'Describe how the buyer will receive or access the digital item after purchase.'
+											: 'Describe your physical shipping option...'
+								}
 								rows={3}
 								className={fieldErrors.description ? 'border-red-500' : ''}
 							/>
@@ -640,9 +703,18 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 							)}
 						</div>
 
-						{/* Pickup Address - Only show for pickup service */}
-						{formData.service === 'pickup' && (
+						{deliveryMode === 'digital' && (
+							<div className="rounded-md border p-3 text-sm text-muted-foreground">
+								Digital delivery has no shipping cost and no country coverage controls. Use the instructions above to describe post-purchase
+								fulfillment.
+							</div>
+						)}
+
+						{deliveryMode === 'pickup' && (
 							<div className="space-y-4">
+								<div className="rounded-md border p-3 text-sm text-muted-foreground">
+									Local pickup has no shipping cost. The pickup address and instructions are used for buyer handoff.
+								</div>
 								<Label className="font-medium text-base">Pickup Address *</Label>
 								<div className="grid grid-cols-1 gap-4">
 									<div className="space-y-2">
@@ -765,8 +837,11 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 																country: e.target.value,
 															},
 														}
-														// Auto-populate countries for pickup services
-														if (prev.service === 'pickup' && e.target.value && !prev.countries.includes(e.target.value)) {
+														if (
+															resolveProductDeliveryMode(prev.service) === 'pickup' &&
+															e.target.value &&
+															!prev.countries.includes(e.target.value)
+														) {
 															newFormData.countries = [e.target.value]
 														}
 														return newFormData
@@ -781,342 +856,343 @@ function ShippingOptionForm({ shippingOption, isOpen, onOpenChange, onSuccess }:
 						)}
 					</div>
 
-					{/* Optional Details */}
-					<Collapsible open={isOptionalDetailsOpen} onOpenChange={setIsOptionalDetailsOpen}>
-						<CollapsibleTrigger asChild>
-							<div className="group flex w-full justify-between items-center cursor-pointer">
-								<h3 className="text-lg font-semibold">Optional Details</h3>
-								<ChevronLeftIcon className="w-4 h-4 transition-transform duration-200 group-data-[state=open]:-rotate-90" />
-							</div>
-						</CollapsibleTrigger>
-						<CollapsibleContent>
-							<div className="space-y-4 pt-4">
-								<div className="space-y-2">
-									<Label htmlFor="carrier" className="font-medium">
-										Carrier
-									</Label>
-									<Input
-										id="carrier"
-										value={formData.carrier || ''}
-										onChange={(e) => setFormData((prev) => ({ ...prev, carrier: e.target.value }))}
-										placeholder="e.g., FedEx, UPS, DHL"
-									/>
+					{deliveryMode === 'physical' && (
+						<Collapsible open={isOptionalDetailsOpen} onOpenChange={setIsOptionalDetailsOpen}>
+							<CollapsibleTrigger asChild>
+								<div className="group flex w-full justify-between items-center cursor-pointer">
+									<h3 className="text-lg font-semibold">Physical Shipping Details</h3>
+									<ChevronLeftIcon className="w-4 h-4 transition-transform duration-200 group-data-[state=open]:-rotate-90" />
 								</div>
-
-								<div className="space-y-2">
-									<Label htmlFor="location" className="font-medium">
-										Location
-									</Label>
-									<Input
-										id="location"
-										value={formData.location || ''}
-										onChange={(e) => setFormData((prev) => ({ ...prev, location: e.target.value }))}
-										placeholder="e.g., 123 Main St, Downtown, FL"
-									/>
-								</div>
-
-								<div className="space-y-2">
-									<Label htmlFor="region" className="font-medium">
-										Region
-									</Label>
-									<Input
-										id="region"
-										value={formData.region || ''}
-										onChange={(e) => setFormData((prev) => ({ ...prev, region: e.target.value }))}
-										placeholder="e.g., US-FL (ISO 3166-2 format)"
-									/>
-								</div>
-
-								<div className="space-y-2">
-									<Label htmlFor="geohash" className="font-medium">
-										Geohash
-									</Label>
-									<Input
-										id="geohash"
-										value={formData.geohash || ''}
-										onChange={(e) => setFormData((prev) => ({ ...prev, geohash: e.target.value }))}
-										placeholder="e.g., dhwm9c4ws (precise location hash)"
-									/>
-								</div>
-
-								{/* Duration */}
-								<div className="space-y-2">
-									<Label className="font-medium">Delivery Duration</Label>
-									<div className="flex flex-col gap-2">
-										<Select
-											value={formData.duration?.unit || 'D'}
-											onValueChange={(value: any) =>
-												setFormData((prev) => ({
-													...prev,
-													duration: {
-														...prev.duration,
-														min: prev.duration?.min || '1',
-														max: prev.duration?.max || '1',
-														unit: value,
-													},
-												}))
-											}
-										>
-											<SelectTrigger className="w-full">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{DURATION_UNITS.map((unit) => (
-													<SelectItem key={unit.value} value={unit.value}>
-														{unit.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
+							</CollapsibleTrigger>
+							<CollapsibleContent>
+								<div className="space-y-4 pt-4">
+									<div className="space-y-2">
+										<Label htmlFor="carrier" className="font-medium">
+											Carrier
+										</Label>
 										<Input
-											type="number"
-											min="1"
-											value={formData.duration?.min || ''}
-											onChange={(e) =>
-												setFormData((prev) => ({
-													...prev,
-													duration: {
-														...prev.duration,
-														min: e.target.value,
-														max: prev.duration?.max || e.target.value,
-														unit: prev.duration?.unit || 'D',
-													},
-												}))
-											}
-											placeholder="Min"
-											className="w-full"
-										/>
-										<Input
-											type="number"
-											min="1"
-											value={formData.duration?.max || ''}
-											onChange={(e) =>
-												setFormData((prev) => ({
-													...prev,
-													duration: {
-														...prev.duration,
-														min: prev.duration?.min || '1',
-														max: e.target.value,
-														unit: prev.duration?.unit || 'D',
-													},
-												}))
-											}
-											placeholder="Max"
-											className="w-full"
+											id="carrier"
+											value={formData.carrier || ''}
+											onChange={(e) => setFormData((prev) => ({ ...prev, carrier: e.target.value }))}
+											placeholder="e.g., FedEx, UPS, DHL"
 										/>
 									</div>
-								</div>
 
-								{/* Weight Limits */}
-								<div className="space-y-2">
-									<Label className="font-medium">Weight Limits</Label>
-									<div className="space-y-4">
-										<div className="flex gap-2 items-center">
-											<Input
-												type="number"
-												step="0.1"
-												min="0"
-												value={formData.weightLimits?.min?.value || ''}
-												onChange={(e) =>
-													setFormData((prev) => ({
-														...prev,
-														weightLimits: {
-															...prev.weightLimits,
-															min: {
-																value: e.target.value,
-																unit: prev.weightLimits?.min?.unit || 'kg',
-															},
-														},
-													}))
-												}
-												placeholder="Min e.g. 0.0"
-												className="flex-1"
-											/>
+									<div className="space-y-2">
+										<Label htmlFor="location" className="font-medium">
+											Location
+										</Label>
+										<Input
+											id="location"
+											value={formData.location || ''}
+											onChange={(e) => setFormData((prev) => ({ ...prev, location: e.target.value }))}
+											placeholder="e.g., 123 Main St, Downtown, FL"
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="region" className="font-medium">
+											Region
+										</Label>
+										<Input
+											id="region"
+											value={formData.region || ''}
+											onChange={(e) => setFormData((prev) => ({ ...prev, region: e.target.value }))}
+											placeholder="e.g., US-FL (ISO 3166-2 format)"
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="geohash" className="font-medium">
+											Geohash
+										</Label>
+										<Input
+											id="geohash"
+											value={formData.geohash || ''}
+											onChange={(e) => setFormData((prev) => ({ ...prev, geohash: e.target.value }))}
+											placeholder="e.g., dhwm9c4ws (precise location hash)"
+										/>
+									</div>
+
+									{/* Duration */}
+									<div className="space-y-2">
+										<Label className="font-medium">Delivery Duration</Label>
+										<div className="flex flex-col gap-2">
 											<Select
-												value={formData.weightLimits?.min?.unit || 'kg'}
-												onValueChange={(value) =>
+												value={formData.duration?.unit || 'D'}
+												onValueChange={(value: any) =>
 													setFormData((prev) => ({
 														...prev,
-														weightLimits: {
-															...prev.weightLimits,
-															min: {
-																value: prev.weightLimits?.min?.value || '0',
-																unit: value,
-															},
+														duration: {
+															...prev.duration,
+															min: prev.duration?.min || '1',
+															max: prev.duration?.max || '1',
+															unit: value,
 														},
 													}))
 												}
 											>
-												<SelectTrigger className="w-20">
+												<SelectTrigger className="w-full">
 													<SelectValue />
 												</SelectTrigger>
 												<SelectContent>
-													{WEIGHT_UNITS.map((unit) => (
-														<SelectItem key={unit} value={unit}>
-															{unit}
+													{DURATION_UNITS.map((unit) => (
+														<SelectItem key={unit.value} value={unit.value}>
+															{unit.label}
 														</SelectItem>
 													))}
 												</SelectContent>
 											</Select>
-										</div>
-
-										<div className="flex gap-2 items-center">
 											<Input
 												type="number"
-												step="0.1"
-												min="0"
-												value={formData.weightLimits?.max?.value || ''}
+												min="1"
+												value={formData.duration?.min || ''}
 												onChange={(e) =>
 													setFormData((prev) => ({
 														...prev,
-														weightLimits: {
-															...prev.weightLimits,
-															max: {
-																value: e.target.value,
-																unit: prev.weightLimits?.max?.unit || 'kg',
-															},
+														duration: {
+															...prev.duration,
+															min: e.target.value,
+															max: prev.duration?.max || e.target.value,
+															unit: prev.duration?.unit || 'D',
 														},
 													}))
 												}
-												placeholder="Max e.g. 0.0"
-												className="flex-1"
+												placeholder="Min"
+												className="w-full"
 											/>
-											<Select
-												value={formData.weightLimits?.max?.unit || 'kg'}
-												onValueChange={(value) =>
+											<Input
+												type="number"
+												min="1"
+												value={formData.duration?.max || ''}
+												onChange={(e) =>
 													setFormData((prev) => ({
 														...prev,
-														weightLimits: {
-															...prev.weightLimits,
-															max: {
-																value: prev.weightLimits?.max?.value || '0',
-																unit: value,
-															},
+														duration: {
+															...prev.duration,
+															min: prev.duration?.min || '1',
+															max: e.target.value,
+															unit: prev.duration?.unit || 'D',
 														},
 													}))
 												}
-											>
-												<SelectTrigger className="w-20">
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													{WEIGHT_UNITS.map((unit) => (
-														<SelectItem key={unit} value={unit}>
-															{unit}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
+												placeholder="Max"
+												className="w-full"
+											/>
 										</div>
-										{fieldErrors.price && (
-											<div className="flex items-center gap-1 text-sm text-red-600">
-												<AlertCircleIcon className="h-4 w-4" />
-												{fieldErrors.price}
+									</div>
+
+									{/* Weight Limits */}
+									<div className="space-y-2">
+										<Label className="font-medium">Weight Limits</Label>
+										<div className="space-y-4">
+											<div className="flex gap-2 items-center">
+												<Input
+													type="number"
+													step="0.1"
+													min="0"
+													value={formData.weightLimits?.min?.value || ''}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															weightLimits: {
+																...prev.weightLimits,
+																min: {
+																	value: e.target.value,
+																	unit: prev.weightLimits?.min?.unit || 'kg',
+																},
+															},
+														}))
+													}
+													placeholder="Min e.g. 0.0"
+													className="flex-1"
+												/>
+												<Select
+													value={formData.weightLimits?.min?.unit || 'kg'}
+													onValueChange={(value) =>
+														setFormData((prev) => ({
+															...prev,
+															weightLimits: {
+																...prev.weightLimits,
+																min: {
+																	value: prev.weightLimits?.min?.value || '0',
+																	unit: value,
+																},
+															},
+														}))
+													}
+												>
+													<SelectTrigger className="w-20">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{WEIGHT_UNITS.map((unit) => (
+															<SelectItem key={unit} value={unit}>
+																{unit}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
 											</div>
-										)}
-									</div>
-								</div>
 
-								{/* Dimension Limits (LxWxH) */}
-								<div className="space-y-2">
-									<Label className="font-medium">Dimension Limits (LxWxH)</Label>
-									<div className="space-y-4">
-										<div className="flex gap-2 items-center">
-											<Input
-												value={formData.dimensionLimits?.min?.value || ''}
-												onChange={(e) =>
-													setFormData((prev) => ({
-														...prev,
-														dimensionLimits: {
-															...prev.dimensionLimits,
-															min: {
-																value: e.target.value,
-																unit: prev.dimensionLimits?.min?.unit || 'cm',
+											<div className="flex gap-2 items-center">
+												<Input
+													type="number"
+													step="0.1"
+													min="0"
+													value={formData.weightLimits?.max?.value || ''}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															weightLimits: {
+																...prev.weightLimits,
+																max: {
+																	value: e.target.value,
+																	unit: prev.weightLimits?.max?.unit || 'kg',
+																},
 															},
-														},
-													}))
-												}
-												placeholder="Min e.g. 10x10x10"
-												className="flex-1"
-											/>
-											<Select
-												value={formData.dimensionLimits?.min?.unit || 'cm'}
-												onValueChange={(value) =>
-													setFormData((prev) => ({
-														...prev,
-														dimensionLimits: {
-															...prev.dimensionLimits,
-															min: {
-																value: prev.dimensionLimits?.min?.value || '',
-																unit: value,
+														}))
+													}
+													placeholder="Max e.g. 0.0"
+													className="flex-1"
+												/>
+												<Select
+													value={formData.weightLimits?.max?.unit || 'kg'}
+													onValueChange={(value) =>
+														setFormData((prev) => ({
+															...prev,
+															weightLimits: {
+																...prev.weightLimits,
+																max: {
+																	value: prev.weightLimits?.max?.value || '0',
+																	unit: value,
+																},
 															},
-														},
-													}))
-												}
-											>
-												<SelectTrigger className="w-20">
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													{DIMENSION_UNITS.map((unit) => (
-														<SelectItem key={unit} value={unit}>
-															{unit}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										</div>
-
-										<div className="flex gap-2 items-center">
-											<Input
-												value={formData.dimensionLimits?.max?.value || ''}
-												onChange={(e) =>
-													setFormData((prev) => ({
-														...prev,
-														dimensionLimits: {
-															...prev.dimensionLimits,
-															max: {
-																value: e.target.value,
-																unit: prev.dimensionLimits?.max?.unit || 'cm',
-															},
-														},
-													}))
-												}
-												placeholder="Max e.g. 100x100x100"
-												className="flex-1"
-											/>
-											<Select
-												value={formData.dimensionLimits?.max?.unit || 'cm'}
-												onValueChange={(value) =>
-													setFormData((prev) => ({
-														...prev,
-														dimensionLimits: {
-															...prev.dimensionLimits,
-															max: {
-																value: prev.dimensionLimits?.max?.value || '',
-																unit: value,
-															},
-														},
-													}))
-												}
-											>
-												<SelectTrigger className="w-20">
-													<SelectValue />
-												</SelectTrigger>
-												<SelectContent>
-													{DIMENSION_UNITS.map((unit) => (
-														<SelectItem key={unit} value={unit}>
-															{unit}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
+														}))
+													}
+												>
+													<SelectTrigger className="w-20">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{WEIGHT_UNITS.map((unit) => (
+															<SelectItem key={unit} value={unit}>
+																{unit}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</div>
+											{fieldErrors.price && (
+												<div className="flex items-center gap-1 text-sm text-red-600">
+													<AlertCircleIcon className="h-4 w-4" />
+													{fieldErrors.price}
+												</div>
+											)}
 										</div>
 									</div>
+
+									{/* Dimension Limits (LxWxH) */}
+									<div className="space-y-2">
+										<Label className="font-medium">Dimension Limits (LxWxH)</Label>
+										<div className="space-y-4">
+											<div className="flex gap-2 items-center">
+												<Input
+													value={formData.dimensionLimits?.min?.value || ''}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															dimensionLimits: {
+																...prev.dimensionLimits,
+																min: {
+																	value: e.target.value,
+																	unit: prev.dimensionLimits?.min?.unit || 'cm',
+																},
+															},
+														}))
+													}
+													placeholder="Min e.g. 10x10x10"
+													className="flex-1"
+												/>
+												<Select
+													value={formData.dimensionLimits?.min?.unit || 'cm'}
+													onValueChange={(value) =>
+														setFormData((prev) => ({
+															...prev,
+															dimensionLimits: {
+																...prev.dimensionLimits,
+																min: {
+																	value: prev.dimensionLimits?.min?.value || '',
+																	unit: value,
+																},
+															},
+														}))
+													}
+												>
+													<SelectTrigger className="w-20">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{DIMENSION_UNITS.map((unit) => (
+															<SelectItem key={unit} value={unit}>
+																{unit}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</div>
+
+											<div className="flex gap-2 items-center">
+												<Input
+													value={formData.dimensionLimits?.max?.value || ''}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															dimensionLimits: {
+																...prev.dimensionLimits,
+																max: {
+																	value: e.target.value,
+																	unit: prev.dimensionLimits?.max?.unit || 'cm',
+																},
+															},
+														}))
+													}
+													placeholder="Max e.g. 100x100x100"
+													className="flex-1"
+												/>
+												<Select
+													value={formData.dimensionLimits?.max?.unit || 'cm'}
+													onValueChange={(value) =>
+														setFormData((prev) => ({
+															...prev,
+															dimensionLimits: {
+																...prev.dimensionLimits,
+																max: {
+																	value: prev.dimensionLimits?.max?.value || '',
+																	unit: value,
+																},
+															},
+														}))
+													}
+												>
+													<SelectTrigger className="w-20">
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														{DIMENSION_UNITS.map((unit) => (
+															<SelectItem key={unit} value={unit}>
+																{unit}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</div>
+										</div>
+									</div>
 								</div>
-							</div>
-						</CollapsibleContent>
-					</Collapsible>
+							</CollapsibleContent>
+						</Collapsible>
+					)}
 
 					{/* Actions */}
 					<div className="flex justify-end gap-2 pt-4">

--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -64,13 +64,30 @@ const DURATION_UNITS = [
 	{ value: 'M', label: 'Months' },
 ] as const
 
-const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, defaultCurrency: string): ShippingFormData => {
+const withoutPhysicalOnlyFields = (formData: ShippingFormData): ShippingFormData => {
+	const {
+		carrier: _carrier,
+		location: _location,
+		region: _region,
+		additionalRegions: _additionalRegions,
+		geohash: _geohash,
+		duration: _duration,
+		weightLimits: _weightLimits,
+		dimensionLimits: _dimensionLimits,
+		priceCalculations: _priceCalculations,
+		...nonPhysicalFormData
+	} = formData
+
+	return nonPhysicalFormData
+}
+
+export const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, defaultCurrency: string): ShippingFormData => {
 	const service = canonicalizeProductDeliveryService(formData.service)
 	const deliveryMode = resolveProductDeliveryMode(service)
 
 	if (deliveryMode === 'digital') {
 		return {
-			...formData,
+			...withoutPhysicalOnlyFields(formData),
 			service,
 			price: '0',
 			currency: formData.currency || defaultCurrency,
@@ -82,7 +99,7 @@ const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, de
 		const pickupCountry = formData.pickupAddress?.country || formData.countries[0]
 
 		return {
-			...formData,
+			...withoutPhysicalOnlyFields(formData),
 			service,
 			price: '0',
 			currency: formData.currency || defaultCurrency,

--- a/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/shipping-options.tsx
@@ -11,6 +11,7 @@ import { COUNTRIES_ISO, CURRENCIES, SHIPPING_TEMPLATES } from '@/lib/constants'
 import { uiStore } from '@/lib/stores/ui'
 import { useNDK } from '@/lib/stores/ndk'
 import {
+	canonicalizeProductDeliveryService,
 	getProductDeliveryModeLabel,
 	productDeliveryModeRequiresShippingCost,
 	productDeliveryModeUsesCoverage,
@@ -64,11 +65,13 @@ const DURATION_UNITS = [
 ] as const
 
 const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, defaultCurrency: string): ShippingFormData => {
-	const deliveryMode = resolveProductDeliveryMode(formData.service)
+	const service = canonicalizeProductDeliveryService(formData.service)
+	const deliveryMode = resolveProductDeliveryMode(service)
 
 	if (deliveryMode === 'digital') {
 		return {
 			...formData,
+			service,
 			price: '0',
 			currency: formData.currency || defaultCurrency,
 			countries: [],
@@ -80,13 +83,17 @@ const normalizeShippingFormDataForDeliveryMode = (formData: ShippingFormData, de
 
 		return {
 			...formData,
+			service,
 			price: '0',
 			currency: formData.currency || defaultCurrency,
 			countries: pickupCountry ? [pickupCountry] : formData.countries,
 		}
 	}
 
-	return formData
+	return {
+		...formData,
+		service,
+	}
 }
 
 interface ShippingOptionFormProps {


### PR DESCRIPTION
## Summary

This PR fixes create-workflow policy drift between the two Add Product entrypoints:

- homepage sheet create
- dashboard route create

## What changed

- create mode no longer boots to `shipping` when shipping setup is empty
- fresh create now starts on `name` unless a requested tab is explicitly provided
- homepage sheet create now resolves and passes canonical workflow state into `ProductFormContent`
- homepage fresh-create bootstraps through the existing create-session path before setting the canonical initial tab
- added resolver test coverage for the new create policy
- added a dev-only warning for create-mode `ProductFormContent` mounts without a canonical workflow prop

## Why

Previously, homepage and dashboard create could disagree on:
- first step
- V4V first-publish gating
- fresh create-session bootstrap behavior

This PR aligns those policies without widening scope into the larger authoring refactor.

## Out of scope

This PR does not include:
- shared create shell
- shared readiness hook
- validation extraction
- shipping template UX redesign
- route cleanup
- stage-based authoring

## Validation

Ran:
- `bun prettier --write src/lib/workflow/productWorkflowResolver.ts src/lib/workflow/productWorkflowResolver.test.ts src/components/sheet-contents/products/index.tsx src/components/sheet-contents/products/ProductFormContent.tsx
`
- `bun prettier --check src/lib/workflow/productWorkflowResolver.ts src/lib/workflow/productWorkflowResolver.test.ts src/components/sheet-contents/products/index.tsx src/components/sheet-contents/products/ProductFormContent.tsx
`
- `bun test src/lib/workflow/productWorkflowResolver.test.ts`

## Follow-up

Planned next slices:
- shipping bootstrap/template cleanup
- shared readiness extraction
- shared create shell
- stage-based authoring workstream