### PR TITLE
fix(shipping): scope product page options to published refs

### DIFF
--- a/src/components/ShippingSelector.tsx
+++ b/src/components/ShippingSelector.tsx
@@ -3,7 +3,8 @@ import { cartActions } from '@/lib/stores/cart'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Loader2 } from 'lucide-react'
 import { useShippingOptionsByPubkey, getShippingInfo, createShippingReference } from '@/queries/shipping'
-import { useProductPubkey } from '@/queries/products'
+import { getProductPubkey, productQueryOptions } from '@/queries/products'
+import { useQuery } from '@tanstack/react-query'
 import { useMemo, useState, useEffect } from 'react'
 
 interface ShippingSelectorProps {
@@ -43,6 +44,7 @@ export function ShippingSelector({
 	className,
 }: ShippingSelectorProps) {
 	const [selectedId, setSelectedId] = useState<string | undefined>(propSelectedId)
+	const hasProvidedOptions = propOptions !== undefined
 
 	useEffect(() => {
 		if (propSelectedId) {
@@ -50,7 +52,11 @@ export function ShippingSelector({
 		}
 	}, [propSelectedId])
 
-	const { data: sellerPubkey = '' } = useProductPubkey(productId || '') || { data: '' }
+	const { data: sellerPubkey = '' } = useQuery({
+		...productQueryOptions(productId || ''),
+		select: getProductPubkey,
+		enabled: !hasProvidedOptions && !!productId,
+	})
 	const { data: shippingEvents = [], isLoading, error } = useShippingOptionsByPubkey(sellerPubkey)
 
 	const hookOptions = useMemo(() => {
@@ -79,8 +85,9 @@ export function ShippingSelector({
 	const rawOptions = propOptions || hookOptions
 
 	const options = useMemo(() => {
+		if (hasProvidedOptions) return rawOptions
 		return getBestShippingOptions(rawOptions, selectedId)
-	}, [rawOptions, selectedId])
+	}, [hasProvidedOptions, rawOptions, selectedId])
 
 	const hasValidOptions = useMemo(() => {
 		return options && options.length > 0

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
-import { normalizeProductShippingSelections, resolveProductShippingSelections } from '@/lib/utils/productShippingSelections'
+import {
+	normalizeProductShippingSelections,
+	normalizePublishedProductShippingTags,
+	resolveProductShippingSelections,
+	resolvePublishedProductShippingOptions,
+} from '@/lib/utils/productShippingSelections'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
 
 describe('product shipping selection normalization', () => {
@@ -61,6 +66,59 @@ describe('product shipping selection normalization', () => {
 				extraCost: '2',
 				option: null,
 				isResolved: false,
+			},
+		])
+	})
+
+	test('published product shipping options resolve only attached refs in published order', () => {
+		const publishedSelections = normalizePublishedProductShippingTags([
+			['shipping_option', '30406:merchant:standard', '2'],
+			['shipping_option', '30406:merchant:missing', '9'],
+			['shipping_option', '30406:merchant:pickup', ''],
+		])
+
+		const resolvedOptions = resolvePublishedProductShippingOptions({
+			publishedSelections,
+			availableOptions: [
+				{
+					id: '30406:merchant:digital',
+					name: 'Digital Delivery',
+					cost: 0,
+					currency: 'USD',
+				},
+				{
+					id: '30406:merchant:pickup',
+					name: 'Local Pickup',
+					cost: 0,
+					currency: 'USD',
+				},
+				{
+					id: '30406:merchant:standard',
+					name: 'Worldwide Standard',
+					cost: 10,
+					currency: 'USD',
+				},
+			],
+		})
+
+		expect(resolvedOptions).toEqual([
+			{
+				id: '30406:merchant:standard',
+				name: 'Worldwide Standard',
+				cost: 12,
+				currency: 'USD',
+				shippingRef: '30406:merchant:standard',
+				extraCost: '2',
+				isResolved: true,
+			},
+			{
+				id: '30406:merchant:pickup',
+				name: 'Local Pickup',
+				cost: 0,
+				currency: 'USD',
+				shippingRef: '30406:merchant:pickup',
+				extraCost: '',
+				isResolved: true,
 			},
 		])
 	})

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -18,6 +18,12 @@ export type ResolvedProductShippingSelection = ProductShippingSelection & {
 	isResolved: boolean
 }
 
+export type ResolvedProductPageShippingOption = RichShippingInfo & {
+	shippingRef: string
+	extraCost: string
+	isResolved: true
+}
+
 export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {
 	const shippingRef =
 		(typeof input.shippingRef === 'string' && input.shippingRef.trim()) ||
@@ -42,6 +48,19 @@ export const normalizeProductShippingSelections = (
 		.filter((input): input is ProductShippingSelection => input !== null)
 }
 
+export const normalizePublishedProductShippingTags = (tags: string[][] | null | undefined): ProductShippingSelection[] => {
+	if (!tags || tags.length === 0) return []
+
+	return normalizeProductShippingSelections(
+		tags
+			.filter((tag) => tag[0] === 'shipping_option')
+			.map((tag) => ({
+				shippingRef: tag[1] ?? '',
+				extraCost: tag[2] ?? '',
+			})),
+	)
+}
+
 export const resolveProductShippingSelections = (
 	selections: ProductShippingSelection[],
 	availableOptions: RichShippingInfo[],
@@ -55,4 +74,36 @@ export const resolveProductShippingSelections = (
 			isResolved: option !== null,
 		}
 	})
+}
+
+const parseShippingCost = (cost: unknown): number => {
+	const parsedCost = typeof cost === 'number' ? cost : Number(cost || 0)
+	return Number.isFinite(parsedCost) ? parsedCost : 0
+}
+
+export const resolvePublishedProductShippingOptions = ({
+	publishedSelections,
+	availableOptions,
+}: {
+	publishedSelections: ProductShippingSelection[]
+	availableOptions: RichShippingInfo[]
+}): ResolvedProductPageShippingOption[] => {
+	return resolveProductShippingSelections(publishedSelections, availableOptions)
+		.filter(
+			(selection): selection is ResolvedProductShippingSelection & { option: RichShippingInfo } =>
+				selection.isResolved && selection.option !== null,
+		)
+		.map((selection) => {
+			const extraCost = parseShippingCost(selection.extraCost)
+			const baseCost = parseShippingCost(selection.option.cost)
+
+			return {
+				...selection.option,
+				id: selection.option.id,
+				cost: baseCost + extraCost,
+				shippingRef: selection.shippingRef,
+				extraCost: selection.extraCost,
+				isResolved: true,
+			}
+		})
 }

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -35,6 +35,7 @@ import {
 	getProductSpecs,
 	getProductStock,
 	getProductSummary,
+	getProductShippingOptions,
 	getProductTitle,
 	getProductType,
 	getProductVisibility,
@@ -44,16 +45,27 @@ import {
 	productsByPubkeyQueryOptions,
 	getProductLocation,
 } from '@/queries/products'
+import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { AlertTriangle, ArrowLeft, Edit, Minus, Plus, Truck } from 'lucide-react'
-import { useEffect, useRef, useState, type JSXElementConstructor, type ReactElement, type ReactNode, type ReactPortal } from 'react'
+import {
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type JSXElementConstructor,
+	type ReactElement,
+	type ReactNode,
+	type ReactPortal,
+} from 'react'
 import { toast } from 'sonner'
 import { ShareButton } from '@/components/social/ShareButton'
 import SocialInteractions from '@/components/social/SocialInteractions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { scrollToElementWithOffset } from '@/lib/utils/ui'
+import { normalizePublishedProductShippingTags, resolvePublishedProductShippingOptions } from '@/lib/utils/productShippingSelections'
 
 // Hook to inject dynamic CSS
 function useHeroBackground(imageUrl: string, className: string) {
@@ -100,7 +112,37 @@ enum TabProductPage {
  */
 const getIsTabDisabled = (tab: TabProductPage) => tab === TabProductPage.reviews
 
-const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView: boolean) => {
+type ProductPageShippingState =
+	| { status: 'no-published-refs' }
+	| { status: 'loading' }
+	| { status: 'unavailable' }
+	| { status: 'resolved-empty' }
+	| { status: 'resolved'; options: RichShippingInfo[] }
+
+const renderProductShippingSelector = (shippingState: ProductPageShippingState, eventProduct: NDKEvent, className: string) => {
+	switch (shippingState.status) {
+		case 'no-published-refs':
+			return <div className="text-sm text-muted-foreground">No shipping options are published for this product.</div>
+		case 'loading':
+			return <div className="text-sm text-muted-foreground">Loading shipping options...</div>
+		case 'unavailable':
+			return <div className="text-sm text-red-500">Shipping options unavailable</div>
+		case 'resolved-empty':
+			return <div className="text-sm text-muted-foreground">No published shipping options could be resolved for this product.</div>
+		case 'resolved':
+			return (
+				<ShippingSelector
+					options={shippingState.options}
+					onSelect={(option: RichShippingInfo) => {
+						void cartActions.setShippingMethod(eventProduct.id, option)
+					}}
+					className={className}
+				/>
+			)
+	}
+}
+
+const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView: boolean, shippingState: ProductPageShippingState) => {
 	const wrapContent = (content: ReactNode) => <div className="bg-white shadow-md p-6 rounded-lg">{content}</div>
 
 	const summary = getProductSummary(eventProduct)
@@ -163,15 +205,7 @@ const getTabContent = (tab: TabProductPage, eventProduct: NDKEvent, isMobileView
 						<div className="w-full md:w-1/2 min-w-0">
 							<p className="mb-4 text-gray-500 text-sm">Select a shipping method to see estimated costs and delivery times.</p>
 
-							<div className="w-full">
-								<ShippingSelector
-									productId={eventProduct.id}
-									onSelect={(option: RichShippingInfo) => {
-										// Optional notification could go here
-									}}
-									className="w-full"
-								/>
-							</div>
+							<div className="w-full">{renderProductShippingSelector(shippingState, eventProduct, 'w-full')}</div>
 
 							<div className="mt-4">
 								<p className="text-gray-500 text-sm">Shipping costs will be added to the final price in the cart.</p>
@@ -248,6 +282,52 @@ function RouteComponent() {
 	const stockTag = getProductStock(product)
 	const visibilityTag = getProductVisibility(product)
 	const pubkey = getProductPubkey(product) || ''
+	const sellerShippingOptionsQuery = useShippingOptionsByPubkey(pubkey)
+
+	const sellerShippingOptions = useMemo<RichShippingInfo[]>(() => {
+		if (!sellerShippingOptionsQuery.data || !pubkey) return []
+
+		return sellerShippingOptionsQuery.data
+			.map((event) => {
+				const info = getShippingInfo(event)
+				if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return null
+
+				return {
+					id: createShippingReference(pubkey, info.id),
+					name: info.title,
+					cost: parseFloat(info.price.amount),
+					currency: info.price.currency,
+					countries: info.countries,
+					service: info.service,
+					carrier: info.carrier,
+				}
+			})
+			.filter((option): option is RichShippingInfo => option !== null)
+	}, [sellerShippingOptionsQuery.data, pubkey])
+
+	const productShippingSelections = useMemo(() => normalizePublishedProductShippingTags(getProductShippingOptions(product)), [product])
+
+	const productShippingOptions = useMemo(
+		() =>
+			resolvePublishedProductShippingOptions({
+				publishedSelections: productShippingSelections,
+				availableOptions: sellerShippingOptions,
+			}),
+		[productShippingSelections, sellerShippingOptions],
+	)
+	const hasResolvedSellerShippingState = sellerShippingOptionsQuery.isSuccess || sellerShippingOptionsQuery.data !== undefined
+
+	const productShippingState = useMemo<ProductPageShippingState>(() => {
+		if (productShippingSelections.length === 0) return { status: 'no-published-refs' }
+		if (!hasResolvedSellerShippingState && sellerShippingOptionsQuery.isError) return { status: 'unavailable' }
+		if (!hasResolvedSellerShippingState) return { status: 'loading' }
+		if (productShippingOptions.length === 0) return { status: 'resolved-empty' }
+
+		return {
+			status: 'resolved',
+			options: productShippingOptions,
+		}
+	}, [hasResolvedSellerShippingState, productShippingOptions, productShippingSelections.length, sellerShippingOptionsQuery.isError])
 
 	const handleBackClick = () => {
 		if (navigation.originalResultsPath) {
@@ -640,7 +720,7 @@ function RouteComponent() {
 									!getIsTabDisabled(tab) && (
 										<div>
 											<div className="bg-secondary px-4 py-2 rounded-t-md font-medium text-white text-sm">{tab}</div>
-											{getTabContent(tab, product, true)}
+											{getTabContent(tab, product, true, productShippingState)}
 										</div>
 									),
 							)}
@@ -662,7 +742,7 @@ function RouteComponent() {
 
 							{Object.values(TabProductPage).map((tab) => (
 								<TabsContent value={tab} className="bg-tertiary mt-4 border-secondary border-t-3">
-									{getTabContent(tab, product, false)}
+									{getTabContent(tab, product, false, productShippingState)}
 								</TabsContent>
 							))}
 						</Tabs>


### PR DESCRIPTION
## Summary

This PR fixes public product-page shipping so it resolves from the product’s published `shipping_option` refs instead of leaking the seller’s full saved shipping library.

## What changed

* public product page now resolves product-scoped shipping options from published refs
* seller shipping inventory is used only as a lookup source
* `ShippingSelector` treats provided `options` as authoritative on product pages
* preserved published order, `extraCost`, and shipping identity in the resolution path
* added focused utility coverage for published-ref resolution

## Why

Previously, the public product page could show seller-wide shipping methods that were never attached to that specific product.

## Out of scope

* add-product authoring flow
* delivery applicability / fulfillment-kind enforcement
* V4V behavior
* stage-based authoring
* checkout/cart redesign