### PR TITLE
Auctions/fix auction filters default

### DIFF
--- a/src/components/AuctionFilters.tsx
+++ b/src/components/AuctionFilters.tsx
@@ -21,7 +21,8 @@ interface AuctionFiltersProps {
 
 export function AuctionFilters({ filters, onFiltersChange, className }: AuctionFiltersProps) {
 	const appliedFilterCount = calculateAppliedFilterCount(filters)
-	const hasEnabledHideEnded = filters.hideEnded !== defaultAuctionFilters.hideEnded
+	const hasEnabledHideEnded = filters.hideEnded ?? defaultAuctionFilters.hideEnded
+	const sort = filters.sort ?? defaultAuctionFilters.sort
 
 	const toggleFilterHideEnded = () => {
 		onFiltersChange({ ...filters, hideEnded: !hasEnabledHideEnded })
@@ -67,13 +68,15 @@ export function AuctionFilters({ filters, onFiltersChange, className }: AuctionF
 								<SortAsc className="w-4 h-4" />
 								Sort by
 							</div>
-							<Select value={filters.sort} onValueChange={handleSortChange}>
+							<Select value={sort} onValueChange={handleSortChange}>
 								<SelectTrigger className="w-full">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
 									{auctionSortOptionValues.map((value) => (
-										<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+										<SelectItem key={value} value={value}>
+											{getAuctionSortOptionTitle(value)}
+										</SelectItem>
 									))}
 								</SelectContent>
 							</Select>

--- a/src/components/AuctionFilters.tsx
+++ b/src/components/AuctionFilters.tsx
@@ -3,14 +3,15 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import {
+	auctionSortOptionValues,
+	calculateAppliedFilterCount,
+	defaultAuctionFilters,
+	getAuctionSortOptionTitle,
+	type AuctionFilterState,
+	type AuctionSortOption,
+} from '@/lib/utils/auctions'
 import { Filter, SortAsc } from 'lucide-react'
-
-export type AuctionSortOption = 'newest' | 'oldest' | 'ending-soon' | 'highest-starting-bid' | 'title-a-z'
-
-export interface AuctionFilterState {
-	showEnded: boolean
-	sort: AuctionSortOption
-}
 
 interface AuctionFiltersProps {
 	filters: AuctionFilterState
@@ -18,18 +19,12 @@ interface AuctionFiltersProps {
 	className?: string
 }
 
-export const defaultAuctionFilters: AuctionFilterState = {
-	showEnded: true,
-	sort: 'ending-soon',
-}
-
 export function AuctionFilters({ filters, onFiltersChange, className }: AuctionFiltersProps) {
-	const hasFilterHideEnded = filters.showEnded === defaultAuctionFilters.showEnded
-	const hasFilterSortLatest = filters.sort === defaultAuctionFilters.sort
-	const hasActiveFilters = hasFilterHideEnded || hasFilterSortLatest
+	const appliedFilterCount = calculateAppliedFilterCount(filters)
+	const hasEnabledHideEnded = filters.hideEnded !== defaultAuctionFilters.hideEnded
 
-	const handleShowEndedChange = (checked: boolean) => {
-		onFiltersChange({ ...filters, showEnded: checked })
+	const toggleFilterHideEnded = () => {
+		onFiltersChange({ ...filters, hideEnded: !hasEnabledHideEnded })
 	}
 
 	const handleSortChange = (value: AuctionSortOption) => {
@@ -47,9 +42,9 @@ export function AuctionFilters({ filters, onFiltersChange, className }: AuctionF
 					<Button variant="outline" size="sm" className="gap-2">
 						<Filter className="w-4 h-4" />
 						<span>Filter & Sort</span>
-						{hasActiveFilters && (
+						{appliedFilterCount > 0 && (
 							<span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
-								{(hasFilterHideEnded ? 1 : 0) + (hasFilterSortLatest ? 1 : 0)}
+								{appliedFilterCount}
 							</span>
 						)}
 					</Button>
@@ -60,12 +55,8 @@ export function AuctionFilters({ filters, onFiltersChange, className }: AuctionF
 
 						<div className="space-y-3">
 							<div className="flex items-center space-x-2">
-								<Checkbox
-									id="showEndedAuctions"
-									checked={hasFilterHideEnded}
-									onCheckedChange={() => handleShowEndedChange(hasFilterHideEnded)}
-								/>
-								<Label htmlFor="showEndedAuctions" className="text-sm font-normal cursor-pointer">
+								<Checkbox id="hideEndedAuctions" checked={hasEnabledHideEnded} onCheckedChange={toggleFilterHideEnded} />
+								<Label htmlFor="hideEndedAuctions" className="text-sm font-normal cursor-pointer">
 									Hide ended auctions
 								</Label>
 							</div>
@@ -81,16 +72,14 @@ export function AuctionFilters({ filters, onFiltersChange, className }: AuctionF
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									<SelectItem value="ending-soon">Ending soon</SelectItem>
-									<SelectItem value="newest">Newest first</SelectItem>
-									<SelectItem value="highest-starting-bid">Highest starting bid</SelectItem>
-									<SelectItem value="title-a-z">Title (A-Z)</SelectItem>
-									<SelectItem value="oldest">Oldest first</SelectItem>
+									{auctionSortOptionValues.map((value) => (
+										<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+									))}
 								</SelectContent>
 							</Select>
 						</div>
 
-						{hasActiveFilters && (
+						{appliedFilterCount > 0 && (
 							<div className="border-t pt-4">
 								<Button variant="ghost" size="sm" onClick={handleReset} className="w-full">
 									Reset filters

--- a/src/lib/utils/auctions.ts
+++ b/src/lib/utils/auctions.ts
@@ -1,0 +1,144 @@
+import {
+	getAuctionCategories,
+	getAuctionEffectiveEndAt,
+	getAuctionRootEventId,
+	getAuctionStartingBid,
+	getAuctionTitle,
+} from '@/queries/auctions'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { useMemo } from 'react'
+
+export type AuctionSortOption = 'newest' | 'oldest' | 'ending-soon' | 'highest-starting-bid' | 'title-a-z' | 'title-z-a'
+
+export const auctionSortOptionValues: AuctionSortOption[] = [
+	'ending-soon',
+	'newest',
+	'oldest',
+	'highest-starting-bid',
+	'title-a-z',
+	'title-z-a',
+]
+
+export const getAuctionSortOptionTitle = (value: AuctionSortOption): string => {
+	switch (value) {
+		case 'ending-soon':
+			return 'Ending Soon'
+		case 'newest':
+			return 'Newest First'
+		case 'oldest':
+			return 'Oldest First'
+		case 'highest-starting-bid':
+			return 'Highest Starting Bid'
+		case 'title-a-z':
+			return 'Alphabetical'
+		case 'title-z-a':
+			return 'Alphabetical - Reverse'
+	}
+}
+
+export interface AuctionFilterState {
+	hideEnded?: boolean
+	sort?: AuctionSortOption
+}
+
+export interface UseFilteredAuctionsProps {
+	auctions: NDKEvent[]
+	bidsByAuctionId: Map<string, any> | undefined // Adjust 'any' to your actual bid type if known
+	filters: AuctionFilterState
+	tag: string | undefined
+}
+
+export const defaultAuctionFilters: AuctionFilterState = {
+	hideEnded: false,
+	sort: 'ending-soon',
+}
+
+/**
+ * Calculates how many filter criteria are currently active compared to defaults.
+ *
+ * @param filters - The current filter state
+ * @returns The number of active filters
+ */
+export function calculateAppliedFilterCount(filters: AuctionFilterState): number {
+	let count = 0
+
+	// 1. Hide Ended Filter
+	// Since default is false, this checks if the user explicitly enabled it.
+	const isHideEndedActive = filters.hideEnded ?? defaultAuctionFilters.hideEnded
+	if (isHideEndedActive) count++
+
+	// 2. Sort Filter
+	const currentSort = filters.sort ?? defaultAuctionFilters.sort
+	if (currentSort !== defaultAuctionFilters.sort) count++
+
+	return count
+}
+
+export function useFilteredAuctions({ auctions, bidsByAuctionId, filters, tag }: UseFilteredAuctionsProps) {
+	const hideEnded = filters.hideEnded ?? defaultAuctionFilters.hideEnded
+	const sort = filters.sort ?? defaultAuctionFilters.sort
+
+	return useMemo(() => {
+		const now = Math.floor(Date.now() / 1000)
+		let filtered = auctions
+
+		// 1. Filter by URL Tag
+		if (tag) {
+			filtered = filtered.filter((auction) => getAuctionCategories(auction).includes(tag))
+		}
+
+		// 2. Filter by UI State (Hide Ended)
+		if (hideEnded) {
+			filtered = filtered.filter((auction) => {
+				const rootId = getAuctionRootEventId(auction) || auction.id
+				const bids = bidsByAuctionId?.get(rootId) ?? []
+				const visibleEndAt = getAuctionEffectiveEndAt(auction, bids)
+
+				return visibleEndAt > 0 && visibleEndAt > now
+			})
+		}
+
+		// 3. Sort
+		const sorted = [...filtered]
+		switch (sort) {
+			case 'oldest':
+				sorted.sort((a, b) => (a.created_at || 0) - (b.created_at || 0))
+				break
+
+			case 'ending-soon':
+				sorted.sort((a, b) => {
+					const aBids = bidsByAuctionId?.get(getAuctionRootEventId(a) || a.id) ?? []
+					const bBids = bidsByAuctionId?.get(getAuctionRootEventId(b) || b.id) ?? []
+
+					const aEnd = getAuctionEffectiveEndAt(a, aBids)
+					const bEnd = getAuctionEffectiveEndAt(b, bBids)
+
+					const aEnded = aEnd > 0 && aEnd <= now
+					const bEnded = bEnd > 0 && bEnd <= now
+
+					if (aEnded !== bEnded) return aEnded ? 1 : -1
+					return aEnd - bEnd
+				})
+				break
+
+			case 'highest-starting-bid':
+				sorted.sort((a, b) => getAuctionStartingBid(b) - getAuctionStartingBid(a))
+				break
+
+			case 'title-a-z':
+				sorted.sort((a, b) => getAuctionTitle(a).localeCompare(getAuctionTitle(b)))
+				break
+
+			case 'title-z-a':
+				sorted.sort((a, b) => getAuctionTitle(b).localeCompare(getAuctionTitle(a)))
+				break
+
+			case 'newest':
+			default:
+				sorted.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+				break
+		}
+
+		return sorted
+	}, [auctions, bidsByAuctionId, filters, tag])
+}

--- a/src/lib/utils/auctions.ts
+++ b/src/lib/utils/auctions.ts
@@ -43,7 +43,7 @@ export interface AuctionFilterState {
 
 export interface UseFilteredAuctionsProps {
 	auctions: NDKEvent[]
-	bidsByAuctionId: Map<string, any> | undefined // Adjust 'any' to your actual bid type if known
+	bidsByAuctionId?: Map<string, NDKEvent[]>
 	filters: AuctionFilterState
 	tag: string | undefined
 }

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -22,6 +22,7 @@ import { queryOptions, useQuery } from '@tanstack/react-query'
 import { auctionKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
+import type { AuctionFilterState } from '@/components/AuctionFilters'
 
 export type AuctionSettlementStatus = 'settled' | 'reserve_not_met' | 'cancelled' | 'unknown'
 
@@ -366,6 +367,10 @@ export const auctionBidsForListQueryOptions = (auctionRootEventIds: string[], li
 	})
 }
 
+/*
+ * One batched bid query for the whole list.
+ * See `auctionBidsForListQueryOptions` for rationale.
+ */
 export const useAuctionBidsForList = (auctionRootEventIds: string[], limit: number = 1000) =>
 	useQuery({
 		...auctionBidsForListQueryOptions(auctionRootEventIds, limit),

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -22,7 +22,6 @@ import { queryOptions, useQuery } from '@tanstack/react-query'
 import { auctionKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
-import type { AuctionFilterState } from '@/components/AuctionFilters'
 
 export type AuctionSettlementStatus = 'settled' | 'reserve_not_met' | 'cancelled' | 'unknown'
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -21,6 +21,7 @@ import {
 	getAuctionSummary,
 	getAuctionTitle,
 	useAuctionBids,
+	useAuctionBidsForList,
 	useAuctionSettlements,
 } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -31,9 +32,13 @@ import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tans
 import { useStore } from '@tanstack/react-store'
 import { Clock, Eye, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import { toast } from 'sonner'
-
-type AuctionOrder = 'newest' | 'oldest' | 'ending-soon' | 'ending-latest'
+import {
+	auctionSortOptionValues,
+	defaultAuctionFilters,
+	getAuctionSortOptionTitle,
+	useFilteredAuctions,
+	type AuctionSortOption,
+} from '@/lib/utils/auctions'
 
 function formatAuctionStatus(startAt: number, endAt: number, now: number): string {
 	if (endAt > 0 && now >= endAt) return 'Ended'
@@ -263,7 +268,7 @@ function AuctionsOverviewComponent() {
 	const navigate = useNavigate()
 	const matchRoute = useMatchRoute()
 	const [expandedAuction, setExpandedAuction] = useState<string | null>(null)
-	const [orderBy, setOrderBy] = useState<AuctionOrder>('newest')
+	const [sort, setSort] = useState<AuctionSortOption>(defaultAuctionFilters.sort ?? 'ending-soon')
 	const settlementMutation = usePublishAuctionSettlementMutation()
 	const [settlingAuctionId, setSettlingAuctionId] = useState<string | null>(null)
 	const [animationParent] = useAutoAnimate()
@@ -284,19 +289,12 @@ function AuctionsOverviewComponent() {
 		enabled: !!user?.pubkey && isAuthenticated,
 	})
 
-	const sortedAuctions = useMemo(() => {
-		if (!auctions) return []
-		const now = Math.floor(Date.now() / 1000)
-		return [...auctions].sort((a, b) => {
-			if (orderBy === 'newest') return (b.created_at || 0) - (a.created_at || 0)
-			if (orderBy === 'oldest') return (a.created_at || 0) - (b.created_at || 0)
-
-			const aEnd = getAuctionEndAt(a) || now
-			const bEnd = getAuctionEndAt(b) || now
-			if (orderBy === 'ending-soon') return aEnd - bEnd
-			return bEnd - aEnd
-		})
-	}, [auctions, orderBy])
+	const auctionRootEventIdsForBids = useMemo(
+		() => (auctions ?? []).map((auction) => getAuctionRootEventId(auction) || auction.id),
+		[auctions],
+	)
+	const { data: bidsByAuctionId } = useAuctionBidsForList(auctionRootEventIdsForBids)
+	const sortedAuctions = useFilteredAuctions({ auctions: auctions ?? [], filters: { sort: sort }, bidsByAuctionId, tag: undefined })
 
 	const handlePublishSettlement = async (auction: NDKEvent) => {
 		const auctionRootEventId = getAuctionRootEventId(auction)
@@ -344,15 +342,14 @@ function AuctionsOverviewComponent() {
 			<div className="hidden lg:flex sticky top-0 z-10 bg-white border-b py-4 px-4 lg:px-6 items-center justify-between">
 				<h1 className="text-2xl font-bold">Auctions</h1>
 				<div className="flex items-center gap-4">
-					<Select value={orderBy} onValueChange={(value) => setOrderBy(value as AuctionOrder)}>
+					<Select value={sort} onValueChange={(value) => setSort(value as AuctionSortOption)}>
 						<SelectTrigger className="w-56">
 							<SelectValue placeholder="Order By" />
 						</SelectTrigger>
 						<SelectContent>
-							<SelectItem value="newest">Newest First</SelectItem>
-							<SelectItem value="oldest">Oldest First</SelectItem>
-							<SelectItem value="ending-soon">Ending Soon</SelectItem>
-							<SelectItem value="ending-latest">Ending Latest</SelectItem>
+							{auctionSortOptionValues.map((value) => (
+								<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+							))}
 						</SelectContent>
 					</Select>
 					<Link to="/auctions">
@@ -373,15 +370,14 @@ function AuctionsOverviewComponent() {
 
 			<div className="space-y-6 p-4 lg:p-6">
 				<div className="lg:hidden space-y-4">
-					<Select value={orderBy} onValueChange={(value) => setOrderBy(value as AuctionOrder)}>
+					<Select value={sort} onValueChange={(value) => setSort(value as AuctionSortOption)}>
 						<SelectTrigger className="w-full">
 							<SelectValue placeholder="Order By" />
 						</SelectTrigger>
 						<SelectContent>
-							<SelectItem value="newest">Newest First</SelectItem>
-							<SelectItem value="oldest">Oldest First</SelectItem>
-							<SelectItem value="ending-soon">Ending Soon</SelectItem>
-							<SelectItem value="ending-latest">Ending Latest</SelectItem>
+							{auctionSortOptionValues.map((value) => (
+								<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+							))}
 						</SelectContent>
 					</Select>
 					<Button

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -348,7 +348,9 @@ function AuctionsOverviewComponent() {
 						</SelectTrigger>
 						<SelectContent>
 							{auctionSortOptionValues.map((value) => (
-								<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+								<SelectItem key={value} value={value}>
+									{getAuctionSortOptionTitle(value)}
+								</SelectItem>
 							))}
 						</SelectContent>
 					</Select>
@@ -376,7 +378,9 @@ function AuctionsOverviewComponent() {
 						</SelectTrigger>
 						<SelectContent>
 							{auctionSortOptionValues.map((value) => (
-								<SelectItem value={value}>{getAuctionSortOptionTitle(value)}</SelectItem>
+								<SelectItem key={value} value={value}>
+									{getAuctionSortOptionTitle(value)}
+								</SelectItem>
 							))}
 						</SelectContent>
 					</Select>

--- a/src/routes/auctions.index.tsx
+++ b/src/routes/auctions.index.tsx
@@ -1,5 +1,5 @@
 import { AuctionCard } from '@/components/AuctionCard'
-import { AuctionFilters, defaultAuctionFilters, type AuctionFilterState } from '@/components/AuctionFilters'
+import { AuctionFilters } from '@/components/AuctionFilters'
 import { ItemGrid } from '@/components/ItemGrid'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -7,6 +7,7 @@ import { PRODUCT_CATEGORIES } from '@/lib/constants'
 import { authStore } from '@/lib/stores/auth'
 import { uiStore } from '@/lib/stores/ui'
 import { uiActions } from '@/lib/stores/ui'
+import { defaultAuctionFilters, useFilteredAuctions, type AuctionFilterState } from '@/lib/utils/auctions'
 import {
 	auctionByATagQueryOptions,
 	auctionsQueryOptions,
@@ -89,10 +90,6 @@ function AuctionsRoute() {
 
 	const auctions = filterNSFWAuctions((auctionsQuery.data ?? []) as NDKEvent[], showNSFWContent)
 
-	// One batched bid query for the whole list — see queries/auctions.tsx
-	// (auctionBidsForListQueryOptions) for rationale. Each AuctionCard reads
-	// its own bid bucket from this Map instead of mounting its own polling
-	// subscription.
 	const auctionRootEventIdsForBids = useMemo(() => auctions.map((auction) => getAuctionRootEventId(auction) || auction.id), [auctions])
 	const { data: bidsByAuctionId } = useAuctionBidsForList(auctionRootEventIdsForBids)
 
@@ -115,50 +112,7 @@ function AuctionsRoute() {
 
 	const defaultTags: string[] = PRODUCT_CATEGORIES.filter((category) => allTags.includes(category))
 
-	const filteredAndSortedAuctions = useMemo(() => {
-		const now = Math.floor(Date.now() / 1000)
-		let filtered = auctions
-
-		if (tag) {
-			filtered = filtered.filter((auction) => getAuctionCategories(auction).includes(tag))
-		}
-
-		if (!filters.showEnded) {
-			filtered = filtered.filter((auction) => {
-				const visibleEndAt = getAuctionMaxEndAt(auction)
-				return visibleEndAt > 0 && visibleEndAt > now
-			})
-		}
-
-		const sorted = [...filtered]
-		switch (filters.sort) {
-			case 'oldest':
-				sorted.sort((a, b) => (a.created_at || 0) - (b.created_at || 0))
-				break
-			case 'ending-soon':
-				sorted.sort((a, b) => {
-					const aEnd = getAuctionMaxEndAt(a)
-					const bEnd = getAuctionMaxEndAt(b)
-					const aEnded = aEnd > 0 && aEnd <= now
-					const bEnded = bEnd > 0 && bEnd <= now
-					if (aEnded !== bEnded) return aEnded ? 1 : -1
-					return aEnd - bEnd
-				})
-				break
-			case 'highest-starting-bid':
-				sorted.sort((a, b) => getAuctionStartingBid(b) - getAuctionStartingBid(a))
-				break
-			case 'title-a-z':
-				sorted.sort((a, b) => getAuctionTitle(a).localeCompare(getAuctionTitle(b)))
-				break
-			case 'newest':
-			default:
-				sorted.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
-				break
-		}
-
-		return sorted
-	}, [auctions, filters, tag])
+	const filteredAndSortedAuctions = useFilteredAuctions({ auctions, filters, tag, bidsByAuctionId })
 
 	const handleTagClick = (selectedTag: string) => {
 		if (tag === selectedTag) {

--- a/src/routes/auctions.index.tsx
+++ b/src/routes/auctions.index.tsx
@@ -14,9 +14,7 @@ import {
 	filterNSFWAuctions,
 	getAuctionCategories,
 	getAuctionImages,
-	getAuctionMaxEndAt,
 	getAuctionRootEventId,
-	getAuctionStartingBid,
 	getAuctionTitle,
 	useAuctionBidsForList,
 } from '@/queries/auctions'


### PR DESCRIPTION
**Changes:**
- Unified Auctions filtering options and logic under `src/lib/utils/auctions.ts`
- Fixed filtering logic for `ending-soon` to reflect `effectiveEndAt` using auction bids to calculate extension times
- Fixed applied-filters-count calculation to reflect default filter settings
- Added filter option "Reverse Alphabetical"
- Refactored `src/components/AuctionFilters.tsx`, `src/routes/auctions.index.tsx` and `src/routes/_dashboard-layout/dashboard/products/auctions.tsx` to use the unified filtering options and logic

Purposely did not fix (out of scope):
- Invalid shadcn component variants in `src/routes/auctions.index.tsx`
- Other UI issues concerning auctions

Fixes #877