### PR TITLE
fix(auctions): preflight settlement p2pk keys

### DIFF
--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test'
+import { HDKey } from '@scure/bip32'
+import { getEncodedToken, type Proof } from '@cashu/cashu-ts'
+import { deriveAuctionChildP2pkPubkeyFromXpub } from '@/lib/auctionP2pk'
+import { preflightAuctionSettlementP2pk } from '@/lib/auctionSettlementP2pk'
+
+const makeFixture = () => {
+	const seed = Uint8Array.from({ length: 32 }, (_, index) => index + 1)
+	const account = HDKey.fromMasterSeed(seed).derive("m/30408'/0'/0'")
+	const xpub = account.publicExtendedKey
+	if (!xpub) throw new Error('Failed to derive test xpub')
+
+	const derivationPath = '7/11/13/17/19'
+	const childPubkey = deriveAuctionChildP2pkPubkeyFromXpub(xpub, derivationPath)
+
+	return {
+		xpub,
+		derivationPath,
+		childPubkey,
+		childPubkeyXOnly: childPubkey.slice(2),
+		mismatchedChildPubkey: deriveAuctionChildP2pkPubkeyFromXpub(xpub, '1/2/3/4/5'),
+	}
+}
+
+const makeP2pkSecret = (lockPubkey: string): string =>
+	JSON.stringify([
+		'P2PK',
+		{
+			nonce: '00'.repeat(32),
+			data: lockPubkey,
+			tags: [['locktime', '2000000000']],
+		},
+	])
+
+const makeToken = (secret: string): string => {
+	const proof: Proof = {
+		id: '009a1f293253e41e',
+		amount: 1,
+		secret,
+		C: '02'.padEnd(66, '1'),
+	}
+
+	return getEncodedToken({
+		mint: 'https://mint.example',
+		proofs: [proof],
+	})
+}
+
+describe('auction settlement P2PK preflight', () => {
+	test('accepts compressed token lock pubkey matching derived child key', () => {
+		const fixture = makeFixture()
+		const result = preflightAuctionSettlementP2pk({
+			auctionP2pkXpub: fixture.xpub,
+			derivationPath: fixture.derivationPath,
+			settlementPlanChildPubkey: fixture.childPubkey,
+			token: makeToken(makeP2pkSecret(fixture.childPubkey)),
+		})
+
+		expect(result.derivedChildPubkey).toBe(fixture.childPubkey)
+		expect(result.tokenLockPubkey).toBe(fixture.childPubkey)
+	})
+
+	test('accepts settlement-plan childPubkey in x-only form only as comparison metadata', () => {
+		const fixture = makeFixture()
+		const result = preflightAuctionSettlementP2pk({
+			auctionP2pkXpub: fixture.xpub,
+			derivationPath: fixture.derivationPath,
+			settlementPlanChildPubkey: fixture.childPubkeyXOnly,
+			token: makeToken(makeP2pkSecret(fixture.childPubkey)),
+		})
+
+		expect(result.settlementPlanChildPubkey).toBe(fixture.childPubkeyXOnly)
+		expect(result.tokenLockPubkey).toBe(fixture.childPubkey)
+	})
+
+	test('rejects token lock pubkey that is x-only', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: fixture.xpub,
+				derivationPath: fixture.derivationPath,
+				settlementPlanChildPubkey: fixture.childPubkey,
+				token: makeToken(makeP2pkSecret(fixture.childPubkeyXOnly)),
+			}),
+		).toThrow('Winner token P2PK lock pubkey is not compressed; cannot settle this bid safely')
+	})
+
+	test('rejects malformed token P2PK secret', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: fixture.xpub,
+				derivationPath: fixture.derivationPath,
+				settlementPlanChildPubkey: fixture.childPubkey,
+				token: makeToken('not-json'),
+			}),
+		).toThrow('Winner token proof secret is not a valid P2PK secret')
+	})
+
+	test('rejects derived child key mismatch against token lock pubkey', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: fixture.xpub,
+				derivationPath: fixture.derivationPath,
+				settlementPlanChildPubkey: fixture.childPubkey,
+				token: makeToken(makeP2pkSecret(fixture.mismatchedChildPubkey)),
+			}),
+		).toThrow('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')
+	})
+
+	test('rejects settlement-plan childPubkey mismatch', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: fixture.xpub,
+				derivationPath: fixture.derivationPath,
+				settlementPlanChildPubkey: fixture.mismatchedChildPubkey,
+				token: makeToken(makeP2pkSecret(fixture.childPubkey)),
+			}),
+		).toThrow('Settlement plan child pubkey does not match auction p2pk_xpub + derivation path')
+	})
+
+	test('rejects #824-shaped x-only settlement metadata and x-only token lock before redemption', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: fixture.xpub,
+				derivationPath: fixture.derivationPath,
+				settlementPlanChildPubkey: fixture.childPubkeyXOnly,
+				token: makeToken(makeP2pkSecret(fixture.childPubkeyXOnly)),
+			}),
+		).toThrow('Winner token P2PK lock pubkey is not compressed; cannot settle this bid safely')
+	})
+})

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -1,0 +1,104 @@
+import { auctionP2pkPubkeysMatch, deriveAuctionChildP2pkPubkeyFromXpub, toCompressedAuctionP2pkPubkey } from '@/lib/auctionP2pk'
+import { getDecodedToken } from '@cashu/cashu-ts'
+
+export interface AuctionSettlementP2pkPreflightInput {
+	auctionP2pkXpub: string
+	derivationPath?: string
+	settlementPlanChildPubkey?: string
+	token: string
+}
+
+export interface AuctionSettlementP2pkPreflightResult {
+	derivationPath: string
+	derivedChildPubkey: string
+	settlementPlanChildPubkey: string
+	tokenLockPubkey: string
+}
+
+type CashuP2pkSecretPayload = {
+	data?: unknown
+}
+
+const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/i
+
+const extractP2pkLockPubkeyFromSecret = (secret: string): string => {
+	let parsed: unknown
+	try {
+		parsed = JSON.parse(secret)
+	} catch {
+		throw new Error('Winner token proof secret is not a valid P2PK secret')
+	}
+
+	if (!Array.isArray(parsed) || parsed[0] !== 'P2PK' || typeof parsed[1] !== 'object' || parsed[1] === null) {
+		throw new Error('Winner token proof secret is not a valid P2PK secret')
+	}
+
+	const payload = parsed[1] as CashuP2pkSecretPayload
+	if (typeof payload.data !== 'string' || !payload.data.trim()) {
+		throw new Error('Winner token proof secret is missing a P2PK lock pubkey')
+	}
+
+	return payload.data
+}
+
+const requireCompressedTokenLockPubkey = (pubkey: string): string => {
+	try {
+		return toCompressedAuctionP2pkPubkey(pubkey)
+	} catch {
+		if (X_ONLY_HEX_RE.test(pubkey.trim())) {
+			throw new Error('Winner token P2PK lock pubkey is not compressed; cannot settle this bid safely')
+		}
+		throw new Error('Winner token P2PK lock pubkey is malformed; cannot settle this bid safely')
+	}
+}
+
+export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPreflightInput): AuctionSettlementP2pkPreflightResult => {
+	const derivationPath = input.derivationPath?.trim()
+	if (!derivationPath) {
+		throw new Error('Winner token derivation path is required')
+	}
+
+	const settlementPlanChildPubkey = input.settlementPlanChildPubkey?.trim()
+	if (!settlementPlanChildPubkey) {
+		throw new Error('Winner token child pubkey is required')
+	}
+
+	const derivedChildPubkey = deriveAuctionChildP2pkPubkeyFromXpub(input.auctionP2pkXpub, derivationPath)
+
+	let settlementPlanChildMatches = false
+	try {
+		settlementPlanChildMatches = auctionP2pkPubkeysMatch(derivedChildPubkey, settlementPlanChildPubkey)
+	} catch {
+		throw new Error('Settlement plan child pubkey is malformed')
+	}
+	if (!settlementPlanChildMatches) {
+		throw new Error('Settlement plan child pubkey does not match auction p2pk_xpub + derivation path')
+	}
+
+	let decodedToken: ReturnType<typeof getDecodedToken>
+	try {
+		decodedToken = getDecodedToken(input.token)
+	} catch {
+		throw new Error('Winner token could not be decoded')
+	}
+
+	if (!decodedToken.proofs.length) {
+		throw new Error('Winner token contains no proofs')
+	}
+
+	let tokenLockPubkey = ''
+	for (const proof of decodedToken.proofs) {
+		const proofLockPubkey = requireCompressedTokenLockPubkey(extractP2pkLockPubkeyFromSecret(proof.secret))
+		if (proofLockPubkey !== derivedChildPubkey) {
+			throw new Error('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')
+		}
+		tokenLockPubkey = proofLockPubkey
+	}
+
+	return {
+		derivationPath,
+		derivedChildPubkey,
+		settlementPlanChildPubkey,
+		tokenLockPubkey,
+	}
+}

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -4,6 +4,7 @@ import {
 	AUCTION_TRANSFER_DM_KIND,
 	type AuctionBidTokenEnvelope,
 } from '@/lib/auctionTransfers'
