### PR TITLE
Fix: Auction Shipping Ref Deduplication

### DIFF
--- a/e2e/scenarios/index.ts
+++ b/e2e/scenarios/index.ts
@@ -591,3 +591,62 @@ export async function seedV4VWithRecipients(skHex: string, recipients: Array<{ p
 		relay.close()
 	}
 }
+
+export async function seedAuction(
+	relay: Relay,
+	skHex: string,
+	opts: {
+		title?: string
+		description?: string
+		startingBid?: number
+		bidIncrement?: number
+		reserve?: number
+		shippingOptions?: Array<{ shippingRef: string; extraCost?: string }>
+	},
+): Promise<VerifiedEvent> {
+	const now = Math.floor(Date.now() / 1000)
+	const auctionId = `e2e-auction-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`
+	const startingBid = opts.startingBid ?? 1000
+	const bidIncrement = opts.bidIncrement ?? 100
+	const reserve = opts.reserve ?? 0
+
+	const shippingTags: string[][] = []
+	for (const so of opts.shippingOptions ?? []) {
+		if (so.extraCost) {
+			shippingTags.push(['shipping_option', so.shippingRef, so.extraCost])
+		} else {
+			shippingTags.push(['shipping_option', so.shippingRef])
+		}
+	}
+
+	const event = await publish(relay, skHex, {
+		kind: 30408,
+		created_at: now,
+		content: opts.description ?? 'E2E test auction description.',
+		tags: [
+			['d', auctionId],
+			['title', opts.title ?? `Test Auction ${auctionId}`],
+			['summary', 'E2E test auction'],
+			['auction_type', 'english'],
+			['start_at', String(now)],
+			['end_at', String(now + 86400)],
+			['currency', 'SAT'],
+			['price', String(startingBid), 'SAT'],
+			['starting_bid', String(startingBid), 'SAT'],
+			['bid_increment', String(bidIncrement)],
+			['reserve', String(reserve)],
+			['mint', 'https://nofees.testnut.cashu.space'],
+			['escrow_pubkey', '02' + '00'.repeat(32)],
+			['key_scheme', 'hd_p2pk'],
+			['p2pk_xpub', 'xpub' + '0'.repeat(100)],
+			['settlement_policy', 'cashu_p2pk_v1'],
+			['schema', 'auction_v1'],
+			['image', 'https://cdn.satellite.earth/f8f1513ec22f966626dc05342a3bb1f36096d28dd0e6eeae640b5df44f2c7c84.png'],
+			['t', 'Bitcoin'],
+			...shippingTags,
+		],
+	})
+
+	console.log(`    Published auction: ${opts.title ?? auctionId}`)
+	return event
+}

--- a/e2e/tests/auction-shipping.spec.ts
+++ b/e2e/tests/auction-shipping.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../fixtures'
+import { Relay } from 'nostr-tools/relay'
+import { useWebSocketImplementation } from 'nostr-tools/relay'
+import { RELAY_URL } from 'e2e-new/test-config'
+import { devUser1 } from '@/lib/fixtures'
+import { seedAuction } from 'e2e-new/scenarios'
+import WebSocket from 'ws'
+
+useWebSocketImplementation(WebSocket)
+
+test.use({ scenario: 'merchant' })
+
+test.describe('Auction Shipping Display', () => {
+	test('shows resolved shipping option details', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'Shipping Display Test',
+			shippingOptions: [{ shippingRef: `30406:${devUser1.pk}:worldwide-standard` }],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		await expect(merchantPage.getByText('Worldwide Standard')).toBeVisible({ timeout: 15_000 })
+		await expect(merchantPage.getByText('Base:')).toBeVisible()
+	})
+
+	test('deduplicates shipping refs by shippingRef, first occurrence wins', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const shippingRef = `30406:${devUser1.pk}:digital-delivery`
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'Dedup Test',
+			shippingOptions: [
+				{ shippingRef, extraCost: '0' },
+				{ shippingRef, extraCost: '500' },
+			],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		const shippingItems = merchantPage.locator('li').filter({ hasText: 'Digital Delivery' })
+		await expect(shippingItems).toHaveCount(1, { timeout: 15_000 })
+	})
+
+	test('shows unavailable for unresolvable shipping ref', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'NotFound Test',
+			shippingOptions: [{ shippingRef: '30406:deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678:nonexistent' }],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		await expect(merchantPage.getByText('Shipping option unavailable')).toBeVisible({ timeout: 15_000 })
+	})
+})

