### PR TITLE
fix(auctions): dedupe auction shipping refs

### DIFF
--- a/src/lib/__tests__/auctionShippingRefs.test.ts
+++ b/src/lib/__tests__/auctionShippingRefs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test'
+import { getUniqueAuctionShippingRefs, parseAuctionShippingRef } from '@/lib/auctionShippingRefs'
+
+const sellerA = 'a'.repeat(64)
+const sellerB = 'b'.repeat(64)
+
+describe('auction shipping refs', () => {
+	test('parses valid shipping coordinate refs', () => {
+		expect(parseAuctionShippingRef(`30406:${sellerA}:standard`)).toEqual({
+			shippingRef: `30406:${sellerA}:standard`,
+			pubkey: sellerA,
+			dTag: 'standard',
+		})
+	})
+
+	test('marks malformed refs invalid', () => {
+		const refs = getUniqueAuctionShippingRefs([
+			{ shippingRef: 'shipping:standard', extraCost: '' },
+			{ shippingRef: '30406:not-a-pubkey:standard', extraCost: '1' },
+			{ shippingRef: `30406:${sellerA}:`, extraCost: '2' },
+		])
+
+		expect(refs).toEqual([
+			{ shippingRef: 'shipping:standard', extraCost: '', status: 'invalid', pubkey: '', dTag: '' },
+			{ shippingRef: '30406:not-a-pubkey:standard', extraCost: '1', status: 'invalid', pubkey: '', dTag: '' },
+			{ shippingRef: `30406:${sellerA}:`, extraCost: '2', status: 'invalid', pubkey: '', dTag: '' },
+		])
+	})
+
+	test('dedupes duplicate refs with first occurrence winning', () => {
+		const refs = getUniqueAuctionShippingRefs([
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '10' },
+			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '' },
+		])
+
+		expect(refs).toEqual([
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5', status: 'valid', pubkey: sellerA, dTag: 'standard' },
+			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '', status: 'valid', pubkey: sellerB, dTag: 'pickup' },
+		])
+	})
+})

--- a/src/lib/auctionShippingRefs.ts
+++ b/src/lib/auctionShippingRefs.ts
@@ -1,0 +1,53 @@
+export type AuctionShippingRefInput = {
+	shippingRef: string
+	extraCost: string
+}
+
+export type ValidAuctionShippingRef = AuctionShippingRefInput & {
+	status: 'valid'
+	pubkey: string
+	dTag: string
+}
+
+export type InvalidAuctionShippingRef = AuctionShippingRefInput & {
+	status: 'invalid'
+	pubkey: ''
+	dTag: ''
+}
+
+export type AuctionShippingRef = ValidAuctionShippingRef | InvalidAuctionShippingRef
+
+const SHIPPING_OPTION_KIND = '30406'
+const NOSTR_PUBKEY_HEX = /^[0-9a-f]{64}$/i
+
+export function parseAuctionShippingRef(shippingRef: string): Pick<ValidAuctionShippingRef, 'shippingRef' | 'pubkey' | 'dTag'> | null {
+	const parts = shippingRef.split(':')
+	if (parts.length !== 3) return null
+
+	const [kind, pubkey, dTag] = parts
+	if (kind !== SHIPPING_OPTION_KIND) return null
+	if (!NOSTR_PUBKEY_HEX.test(pubkey)) return null
+	if (!dTag) return null
+
+	return { shippingRef, pubkey, dTag }
+}
+
+export function getUniqueAuctionShippingRefs(inputs: AuctionShippingRefInput[]): AuctionShippingRef[] {
+	const seenShippingRefs = new Set<string>()
+	const refs: AuctionShippingRef[] = []
+
+	for (const input of inputs) {
+		if (seenShippingRefs.has(input.shippingRef)) continue
+		seenShippingRefs.add(input.shippingRef)
+
+		const parsed = parseAuctionShippingRef(input.shippingRef)
+		if (!parsed) {
+			refs.push({ ...input, status: 'invalid', pubkey: '', dTag: '' })
+			continue
+		}
+
+		refs.push({ ...input, ...parsed, status: 'valid' })
+	}
+
+	return refs
+}

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -9,6 +9,7 @@ import { ItemGrid } from '@/components/ItemGrid'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { getUniqueAuctionShippingRefs } from '@/lib/auctionShippingRefs'
 import { ndkActions } from '@/lib/stores/ndk'
 import { uiStore } from '@/lib/stores/ui'
 import { usePublishAuctionBidMutation } from '@/publish/auctions'