+import { preflightAuctionSettlementP2pk } from '@/lib/auctionSettlementP2pk'
 import {
 	AUCTION_BID_KIND,
 	AUCTION_KIND,
@@ -705,9 +706,15 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 			throw new Error('Settlement plan did not provide a valid winning bid')
 		}
 		for (const winnerToken of settlementPlan.winnerTokens) {
-			const childPrivkey = await nip60Actions.getAuctionHdChildPrivkey({
+			const p2pkPreflight = preflightAuctionSettlementP2pk({
+				auctionP2pkXpub,
 				derivationPath: winnerToken.derivationPath,
-				expectedPubkey: winnerToken.childPubkey || undefined,
+				settlementPlanChildPubkey: winnerToken.childPubkey,
+				token: winnerToken.token,
+			})
+			const childPrivkey = await nip60Actions.getAuctionHdChildPrivkey({
+				derivationPath: p2pkPreflight.derivationPath,
+				expectedPubkey: p2pkPreflight.derivedChildPubkey,
 			})
 			try {
 				await nip60Actions.receiveLockedEcash(winnerToken.token, childPrivkey)


### PR DESCRIPTION
## Summary

Fixes #824 by adding settlement-time P2PK preflight validation before attempting to redeem winning Cashu bid tokens.

The settlement path now verifies that the seller auction xpub, winner token derivation path, settlement-plan child pubkey, and token P2PK lock pubkey all identify the same compressed child key before calling the mint.

## What changed

- Added a pure settlement P2PK preflight helper
- Decodes winner Cashu tokens before redemption
- Extracts the P2PK lock pubkey from token proof secrets
- Requires token lock pubkeys to be compressed secp256k1 keys
- Allows settlement-plan child pubkeys to be x-only only as comparison metadata
- Rejects x-only or malformed token lock pubkeys before mint redemption
- Rejects settlement-plan child pubkey mismatches
- Rejects token lock pubkey mismatches against the derived xpub/path key
- Uses the derived compressed child pubkey as the expected key for seller HD private-key derivation
- Preserves existing already-spent token handling
- Keeps valid compressed-key settlement behavior unchanged

## Why

#824 reported seller settlement failing with:

`Witness is missing for p2pk signature`

The failure shape indicates settlement can reach mint redemption with invalid or mismatched P2PK key material. This PR moves that failure to a deterministic local preflight boundary before `/v1/swap`.

## Out of scope

- Auction publish/form validation covered by #846
- Auction detail shipping refs covered by #847
- Countdown UI covered by #848
- Changing Nostr event kinds or tag semantics
- Changing bid ordering, reserve, anti-sniping, or settlement-plan outcome logic
- Redesigning the settlement-plan API
- Redesigning auction claim/order fulfillment UX
- Changing wallet custody assumptions

## Validation

Automated:

- `bun test src/lib/__tests__/auctionP2pk.test.ts`
- `bun test src/lib/__tests__/auctionSettlementP2pk.test.ts`
- `bun run test:unit`
- `bunx prettier --check src/publish/auctions.tsx src/lib/auctionP2pk.ts src/lib/auctionSettlementP2pk.ts src/lib/__tests__/auctionP2pk.test.ts src/lib/__tests__/auctionSettlementP2pk.test.ts`
- `git diff --check`
- `bun run build.ts`

Manual auction workflow:

- Created a short auction
- Placed multiple bids from separate bidder wallets
- Observed anti-sniping extend the effective end time
- Waited until the auction ended
- Opened the seller dashboard auction detail page
- Published settlement from the seller-facing settlement action
- Confirmed dashboard moved from `Ready to settle` to `settled`
- Confirmed settlement lock changed to `Published`
- Confirmed latest settlement shows:
  - winning bidder selected
  - final amount: 222 sats
  - winning bid event present
  - winner pubkey present
- Did not observe `Witness is missing for p2pk signature` in the console during settlement
- Logged in as the winning bidder and confirmed:
  - bid is marked as winning
  - settlement status is `settled`
  - shipping address flow is available
  - shipping details can be submitted
- Logged in as an outbid bidder and confirmed:
  - bid is marked as outbid
  - settlement status is `settled`
  - reclaim remains locked until bid locktime
- Logged back in as seller and confirmed:
  - auction claim order appears in Sales
  - shipping address is visible
  - order can move from Pending to Processing
  - seller can open the shipping/tracking dialog

Not directly verified from raw event inspection:

- raw kind 1024 event payload/tags
- raw `payout` tag

## Review focus

- settlement does not call the mint when token P2PK data is x-only, malformed, or mismatched
- valid compressed-key settlements still succeed
- settlement-plan child pubkey is verified against the seller auction xpub and derivation path
- token proof P2PK lock pubkey is verified against the same derived compressed child key
- no form/UI/shipping/countdown behavior changed