--- a/e2e/tests/auction-shipping.spec.ts
+++ b/e2e/tests/auction-shipping.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '../fixtures'
 import { Relay } from 'nostr-tools/relay'
 import { useWebSocketImplementation } from 'nostr-tools/relay'
-import { RELAY_URL } from 'e2e-new/test-config'
+import { RELAY_URL } from '../test-config'
 import { devUser1 } from '@/lib/fixtures'
-import { seedAuction } from 'e2e-new/scenarios'
+import { seedAuction } from '../scenarios'
 import WebSocket from 'ws'
 
 useWebSocketImplementation(WebSocket)

--- a/src/lib/__tests__/auctionShippingRefs.test.ts
+++ b/src/lib/__tests__/auctionShippingRefs.test.ts
@@ -27,16 +27,33 @@ describe('auction shipping refs', () => {
 		])
 	})
 
-	test('dedupes duplicate refs with first occurrence winning', () => {
+	test('dedupes by shippingRef only, first occurrence wins', () => {
 		const refs = getUniqueAuctionShippingRefs([
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5' },
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '10' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '0' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '500' },
 			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '' },
 		])
 
 		expect(refs).toEqual([
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5', status: 'valid', pubkey: sellerA, dTag: 'standard' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '0', status: 'valid', pubkey: sellerA, dTag: 'standard' },
 			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '', status: 'valid', pubkey: sellerB, dTag: 'pickup' },
 		])
+	})
+
+	test('preserves first-occurrence order', () => {
+		const refs = getUniqueAuctionShippingRefs([
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5' },
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '' },
+		])
+
+		expect(refs).toEqual([
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '', status: 'valid', pubkey: sellerB, dTag: 'express' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5', status: 'valid', pubkey: sellerA, dTag: 'standard' },
+		])
+	})
+
+	test('returns empty array for empty input', () => {
+		expect(getUniqueAuctionShippingRefs([])).toEqual([])
 	})
 })

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -203,28 +203,32 @@ function AuctionDetailRoute() {
 	const auctionCoordinates = auctionDTag && auction ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 
 	const parsedShippingRefs = useMemo(() => getUniqueAuctionShippingRefs(shippingOptions), [shippingOptions])
-	const validShippingRefs = useMemo(() => parsedShippingRefs.filter((entry) => entry.status === 'valid'), [parsedShippingRefs])
 
 	const shippingQueryResults = useQueries({
-		queries: validShippingRefs.map(({ pubkey, dTag }) => ({
-			...shippingOptionByCoordinatesQueryOptions(pubkey, dTag),
-			enabled: true,
+		queries: parsedShippingRefs.map((entry) => ({
+			...shippingOptionByCoordinatesQueryOptions(entry.pubkey, entry.dTag),
+			enabled: entry.status === 'valid',
 		})),
 	})
 
-	const resolvedShippingOptions = useMemo(() => {
-		const shippingInfoByRef = new Map<string, ReturnType<typeof getShippingInfo> | null>()
-		validShippingRefs.forEach((entry, index) => {
-			const event = shippingQueryResults[index]?.data ?? null
-			const info = event ? getShippingInfo(event) : null
-			shippingInfoByRef.set(entry.shippingRef, info)
-		})
-
-		return parsedShippingRefs.map((entry) => ({
-			...entry,
-			info: entry.status === 'valid' ? (shippingInfoByRef.get(entry.shippingRef) ?? null) : null,
-		}))
-	}, [parsedShippingRefs, validShippingRefs, shippingQueryResults])
+	const resolvedShippingOptions = useMemo(
+		() =>
+			parsedShippingRefs.map((entry, index) => {
+				if (entry.status !== 'valid') {
+					return { ...entry, info: null as ReturnType<typeof getShippingInfo> | null, isLoading: false, isNotFound: false }
+				}
+				const queryResult = shippingQueryResults[index]
+				const event = queryResult?.data ?? null
+				const info = event ? getShippingInfo(event) : null
+				return {
+					...entry,
+					info,
+					isLoading: (queryResult?.isLoading ?? false) && !queryResult?.data,
+					isNotFound: !queryResult?.isLoading && !queryResult?.data,
+				}
+			}),
+		[parsedShippingRefs, shippingQueryResults],
+	)
 
 	const bidsQuery = useAuctionBids(auctionRootEventId || auctionId, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
@@ -624,6 +628,8 @@ function AuctionDetailRoute() {
 																	<p className="font-medium text-zinc-900">Invalid shipping reference</p>
 																	<p className="break-all text-xs text-zinc-500">{option.shippingRef}</p>
 																</div>
+															) : option.isLoading ? (
+																<p className="text-sm text-zinc-400">Loading shipping details...</p>
 															) : option.info ? (
 																<div className="space-y-1">
 																	<p className="font-medium text-zinc-900">{option.info.title}</p>


### PR DESCRIPTION
## #838 — Test: Auction Shipping Ref Coverage + Loading State

**Branch:** `fix/auction-shipping-ref-dedupe` (3 commits)
**Target:** `auctions/p2pk-path-oracle-via-cvm-v1`
**Closes:** #837

### Note to reviewers

@maximotodev already implemented the shipping dedupe logic in #847 (one row per `shippingRef`, first occurrence wins). This PR has been fully reverted to match that behavior — the only remaining changes are:

1. **Loading state** — A "Loading shipping details..." indicator while relay queries are in-flight (functional improvement, not a design choice)
2. **Test coverage** — 5 unit tests + 3 E2E tests + `seedAuction()` helper exercising the existing #847 dedupe and query logic
3. **Pre-existing fix** — `nip60.ts` broken imports (`getTokenMetadata` → `getDecodedToken`, `getP2PKLocktime` via `@cashu/crypto`)

Feel free to merge or close as you see fit.

### What changed vs the target

| File | Diff summary |
|---|---|
| `src/lib/auctionShippingRefs.ts` | **No diff** — matches #847/target exactly |
| `src/routes/auctions.$auctionId.tsx` | Loading state only — queries all parsed refs with `enabled` flag, adds `isLoading` render branch |
| `src/lib/__tests__/auctionShippingRefs.test.ts` | 5 unit tests (parsing, dedupe by shippingRef, first-occurrence order, empty input, invalid refs) |
| `e2e-new/tests/auction-shipping.spec.ts` | 3 E2E tests (resolved display, dedup, unavailable state) |
| `e2e-new/scenarios/index.ts` | New `seedAuction()` helper for publishing kind-30408 auction events |

All design/color changes from earlier iterations have been reverted. Colors, text, and key structure match the target branch exactly.

### Pre-existing fix included

Same `nip60.ts` import fix as #890 (`getTokenMetadata` → `getDecodedToken`, `getP2PKLocktime` via `@cashu/crypto`).

### Commit history (clean)

```
120b82ae revert: align with #847 shipping dedupe behavior, keep loading state + tests
591cb99e fix: replace missing cashu-ts imports with local implementations
0273f198 fix(auctions): dedupe shipping refs by {ref, extraCost} and show explicit unresolved states
```

### Test results

- **E2E (Playwright, local):** 3/3 pass (47.1s)
  - `shows resolved shipping option details` ✓ (11.0s)
  - `deduplicates shipping refs by shippingRef, first occurrence wins` ✓ (10.6s)
  - `shows unavailable for unresolvable shipping ref` ✓ (17.3s)
- **E2E (Playwright, VPS):** 5/5 pass (1.1m)
  - `homepage loads and returns 200` ✓
  - `/api/config returns valid JSON` ✓
  - `/auctions route loads` ✓
  - `static assets load (logo, css)` ✓
  - `nonexistent auction page renders without crash` ✓
- **Unit:** 136/136 pass (`bun run test:unit`)
- **Build:** `bun run build` succeeds

### Manual testing — happy path

**Goal:** Verify the loading state and existing dedupe behavior on the deployed instance.

1. Open https://shipping-dedupe.plebeian.orangesync.tech
2. Verify the homepage loads (HTTP 200, app renders)
3. Navigate to `/auctions` — verify the page renders without errors
4. Navigate to `/auctions/<any-id>` — verify the auction detail page renders
5. Click the **"Description"** tab — verify shipping options section appears
6. For a resolved shipping ref: verify the shipping name + base price renders
7. For an unresolved ref: verify **"Shipping option unavailable"** appears (matching target)
8. For an invalid ref: verify **"Invalid shipping reference"** appears (matching target)