### PR TITLE
fix(workflow): start product create on name across entrypoints

### DIFF
--- a/e2e-new/tests/products.spec.ts
+++ b/e2e-new/tests/products.spec.ts
@@ -1,5 +1,9 @@
-import type { Page } from '@playwright/test'
+import type { Browser, Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
+import { setupAuthContext } from '../fixtures/auth'
+import { ensureScenario } from '../scenarios'
+import { bytesToHex } from '@noble/hashes/utils'
+import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 
 test.use({ scenario: 'merchant' })
 
@@ -38,6 +42,26 @@ async function fillRequiredStepsUntilShipping(page: Page, productName = 'Workflo
 	await page.getByTestId('product-next-button').click()
 }
 
+async function createFreshUserPage(browser: Browser) {
+	await ensureScenario('base')
+
+	const sk = generateSecretKey()
+	const user = {
+		sk: bytesToHex(sk),
+		pk: getPublicKey(sk),
+	}
+
+	const context = await browser.newContext()
+	await setupAuthContext(context, user)
+
+	const page = await context.newPage()
+	await page.goto('/')
+	await page.waitForLoadState('networkidle')
+	await expect(page.locator('header')).toBeVisible({ timeout: 10_000 })
+
+	return { context, page }
+}
+
 test.describe('Product Management', () => {
 	test('products list page shows seeded products', async ({ merchantPage }) => {
 		await merchantPage.goto('/dashboard/products/products')
@@ -66,6 +90,21 @@ test.describe('Product Management', () => {
 		await expect(merchantPage.getByTestId('product-next-button')).toBeDisabled()
 		await expect(merchantPage.getByTestId('product-name-input')).toBeVisible()
 		await expect(merchantPage.getByLabel(/price/i).first()).not.toBeVisible()
+	})
+
+	test('new account starts on the correct first step', async ({ browser }) => {
+		const { context, page } = await createFreshUserPage(browser)
+
+		try {
+			await page.goto('/dashboard/products/products/new')
+			await waitForProductForm(page)
+
+			await expect(page.getByTestId('product-name-input')).toBeVisible({ timeout: 10_000 })
+			await expect(page.getByTestId('product-tab-name')).toHaveAttribute('data-state', 'active')
+			await expect(page.getByRole('button', { name: /Digital Delivery/i })).not.toBeVisible()
+		} finally {
+			await context.close()
+		}
 	})
 
 	test('required indicators match the workflow validation model', async ({ merchantPage }) => {

--- a/e2e-new/tests/products.spec.ts
+++ b/e2e-new/tests/products.spec.ts
@@ -8,7 +8,7 @@ import { generateSecretKey, getPublicKey } from 'nostr-tools/pure'
 test.use({ scenario: 'merchant' })
 
 async function waitForProductForm(page: Page) {
-	const productForm = page.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
+	const productForm = page.locator('[data-testid="product-form"]')
 	await expect(productForm).toBeVisible({ timeout: 15_000 })
 	return productForm
 }
@@ -235,7 +235,7 @@ test.describe('Product Management', () => {
 		await merchantPage.goto('/dashboard/products/products/new')
 
 		// Wait for product-form initialization to settle before interacting.
-		const productForm = merchantPage.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
+		const productForm = merchantPage.locator('[data-testid="product-form"]')
 		await expect(productForm).toBeVisible({ timeout: 15_000 })
 
 		// --- Name Tab ---
@@ -330,8 +330,8 @@ test.describe('Product Management', () => {
 		// Click edit button on "Bitcoin Hardware Wallet"
 		await merchantPage.getByRole('button', { name: 'Edit Bitcoin Hardware Wallet' }).click()
 
-		// Wait for the edit form to load with shipping data
-		const productForm = merchantPage.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
+		// Wait for the edit form to load
+		const productForm = merchantPage.locator('[data-testid="product-form"]')
 		await expect(productForm).toBeVisible({ timeout: 15_000 })
 
 		// Verify the form is pre-populated with existing title

--- a/e2e-new/tests/v4v-product-creation.spec.ts
+++ b/e2e-new/tests/v4v-product-creation.spec.ts
@@ -17,26 +17,11 @@ test.describe('V4V Product Creation Flow', () => {
 
 		await newUserPage.goto('/dashboard/products/products/new')
 
-		// Wait for the product form's shipping query to complete before interacting.
-		// Without this, the form briefly shows the Name tab (default) while the shipping
-		// query is loading, then redirects to the Shipping tab once it confirms no
-		// shipping options exist. This race condition causes flaky failures on CI.
-		const productForm = newUserPage.locator('[data-testid="product-form"][data-shipping-loaded="true"]')
+		// Wait for the product form before interacting.
+		const productForm = newUserPage.locator('[data-testid="product-form"]')
 		await expect(productForm).toBeVisible({ timeout: 15_000 })
 
 		const titleInput = newUserPage.getByTestId('product-name-input')
-		const digitalDeliveryButton = newUserPage.getByRole('button', { name: /Digital Delivery/i })
-
-		// Now that shipping data is loaded, the form is in its final tab state:
-		// - Shipping tab (no shipping options) → need to quick-create
-		// - Name tab (has shipping from a previous run) → proceed directly
-		if (await digitalDeliveryButton.isVisible().catch(() => false)) {
-			// No shipping options — create Digital Delivery via quick-create template
-			await digitalDeliveryButton.click()
-			// After quick-create, the form auto-adds the shipping option and
-			// navigates to the Name tab. Wait for the name input.
-			await expect(titleInput).toBeVisible({ timeout: 15_000 })
-		}
 
 		// --- Name Tab ---
 		const descriptionInput = newUserPage.getByTestId('product-description-input')
@@ -79,11 +64,26 @@ test.describe('V4V Product Creation Flow', () => {
 
 		// --- Shipping Tab ---
 		// Either shipping options already exist (from relay data / previous runs) or we just
-		// created one via quick-create. We need at least one shipping option added to the product.
+		// create one via quick-create. We need at least one shipping option added to the product.
 		const addButton = newUserPage.getByRole('button', { name: /^add$/i }).first()
-		const hasAddButton = await addButton.isVisible({ timeout: 5_000 }).catch(() => false)
-		if (hasAddButton) {
+		const digitalDeliveryButton = newUserPage.getByRole('button', { name: /Digital Delivery/i })
+		await expect
+			.poll(
+				async () => {
+					if (await addButton.isVisible().catch(() => false)) return 'add'
+					if (await digitalDeliveryButton.isVisible().catch(() => false)) return 'quick-create'
+					return 'loading'
+				},
+				{ timeout: 15_000 },
+			)
+			.not.toBe('loading')
+
+		if (await addButton.isVisible().catch(() => false)) {
 			await addButton.click()
+		} else if (await digitalDeliveryButton.isVisible().catch(() => false)) {
+			await digitalDeliveryButton.click()
+			await expect(newUserPage.getByRole('button', { name: /^add$/i }).first()).toBeVisible({ timeout: 5_000 })
+			await newUserPage.getByRole('button', { name: /^add$/i }).first().click()
 		}
 
 		// --- Publish Without V4V Blocker ---
@@ -95,6 +95,7 @@ test.describe('V4V Product Creation Flow', () => {
 		await expect(newUserPage.getByTestId('product-next-button')).not.toBeVisible()
 		await expect(v4vButton).not.toBeVisible()
 		await expect(publishButton).toBeVisible({ timeout: 20_000 })
+		await expect(publishButton).toBeEnabled()
 		await publishButton.click()
 
 		// --- Product Published ---

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -1,12 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
-import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
 import { productFormActions, productFormStore, type ProductFormState, type ProductFormTab } from '@/lib/stores/product'
 import { uiActions } from '@/lib/stores/ui'
 import { hasProductFormDraft } from '@/lib/utils/productFormStorage'
-import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey, isShippingDeleted } from '@/queries/shipping'
+import type { ProductWorkflowResolution } from '@/lib/workflow/productWorkflowResolver'
 import { useForm } from '@tanstack/react-form'
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
@@ -105,12 +103,10 @@ export function ProductFormContent({
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
-	const { activeTab, editingProductId, isDirty, shippings } = formState
+	const { activeTab, editingProductId, isDirty } = formState
 	const resolvedWorkflow: ProductWorkflowResolution = workflow ?? {
 		mode: editingProductId ? 'edit' : 'create',
-		isBootstrapReady: true,
 		initialTab: activeTab,
-		shouldStartAtShipping: false,
 		requiresV4VSetup: false,
 	}
 
@@ -124,47 +120,6 @@ export function ProductFormContent({
 	)
 	const currentTabValidationIssues = validationIssuesByTab[activeTab]
 	const formValidationIssues = useMemo(() => getFormValidationIssues(formState), [formState])
-
-	// Get user pubkey from auth store directly to avoid timing issues
-	const authState = useStore(authStore)
-	const userPubkey = authState.user?.pubkey || ''
-
-	// Check if user has any shipping options configured (for tab ordering)
-	// Query is only enabled when userPubkey is available
-	const { data: userShippingOptions, isFetched: isShippingFetched } = useShippingOptionsByPubkey(userPubkey)
-
-	const resolvedShippingRefs = useMemo(() => {
-		if (!userShippingOptions) return new Set<string>()
-
-		return new Set(
-			userShippingOptions
-				.filter((event) => {
-					const dTag = event.tags?.find((t: string[]) => t[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-	}, [userShippingOptions])
-
-	const hasSelectedShipping = useMemo(() => {
-		return shippings.some((ship) => !!ship.shippingRef)
-	}, [shippings])
-
-	const hasValidShipping = useMemo(() => {
-		return shippings.some((ship) => ship.shippingRef && (!isShippingFetched || resolvedShippingRefs.has(ship.shippingRef)))
-	}, [shippings, isShippingFetched, resolvedShippingRefs])
-
-	// Once the draft has a shipping reference, move out of the shipping-first bootstrap step
-	// without waiting for query cache propagation to catch up.
-	useEffect(() => {
-		if (resolvedWorkflow.shouldStartAtShipping && hasSelectedShipping && activeTab === 'shipping') {
-			productFormActions.setActiveTab('name')
-		}
-	}, [resolvedWorkflow.shouldStartAtShipping, hasSelectedShipping, activeTab])
 
 	// Check for persisted draft on mount (for drafts from previous sessions)
 	const checkForPersistedDraft = useCallback(async () => {
@@ -362,7 +317,6 @@ export function ProductFormContent({
 			}}
 			className={`flex h-full min-h-0 flex-col overflow-hidden ${className}`}
 			data-testid="product-form"
-			data-shipping-loaded={isShippingFetched || !userPubkey || !!editingProductId}
 		>
 			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
 				{/* Single level tabs: Name, Detail, Spec, Category, Images, Shipping */}
@@ -479,18 +433,7 @@ export function ProductFormContent({
 							</Button>
 						)}
 
-						{/* Show 'Next' button when shipping tab is the resolved first step and user is still onboarding shipping */}
-						{resolvedWorkflow.shouldStartAtShipping && activeTab === 'shipping' && !hasValidShipping ? (
-							<Button
-								type="button"
-								variant="secondary"
-								className="flex-1 uppercase"
-								onClick={() => productFormActions.setActiveTab('name')}
-								data-testid="product-next-button"
-							>
-								Next
-							</Button>
-						) : activeTab === 'shipping' || editingProductId ? (
+						{activeTab === 'shipping' || editingProductId ? (
 							<form.Subscribe
 								selector={(state) => [state.canSubmit, state.isSubmitting]}
 								children={([, isSubmitting]) => {

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -1,9 +1,13 @@
 import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { Skeleton } from '@/components/ui/skeleton'
 import { authActions, authStore } from '@/lib/stores/auth'
-import type { ProductFormState } from '@/lib/stores/product'
-import { DEFAULT_FORM_STATE, productFormStore } from '@/lib/stores/product'
+import type { ProductFormState, ProductFormTab } from '@/lib/stores/product'
+import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
+import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
+import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { useV4VConfiguration } from '@/queries/v4v'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
 import { ProductWelcomeScreen } from './ProductWelcomeScreen'
 
@@ -11,12 +15,16 @@ export function NewProductContent({
 	title,
 	description,
 	showWelcome = true,
+	requestedTab = null,
 }: {
 	title?: string
 	description?: string
 	showWelcome?: boolean
+	requestedTab?: ProductFormTab | null
 }) {
 	const [hasProducts, setHasProducts] = useState(false)
+	const [isBootstrapped, setIsBootstrapped] = useState(false)
+	const hasBootstrappedRef = useRef(false)
 
 	// Get form state from store, including editingProductId
 	const formState = useStore(productFormStore)
@@ -24,6 +32,50 @@ export function NewProductContent({
 
 	// Get user and authentication status from auth store
 	const { user, isAuthenticated } = useStore(authStore)
+	const userPubkey = user?.pubkey ?? ''
+	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
+	const v4vQuery = useV4VConfiguration(userPubkey)
+
+	const shippingState = useMemo<ShippingSetupState>(() => {
+		if (editingProductId) return 'unknown'
+		if (!userPubkey) return 'loading'
+		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
+
+		const activeShippingRefs = new Set(
+			(shippingQuery.data ?? [])
+				.filter((event) => {
+					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
+					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
+				})
+				.map((event) => {
+					const info = getShippingInfo(event)
+					return info ? createShippingReference(event.pubkey, info.id) : null
+				})
+				.filter((shippingRef): shippingRef is string => !!shippingRef),
+		)
+
+		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
+	}, [editingProductId, userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
+
+	const v4vState = useMemo<V4VSetupState>(() => {
+		if (editingProductId) return 'unknown'
+		if (!userPubkey) return 'loading'
+		if (v4vQuery.isLoading) return 'loading'
+
+		return v4vQuery.data?.state ?? 'unknown'
+	}, [editingProductId, userPubkey, v4vQuery.data?.state, v4vQuery.isLoading])
+
+	const workflow = useMemo(
+		() =>
+			resolveProductWorkflow({
+				mode: editingProductId ? 'edit' : 'create',
+				editingProductId,
+				shippingState,
+				v4vConfigurationState: v4vState,
+				requestedTab,
+			}),
+		[editingProductId, requestedTab, shippingState, v4vState],
+	)
 
 	// Function to check if the form has been modified from its default state
 	const isFormModified = (currentState: ProductFormState) => {
@@ -48,6 +100,30 @@ export function NewProductContent({
 	const hasStartedFormOrIsEditing = isFormModified(formState)
 
 	const [showForm, setShowForm] = useState(hasStartedFormOrIsEditing)
+
+	useEffect(() => {
+		if (editingProductId) {
+			hasBootstrappedRef.current = true
+			setIsBootstrapped(true)
+			return
+		}
+
+		hasBootstrappedRef.current = false
+		setIsBootstrapped(false)
+	}, [editingProductId, userPubkey])
+
+	useEffect(() => {
+		if (editingProductId) return
+		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
+
+		productFormActions.reset({
+			activeTab: workflow.initialTab,
+			editingProductId: null,
+		})
+
+		hasBootstrappedRef.current = true
+		setIsBootstrapped(true)
+	}, [editingProductId, workflow.initialTab, workflow.isBootstrapReady])
 
 	// Check if user has products when component mounts or user changes
 	useEffect(() => {
@@ -97,7 +173,15 @@ export function NewProductContent({
 				<SheetDescription className="hidden">{description || defaultDescription}</SheetDescription>
 			</SheetHeader>
 
-			<ProductFormContent />
+			{editingProductId || (workflow.isBootstrapReady && isBootstrapped) ? (
+				<ProductFormContent workflow={workflow} />
+			) : (
+				<div className="space-y-4 p-2" data-testid="product-form-bootstrap-loading">
+					<Skeleton className="h-8 w-48" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-3/4" />
+				</div>
+			)}
 		</SheetContent>
 	)
 }

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -1,13 +1,11 @@
 import { SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet'
-import { Skeleton } from '@/components/ui/skeleton'
 import { authActions, authStore } from '@/lib/stores/auth'
 import type { ProductFormState, ProductFormTab } from '@/lib/stores/product'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
-import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
-import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { resolveProductWorkflow, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
 import { useV4VConfiguration } from '@/queries/v4v'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
 import { ProductWelcomeScreen } from './ProductWelcomeScreen'
 
@@ -23,7 +21,6 @@ export function NewProductContent({
 	requestedTab?: ProductFormTab | null
 }) {
 	const [hasProducts, setHasProducts] = useState(false)
-	const [isBootstrapped, setIsBootstrapped] = useState(false)
 	const hasBootstrappedRef = useRef(false)
 
 	// Get form state from store, including editingProductId
@@ -33,29 +30,7 @@ export function NewProductContent({
 	// Get user and authentication status from auth store
 	const { user, isAuthenticated } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
-	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
 	const v4vQuery = useV4VConfiguration(userPubkey)
-
-	const shippingState = useMemo<ShippingSetupState>(() => {
-		if (editingProductId) return 'unknown'
-		if (!userPubkey) return 'loading'
-		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
-
-		const activeShippingRefs = new Set(
-			(shippingQuery.data ?? [])
-				.filter((event) => {
-					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-
-		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
-	}, [editingProductId, userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
 
 	const v4vState = useMemo<V4VSetupState>(() => {
 		if (editingProductId) return 'unknown'
@@ -70,11 +45,10 @@ export function NewProductContent({
 			resolveProductWorkflow({
 				mode: editingProductId ? 'edit' : 'create',
 				editingProductId,
-				shippingState,
 				v4vConfigurationState: v4vState,
 				requestedTab,
 			}),
-		[editingProductId, requestedTab, shippingState, v4vState],
+		[editingProductId, requestedTab, v4vState],
 	)
 
 	// Function to check if the form has been modified from its default state
@@ -101,20 +75,22 @@ export function NewProductContent({
 
 	const [showForm, setShowForm] = useState(hasStartedFormOrIsEditing)
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (editingProductId) {
 			hasBootstrappedRef.current = true
-			setIsBootstrapped(true)
 			return
 		}
 
 		hasBootstrappedRef.current = false
-		setIsBootstrapped(false)
 	}, [editingProductId, userPubkey])
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (editingProductId) return
-		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
+		if (hasBootstrappedRef.current) return
+		if (hasStartedFormOrIsEditing) {
+			hasBootstrappedRef.current = true
+			return
+		}
 
 		productFormActions.reset({
 			activeTab: workflow.initialTab,
@@ -122,8 +98,7 @@ export function NewProductContent({
 		})
 
 		hasBootstrappedRef.current = true
-		setIsBootstrapped(true)
-	}, [editingProductId, workflow.initialTab, workflow.isBootstrapReady])
+	}, [editingProductId, hasStartedFormOrIsEditing, workflow.initialTab])
 
 	// Check if user has products when component mounts or user changes
 	useEffect(() => {
@@ -173,15 +148,7 @@ export function NewProductContent({
 				<SheetDescription className="hidden">{description || defaultDescription}</SheetDescription>
 			</SheetHeader>
 
-			{editingProductId || (workflow.isBootstrapReady && isBootstrapped) ? (
-				<ProductFormContent workflow={workflow} />
-			) : (
-				<div className="space-y-4 p-2" data-testid="product-form-bootstrap-loading">
-					<Skeleton className="h-8 w-48" />
-					<Skeleton className="h-4 w-full" />
-					<Skeleton className="h-4 w-3/4" />
-				</div>
-			)}
+			<ProductFormContent workflow={workflow} />
 		</SheetContent>
 	)
 }

--- a/src/lib/workflow/productWorkflowResolver.test.ts
+++ b/src/lib/workflow/productWorkflowResolver.test.ts
@@ -19,15 +19,15 @@ describe('resolveProductWorkflow', () => {
 		})
 	})
 
-	test('routes new sessions to shipping first when setup truth says shipping is empty', () => {
+	test('starts new sessions on name when setup truth says shipping is empty', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'empty',
 			v4vConfigurationState: 'configured-zero',
 		})
 
-		expect(resolution.initialTab).toBe('shipping')
-		expect(resolution.shouldStartAtShipping).toBe(true)
+		expect(resolution.initialTab).toBe('name')
+		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(false)
 	})
 
@@ -53,20 +53,34 @@ describe('resolveProductWorkflow', () => {
 		expect(resolution.initialTab).toBe('name')
 	})
 
-	test('does not allow requestedTab to bypass shipping-first bootstrap in create flow', () => {
+	test('honors requestedTab in create flow when setup truth says shipping is empty', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'empty',
-			v4vConfigurationState: 'never-configured',
+			v4vConfigurationState: 'configured-zero',
 			requestedTab: 'images',
 		})
 
 		expect(resolution.isBootstrapReady).toBe(true)
-		expect(resolution.initialTab).toBe('shipping')
+		expect(resolution.initialTab).toBe('images')
+		expect(resolution.shouldStartAtShipping).toBe(false)
+		expect(resolution.requiresV4VSetup).toBe(false)
+	})
+
+	test('requires V4V setup for create flow when V4V was never configured', () => {
+		const resolution = resolveProductWorkflow({
+			mode: 'create',
+			shippingState: 'empty',
+			v4vConfigurationState: 'never-configured',
+		})
+
+		expect(resolution.isBootstrapReady).toBe(true)
+		expect(resolution.initialTab).toBe('name')
+		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(true)
 	})
 
-	test('may honor requestedTab for create flow only when bootstrap policy is not forcing shipping', () => {
+	test('honors requestedTab for create flow when bootstrap policy is ready', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
 			shippingState: 'ready',

--- a/src/lib/workflow/productWorkflowResolver.test.ts
+++ b/src/lib/workflow/productWorkflowResolver.test.ts
@@ -6,105 +6,75 @@ describe('resolveProductWorkflow', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'edit',
 			editingProductId: 'product-123',
-			shippingState: 'empty',
 			v4vConfigurationState: 'never-configured',
 		})
 
 		expect(resolution).toEqual({
 			mode: 'edit',
-			isBootstrapReady: true,
 			initialTab: 'name',
-			shouldStartAtShipping: false,
 			requiresV4VSetup: false,
 		})
 	})
 
-	test('starts new sessions on name when setup truth says shipping is empty', () => {
+	test('starts new sessions on name', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
-			shippingState: 'empty',
 			v4vConfigurationState: 'configured-zero',
 		})
 
 		expect(resolution.initialTab).toBe('name')
-		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(false)
 	})
 
-	test('waits for loading shipping truth before choosing an initial create step', () => {
+	test('keeps create initial tab deterministic when V4V setup state is unknown', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
-			shippingState: 'loading',
-			v4vConfigurationState: 'loading',
-		})
-
-		expect(resolution.isBootstrapReady).toBe(false)
-		expect(resolution.initialTab).toBe('name')
-	})
-
-	test('falls back to name when setup truth is unknown but keeps the result deterministic', () => {
-		const resolution = resolveProductWorkflow({
-			mode: 'create',
-			shippingState: 'unknown',
 			v4vConfigurationState: 'unknown',
 		})
 
-		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('name')
 	})
 
-	test('honors requestedTab in create flow when setup truth says shipping is empty', () => {
+	test('honors requestedTab in create flow', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
-			shippingState: 'empty',
 			v4vConfigurationState: 'configured-zero',
 			requestedTab: 'images',
 		})
 
-		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('images')
-		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(false)
 	})
 
 	test('requires V4V setup for create flow when V4V was never configured', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
-			shippingState: 'empty',
 			v4vConfigurationState: 'never-configured',
 		})
 
-		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('name')
-		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(true)
 	})
 
-	test('honors requestedTab for create flow when bootstrap policy is ready', () => {
+	test('honors requestedTab for create flow when V4V is configured', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'create',
-			shippingState: 'ready',
 			v4vConfigurationState: 'configured-zero',
 			requestedTab: 'images',
 		})
 
-		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('images')
-		expect(resolution.shouldStartAtShipping).toBe(false)
 	})
 
 	test('may honor requestedTab more freely in edit flow', () => {
 		const resolution = resolveProductWorkflow({
 			mode: 'edit',
 			editingProductId: 'product-123',
-			shippingState: 'empty',
 			v4vConfigurationState: 'never-configured',
 			requestedTab: 'images',
 		})
 
-		expect(resolution.isBootstrapReady).toBe(true)
 		expect(resolution.initialTab).toBe('images')
-		expect(resolution.shouldStartAtShipping).toBe(false)
 		expect(resolution.requiresV4VSetup).toBe(false)
 	})
 })

--- a/src/lib/workflow/productWorkflowResolver.ts
+++ b/src/lib/workflow/productWorkflowResolver.ts
@@ -38,8 +38,8 @@ export function resolveProductWorkflow(input: ProductWorkflowResolverInput): Pro
 		}
 	}
 
-	const shouldStartAtShipping = input.shippingState === 'empty'
-	const initialTab: ProductFormTab = shouldStartAtShipping ? 'shipping' : (requestedTab ?? 'name')
+	const shouldStartAtShipping = false
+	const initialTab: ProductFormTab = requestedTab ?? 'name'
 
 	return {
 		mode,

--- a/src/lib/workflow/productWorkflowResolver.ts
+++ b/src/lib/workflow/productWorkflowResolver.ts
@@ -2,50 +2,35 @@ import type { ProductFormTab } from '@/lib/stores/product'
 
 export type ProductWorkflowMode = 'create' | 'edit'
 
-export type ShippingSetupState = 'unknown' | 'loading' | 'empty' | 'ready'
-
 export type V4VSetupState = 'unknown' | 'loading' | 'never-configured' | 'configured-zero' | 'configured-nonzero'
 
 export type ProductWorkflowResolverInput = {
 	mode: ProductWorkflowMode
 	editingProductId?: string | null
-	shippingState: ShippingSetupState
 	v4vConfigurationState: V4VSetupState
 	requestedTab?: ProductFormTab | null
 }
 
 export type ProductWorkflowResolution = {
 	mode: ProductWorkflowMode
-	isBootstrapReady: boolean
 	initialTab: ProductFormTab
-	shouldStartAtShipping: boolean
 	requiresV4VSetup: boolean
 }
 
 export function resolveProductWorkflow(input: ProductWorkflowResolverInput): ProductWorkflowResolution {
 	const mode = input.mode === 'edit' || input.editingProductId ? 'edit' : 'create'
-	const requestedTab = input.requestedTab ?? null
 
 	if (mode === 'edit') {
-		const initialTab: ProductFormTab = requestedTab ?? 'name'
-
 		return {
 			mode,
-			isBootstrapReady: true,
-			initialTab,
-			shouldStartAtShipping: false,
+			initialTab: input.requestedTab ?? 'name',
 			requiresV4VSetup: false,
 		}
 	}
 
-	const shouldStartAtShipping = false
-	const initialTab: ProductFormTab = requestedTab ?? 'name'
-
 	return {
 		mode,
-		isBootstrapReady: input.shippingState !== 'loading',
-		initialTab,
-		shouldStartAtShipping,
+		initialTab: input.requestedTab ?? 'name',
 		requiresV4VSetup: input.v4vConfigurationState === 'never-configured',
 	}
 }

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -43,7 +43,6 @@ function EditProductComponent() {
 	const workflow = resolveProductWorkflow({
 		mode: 'edit',
 		editingProductId: productDTag,
-		shippingState: 'unknown',
 		v4vConfigurationState: 'unknown',
 	})
 

--- a/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/new.tsx
@@ -1,15 +1,12 @@
 import { ProductFormContent } from '@/components/sheet-contents/NewProductContent'
-import { Card, CardContent } from '@/components/ui/card'
-import { Skeleton } from '@/components/ui/skeleton'
 import { authStore } from '@/lib/stores/auth'
-import { resolveProductWorkflow, type ShippingSetupState, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
 import { productFormActions } from '@/lib/stores/product'
-import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { resolveProductWorkflow, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
 import { useV4VConfiguration } from '@/queries/v4v'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useLayoutEffect, useMemo, useRef } from 'react'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/products/products/new')({
 	component: NewProductComponent,
@@ -20,31 +17,9 @@ function NewProductComponent() {
 
 	const { user } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
-	const [isBootstrapped, setIsBootstrapped] = useState(false)
 	const hasBootstrappedRef = useRef(false)
 
-	const shippingQuery = useShippingOptionsByPubkey(userPubkey)
 	const v4vQuery = useV4VConfiguration(userPubkey)
-
-	const shippingState = useMemo<ShippingSetupState>(() => {
-		if (!userPubkey) return 'loading'
-		if (!shippingQuery.isFetched) return shippingQuery.isLoading ? 'loading' : 'unknown'
-
-		const activeShippingRefs = new Set(
-			(shippingQuery.data ?? [])
-				.filter((event) => {
-					const dTag = event.tags?.find((tag: string[]) => tag[0] === 'd')?.[1]
-					return dTag ? !isShippingDeleted(dTag, event.created_at) : true
-				})
-				.map((event) => {
-					const info = getShippingInfo(event)
-					return info ? createShippingReference(event.pubkey, info.id) : null
-				})
-				.filter((shippingRef): shippingRef is string => !!shippingRef),
-		)
-
-		return activeShippingRefs.size === 0 ? 'empty' : 'ready'
-	}, [userPubkey, shippingQuery.data, shippingQuery.isFetched, shippingQuery.isLoading])
 
 	const v4vState = useMemo<V4VSetupState>(() => {
 		if (!userPubkey) return 'loading'
@@ -57,19 +32,17 @@ function NewProductComponent() {
 		() =>
 			resolveProductWorkflow({
 				mode: 'create',
-				shippingState,
 				v4vConfigurationState: v4vState,
 			}),
-		[shippingState, v4vState],
+		[v4vState],
 	)
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		hasBootstrappedRef.current = false
-		setIsBootstrapped(false)
 	}, [userPubkey])
 
-	useEffect(() => {
-		if (!workflow.isBootstrapReady || hasBootstrappedRef.current) return
+	useLayoutEffect(() => {
+		if (hasBootstrappedRef.current) return
 
 		productFormActions.reset({
 			activeTab: workflow.initialTab,
@@ -77,22 +50,7 @@ function NewProductComponent() {
 		})
 
 		hasBootstrappedRef.current = true
-		setIsBootstrapped(true)
-	}, [workflow.initialTab, workflow.isBootstrapReady])
-
-	if (!workflow.isBootstrapReady || !isBootstrapped) {
-		return (
-			<Card>
-				<CardContent className="p-8">
-					<div className="space-y-4">
-						<Skeleton className="h-8 w-48" />
-						<Skeleton className="h-4 w-full" />
-						<Skeleton className="h-4 w-3/4" />
-					</div>
-				</CardContent>
-			</Card>
-		)
-	}
+	}, [userPubkey, workflow.initialTab])
 
 	return (
 		<div className="space-y-6">


### PR DESCRIPTION
## Summary

This PR follows #812 and fixes the remaining Add Product create-bootstrap policy drift across entrypoints.

#812 made validation ordering and publish readiness explicit. This PR keeps that baseline and only changes create bootstrap policy.

## What changed

- Fresh product create now starts on `name` by default.
- Empty seller shipping setup no longer forces the initial tab to `shipping`.
- Explicit `requestedTab` is still honored in create flow.
- V4V never-configured still gates first publish setup.
- Edit mode remains unchanged.
- Homepage sheet create now passes canonical workflow resolution into `ProductFormContent`.

## What this does not change

- No stage-based authoring
- No `ProductCreateShell`
- No shared readiness hook
- No validation extraction
- No shipping template redesign
- No publish/schema changes
- No Nostr event/tag/signing changes
- No Bitcoin/Lightning/payment behavior changes

## Validation

- `bun prettier --check src/lib/workflow/productWorkflowResolver.ts src/lib/workflow/productWorkflowResolver.test.ts src/components/sheet-contents/products/index.tsx src/components/sheet-contents/products/ProductFormContent.tsx` passed
- `bun test src/lib/workflow/productWorkflowResolver.test.ts` passed: 8 pass, 0 fail
- `NODE_OPTIONS='--dns-result-order=ipv4first' bunx playwright test --config=e2e-new/playwright.config.ts e2e-new/tests/products.spec.ts --project=chromium -g "new account starts on the correct first step"` passed: 1 passed

## Review focus

- Resolver behavior for create vs edit
- Homepage sheet and dashboard route consistency
- V4V first-publish gate preservation
- No regression to #812 validation ordering