### PR TITLE
fix(auctions): validate auction publish invariants

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -7,6 +7,13 @@ import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import {
+	AUCTION_MIN_DURATION_SECONDS,
+	getAuctionPublishValidationIssues,
+	validateAuctionPublishInput,
+	type AuctionPublishValidationField,
+	type AuctionPublishValidationIssue,
+} from '@/lib/auctionPublishValidation'
 import { DEFAULT_TRUSTED_MINTS, PRODUCT_CATEGORIES } from '@/lib/constants'
 import { authStore } from '@/lib/stores/auth'
 import { configStore } from '@/lib/stores/config'
@@ -17,11 +24,12 @@ import { createShippingReference, getShippingInfo, isShippingDeleted, useShippin
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, X } from 'lucide-react'
-import { useMemo, useState, type Dispatch, type SetStateAction } from 'react'
+import { useMemo, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 
 type AuctionTab = 'name' | 'auction' | 'category' | 'spec' | 'images' | 'shipping'
+type ValidationMessages = Partial<Record<AuctionPublishValidationField, string>>
 
 const INITIAL_FORM: AuctionFormData = {
 	title: '',
@@ -50,6 +58,27 @@ function parseListInput(value: string): string[] {
 		.split(/[\n,]/)
 		.map((item) => item.trim())
 		.filter(Boolean)
+}
+
+function toValidationMessages(issues: AuctionPublishValidationIssue[]): ValidationMessages {
+	const messages: ValidationMessages = {}
+	for (const issue of issues) {
+		messages[issue.field] ??= issue.message
+	}
+	return messages
+}
+
+function toIndexedValidationMessages(
+	issues: AuctionPublishValidationIssue[],
+	field: AuctionPublishValidationField,
+): Record<number, string> {
+	const messages: Record<number, string> = {}
+	for (const issue of issues) {
+		if (issue.field === field && issue.index !== undefined) {
+			messages[issue.index] ??= issue.message
+		}
+	}
+	return messages
 }
 
 type TabProps = {
@@ -286,6 +315,7 @@ function AuctionTabContent({
 	setEndMode,
 	durationSeconds,
 	setDurationSeconds,
+	validationMessages,
 }: TabProps & {
 	availableMints: readonly string[]
 	startMode: StartMode
@@ -294,6 +324,7 @@ function AuctionTabContent({
 	setEndMode: Dispatch<SetStateAction<EndMode>>
 	durationSeconds: number
 	setDurationSeconds: Dispatch<SetStateAction<number>>
+	validationMessages: ValidationMessages
 }) {
 	const selectedMints = formData.trustedMints
 	const unselectedMints = availableMints.filter((mint) => !selectedMints.includes(mint))
@@ -315,6 +346,7 @@ function AuctionTabContent({
 	const antiSnipingWindowSeconds = parseInt(formData.antiSnipingWindowSeconds, 10)
 	const antiSnipingExtensionSeconds = parseInt(formData.antiSnipingExtensionSeconds, 10)
 	const antiSnipingMaxExtensions = parseInt(formData.antiSnipingMaxExtensions, 10)
+	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 
 	const effectiveStartSeconds = useMemo(() => {
 		if (startMode === 'immediate') return Math.floor(Date.now() / 1000)
@@ -381,6 +413,7 @@ function AuctionTabContent({
 						value={formData.startingBid}
 						onChange={(e) => setFormData((prev) => ({ ...prev, startingBid: e.target.value }))}
 					/>
+					{validationMessages.startingBid && <p className="text-xs text-red-600">{validationMessages.startingBid}</p>}
 				</div>
 				<div className="grid w-full gap-1.5">
 					<Label htmlFor="auction-bid-increment">
@@ -393,6 +426,7 @@ function AuctionTabContent({
 						value={formData.bidIncrement}
 						onChange={(e) => setFormData((prev) => ({ ...prev, bidIncrement: e.target.value }))}
 					/>
+					{validationMessages.bidIncrement && <p className="text-xs text-red-600">{validationMessages.bidIncrement}</p>}
 				</div>
 			</div>
 
@@ -405,6 +439,7 @@ function AuctionTabContent({
 					value={formData.reserve}
 					onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
 				/>
+				{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
 			</div>
 
 			<BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />
@@ -510,6 +545,7 @@ function AuctionTabContent({
 								<span className="font-semibold text-zinc-900">Ends:</span> {formatAbsolute(virtualEndSeconds)}
 							</p>
 						</div>
+						{endTimeError && <p className="text-xs text-red-600">{endTimeError}</p>}
 					</div>
 				) : (
 					<div className="space-y-2">
@@ -521,6 +557,7 @@ function AuctionTabContent({
 						{virtualEndSeconds > 0 && (
 							<p className="text-xs text-zinc-500">Runs for approximately {formatDuration(virtualDurationSeconds)}.</p>
 						)}
+						{endTimeError && <p className="text-xs text-red-600">{endTimeError}</p>}
 					</div>
 				)}
 			</div>
@@ -555,6 +592,9 @@ function AuctionTabContent({
 									value={formData.antiSnipingWindowSeconds}
 									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingWindowSeconds: e.target.value }))}
 								/>
+								{validationMessages.antiSnipingWindowSeconds && (
+									<p className="text-xs text-red-600">{validationMessages.antiSnipingWindowSeconds}</p>
+								)}
 							</div>
 							<div className="grid w-full gap-1.5">
 								<Label htmlFor="auction-anti-sniping-extension">Extension (seconds)</Label>
@@ -565,6 +605,9 @@ function AuctionTabContent({
 									value={formData.antiSnipingExtensionSeconds}
 									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingExtensionSeconds: e.target.value }))}
 								/>
+								{validationMessages.antiSnipingExtensionSeconds && (
+									<p className="text-xs text-red-600">{validationMessages.antiSnipingExtensionSeconds}</p>
+								)}
 							</div>
 							<div className="grid w-full gap-1.5">
 								<Label htmlFor="auction-anti-sniping-max-extensions">Max extensions</Label>
@@ -575,6 +618,9 @@ function AuctionTabContent({
 									value={formData.antiSnipingMaxExtensions}
 									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingMaxExtensions: e.target.value }))}
 								/>
+								{validationMessages.antiSnipingMaxExtensions && (
+									<p className="text-xs text-red-600">{validationMessages.antiSnipingMaxExtensions}</p>
+								)}
 							</div>
 						</div>
 
@@ -601,6 +647,7 @@ function AuctionTabContent({
 				<p className="text-xs text-zinc-500">
 					Bids will be rejected unless the token is minted by one of these mints. At least one is required.
 				</p>
+				{validationMessages.trustedMints && <p className="text-xs text-red-600">{validationMessages.trustedMints}</p>}
 
 				<div className="space-y-2 mt-1">
 					{selectedMints.map((mint) => (
@@ -747,7 +794,15 @@ function SpecTab({ formData, setFormData }: TabProps) {
 	)
 }
 
-function ImagesTab({ images, setImages }: { images: AuctionImage[]; setImages: Dispatch<SetStateAction<AuctionImage[]>> }) {
+function ImagesTab({
+	images,
+	setImages,
+	error,
+}: {
+	images: AuctionImage[]
+	setImages: Dispatch<SetStateAction<AuctionImage[]>>
+	error?: string
+}) {
 	const [needsUploader, setNeedsUploader] = useState(true)
 
 	const handleSaveImage = ({ url, index }: { url: string; index: number }) => {
@@ -797,7 +852,7 @@ function ImagesTab({ images, setImages }: { images: AuctionImage[]; setImages: D
 				<Label>
 					<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Image Upload</span>
 					<span className="sr-only">required</span>
-					{images.length === 0 && <span className="text-sm text-red-500 ml-2">(At least one image required)</span>}
+					{error && <span className="text-sm text-red-500 ml-2">({error})</span>}
 				</Label>
 
 				{images.map((image, i) => (
@@ -837,7 +892,12 @@ type AvailableShipping = {
 	carrier: string | undefined
 }
 
-function ShippingTab({ formData, setFormData, userPubkey }: TabProps & { userPubkey: string }) {
+function ShippingTab({
+	formData,
+	setFormData,
+	userPubkey,
+	shippingExtraCostErrors,
+}: TabProps & { userPubkey: string; shippingExtraCostErrors: Record<number, string> }) {
 	const shippingOptionsQuery = useShippingOptionsByPubkey(userPubkey)
 
 	const availableShippingOptions = useMemo<AvailableShipping[]>(() => {
@@ -940,6 +1000,7 @@ function ShippingTab({ formData, setFormData, userPubkey }: TabProps & { userPub
 									value={selection.extraCost}
 									onChange={(e) => updateExtraCost(index, e.target.value)}
 								/>
+								{shippingExtraCostErrors[index] && <p className="text-xs text-red-600">{shippingExtraCostErrors[index]}</p>}
 							</div>
 						</div>
 					))}
@@ -1010,37 +1071,16 @@ export function AuctionFormContent() {
 	const [endMode, setEndMode] = useState<EndMode>('duration')
 	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
 
-	const hasValidName = formData.title.trim().length > 0
-	const hasValidDescription = formData.description.trim().length > 0
-	const hasValidBiddingAmounts = formData.startingBid.trim().length > 0 && formData.bidIncrement.trim().length > 0
-	const hasValidEndTime = endMode === 'duration' ? durationSeconds > 0 : formData.endAt.trim().length > 0
-	const hasValidAntiSniping =
-		!formData.antiSnipingEnabled ||
-		(formData.antiSnipingWindowSeconds.trim().length > 0 &&
-			parseInt(formData.antiSnipingWindowSeconds, 10) > 0 &&
-			formData.antiSnipingExtensionSeconds.trim().length > 0 &&
-			parseInt(formData.antiSnipingExtensionSeconds, 10) > 0 &&
-			formData.antiSnipingMaxExtensions.trim().length > 0 &&
-			parseInt(formData.antiSnipingMaxExtensions, 10) > 0)
-	const hasValidBidding = hasValidBiddingAmounts && hasValidEndTime && hasValidAntiSniping
-	const hasValidImages = images.filter((img) => img.imageUrl.trim().length > 0).length > 0
-	const hasValidMints = formData.trustedMints.length > 0
-
-	const canSubmit = hasValidName && hasValidDescription && hasValidBidding && hasValidImages && hasValidMints
-
-	const handleSubmit = async (event: React.BaseSyntheticEvent) => {
-		event.preventDefault()
-		event.stopPropagation()
-
+	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')
 		let effectiveEndAt = formData.endAt
 		if (endMode === 'duration') {
 			const parsedStart = formData.startAt ? parseDatetimeLocalSeconds(formData.startAt) : null
-			const startSeconds = startMode === 'immediate' ? Math.floor(Date.now() / 1000) : (parsedStart ?? Math.floor(Date.now() / 1000))
+			const startSeconds = startMode === 'immediate' ? nowSeconds : (parsedStart ?? nowSeconds)
 			effectiveEndAt = toDatetimeLocal(new Date((startSeconds + durationSeconds) * 1000))
 		}
 
-		const nextFormData: AuctionFormData = {
+		return {
 			...formData,
 			startAt: effectiveStartAt,
 			endAt: effectiveEndAt,
@@ -1052,8 +1092,42 @@ export function AuctionFormContent() {
 			categories: parseListInput(subCategoryInput),
 			specs: formData.specs.filter((spec: AuctionSpecEntry) => spec.key.trim() && spec.value.trim()),
 		}
+	}
+
+	const validationNowSeconds = Math.floor(Date.now() / 1000)
+	const validationIssues = getAuctionPublishValidationIssues(buildPublishFormData(validationNowSeconds), {
+		nowSeconds: validationNowSeconds,
+		minDurationSeconds: AUCTION_MIN_DURATION_SECONDS,
+	})
+	const validationMessages = toValidationMessages(validationIssues)
+	const shippingExtraCostErrors = toIndexedValidationMessages(validationIssues, 'shippingExtraCost')
+
+	const hasValidName = !validationMessages.title
+	const hasValidDescription = !validationMessages.description
+	const hasValidBidding =
+		!validationMessages.startingBid &&
+		!validationMessages.bidIncrement &&
+		!validationMessages.reserve &&
+		!validationMessages.startAt &&
+		!validationMessages.endAt &&
+		!validationMessages.duration &&
+		!validationMessages.antiSnipingWindowSeconds &&
+		!validationMessages.antiSnipingExtensionSeconds &&
+		!validationMessages.antiSnipingMaxExtensions
+	const hasValidImages = !validationMessages.imageUrls
+	const hasValidMints = !validationMessages.trustedMints
+
+	const canSubmit = validationIssues.length === 0
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault()
+		event.stopPropagation()
+
+		const nowSeconds = Math.floor(Date.now() / 1000)
+		const nextFormData = buildPublishFormData(nowSeconds)
 
 		try {
+			validateAuctionPublishInput(nextFormData, { nowSeconds, minDurationSeconds: AUCTION_MIN_DURATION_SECONDS })
 			const publishedEventId = await publishMutation.mutateAsync(nextFormData)
 			if (!publishedEventId) return
 
@@ -1070,7 +1144,7 @@ export function AuctionFormContent() {
 		{ value: 'category', label: 'Category', showAsterisk: false },
 		{ value: 'spec', label: 'Spec', showAsterisk: false },
 		{ value: 'images', label: 'Images', showAsterisk: !hasValidImages },
-		{ value: 'shipping', label: 'Shipping', showAsterisk: false },
+		{ value: 'shipping', label: 'Shipping', showAsterisk: Object.keys(shippingExtraCostErrors).length > 0 },
 	]
 
 	return (
@@ -1109,6 +1183,7 @@ export function AuctionFormContent() {
 								setEndMode={setEndMode}
 								durationSeconds={durationSeconds}
 								setDurationSeconds={setDurationSeconds}
+								validationMessages={validationMessages}
 							/>
 						</TabsContent>
 						<TabsContent value="category" className="mt-4">
@@ -1123,10 +1198,15 @@ export function AuctionFormContent() {
 							<SpecTab formData={formData} setFormData={setFormData} />
 						</TabsContent>
 						<TabsContent value="images" className="mt-4">
-							<ImagesTab images={images} setImages={setImages} />
+							<ImagesTab images={images} setImages={setImages} error={validationMessages.imageUrls} />
 						</TabsContent>
 						<TabsContent value="shipping" className="mt-4">
-							<ShippingTab formData={formData} setFormData={setFormData} userPubkey={userPubkey} />
+							<ShippingTab
+								formData={formData}
+								setFormData={setFormData}
+								userPubkey={userPubkey}
+								shippingExtraCostErrors={shippingExtraCostErrors}
+							/>
 						</TabsContent>
 					</div>
 				</Tabs>

--- a/src/lib/__tests__/auctionPublishValidation.test.ts
+++ b/src/lib/__tests__/auctionPublishValidation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+import { AUCTION_MIN_DURATION_SECONDS, validateAuctionPublishInput } from '@/lib/auctionPublishValidation'
+
+const NOW_SECONDS = 1_800_000_000
+
+const at = (seconds: number): string => new Date(seconds * 1000).toISOString()
+
+const baseInput = {
+	title: 'Auction title',
+	summary: 'Short summary',
+	description: 'Auction description',
+	startingBid: '100',
+	bidIncrement: '10',
+	reserve: '100',
+	startAt: at(NOW_SECONDS + 60),
+	endAt: at(NOW_SECONDS + 3_600),
+	antiSnipingEnabled: false,
+	antiSnipingWindowSeconds: '300',
+	antiSnipingExtensionSeconds: '300',
+	antiSnipingMaxExtensions: '12',
+	imageUrls: ['https://example.com/auction.png'],
+	shippings: [{ shippingRef: '30406:seller:standard', extraCost: '' }],
+	trustedMints: ['https://mint.example'],
+}
+
+const validate = (input: Partial<typeof baseInput> = {}) =>
+	validateAuctionPublishInput(
+		{
+			...baseInput,
+			...input,
+		},
+		{ nowSeconds: NOW_SECONDS, minDurationSeconds: AUCTION_MIN_DURATION_SECONDS },
+	)
+
+describe('auction publish validation', () => {
+	test('reserve lower than starting bid is rejected', () => {
+		expect(() => validate({ reserve: '99' })).toThrow('Reserve must be greater than or equal to the starting bid')
+	})
+
+	test('invalid bid increment is rejected', () => {
+		expect(() => validate({ bidIncrement: '0' })).toThrow('Bid increment must be greater than 0')
+	})
+
+	test('end time at or before max start/current time is rejected', () => {
+		expect(() => validate({ startAt: at(NOW_SECONDS + 600), endAt: at(NOW_SECONDS + 600) })).toThrow(
+			'Auction end time must be after the start time and current time',
+		)
+	})
+
+	test('duration under 30 minutes is rejected when a minimum duration is set', () => {
+		expect(() => validate({ startAt: '', endAt: at(NOW_SECONDS + AUCTION_MIN_DURATION_SECONDS - 1) })).toThrow(
+			'Auction duration must be at least 30 minutes',
+		)
+	})
+
+	test('negative shipping extra cost is rejected', () => {
+		expect(() => validate({ shippings: [{ shippingRef: '30406:seller:standard', extraCost: '-1' }] })).toThrow(
+			'Shipping extra cost must be an integer greater than or equal to 0',
+		)
+	})
+
+	test('duplicate shipping refs are deduped with first occurrence winning', () => {
+		const validated = validate({
+			shippings: [
+				{ shippingRef: '30406:seller:standard', extraCost: '5' },
+				{ shippingRef: '30406:seller:standard', extraCost: '10' },
+				{ shippingRef: '30406:seller:pickup', extraCost: '' },
+			],
+		})
+
+		expect(validated.shippings).toEqual([
+			{ shippingRef: '30406:seller:standard', extraCost: '5' },
+			{ shippingRef: '30406:seller:pickup', extraCost: '' },
+		])
+	})
+
+	test('valid input returns normalized values', () => {
+		const validated = validate({
+			title: '  Auction title  ',
+			description: '  Auction description  ',
+			startingBid: '00100',
+			bidIncrement: '0010',
+			reserve: '00120',
+			antiSnipingEnabled: true,
+			antiSnipingWindowSeconds: '0300',
+			antiSnipingExtensionSeconds: '0600',
+			antiSnipingMaxExtensions: '02',
+			imageUrls: ['  https://example.com/auction.png  '],
+			shippings: [{ shippingRef: ' 30406:seller:standard ', extraCost: '0005' }],
+			trustedMints: ['  https://mint.example  '],
+		})
+
+		expect(validated.title).toBe('Auction title')
+		expect(validated.description).toBe('Auction description')
+		expect(validated.startingBid).toBe(100)
+		expect(validated.bidIncrement).toBe(10)
+		expect(validated.reserve).toBe(120)
+		expect(validated.antiSnipingWindowSeconds).toBe(300)
+		expect(validated.antiSnipingExtensionSeconds).toBe(600)
+		expect(validated.antiSnipingMaxExtensions).toBe(2)
+		expect(validated.imageUrls).toEqual(['https://example.com/auction.png'])
+		expect(validated.shippings).toEqual([{ shippingRef: '30406:seller:standard', extraCost: '5' }])
+		expect(validated.trustedMints).toEqual(['https://mint.example'])
+		expect(validated.maxEndAt).toBe(validated.endAt + 1_200)
+	})
+})

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -1,0 +1,294 @@
+import {
+	normalizeProductShippingSelection,
+	type ProductShippingSelection,
+	type ProductShippingSelectionInput,
+} from './utils/productShippingSelections'
+
+export const AUCTION_MIN_DURATION_SECONDS = 30 * 60
+
+export type AuctionPublishValidationField =
+	| 'title'
+	| 'description'
+	| 'startingBid'
+	| 'bidIncrement'
+	| 'reserve'
+	| 'startAt'
+	| 'endAt'
+	| 'duration'
+	| 'antiSnipingWindowSeconds'
+	| 'antiSnipingExtensionSeconds'
+	| 'antiSnipingMaxExtensions'
+	| 'shippingExtraCost'
+	| 'trustedMints'
+	| 'imageUrls'
+
+export type AuctionPublishValidationIssue = {
+	field: AuctionPublishValidationField
+	message: string
+	index?: number
+}
+
+export type AuctionPublishValidationInput = {
+	title?: string | null
+	summary?: string | null
+	description?: string | null
+	startingBid?: string | number | null
+	bidIncrement?: string | number | null
+	reserve?: string | number | null
+	startAt?: string | null
+	endAt?: string | null
+	antiSnipingEnabled?: boolean | null
+	antiSnipingWindowSeconds?: string | number | null
+	antiSnipingExtensionSeconds?: string | number | null
+	antiSnipingMaxExtensions?: string | number | null
+	imageUrls?: string[] | null
+	shippings?: ProductShippingSelectionInput[] | null
+	trustedMints?: string[] | null
+}
+
+export type ValidatedAuctionPublishData = {
+	title: string
+	summary: string
+	description: string
+	startingBid: number
+	bidIncrement: number
+	reserve: number
+	startAt: number
+	endAt: number
+	durationSeconds: number
+	antiSnipingEnabled: boolean
+	antiSnipingWindowSeconds: number
+	antiSnipingExtensionSeconds: number
+	antiSnipingMaxExtensions: number
+	maxEndAt: number
+	imageUrls: string[]
+	shippings: ProductShippingSelection[]
+	trustedMints: string[]
+}
+
+export type AuctionPublishValidationOptions = {
+	nowSeconds?: number
+	minDurationSeconds?: number
+}
+
+export class AuctionPublishValidationError extends Error {
+	issues: AuctionPublishValidationIssue[]
+
+	constructor(issues: AuctionPublishValidationIssue[]) {
+		super(issues[0]?.message ?? 'Invalid auction publish data')
+		this.name = 'AuctionPublishValidationError'
+		this.issues = issues
+	}
+}
+
+const INTEGER_PATTERN = /^\d+$/
+
+const toTrimmedString = (value: string | number | null | undefined): string =>
+	value === null || value === undefined ? '' : String(value).trim()
+
+const parseNonNegativeInteger = (
+	value: string | number | null | undefined,
+	field: AuctionPublishValidationField,
+	label: string,
+	issues: AuctionPublishValidationIssue[],
+): number | null => {
+	const text = toTrimmedString(value)
+	if (!INTEGER_PATTERN.test(text)) {
+		issues.push({ field, message: `${label} must be an integer greater than or equal to 0` })
+		return null
+	}
+
+	const parsed = Number(text)
+	if (!Number.isSafeInteger(parsed)) {
+		issues.push({ field, message: `${label} must be a safe integer greater than or equal to 0` })
+		return null
+	}
+
+	return parsed
+}
+
+const parsePositiveInteger = (
+	value: string | number | null | undefined,
+	field: AuctionPublishValidationField,
+	label: string,
+	issues: AuctionPublishValidationIssue[],
+): number | null => {
+	const parsed = parseNonNegativeInteger(value, field, label, issues)
+	if (parsed === null) return null
+	if (parsed <= 0) {
+		issues.push({ field, message: `${label} must be greater than 0` })
+		return null
+	}
+
+	return parsed
+}
+
+const parseOptionalUnixTimestamp = (
+	value: string | null | undefined,
+	field: AuctionPublishValidationField,
+	label: string,
+	issues: AuctionPublishValidationIssue[],
+): number | null => {
+	const text = toTrimmedString(value)
+	if (!text) return null
+
+	const timestampMs = new Date(text).getTime()
+	if (!Number.isFinite(timestampMs)) {
+		issues.push({ field, message: `${label} must be a valid date and time` })
+		return null
+	}
+
+	return Math.floor(timestampMs / 1000)
+}
+
+const normalizeImages = (imageUrls: string[] | null | undefined): string[] =>
+	(imageUrls ?? []).map((url) => url.trim()).filter((url) => url.length > 0)
+
+const normalizeTrustedMints = (trustedMints: string[] | null | undefined): string[] =>
+	(trustedMints ?? []).map((mint) => mint.trim()).filter((mint) => mint.length > 0)
+
+const normalizeShippingSelections = (
+	inputs: ProductShippingSelectionInput[] | null | undefined,
+	issues: AuctionPublishValidationIssue[],
+): ProductShippingSelection[] => {
+	const seenShippingRefs = new Set<string>()
+	const normalized: ProductShippingSelection[] = []
+
+	for (const [index, input] of (inputs ?? []).entries()) {
+		const selection = normalizeProductShippingSelection(input)
+		if (!selection) continue
+
+		const shippingRef = selection.shippingRef.trim()
+		if (!shippingRef || seenShippingRefs.has(shippingRef)) continue
+		seenShippingRefs.add(shippingRef)
+
+		const extraCost = selection.extraCost.trim()
+		if (!extraCost) {
+			normalized.push({ shippingRef, extraCost: '' })
+			continue
+		}
+
+		const parsedExtraCost = parseNonNegativeInteger(extraCost, 'shippingExtraCost', 'Shipping extra cost', issues)
+		if (parsedExtraCost === null) {
+			const issue = issues[issues.length - 1]
+			if (issue?.field === 'shippingExtraCost') issue.index = index
+			continue
+		}
+
+		normalized.push({ shippingRef, extraCost: String(parsedExtraCost) })
+	}
+
+	return normalized
+}
+
+const normalizeAuctionPublishInput = (
+	input: AuctionPublishValidationInput,
+	options: AuctionPublishValidationOptions = {},
+): { value: ValidatedAuctionPublishData; issues: AuctionPublishValidationIssue[] } => {
+	const issues: AuctionPublishValidationIssue[] = []
+	const nowSeconds = options.nowSeconds ?? Math.floor(Date.now() / 1000)
+
+	const title = toTrimmedString(input.title)
+	if (!title) {
+		issues.push({ field: 'title', message: 'Auction title is required' })
+	}
+
+	const description = toTrimmedString(input.description)
+	if (!description) {
+		issues.push({ field: 'description', message: 'Auction description is required' })
+	}
+
+	const startingBid = parseNonNegativeInteger(input.startingBid, 'startingBid', 'Starting bid', issues)
+	const bidIncrement = parsePositiveInteger(input.bidIncrement, 'bidIncrement', 'Bid increment', issues)
+	const reserve = parseNonNegativeInteger(input.reserve, 'reserve', 'Reserve', issues)
+
+	if (startingBid !== null && reserve !== null && reserve < startingBid) {
+		issues.push({ field: 'reserve', message: 'Reserve must be greater than or equal to the starting bid' })
+	}
+
+	const parsedStartAt = parseOptionalUnixTimestamp(input.startAt, 'startAt', 'Auction start time', issues)
+	const startAt = parsedStartAt ?? nowSeconds
+	const parsedEndAt = parseOptionalUnixTimestamp(input.endAt, 'endAt', 'Auction end time', issues)
+	if (!toTrimmedString(input.endAt)) {
+		issues.push({ field: 'endAt', message: 'Auction end time is required' })
+	}
+
+	const endAt = parsedEndAt ?? 0
+	const effectiveStartBoundary = Math.max(startAt, nowSeconds)
+	if (parsedEndAt !== null && parsedEndAt <= effectiveStartBoundary) {
+		issues.push({ field: 'endAt', message: 'Auction end time must be after the start time and current time' })
+	}
+
+	const durationSeconds = parsedEndAt === null ? 0 : parsedEndAt - effectiveStartBoundary
+	if (parsedEndAt !== null && options.minDurationSeconds !== undefined && durationSeconds < options.minDurationSeconds) {
+		issues.push({ field: 'duration', message: 'Auction duration must be at least 30 minutes' })
+	}
+
+	const antiSnipingEnabled = input.antiSnipingEnabled === true
+	const antiSnipingWindowSeconds = antiSnipingEnabled
+		? parsePositiveInteger(input.antiSnipingWindowSeconds, 'antiSnipingWindowSeconds', 'Anti-sniping window', issues)
+		: 0
+	const antiSnipingExtensionSeconds = antiSnipingEnabled
+		? parsePositiveInteger(input.antiSnipingExtensionSeconds, 'antiSnipingExtensionSeconds', 'Anti-sniping extension', issues)
+		: 0
+	const antiSnipingMaxExtensions = antiSnipingEnabled
+		? parsePositiveInteger(input.antiSnipingMaxExtensions, 'antiSnipingMaxExtensions', 'Max anti-sniping extensions', issues)
+		: 0
+
+	const imageUrls = normalizeImages(input.imageUrls)
+	if (imageUrls.length === 0) {
+		issues.push({ field: 'imageUrls', message: 'At least one image is required' })
+	}
+
+	const trustedMints = normalizeTrustedMints(input.trustedMints)
+	if (trustedMints.length === 0) {
+		issues.push({ field: 'trustedMints', message: 'At least one trusted mint is required' })
+	}
+
+	const shippings = normalizeShippingSelections(input.shippings, issues)
+
+	const maxEndAt =
+		antiSnipingEnabled && antiSnipingExtensionSeconds !== null && antiSnipingMaxExtensions !== null
+			? endAt + antiSnipingExtensionSeconds * antiSnipingMaxExtensions
+			: endAt
+
+	return {
+		value: {
+			title,
+			summary: toTrimmedString(input.summary),
+			description,
+			startingBid: startingBid ?? 0,
+			bidIncrement: bidIncrement ?? 0,
+			reserve: reserve ?? 0,
+			startAt,
+			endAt,
+			durationSeconds,
+			antiSnipingEnabled,
+			antiSnipingWindowSeconds: antiSnipingWindowSeconds ?? 0,
+			antiSnipingExtensionSeconds: antiSnipingExtensionSeconds ?? 0,
+			antiSnipingMaxExtensions: antiSnipingMaxExtensions ?? 0,
+			maxEndAt,
+			imageUrls,
+			shippings,
+			trustedMints,
+		},
+		issues,
+	}
+}
+
+export const getAuctionPublishValidationIssues = (
+	input: AuctionPublishValidationInput,
+	options: AuctionPublishValidationOptions = {},
+): AuctionPublishValidationIssue[] => normalizeAuctionPublishInput(input, options).issues
+
+export const validateAuctionPublishInput = (
+	input: AuctionPublishValidationInput,
+	options: AuctionPublishValidationOptions = {},
+): ValidatedAuctionPublishData => {
+	const result = normalizeAuctionPublishInput(input, options)
+	if (result.issues.length > 0) {
+		throw new AuctionPublishValidationError(result.issues)
+	}
+
+	return result.value
+}

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -13,15 +13,12 @@ import {
 	type AuctionSettlementPlanResponse,
 	type AuctionSettlementPublishStatus,
 } from '@/lib/auctionSettlement'
+import { AUCTION_MIN_DURATION_SECONDS, validateAuctionPublishInput } from '@/lib/auctionPublishValidation'
 import { ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import { configStore } from '@/lib/stores/config'
 import { ndkActions } from '@/lib/stores/ndk'
 import { getAuctionSettlementGraceSeconds, nip60Actions, type AuctionP2pkKeyScheme } from '@/lib/stores/nip60'
-import {
-	normalizeProductShippingSelections,
-	type ProductShippingSelection,
-	type ProductShippingSelectionInput,
-} from '@/lib/utils/productShippingSelections'
+import type { ProductShippingSelectionInput } from '@/lib/utils/productShippingSelections'
 import { verifyAuctionPathGrant } from '@/lib/auctionP2pk'
 import { rememberAuctionPathGrant } from '@/lib/auctionPathOracle'
 import { getBidAmount, getBidStatus, markAuctionAsDeleted } from '@/queries/auctions'
@@ -30,8 +27,6 @@ import NDK, { NDKEvent, NDKUser, type NDKFilter, type NDKSigner, type NDKTag } f
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { v4 as uuidv4 } from 'uuid'
-
-const DEFAULT_AUCTION_MINT = 'https://nofees.testnut.cashu.space'
 
 export interface AuctionSpecEntry {
 	key: string
@@ -164,21 +159,6 @@ export interface AuctionSettlementFormData {
 	reason?: string
 }
 
-const parseUnixTimestamp = (isoDateTime?: string): number | null => {
-	if (!isoDateTime) return null
-	const timestampMs = new Date(isoDateTime).getTime()
-	if (Number.isNaN(timestampMs)) return null
-	return Math.floor(timestampMs / 1000)
-}
-
-const parsePositiveInt = (value: string, fieldName: string): number => {
-	const parsed = parseInt(value, 10)
-	if (!Number.isFinite(parsed) || parsed <= 0) {
-		throw new Error(`${fieldName} must be greater than 0`)
-	}
-	return parsed
-}
-
 const getAuctionPathIssuerPubkeyOrThrow = (): string => {
 	const appPubkey = configStore.state.config.appPublicKey?.trim()
 	if (!appPubkey) {
@@ -202,27 +182,18 @@ const tagBidError = (step: string, cause: unknown): Error => {
 }
 
 export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKSigner, ndk: NDK, auctionId?: string): Promise<NDKEvent> => {
+	const validated = validateAuctionPublishInput(formData, { minDurationSeconds: AUCTION_MIN_DURATION_SECONDS })
 	const event = new NDKEvent(ndk)
 	event.kind = 30408
-	event.content = formData.description
+	event.content = validated.description
 
 	const id = auctionId || `auction_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`
-	const now = Math.floor(Date.now() / 1000)
-
-	const startAt = parseUnixTimestamp(formData.startAt) ?? now
-	const endAt = parseUnixTimestamp(formData.endAt) ?? now + 86400
-	const startingBid = formData.startingBid.trim() || '0'
-	const bidIncrement = formData.bidIncrement.trim() || '1'
-	const reserve = formData.reserve.trim() || '0'
-	const antiSnipingEnabled = formData.antiSnipingEnabled === true
-	const antiSnipingWindowSeconds = antiSnipingEnabled ? parsePositiveInt(formData.antiSnipingWindowSeconds, 'Anti-sniping window') : 0
-	const antiSnipingExtensionSeconds = antiSnipingEnabled
-		? parsePositiveInt(formData.antiSnipingExtensionSeconds, 'Anti-sniping extension')
-		: 0
-	const antiSnipingMaxExtensions = antiSnipingEnabled
-		? parsePositiveInt(formData.antiSnipingMaxExtensions, 'Max anti-sniping extensions')
-		: 0
-	const extensionRule = antiSnipingEnabled ? `anti_sniping:${antiSnipingWindowSeconds}:${antiSnipingExtensionSeconds}` : 'none'
+	const startingBid = String(validated.startingBid)
+	const bidIncrement = String(validated.bidIncrement)
+	const reserve = String(validated.reserve)
+	const extensionRule = validated.antiSnipingEnabled
+		? `anti_sniping:${validated.antiSnipingWindowSeconds}:${validated.antiSnipingExtensionSeconds}`
+		: 'none'
 	// `max_end_at` is the SECOND of the three protocol timestamps:
 	//   end_at      → nominal close (extendable via anti-sniping)
 	//   max_end_at  → hard bidding cutoff (this value)
@@ -230,13 +201,11 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 	// We always emit it — even when anti-sniping is off — so the locktime
 	// computation downstream is unambiguous and bidders never have to guess
 	// from a missing tag. With anti-sniping off, it equals end_at.
-	const maxEndAt = antiSnipingEnabled ? endAt + antiSnipingExtensionSeconds * antiSnipingMaxExtensions : endAt
-	const trustedMints = formData.trustedMints.length > 0 ? formData.trustedMints : [DEFAULT_AUCTION_MINT]
 	const keyScheme: AuctionP2pkKeyScheme = 'hd_p2pk'
 	const pathIssuerPubkey = getAuctionPathIssuerPubkeyOrThrow()
 	const p2pkXpub = await nip60Actions.getAuctionP2pkXpub()
 
-	const imageTags = formData.imageUrls.map((url, index) => ['image', url, '800x600', String(index)] as NDKTag)
+	const imageTags = validated.imageUrls.map((url, index) => ['image', url, '800x600', String(index)] as NDKTag)
 	const categoryTags: NDKTag[] = []
 	if (formData.mainCategory) {
 		categoryTags.push(['t', formData.mainCategory] as NDKTag)
@@ -251,27 +220,26 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 		.filter((spec) => spec && spec.key.trim() && spec.value.trim())
 		.map((spec) => ['spec', spec.key.trim(), spec.value.trim()] as NDKTag)
 
-	const normalizedShippings: ProductShippingSelection[] = normalizeProductShippingSelections(formData.shippings)
-	const shippingTags: NDKTag[] = normalizedShippings.map((ship) =>
+	const shippingTags: NDKTag[] = validated.shippings.map((ship) =>
 		ship.extraCost ? (['shipping_option', ship.shippingRef, ship.extraCost] as NDKTag) : (['shipping_option', ship.shippingRef] as NDKTag),
 	)
 
 	event.tags = [
 		['d', id],
-		['title', formData.title],
-		...(formData.summary.trim() ? ([['summary', formData.summary.trim()] as NDKTag] as NDKTag[]) : []),
+		['title', validated.title],
+		...(validated.summary ? ([['summary', validated.summary] as NDKTag] as NDKTag[]) : []),
 		['auction_type', 'english'],
-		['start_at', String(startAt)],
-		['end_at', String(endAt)],
+		['start_at', String(validated.startAt)],
+		['end_at', String(validated.endAt)],
 		['currency', 'SAT'],
 		['price', startingBid, 'SAT'],
 		['starting_bid', startingBid, 'SAT'],
 		['bid_increment', bidIncrement],
 		['reserve', reserve],
-		...trustedMints.map((mint) => ['mint', mint] as NDKTag),
+		...validated.trustedMints.map((mint) => ['mint', mint] as NDKTag),
 		['path_issuer', pathIssuerPubkey],
 		['extension_rule', extensionRule],
-		['max_end_at', String(maxEndAt)],
+		['max_end_at', String(validated.maxEndAt)],
 		['settlement_grace', String(getAuctionSettlementGraceSeconds())],
 		['key_scheme', keyScheme],
 		['p2pk_xpub', p2pkXpub],
@@ -288,39 +256,7 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 }
 
 export const publishAuction = async (formData: AuctionFormData, signer: NDKSigner, ndk: NDK, auctionId?: string): Promise<string> => {
-	if (!formData.title.trim()) {
-		throw new Error('Auction title is required')
-	}
-	if (!formData.description.trim()) {
-		throw new Error('Auction description is required')
-	}
-	if (!formData.startingBid.trim() || isNaN(Number(formData.startingBid)) || Number(formData.startingBid) < 0) {
-		throw new Error('Valid starting bid is required')
-	}
-	if (!formData.bidIncrement.trim() || isNaN(Number(formData.bidIncrement)) || Number(formData.bidIncrement) <= 0) {
-		throw new Error('Bid increment must be greater than 0')
-	}
-	if (!formData.endAt) {
-		throw new Error('Auction end time is required')
-	}
-
-	const now = Math.floor(Date.now() / 1000)
-	const startAtTs = parseUnixTimestamp(formData.startAt) ?? now
-	const endAtTs = parseUnixTimestamp(formData.endAt)
-	if (!endAtTs) {
-		throw new Error('Invalid auction end time')
-	}
-	if (endAtTs <= startAtTs) {
-		throw new Error('Auction end time must be after start time')
-	}
-	if (formData.antiSnipingEnabled) {
-		parsePositiveInt(formData.antiSnipingWindowSeconds, 'Anti-sniping window')
-		parsePositiveInt(formData.antiSnipingExtensionSeconds, 'Anti-sniping extension')
-		parsePositiveInt(formData.antiSnipingMaxExtensions, 'Max anti-sniping extensions')
-	}
-	if (formData.imageUrls.length === 0) {
-		throw new Error('At least one image is required')
-	}
+	validateAuctionPublishInput(formData, { minDurationSeconds: AUCTION_MIN_DURATION_SECONDS })
 
 	const event = await createAuctionEvent(formData, signer, ndk, auctionId)
 	await event.sign(signer)


### PR DESCRIPTION
## Summary

Fixes the first validation slice of #813 by enforcing auction publish invariants in a shared validation helper used by both the form and the publish path.

## What changed

- Added pure auction publish validation/normalization helper
- Enforced reserve >= starting bid before signing
- Enforced valid bid increment and start/end time invariants
- Rejected invalid shipping extra cost
- Deduped repeated shipping refs before tag emission
- Surfaced matching form-level errors
- Replaced React.BaseSyntheticEvent with FormEvent<HTMLFormElement>
- Added unit tests for validation behavior

## Out of scope

- #824 settlement failures
- Cashu P2PK redemption
- trusted mint state ownership
- auction detail shipping rendering
- tab navigation redesign
- logarithmic duration slider

## Validation

- bun test src/lib/__tests__/auctionPublishValidation.test.ts
- bun run test:unit
- bun run build.ts
- bunx prettier --check touched files
- git diff --check

Note: standard `bun run build` is blocked before app code by the existing TanStack router generator/Zod mismatch under Node v24.