@@ -185,34 +186,29 @@ function AuctionDetailRoute() {
 	const auctionRootEventId = getAuctionRootEventId(auction)
 	const auctionCoordinates = auctionDTag && auction ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 
-	const parsedShippingRefs = useMemo(
-		() =>
-			shippingOptions.map((item) => {
-				const parts = item.shippingRef.split(':')
-				if (parts.length === 3 && parts[0] === '30406') {
-					return { ...item, pubkey: parts[1], dTag: parts[2] }
-				}
-				return { ...item, pubkey: '', dTag: '' }
-			}),
-		[shippingOptions],
-	)
+	const parsedShippingRefs = useMemo(() => getUniqueAuctionShippingRefs(shippingOptions), [shippingOptions])
+	const validShippingRefs = useMemo(() => parsedShippingRefs.filter((entry) => entry.status === 'valid'), [parsedShippingRefs])
 
 	const shippingQueryResults = useQueries({
-		queries: parsedShippingRefs.map(({ pubkey, dTag }) => ({
+		queries: validShippingRefs.map(({ pubkey, dTag }) => ({
 			...shippingOptionByCoordinatesQueryOptions(pubkey, dTag),
-			enabled: !!pubkey && !!dTag,
+			enabled: true,
 		})),
 	})
 
-	const resolvedShippingOptions = useMemo(
-		() =>
-			parsedShippingRefs.map((entry, index) => {
-				const event = shippingQueryResults[index]?.data ?? null
-				const info = event ? getShippingInfo(event) : null
-				return { ...entry, info }
-			}),
-		[parsedShippingRefs, shippingQueryResults],
-	)
+	const resolvedShippingOptions = useMemo(() => {
+		const shippingInfoByRef = new Map<string, ReturnType<typeof getShippingInfo> | null>()
+		validShippingRefs.forEach((entry, index) => {
+			const event = shippingQueryResults[index]?.data ?? null
+			const info = event ? getShippingInfo(event) : null
+			shippingInfoByRef.set(entry.shippingRef, info)
+		})
+
+		return parsedShippingRefs.map((entry) => ({
+			...entry,
+			info: entry.status === 'valid' ? (shippingInfoByRef.get(entry.shippingRef) ?? null) : null,
+		}))
+	}, [parsedShippingRefs, validShippingRefs, shippingQueryResults])
 
 	const bidsQuery = useAuctionBids(auctionRootEventId || auctionId, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
@@ -485,7 +481,7 @@ function AuctionDetailRoute() {
 										/>
 										<ShopperInfoRow
 											label="Shipping options"
-											value={shippingOptions.length > 0 ? `${shippingOptions.length} listed` : 'None listed'}
+											value={resolvedShippingOptions.length > 0 ? `${resolvedShippingOptions.length} listed` : 'None listed'}
 										/>
 									</div>
 
@@ -583,7 +579,12 @@ function AuctionDetailRoute() {
 													const hasExtraCost = !Number.isNaN(extraCostNumber) && extraCostNumber > 0
 													return (
 														<li key={`${option.shippingRef}-${index}`} className="rounded-lg border border-zinc-200 bg-white px-3 py-2">
-															{option.info ? (
+															{option.status === 'invalid' ? (
+																<div className="space-y-1">
+																	<p className="font-medium text-zinc-900">Invalid shipping reference</p>
+																	<p className="break-all text-xs text-zinc-500">{option.shippingRef}</p>
+																</div>
+															) : option.info ? (
 																<div className="space-y-1">
 																	<p className="font-medium text-zinc-900">{option.info.title}</p>
 																	<p className="text-xs text-zinc-600">
@@ -594,7 +595,10 @@ function AuctionDetailRoute() {
 																	{hasExtraCost && <p className="text-xs text-zinc-600">Auction extra cost: {extraCostNumber}</p>}
 																</div>
 															) : (
-																<p className="break-all text-xs text-zinc-500">{option.shippingRef}</p>
+																<div className="space-y-1">
+																	<p className="font-medium text-zinc-900">Shipping option unavailable</p>
+																	<p className="break-all text-xs text-zinc-500">{option.shippingRef}</p>
+																</div>
 															)}
 														</li>
 													)


### PR DESCRIPTION
## Summary

Fixes the auction detail rendering slice of #813 by deduping shipping refs before query fan-out and making invalid/unresolved shipping states explicit.

## What changed

- Added a pure auction shipping ref parser/dedupe helper
- Deduped duplicate refs by canonical `shippingRef`
- Queried only valid `30406:<pubkey>:<dTag>` refs
- Resolved shipping query results by ref instead of original array position
- Rendered invalid refs and unresolved shipping options explicitly
- Added focused unit tests for valid refs, malformed refs, and first-occurrence-wins dedupe

## Out of scope

- #824 settlement/Cashu redemption
- auction publish validation covered by #846
- trusted mint state ownership
- auction form tab UX
- Nostr event semantics

## Validation

- bun test src/lib/__tests__/auctionShippingRefs.test.ts
- bun run test:unit
- bunx prettier --check touched files
- git diff --check
- bun run build.ts

## Review focus

- no duplicate shipping query fan-out
- invalid relay-provided refs do not masquerade as valid shipping options
- unresolved shipping data is visible to users
- no payment/settlement/form behavior changed