### PR TITLE
feat(auctions): colored avatar profile and determinsitic fall back string in bids

### DIFF
--- a/src/components/AvatarUser.tsx
+++ b/src/components/AvatarUser.tsx
@@ -2,19 +2,34 @@ import * as React from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
 import { useProfile } from '@/queries/profiles'
+import { getHexColorFingerprintFromHexPubkey, isValidHexKey } from '@/lib/utils'
 
 interface AvatarUserProps extends React.ComponentProps<typeof AvatarPrimitive.Root> {
 	pubkey?: string
+	colored?: boolean
+	deterministicFallbackText?: boolean
 }
 
-function AvatarUser({ pubkey, className }: AvatarUserProps) {
+function AvatarUser({ pubkey, className, colored = false, deterministicFallbackText = false }: AvatarUserProps) {
 	const { data: profileData } = useProfile(pubkey)
 	const { profile, user } = profileData ?? {}
+	const fallbackBackgroundColor = colored && pubkey && isValidHexKey(pubkey) ? getHexColorFingerprintFromHexPubkey(pubkey) : undefined
+
+	const getDeterministicFallbackText = () => {
+		if (!pubkey || !isValidHexKey(pubkey)) return 'P'
+		return pubkey.slice(0, 2).toUpperCase()
+	}
 
 	// Determine fallback text
 	const getFallbackText = () => {
-		const title = profile?.displayName ?? profile?.name ?? 'p'
-		return title?.charAt(0).toUpperCase()
+		const title = profile?.displayName ?? profile?.name
+		if (title) return title.charAt(0).toUpperCase()
+
+		if (deterministicFallbackText) {
+			return getDeterministicFallbackText()
+		}
+
+		return 'P'
 	}
 
 	return (
@@ -27,6 +42,7 @@ function AvatarUser({ pubkey, className }: AvatarUserProps) {
 				<AvatarPrimitive.Fallback
 					data-slot="avatar-fallback"
 					className="bg-neo-purple text-white flex size-full items-center justify-center rounded-full text-center"
+					style={fallbackBackgroundColor ? { backgroundColor: fallbackBackgroundColor } : undefined}
 				>
 					{getFallbackText()}
 				</AvatarPrimitive.Fallback>

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -466,7 +466,7 @@ function AuctionDetailRoute() {
 										Seller & fulfilment
 									</div>
 									<div className="mt-4 space-y-1">
-										<ShopperInfoRow label="Seller" value={<AvatarUser pubkey={auction.pubkey} />} />
+										<ShopperInfoRow label="Seller" value={<AvatarUser pubkey={auction.pubkey} colored deterministicFallbackText />} />
 										<ShopperInfoRow
 											label="Categories"
 											value={
@@ -647,7 +647,7 @@ function AuctionDetailRoute() {
 												</div>
 
 												<div className="mt-4 flex flex-wrap items-center gap-3 text-sm text-zinc-700">
-													<AvatarUser pubkey={bidEvent.pubkey} />
+													<AvatarUser pubkey={bidEvent.pubkey} colored deterministicFallbackText />
 													<span className="text-zinc-400">•</span>
 													<span>{getBidMint(bidEvent) || 'No mint declared'}</span>
 												</div>
@@ -685,7 +685,7 @@ function AuctionDetailRoute() {
 									Seller
 								</div>
 								<div className="mt-4">
-									<AvatarUser pubkey={auction.pubkey} />
+									<AvatarUser pubkey={auction.pubkey} colored deterministicFallbackText />
 								</div>
 								<div className="mt-5 space-y-1">
 									<ShopperInfoRow label="Seller key" value={shortenHex(auction.pubkey)} />


### PR DESCRIPTION
Added opt-in deterministic avatar fallbacks in src/components/AvatarUser.tsx.

Introduced a [colored] prop to render avatar fallback backgrounds from the pubkey via the existing HSL fingerprint helper.

Introduced a [deterministicFallbackText] prop so unnamed users can show stable fallback text derived from the pubkey.

Updated deterministic fallback text to use the first two characters of the pubkey, while preserving existing default avatar behavior when the new props are not enabled.

<img width="1680" height="726" src="https://github.com/user-attachments/assets/9ed3de71-0343-46a0-91ba-33e98db7ac24" alt="colored-fallback-text-for-bids">

closes #834