### PR TITLE
fix(checkout): require delivery contact for digital products

### DIFF
--- a/e2e-new/tests/marketplace.spec.ts
+++ b/e2e-new/tests/marketplace.spec.ts
@@ -144,6 +144,9 @@ async function proceedToPaymentStep(page: Page): Promise<void> {
 		const nameInput = page.getByRole('textbox', { name: /full name/i })
 		await nameInput.fill('E2E Test Buyer')
 
+		const digitalDeliveryContact = page.getByLabel(/digital delivery contact/i)
+		await digitalDeliveryContact.fill('buyer@example.com')
+
 		// Click the form submit button (has form="shipping-form" attribute)
 		const submitButton = page.locator('button[form="shipping-form"]')
 		await expect(submitButton).toBeEnabled({ timeout: 5_000 })

--- a/src/components/checkout/OrderFinalizeComponent.tsx
+++ b/src/components/checkout/OrderFinalizeComponent.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button'
+import type { CheckoutDeliveryRequirements } from '@/lib/checkout/deliveryRequirements'
 import { cartStore } from '@/lib/stores/cart'
 import { uiActions } from '@/lib/stores/ui'
 import { getShippingEvent, getShippingPickupAddressString, getShippingService } from '@/queries/shipping'
@@ -15,27 +16,42 @@ interface OrderFinalizeComponentProps {
 	totalInSats: number
 	onNewOrder: () => void
 	onViewOrders?: () => void
+	deliveryRequirements: CheckoutDeliveryRequirements
 }
 
-export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, onNewOrder, onViewOrders }: OrderFinalizeComponentProps) {
+export function OrderFinalizeComponent({
+	shippingData,
+	invoices,
+	totalInSats,
+	onNewOrder,
+	onViewOrders,
+	deliveryRequirements,
+}: OrderFinalizeComponentProps) {
 	const { cart } = useStore(cartStore)
 	const [pickupAddresses, setPickupAddresses] = useState<Array<{ sellerName: string; address: string }>>([])
-	const [isAllPickup, setIsAllPickup] = useState(false)
-	const [isAllDigital, setIsAllDigital] = useState(false)
-	const [noAddressRequired, setNoAddressRequired] = useState(false)
+
+	const isAllPickup =
+		deliveryRequirements.isResolved &&
+		deliveryRequirements.hasPickupDelivery &&
+		!deliveryRequirements.hasDigitalDelivery &&
+		!deliveryRequirements.hasPhysicalDelivery
+	const isAllDigital =
+		deliveryRequirements.isResolved &&
+		deliveryRequirements.hasDigitalDelivery &&
+		!deliveryRequirements.hasPickupDelivery &&
+		!deliveryRequirements.hasPhysicalDelivery
+	const noAddressRequired = deliveryRequirements.isResolved && !deliveryRequirements.needsPhysicalAddress
+	const hasDigitalDelivery = deliveryRequirements.hasDigitalDelivery
 
 	const formatSats = (sats: number): string => {
 		return Math.round(sats).toLocaleString()
 	}
 
-	// Check for pickup/digital orders and collect pickup addresses
+	// Collect pickup addresses for display only; delivery requirements are resolved by checkout state.
 	useEffect(() => {
 		const checkShippingOrders = async () => {
 			const products = Object.values(cart.products)
-			if (products.length === 0) {
-				setIsAllPickup(false)
-				setIsAllDigital(false)
-				setNoAddressRequired(false)
+			if (products.length === 0 || !deliveryRequirements.isResolved || !deliveryRequirements.hasPickupDelivery) {
 				setPickupAddresses([])
 				return
 			}
@@ -61,16 +77,7 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 							}
 						}
 
-						if (serviceType === 'digital') {
-							return {
-								isPickup: false,
-								isDigital: true,
-								sellerName: product.sellerPubkey || 'Unknown Seller',
-								address: '',
-							}
-						}
-
-						return { isPickup: false, isDigital: false, sellerName: product.sellerPubkey || 'Unknown Seller', address: '' }
+						return null
 					} catch (error) {
 						console.error('Error checking shipping service:', error)
 						return null
@@ -78,15 +85,8 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 				}),
 			)
 
-			const validData = serviceData.filter(Boolean)
-			const allPickup = validData.every((data) => data?.isPickup)
-			const allDigital = validData.every((data) => data?.isDigital)
-			const allNoAddress = validData.every((data) => data?.isPickup || data?.isDigital)
-			const pickupItems = validData.filter((data) => data?.isPickup)
+			const pickupItems = serviceData.filter((data) => data?.isPickup)
 
-			setIsAllPickup(allPickup)
-			setIsAllDigital(allDigital)
-			setNoAddressRequired(allNoAddress)
 			setPickupAddresses(
 				pickupItems.map((item) => ({
 					sellerName: item?.sellerName || 'Unknown Seller',
@@ -96,7 +96,7 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 		}
 
 		checkShippingOrders()
-	}, [cart.products])
+	}, [cart.products, deliveryRequirements.hasPickupDelivery, deliveryRequirements.isResolved])
 
 	const allInvoicesPaid = invoices.every((invoice) => invoice.status === 'paid')
 	const allInvoicesCompleted = invoices.every((invoice) => invoice.status === 'paid' || invoice.status === 'skipped')
@@ -218,13 +218,18 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 						<Download className="h-5 w-5 text-purple-600" />
 						<h3 className="font-medium text-purple-800">Digital Delivery</h3>
 					</div>
-					<p className="text-sm text-purple-700">Items will be delivered digitally. Check your messages for delivery details.</p>
-					{shippingData?.email && <p className="text-sm text-purple-600 mt-2">Email: {shippingData.email}</p>}
+					<p className="text-sm text-purple-700">The seller will use your delivery contact after payment settles.</p>
+					{shippingData?.email && <p className="text-sm text-purple-600 mt-2">Digital delivery contact: {shippingData.email}</p>}
 				</div>
 			) : noAddressRequired ? (
 				<div className="bg-indigo-50 p-4 rounded-lg border border-indigo-200">
 					<h3 className="font-medium text-indigo-800 mb-2">No Shipping Required</h3>
-					<p className="text-sm text-indigo-700">Items are for pickup or digital delivery.</p>
+					<p className="text-sm text-indigo-700">
+						Items are for pickup or digital delivery. Sellers will use any digital delivery contact after payment settles.
+					</p>
+					{hasDigitalDelivery && shippingData?.email && (
+						<p className="text-sm text-indigo-600 mt-2">Digital delivery contact: {shippingData.email}</p>
+					)}
 				</div>
 			) : (
 				shippingData && (
@@ -232,7 +237,11 @@ export function OrderFinalizeComponent({ shippingData, invoices, totalInSats, on
 						<h3 className="font-medium text-gray-900 mb-3">Shipping Address</h3>
 						<div className="text-sm text-gray-600 space-y-1">
 							<p className="font-medium text-gray-900">{shippingData.name}</p>
-							{shippingData.email && <p>Email: {shippingData.email}</p>}
+							{shippingData.email && (
+								<p>
+									{hasDigitalDelivery ? 'Digital delivery contact' : 'Email'}: {shippingData.email}
+								</p>
+							)}
 							<p>{shippingData.firstLineOfAddress}</p>
 							<p>
 								{shippingData.city}, {shippingData.zipPostcode}

--- a/src/components/checkout/ShippingAddressForm.tsx
+++ b/src/components/checkout/ShippingAddressForm.tsx
@@ -5,9 +5,11 @@ import { Textarea } from '@/components/ui/textarea'
 import { CountryCombobox, isValidCountry } from '@/components/checkout/CountryCombobox'
 import { CityCombobox } from '@/components/checkout/CityCombobox'
 import { PhoneInput } from '@/components/checkout/PhoneInput'
+import type { CheckoutDeliveryRequirements } from '@/lib/checkout/deliveryRequirements'
+import { isValidDigitalDeliveryContact } from '@/lib/checkout/deliveryRequirements'
 import { cartStore } from '@/lib/stores/cart'
 import { useStore } from '@tanstack/react-store'
-import { getShippingEvent, getShippingService, getShippingPickupAddressString, getShippingTitle } from '@/queries/shipping'
+import { getShippingEvent, getShippingPickupAddressString, getShippingService, getShippingTitle } from '@/queries/shipping'
 import { useEffect, useState } from 'react'
 
 export interface CheckoutFormData {
@@ -24,34 +26,53 @@ export interface CheckoutFormData {
 interface ShippingAddressFormProps {
 	form: any
 	hasAllShippingMethods: boolean
+	deliveryRequirements: CheckoutDeliveryRequirements
+	isDeliveryRequirementsLoading: boolean
+	deliveryRequirementsError: string | null
 }
 
-export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAddressFormProps) {
+export function ShippingAddressForm({
+	form,
+	hasAllShippingMethods,
+	deliveryRequirements,
+	isDeliveryRequirementsLoading,
+	deliveryRequirementsError,
+}: ShippingAddressFormProps) {
 	const { cart } = useStore(cartStore)
-	const [isAllPickup, setIsAllPickup] = useState(false)
-	const [isAllDigital, setIsAllDigital] = useState(false)
-	const [noAddressRequired, setNoAddressRequired] = useState(false)
 	const [pickupAddresses, setPickupAddresses] = useState<Array<{ title: string; address: string }>>([])
 
-	// Check if all shipping methods are pickup/digital type and fetch pickup addresses
+	const isAllPickup =
+		deliveryRequirements.isResolved &&
+		deliveryRequirements.hasPickupDelivery &&
+		!deliveryRequirements.hasDigitalDelivery &&
+		!deliveryRequirements.hasPhysicalDelivery
+	const isAllDigital =
+		deliveryRequirements.isResolved &&
+		deliveryRequirements.hasDigitalDelivery &&
+		!deliveryRequirements.hasPickupDelivery &&
+		!deliveryRequirements.hasPhysicalDelivery
+	const noAddressRequired = deliveryRequirements.isResolved && !deliveryRequirements.needsPhysicalAddress
+	const needsPhysicalAddress = deliveryRequirements.isResolved ? deliveryRequirements.needsPhysicalAddress : true
+	const needsDigitalDeliveryContact = deliveryRequirements.isResolved && deliveryRequirements.needsDigitalDeliveryContact
+	const hasDigitalDelivery = deliveryRequirements.hasDigitalDelivery
+	const deliveryRequirementsBlocked =
+		isDeliveryRequirementsLoading || !!deliveryRequirementsError || (hasAllShippingMethods && !deliveryRequirements.isResolved)
+
 	useEffect(() => {
-		const checkShippingStatus = async () => {
+		const fetchPickupAddresses = async () => {
 			const products = Object.values(cart.products)
-			if (products.length === 0) {
-				setIsAllPickup(false)
-				setIsAllDigital(false)
-				setNoAddressRequired(false)
+			if (products.length === 0 || !deliveryRequirements.isResolved || !deliveryRequirements.hasPickupDelivery) {
 				setPickupAddresses([])
 				return
 			}
 
 			const serviceData = await Promise.all(
 				products.map(async (product) => {
-					if (!product.shippingMethodId) return { isPickup: false, isDigital: false, title: '', address: '' }
+					if (!product.shippingMethodId) return null
 
 					try {
 						const shippingEvent = await getShippingEvent(product.shippingMethodId)
-						if (!shippingEvent) return { isPickup: false, isDigital: false, title: '', address: '' }
+						if (!shippingEvent) return null
 
 						const serviceTag = getShippingService(shippingEvent)
 						const serviceType = serviceTag?.[1]
@@ -59,51 +80,33 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 						if (serviceType === 'pickup') {
 							const title = getShippingTitle(shippingEvent)
 							const address = getShippingPickupAddressString(shippingEvent)
-							return { isPickup: true, isDigital: false, title, address: address || 'Address not specified' }
+							return { title, address: address || 'Address not specified' }
 						}
 
-						if (serviceType === 'digital') {
-							return { isPickup: false, isDigital: true, title: '', address: '' }
-						}
-
-						return { isPickup: false, isDigital: false, title: '', address: '' }
+						return null
 					} catch (error) {
 						console.error('Error checking shipping service:', error)
-						return { isPickup: false, isDigital: false, title: '', address: '' }
+						return null
 					}
 				}),
 			)
 
-			const allPickup = serviceData.every((data) => data.isPickup)
-			const allDigital = serviceData.every((data) => data.isDigital)
-			const allNoAddress = serviceData.every((data) => data.isPickup || data.isDigital)
+			const uniqueAddresses = serviceData.filter(Boolean).reduce(
+				(acc, data) => {
+					const key = `${data!.title}-${data!.address}`
+					if (!acc.some((item) => `${item.title}-${item.address}` === key)) {
+						acc.push({ title: data!.title, address: data!.address })
+					}
+					return acc
+				},
+				[] as Array<{ title: string; address: string }>,
+			)
 
-			setIsAllPickup(allPickup)
-			setIsAllDigital(allDigital)
-			setNoAddressRequired(allNoAddress)
-
-			if (allPickup) {
-				const uniqueAddresses = serviceData
-					.filter((data) => data.isPickup)
-					.reduce(
-						(acc, data) => {
-							const key = `${data.title}-${data.address}`
-							if (!acc.some((item) => `${item.title}-${item.address}` === key)) {
-								acc.push({ title: data.title, address: data.address })
-							}
-							return acc
-						},
-						[] as Array<{ title: string; address: string }>,
-					)
-
-				setPickupAddresses(uniqueAddresses)
-			} else {
-				setPickupAddresses([])
-			}
+			setPickupAddresses(uniqueAddresses)
 		}
 
-		checkShippingStatus()
-	}, [cart.products])
+		fetchPickupAddresses()
+	}, [cart.products, deliveryRequirements.hasPickupDelivery, deliveryRequirements.isResolved])
 	return (
 		<div className="flex flex-col h-full">
 			<div className="flex-1 overflow-y-auto space-y-4">
@@ -123,7 +126,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 							validators={{
 								onChange: ({ value }: { value: string }) => {
 									// Name is only required when a physical address is needed
-									if (!noAddressRequired && !value.trim()) return 'Name is required'
+									if (needsPhysicalAddress && !value.trim()) return 'Name is required'
 									if (value.trim() && value.trim().length < 2) return 'Name must be at least 2 characters'
 									return undefined
 								},
@@ -131,7 +134,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 							children={(field: any) => (
 								<div>
 									<Label htmlFor={field.name} className="text-sm font-medium">
-										Full Name {!noAddressRequired && <span className="text-red-500">*</span>}
+										Full Name {needsPhysicalAddress && <span className="text-red-500">*</span>}
 									</Label>
 									<Input
 										id={field.name}
@@ -140,7 +143,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 										value={field.state.value}
 										onChange={(e) => field.handleChange(e.target.value)}
 										onBlur={field.handleBlur}
-										required={!noAddressRequired}
+										required={needsPhysicalAddress}
 									/>
 									{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
 										<p className="text-xs text-red-500 mt-1">{field.state.meta.errors[0]}</p>
@@ -153,18 +156,18 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 							name="email"
 							validators={{
 								onChange: ({ value }: { value: string }) => {
-									// Email is always optional
-									if (value.trim()) {
-										const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-										return !emailRegex.test(value) ? 'Please enter a valid email address' : undefined
+									if (needsDigitalDeliveryContact && !value.trim()) {
+										return 'Digital delivery contact is required'
 									}
+									if (value.trim() && !isValidDigitalDeliveryContact(value)) return 'Please enter a valid email address'
 									return undefined
 								},
 							}}
 							children={(field: any) => (
 								<div>
 									<Label htmlFor={field.name} className="text-sm font-medium">
-										Email Address
+										{hasDigitalDelivery ? 'Digital Delivery Contact (Email)' : 'Email Address'}{' '}
+										{needsDigitalDeliveryContact && <span className="text-red-500">*</span>}
 									</Label>
 									<Input
 										id={field.name}
@@ -173,7 +176,18 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 										value={field.state.value}
 										onChange={(e) => field.handleChange(e.target.value)}
 										onBlur={field.handleBlur}
+										required={needsDigitalDeliveryContact}
 									/>
+									{hasDigitalDelivery && (
+										<div className="mt-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+											<p className="font-medium">Digital delivery contact</p>
+											<p className="mt-1">The seller will use this contact to deliver your digital item after payment settles.</p>
+											<p className="mt-1">
+												Privacy note: this contact will be shared with the seller and may be visible according to the app's current public
+												order metadata model.
+											</p>
+										</div>
+									)}
 									{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
 										<p className="text-xs text-red-500 mt-1">{field.state.meta.errors[0]}</p>
 									)}
@@ -232,8 +246,8 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 						<div className="bg-purple-50 border border-purple-200 rounded-lg p-4">
 							<h3 className="text-sm font-medium text-purple-800 mb-2">Digital Delivery</h3>
 							<p className="text-sm text-purple-700">
-								All items in your order will be delivered digitally. No shipping address is required. Check your messages for delivery
-								details after purchase.
+								All items in your order will be delivered digitally. No shipping address is required. The seller will use your delivery
+								contact after payment settles.
 							</p>
 						</div>
 					)}
@@ -243,21 +257,22 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 						<div className="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
 							<h3 className="text-sm font-medium text-indigo-800 mb-2">No Shipping Required</h3>
 							<p className="text-sm text-indigo-700">
-								All items in your order are either for pickup or digital delivery. No shipping address is required.
+								All items in your order are either for pickup or digital delivery. No shipping address is required. Sellers will use any
+								digital delivery contact after payment settles.
 							</p>
 						</div>
 					)}
 
 					{/* Address - Only show when physical shipping is needed */}
-					{!noAddressRequired && (
+					{needsPhysicalAddress && (
 						<>
 							<form.Field
 								name="firstLineOfAddress"
 								validators={{
 									onChange: ({ value }: { value: string }) =>
-										!noAddressRequired && !value.trim()
+										needsPhysicalAddress && !value.trim()
 											? 'Address is required'
-											: !noAddressRequired && value.trim().length < 5
+											: needsPhysicalAddress && value.trim().length < 5
 												? 'Please enter a complete address'
 												: undefined,
 								}}
@@ -273,7 +288,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 											value={field.state.value}
 											onChange={(e) => field.handleChange(e.target.value)}
 											onBlur={field.handleBlur}
-											required={!noAddressRequired}
+											required={needsPhysicalAddress}
 										/>
 										{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
 											<p className="text-xs text-red-500 mt-1">{field.state.meta.errors[0]}</p>
@@ -289,9 +304,9 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 										name="city"
 										validators={{
 											onChange: ({ value }: { value: string }) =>
-												!noAddressRequired && !value.trim()
+												needsPhysicalAddress && !value.trim()
 													? 'City is required'
-													: !noAddressRequired && value.trim().length < 2
+													: needsPhysicalAddress && value.trim().length < 2
 														? 'Please enter a valid city name'
 														: undefined,
 										}}
@@ -306,7 +321,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 													onChange={(value) => field.handleChange(value)}
 													onBlur={field.handleBlur}
 													placeholder="e.g. San Francisco"
-													required={!noAddressRequired}
+													required={needsPhysicalAddress}
 													selectedCountry={selectedCountry}
 												/>
 												{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
@@ -322,9 +337,9 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 								name="zipPostcode"
 								validators={{
 									onChange: ({ value }: { value: string }) =>
-										!noAddressRequired && !value.trim()
+										needsPhysicalAddress && !value.trim()
 											? 'ZIP/Postcode is required'
-											: !noAddressRequired && value.trim().length < 3
+											: needsPhysicalAddress && value.trim().length < 3
 												? 'Please enter a valid ZIP/Postcode'
 												: undefined,
 								}}
@@ -340,7 +355,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 											value={field.state.value}
 											onChange={(e) => field.handleChange(e.target.value)}
 											onBlur={field.handleBlur}
-											required={!noAddressRequired}
+											required={needsPhysicalAddress}
 										/>
 										{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
 											<p className="text-xs text-red-500 mt-1">{field.state.meta.errors[0]}</p>
@@ -353,9 +368,9 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 								name="country"
 								validators={{
 									onChange: ({ value }: { value: string }) =>
-										!noAddressRequired && !value.trim()
+										needsPhysicalAddress && !value.trim()
 											? 'Country is required'
-											: !noAddressRequired && !isValidCountry(value)
+											: needsPhysicalAddress && !isValidCountry(value)
 												? 'Please select a valid country from the list'
 												: undefined,
 								}}
@@ -370,7 +385,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 											onChange={(value) => field.handleChange(value)}
 											onBlur={field.handleBlur}
 											placeholder="e.g. United Kingdom"
-											required={!noAddressRequired}
+											required={needsPhysicalAddress}
 										/>
 										{field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
 											<p className="text-xs text-red-500 mt-1">{field.state.meta.errors[0]}</p>
@@ -408,6 +423,23 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 							<p className="text-sm text-yellow-700">Please select shipping options for all items in your cart.</p>
 						</div>
 					)}
+					{hasAllShippingMethods && isDeliveryRequirementsLoading && (
+						<div className="bg-yellow-50 border-l-4 border-yellow-400 p-4">
+							<p className="text-sm text-yellow-700">Checking delivery requirements before checkout can continue...</p>
+						</div>
+					)}
+					{hasAllShippingMethods && deliveryRequirementsError && (
+						<div className="bg-red-50 border-l-4 border-red-400 p-4">
+							<p className="text-sm text-red-700">{deliveryRequirementsError}</p>
+						</div>
+					)}
+					{hasAllShippingMethods && !isDeliveryRequirementsLoading && !deliveryRequirementsError && !deliveryRequirements.isResolved && (
+						<div className="bg-red-50 border-l-4 border-red-400 p-4">
+							<p className="text-sm text-red-700">
+								Delivery requirements could not be verified for the selected shipping options. Please reselect shipping before continuing.
+							</p>
+						</div>
+					)}
 				</form>
 			</div>
 			<div className="flex-shrink-0 bg-white border-t pt-4">
@@ -418,7 +450,7 @@ export function ShippingAddressForm({ form, hasAllShippingMethods }: ShippingAdd
 							form="shipping-form"
 							type="submit"
 							className="w-full btn-black"
-							disabled={!canSubmit || !hasAllShippingMethods || isSubmitting}
+							disabled={!canSubmit || !hasAllShippingMethods || deliveryRequirementsBlocked || isSubmitting}
 						>
 							{isSubmitting ? 'Processing...' : 'Continue to Payment'}
 						</Button>

--- a/src/components/orders/OrderDetailComponent.tsx
+++ b/src/components/orders/OrderDetailComponent.tsx
@@ -74,12 +74,14 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 	const sellerPubkey = getSellerPubkey(orderEvent)
 	const isBuyer = buyerPubkey === user?.pubkey
 	const isOrderSeller = sellerPubkey === user?.pubkey
+	const canViewBuyerContact = isBuyer || isOrderSeller
 
 	const totalAmount = getTotalAmount(orderEvent)
 
 	// Extract shipping information
 	const shippingRef = getShippingRef(orderEvent)
 	const shippingAddress = orderEvent.tags.find((tag) => tag[0] === 'address')?.[1]
+	const deliveryContact = orderEvent.tags.find((tag) => tag[0] === 'email')?.[1]
 
 	// Get status styles for coloring the header
 	const { headerBgColor } = getStatusStyles(order)
@@ -291,6 +293,20 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 					</CardContent>
 				</Card>
 
+				{canViewBuyerContact && deliveryContact && (
+					<Card>
+						<CardHeader>
+							<CardTitle>Buyer Contact</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p className="text-sm text-gray-700">
+								<strong>Delivery contact:</strong> {deliveryContact}
+							</p>
+							<p className="text-xs text-gray-500 mt-2">The seller can use this contact for order coordination after payment settles.</p>
+						</CardContent>
+					</Card>
+				)}
+
 				{/* Products */}
 				{products.length > 0 && (
 					<Card>
@@ -347,7 +363,7 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 											<div>
 												<p className="font-medium text-purple-900">Digital Delivery</p>
 												<p className="text-sm text-purple-800 mt-1">
-													This item will be delivered digitally. Check your messages for delivery details.
+													The seller will use the buyer-provided delivery contact after payment settles.
 												</p>
 											</div>
 										</div>

--- a/src/lib/checkout/deliveryRequirements.test.ts
+++ b/src/lib/checkout/deliveryRequirements.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'bun:test'
+import { isValidDigitalDeliveryContact, resolveCheckoutDeliveryRequirements } from '@/lib/checkout/deliveryRequirements'
+
+const product = (id: string, shippingMethodId?: string | null) => ({ id, shippingMethodId })
+
+describe('resolveCheckoutDeliveryRequirements', () => {
+	test('digital-only cart requires delivery contact and not physical address', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('digital-product', '30406:seller:digital')],
+			servicesByShippingRef: {
+				'30406:seller:digital': 'digital',
+			},
+		})
+
+		expect(requirements).toMatchObject({
+			hasDigitalDelivery: true,
+			hasPhysicalDelivery: false,
+			hasPickupDelivery: false,
+			needsDigitalDeliveryContact: true,
+			needsPhysicalAddress: false,
+			isResolved: true,
+		})
+	})
+
+	test('physical-only cart requires physical address and not contact', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('physical-product', '30406:seller:standard')],
+			servicesByShippingRef: {
+				'30406:seller:standard': 'standard',
+			},
+		})
+
+		expect(requirements).toMatchObject({
+			hasDigitalDelivery: false,
+			hasPhysicalDelivery: true,
+			hasPickupDelivery: false,
+			needsDigitalDeliveryContact: false,
+			needsPhysicalAddress: true,
+			isResolved: true,
+		})
+	})
+
+	test('pickup-only cart requires neither physical address nor contact', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('pickup-product', '30406:seller:pickup')],
+			servicesByShippingRef: {
+				'30406:seller:pickup': 'pickup',
+			},
+		})
+
+		expect(requirements).toMatchObject({
+			hasDigitalDelivery: false,
+			hasPhysicalDelivery: false,
+			hasPickupDelivery: true,
+			needsDigitalDeliveryContact: false,
+			needsPhysicalAddress: false,
+			isResolved: true,
+		})
+	})
+
+	test('mixed digital and pickup requires contact and not physical address', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('digital-product', '30406:seller:digital'), product('pickup-product', '30406:seller:pickup')],
+			servicesByShippingRef: {
+				'30406:seller:digital': 'digital',
+				'30406:seller:pickup': 'pickup',
+			},
+		})
+
+		expect(requirements).toMatchObject({
+			hasDigitalDelivery: true,
+			hasPhysicalDelivery: false,
+			hasPickupDelivery: true,
+			needsDigitalDeliveryContact: true,
+			needsPhysicalAddress: false,
+			isResolved: true,
+		})
+	})
+
+	test('mixed digital and physical requires contact and physical address', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('digital-product', '30406:seller:digital'), product('physical-product', '30406:seller:express')],
+			servicesByShippingRef: {
+				'30406:seller:digital': 'digital',
+				'30406:seller:express': 'express',
+			},
+		})
+
+		expect(requirements).toMatchObject({
+			hasDigitalDelivery: true,
+			hasPhysicalDelivery: true,
+			hasPickupDelivery: false,
+			needsDigitalDeliveryContact: true,
+			needsPhysicalAddress: true,
+			isResolved: true,
+		})
+	})
+
+	test('missing shipping method is unresolved', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('missing-method', null)],
+			servicesByShippingRef: {},
+		})
+
+		expect(requirements.isResolved).toBe(false)
+		expect(requirements.unresolvedShippingRefs).toEqual(['product:missing-method:missing-shipping-method'])
+	})
+
+	test('missing service for selected shipping ref is unresolved', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('unknown-service', '30406:seller:unknown')],
+			servicesByShippingRef: {
+				'30406:seller:unknown': null,
+			},
+		})
+
+		expect(requirements.isResolved).toBe(false)
+		expect(requirements.unresolvedShippingRefs).toEqual(['30406:seller:unknown'])
+	})
+
+	test('unknown service is unresolved instead of guessed', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('drone-service', '30406:seller:drone')],
+			servicesByShippingRef: {
+				'30406:seller:drone': 'drone',
+			},
+		})
+
+		expect(requirements.isResolved).toBe(false)
+		expect(requirements.unresolvedShippingRefs).toEqual(['30406:seller:drone'])
+		expect(requirements.needsPhysicalAddress).toBe(false)
+		expect(requirements.needsDigitalDeliveryContact).toBe(false)
+	})
+
+	test('unresolved delivery requirement fails closed', () => {
+		const requirements = resolveCheckoutDeliveryRequirements({
+			products: [product('digital-product', '30406:seller:digital'), product('missing-service', '30406:seller:missing')],
+			servicesByShippingRef: {
+				'30406:seller:digital': 'digital',
+			},
+		})
+
+		expect(requirements.hasDigitalDelivery).toBe(true)
+		expect(requirements.needsDigitalDeliveryContact).toBe(true)
+		expect(requirements.isResolved).toBe(false)
+		expect(requirements.unresolvedShippingRefs).toEqual(['30406:seller:missing'])
+	})
+})
+
+describe('isValidDigitalDeliveryContact', () => {
+	test('accepts valid email contact for v1', () => {
+		expect(isValidDigitalDeliveryContact('buyer@example.com')).toBe(true)
+	})
+
+	test('rejects empty or invalid contact', () => {
+		expect(isValidDigitalDeliveryContact('')).toBe(false)
+		expect(isValidDigitalDeliveryContact('not-an-email')).toBe(false)
+	})
+})

--- a/src/lib/checkout/deliveryRequirements.ts
+++ b/src/lib/checkout/deliveryRequirements.ts
@@ -1,0 +1,77 @@
+export type CheckoutDeliveryMode = 'physical' | 'pickup' | 'digital'
+
+export type CheckoutDeliveryRequirementInput = {
+	products: Array<{
+		id: string
+		shippingMethodId?: string | null
+	}>
+	servicesByShippingRef: Record<string, string | null | undefined>
+}
+
+export type CheckoutDeliveryRequirements = {
+	hasDigitalDelivery: boolean
+	hasPhysicalDelivery: boolean
+	hasPickupDelivery: boolean
+	needsDigitalDeliveryContact: boolean
+	needsPhysicalAddress: boolean
+	isResolved: boolean
+	unresolvedShippingRefs: string[]
+}
+
+const PHYSICAL_SERVICES = new Set(['standard', 'express', 'overnight'])
+
+export function getCheckoutDeliveryMode(service: string | null | undefined): CheckoutDeliveryMode | null {
+	if (service === 'digital') return 'digital'
+	if (service === 'pickup') return 'pickup'
+	if (service && PHYSICAL_SERVICES.has(service)) return 'physical'
+	return null
+}
+
+export function resolveCheckoutDeliveryRequirements(input: CheckoutDeliveryRequirementInput): CheckoutDeliveryRequirements {
+	let hasDigitalDelivery = false
+	let hasPhysicalDelivery = false
+	let hasPickupDelivery = false
+	const unresolvedShippingRefs = new Set<string>()
+
+	for (const product of input.products) {
+		const shippingRef = product.shippingMethodId?.trim()
+
+		if (!shippingRef) {
+			unresolvedShippingRefs.add(`product:${product.id}:missing-shipping-method`)
+			continue
+		}
+
+		const mode = getCheckoutDeliveryMode(input.servicesByShippingRef[shippingRef])
+
+		if (!mode) {
+			unresolvedShippingRefs.add(shippingRef)
+			continue
+		}
+
+		if (mode === 'digital') {
+			hasDigitalDelivery = true
+		} else if (mode === 'pickup') {
+			hasPickupDelivery = true
+		} else {
+			hasPhysicalDelivery = true
+		}
+	}
+
+	return {
+		hasDigitalDelivery,
+		hasPhysicalDelivery,
+		hasPickupDelivery,
+		needsDigitalDeliveryContact: hasDigitalDelivery,
+		needsPhysicalAddress: hasPhysicalDelivery,
+		isResolved: unresolvedShippingRefs.size === 0,
+		unresolvedShippingRefs: Array.from(unresolvedShippingRefs),
+	}
+}
+
+export function isValidDigitalDeliveryContact(value: string | null | undefined): boolean {
+	const trimmed = value?.trim()
+	if (!trimmed) return false
+
+	const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+	return emailRegex.test(trimmed)
+}

--- a/src/publish/orders.test.ts
+++ b/src/publish/orders.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+let shippingServices: Record<string, string | null | undefined> = {}
+const publishedEvents: Array<{ kind?: number; tags: string[][]; content: string }> = []
+
+mock.module('@/queries/shipping', () => ({
+	getShippingEvent: mock(async (shippingRef: string) => {
+		if (!(shippingRef in shippingServices)) return null
+		const service = shippingServices[shippingRef]
+		return service ? { tags: [['service', service]] } : { tags: [] }
+	}),
+	getShippingService: (event: { tags: string[][] }) => event.tags.find((tag) => tag[0] === 'service'),
+}))
+
+mock.module('@/queries/profiles', () => ({
+	fetchProfileByIdentifier: mock(async () => ({
+		profile: {
+			lud16: 'seller@example.com',
+		},
+	})),
+}))
+
+mock.module('@/lib/stores/ndk', () => ({
+	ndkActions: {
+		getNDK: () => ({
+			activeUser: {
+				pubkey: 'buyer-pubkey',
+			},
+		}),
+		getSigner: () => ({}),
+		publishEvent: mock(async (event: { kind?: number; tags: string[][]; content: string }) => {
+			publishedEvents.push(event)
+		}),
+	},
+}))
+
+mock.module('@nostr-dev-kit/ndk', () => ({
+	NDKEvent: class {
+		kind?: number
+		created_at?: number
+		content = ''
+		tags: string[][] = []
+		id = ''
+
+		constructor(_ndk?: unknown) {}
+
+		async sign() {
+			this.id = this.tags.find((tag) => tag[0] === 'order')?.[1] || `event-${publishedEvents.length + 1}`
+		}
+	},
+}))
+
+import { publishOrderWithDependencies } from '@/publish/orders'
+import type { CheckoutFormData } from '@/components/checkout/ShippingAddressForm'
+
+const baseShippingData: CheckoutFormData = {
+	name: 'Satoshi Nakamoto',
+	email: '',
+	phone: '',
+	firstLineOfAddress: '123 Main Street',
+	zipPostcode: '90210',
+	city: 'Los Angeles',
+	country: 'United States',
+	additionalInformation: '',
+}
+
+function paramsFor(overrides: {
+	shippingData?: Partial<CheckoutFormData>
+	productsBySeller: Record<string, Array<{ id: string; amount: number; shippingMethodId?: string | null }>>
+	sellerData?: Record<string, { satsTotal: number; shippingSats: number; shares: { sellerAmount: number } }>
+	sellers?: string[]
+}) {
+	const sellers = overrides.sellers || Object.keys(overrides.productsBySeller)
+	const sellerData =
+		overrides.sellerData ||
+		Object.fromEntries(sellers.map((sellerPubkey) => [sellerPubkey, { satsTotal: 1000, shippingSats: 0, shares: { sellerAmount: 1000 } }]))
+
+	return {
+		shippingData: {
+			...baseShippingData,
+			...overrides.shippingData,
+		},
+		sellers,
+		productsBySeller: overrides.productsBySeller,
+		sellerData,
+		v4vShares: {},
+	}
+}
+
+function orderEvents() {
+	return publishedEvents.filter((event) => event.kind === 16 && event.tags.some((tag) => tag[0] === 'type' && tag[1] === '1'))
+}
+
+describe('publishOrderWithDependencies delivery contact guard', () => {
+	beforeEach(() => {
+		shippingServices = {}
+		publishedEvents.length = 0
+	})
+
+	test('rejects digital order without contact before publishing', async () => {
+		shippingServices = {
+			'30406:seller:digital': 'digital',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					shippingData: { email: '' },
+					productsBySeller: {
+						seller: [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' }],
+					},
+				}),
+			),
+		).rejects.toThrow('Digital delivery contact is required')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('rejects unresolved delivery requirements before publishing', async () => {
+		shippingServices = {
+			'30406:seller:missing-service': null,
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					shippingData: { email: 'buyer@example.com' },
+					productsBySeller: {
+						seller: [{ id: 'unknown-product', amount: 1, shippingMethodId: '30406:seller:missing-service' }],
+					},
+				}),
+			),
+		).rejects.toThrow('Delivery requirements could not be verified')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('preflights every seller group before publishing any order', async () => {
+		shippingServices = {
+			'30406:seller-a:standard': 'standard',
+			'30406:seller-b:digital': 'digital',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					shippingData: { email: '' },
+					sellers: ['seller-a', 'seller-b'],
+					productsBySeller: {
+						'seller-a': [{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller-a:standard' }],
+						'seller-b': [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller-b:digital' }],
+					},
+				}),
+			),
+		).rejects.toThrow('Digital delivery contact is required')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('does not emit fake fallback contact when no email is provided', async () => {
+		shippingServices = {
+			'30406:seller:pickup': 'pickup',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				shippingData: { email: '' },
+				productsBySeller: {
+					seller: [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller:pickup' }],
+				},
+			}),
+		)
+
+		const order = orderEvents()[0]
+		expect(order.tags.some((tag) => tag[0] === 'email')).toBe(false)
+		expect(order.tags.some((tag) => tag.includes('customer@example.com'))).toBe(false)
+		expect(order.tags.some((tag) => tag[0] === 'address')).toBe(false)
+	})
+
+	test('emits buyer-provided digital delivery contact and preserves physical address behavior', async () => {
+		shippingServices = {
+			'30406:seller:digital': 'digital',
+			'30406:seller:standard': 'standard',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				shippingData: { email: 'buyer@example.com' },
+				productsBySeller: {
+					seller: [
+						{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' },
+						{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller:standard' },
+					],
+				},
+			}),
+		)
+
+		const order = orderEvents()[0]
+		expect(order.tags).toContainEqual(['email', 'buyer@example.com'])
+		expect(order.tags.some((tag) => tag[0] === 'address' && tag[1].includes('123 Main Street'))).toBe(true)
+	})
+})

--- a/src/publish/orders.tsx
+++ b/src/publish/orders.tsx
@@ -7,39 +7,47 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { v4 as uuidv4 } from 'uuid'
 import type { CheckoutFormData } from '@/components/checkout/ShippingAddressForm'
+import {
+	isValidDigitalDeliveryContact,
+	resolveCheckoutDeliveryRequirements,
+	type CheckoutDeliveryRequirements,
+} from '@/lib/checkout/deliveryRequirements'
 import { fetchProfileByIdentifier } from '@/queries/profiles'
 import { getShippingEvent, getShippingService } from '@/queries/shipping'
 // import type { CartProduct, SellerData, V4VShare } from '@/lib/stores/cart'
 
-/**
- * Helper function to check if all products require no shipping address
- * (either pickup or digital delivery)
- */
-async function checkIfNoAddressRequired(products: CartProduct[]): Promise<boolean> {
-	try {
-		const checks = await Promise.all(
-			products.map(async (product) => {
-				if (!product.shippingMethodId) return false
+async function resolveDeliveryRequirementsForProducts(
+	products: Array<{ id: string; shippingMethodId?: string | null }>,
+): Promise<CheckoutDeliveryRequirements> {
+	const shippingRefs = Array.from(new Set(products.map((product) => product.shippingMethodId?.trim()).filter(Boolean) as string[]))
+	const servicesByShippingRef: Record<string, string | null> = {}
 
-				try {
-					const shippingEvent = await getShippingEvent(product.shippingMethodId)
-					if (!shippingEvent) return false
+	await Promise.all(
+		shippingRefs.map(async (shippingRef) => {
+			try {
+				const shippingEvent = await getShippingEvent(shippingRef)
+				servicesByShippingRef[shippingRef] = shippingEvent ? getShippingService(shippingEvent)?.[1] || null : null
+			} catch (error) {
+				console.error('Error resolving shipping service:', error)
+				servicesByShippingRef[shippingRef] = null
+			}
+		}),
+	)
 
-					const serviceTag = getShippingService(shippingEvent)
-					const serviceType = serviceTag?.[1]
-					return serviceType === 'pickup' || serviceType === 'digital'
-				} catch (error) {
-					console.error('Error checking shipping service:', error)
-					return false
-				}
-			}),
-		)
+	return resolveCheckoutDeliveryRequirements({
+		products,
+		servicesByShippingRef,
+	})
+}
 
-		return checks.every((noAddress) => noAddress)
-	} catch (error) {
-		console.error('Error checking if no address required:', error)
-		return false
-	}
+function hasRequiredPhysicalAddress(shippingData: CheckoutFormData): boolean {
+	return Boolean(
+		shippingData.name.trim() &&
+		shippingData.firstLineOfAddress.trim() &&
+		shippingData.city.trim() &&
+		shippingData.zipPostcode.trim() &&
+		shippingData.country.trim(),
+	)
 }
 
 // Temporary type definitions - ideally these should be imported from a central types file
@@ -705,6 +713,14 @@ export interface PublishOrderDependenciesParams {
 	v4vShares: Record<string, V4VShare[]>
 }
 
+type SellerOrderPreflight = {
+	sellerPubkey: string
+	sellerProducts: CartProduct[]
+	data: SellerData
+	requirements: CheckoutDeliveryRequirements
+	shippingRef?: string
+}
+
 /**
  * Creates and publishes a spec-compliant order for each seller,
  * then creates and publishes all necessary payment requests (merchant + V4V).
@@ -723,7 +739,12 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 		throw new Error('No active user found for order creation')
 	}
 
-	const newOrderIds: string[] = []
+	const buyerEmail = shippingData.email.trim()
+	if (buyerEmail && !isValidDigitalDeliveryContact(buyerEmail)) {
+		throw new Error('Enter a valid email address before creating the order')
+	}
+
+	const preflight: SellerOrderPreflight[] = []
 
 	for (const sellerPubkey of sellers) {
 		const sellerProducts = productsBySeller[sellerPubkey] || []
@@ -731,12 +752,31 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 
 		if (sellerProducts.length === 0 || !data) continue
 
-		// Check if all products require no shipping address (pickup or digital)
-		const noAddressRequired = await checkIfNoAddressRequired(sellerProducts)
+		const requirements = await resolveDeliveryRequirementsForProducts(sellerProducts)
+		if (!requirements.isResolved) {
+			throw new Error('Delivery requirements could not be verified for one or more selected shipping options')
+		}
 
-		// Extract shippingRef from the first product that has a shipping method
-		const shippingRef = sellerProducts.find((p) => p.shippingMethodId)?.shippingMethodId || undefined
+		if (requirements.needsDigitalDeliveryContact && !isValidDigitalDeliveryContact(buyerEmail)) {
+			throw new Error('Digital delivery contact is required before creating the order')
+		}
 
+		if (requirements.needsPhysicalAddress && !hasRequiredPhysicalAddress(shippingData)) {
+			throw new Error('Shipping address is required before creating the order')
+		}
+
+		preflight.push({
+			sellerPubkey,
+			sellerProducts,
+			data,
+			requirements,
+			shippingRef: sellerProducts.find((p) => p.shippingMethodId)?.shippingMethodId || undefined,
+		})
+	}
+
+	const newOrderIds: string[] = []
+
+	for (const { sellerPubkey, sellerProducts, data, requirements, shippingRef } of preflight) {
 		const orderData: OrderCreationData = {
 			merchantPubkey: sellerPubkey,
 			buyerPubkey: buyerPubkey,
@@ -746,8 +786,10 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 			})),
 			totalAmountSats: data.satsTotal,
 			shippingRef: shippingRef || undefined,
-			shippingAddress: noAddressRequired ? undefined : shippingData,
-			email: shippingData.email || 'customer@example.com',
+			shippingAddress: requirements.needsPhysicalAddress ? shippingData : undefined,
+			// Current app order metadata uses the existing email tag for v1 digital delivery contact.
+			// This is not a NIP-99 listing change.
+			email: buyerEmail || undefined,
 			notes: `Order for ${sellerProducts.length} item(s) from seller.`,
 		}
 

--- a/src/routes/checkout.tsx
+++ b/src/routes/checkout.tsx
@@ -8,6 +8,11 @@ import { WalletSelector, type WalletOption } from '@/components/checkout/WalletS
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import {
+	isValidDigitalDeliveryContact,
+	resolveCheckoutDeliveryRequirements,
+	type CheckoutDeliveryRequirements,
+} from '@/lib/checkout/deliveryRequirements'
 import { authStore } from '@/lib/stores/auth'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { ndkStore } from '@/lib/stores/ndk'
@@ -16,6 +21,7 @@ import { persistInvoicesLocally, updatePersistedInvoiceLocally } from '@/lib/uti
 import type { OrderInvoiceSet } from '@/lib/utils/orderUtils'
 import { publishOrderWithDependencies } from '@/publish/orders'
 import { publishPaymentReceipt } from '@/publish/payment'
+import { getShippingEvent, getShippingService } from '@/queries/shipping'
 import type { PaymentInvoiceData } from '@/lib/types/invoice'
 import { useGenerateInvoiceMutation, useAvailablePaymentOptions, type PaymentDetail } from '@/queries/payment'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
@@ -32,6 +38,11 @@ export const Route = createFileRoute('/checkout')({
 
 type CheckoutStep = 'shipping' | 'summary' | 'payment' | 'complete'
 
+const EMPTY_DELIVERY_REQUIREMENTS: CheckoutDeliveryRequirements = resolveCheckoutDeliveryRequirements({
+	products: [],
+	servicesByShippingRef: {},
+})
+
 function RouteComponent() {
 	const navigate = useNavigate()
 	const { cart, totalInSats, totalShippingInSats, productsBySeller, sellerData, v4vShares } = useStore(cartStore)
@@ -46,6 +57,9 @@ function RouteComponent() {
 	const [selectedWallets, setSelectedWallets] = useState<Record<string, string>>({}) // sellerPubkey -> paymentDetailId
 	const [availableWalletsBySeller, setAvailableWalletsBySeller] = useState<Record<string, PaymentDetail[]>>({})
 	const [isCreatingOrder, setIsCreatingOrder] = useState(false) // Loading state for order creation
+	const [deliveryRequirements, setDeliveryRequirements] = useState<CheckoutDeliveryRequirements>(EMPTY_DELIVERY_REQUIREMENTS)
+	const [isDeliveryRequirementsLoading, setIsDeliveryRequirementsLoading] = useState(false)
+	const [deliveryRequirementsError, setDeliveryRequirementsError] = useState<string | null>(null)
 
 	// Ref to control PaymentContent
 	const paymentContentRef = useRef<PaymentContentRef>(null)
@@ -142,13 +156,84 @@ function RouteComponent() {
 	})()
 	const { mutateAsync: generateInvoice, isPending: isGeneratingInvoices } = useGenerateInvoiceMutation()
 
+	const cartProducts = useMemo(() => Object.values(cart.products), [cart.products])
+
 	const isCartEmpty = useMemo(() => {
-		return Object.keys(cart.products).length === 0
-	}, [cart.products])
+		return cartProducts.length === 0
+	}, [cartProducts])
 
 	const hasAllShippingMethods = useMemo(() => {
-		return Object.values(cart.products).every((product) => product.shippingMethodId !== null)
-	}, [cart.products])
+		return cartProducts.every((product) => !!product.shippingMethodId)
+	}, [cartProducts])
+
+	useEffect(() => {
+		let isCancelled = false
+
+		const resolveDeliveryRequirements = async () => {
+			if (cartProducts.length === 0) {
+				setDeliveryRequirements(EMPTY_DELIVERY_REQUIREMENTS)
+				setIsDeliveryRequirementsLoading(false)
+				setDeliveryRequirementsError(null)
+				return
+			}
+
+			if (!hasAllShippingMethods) {
+				setDeliveryRequirements(
+					resolveCheckoutDeliveryRequirements({
+						products: cartProducts,
+						servicesByShippingRef: {},
+					}),
+				)
+				setIsDeliveryRequirementsLoading(false)
+				setDeliveryRequirementsError(null)
+				return
+			}
+
+			const shippingRefs = Array.from(new Set(cartProducts.map((product) => product.shippingMethodId?.trim()).filter(Boolean) as string[]))
+
+			setIsDeliveryRequirementsLoading(true)
+			setDeliveryRequirementsError(null)
+
+			const servicesByShippingRef: Record<string, string | null> = {}
+
+			try {
+				await Promise.all(
+					shippingRefs.map(async (shippingRef) => {
+						const shippingEvent = await getShippingEvent(shippingRef)
+						servicesByShippingRef[shippingRef] = shippingEvent ? getShippingService(shippingEvent)?.[1] || null : null
+					}),
+				)
+
+				if (isCancelled) return
+
+				setDeliveryRequirements(
+					resolveCheckoutDeliveryRequirements({
+						products: cartProducts,
+						servicesByShippingRef,
+					}),
+				)
+				setIsDeliveryRequirementsLoading(false)
+			} catch (error) {
+				console.error('Failed to resolve checkout delivery requirements:', error)
+				if (isCancelled) return
+
+				setDeliveryRequirements(
+					resolveCheckoutDeliveryRequirements({
+						products: cartProducts,
+						servicesByShippingRef,
+					}),
+				)
+				setDeliveryRequirementsError('Delivery requirements could not be verified. Please retry before continuing to payment.')
+				setIsDeliveryRequirementsLoading(false)
+			}
+		}
+
+		resolveDeliveryRequirements()
+
+		return () => {
+			isCancelled = true
+		}
+	}, [cartProducts, hasAllShippingMethods])
 
 	const sellers = useMemo(() => {
 		return Object.keys(productsBySeller)
@@ -421,6 +506,14 @@ function RouteComponent() {
 		} as CheckoutFormData,
 		onSubmit: async ({ value }) => {
 			if (!hasAllShippingMethods) return
+			if (isDeliveryRequirementsLoading || deliveryRequirementsError || !deliveryRequirements.isResolved) {
+				toast.error('Delivery requirements must be verified before checkout can continue.')
+				return
+			}
+			if (deliveryRequirements.needsDigitalDeliveryContact && !isValidDigitalDeliveryContact(value.email)) {
+				toast.error('Enter a valid digital delivery contact before checkout can continue.')
+				return
+			}
 
 			setShippingData(value)
 			setCurrentStep('summary')
@@ -691,7 +784,19 @@ function RouteComponent() {
 		}
 	}
 
+	const canContinueToPayment =
+		!!shippingData &&
+		deliveryRequirements.isResolved &&
+		!isDeliveryRequirementsLoading &&
+		!deliveryRequirementsError &&
+		(!deliveryRequirements.needsDigitalDeliveryContact || isValidDigitalDeliveryContact(shippingData.email))
+
 	const handleContinueToPayment = async () => {
+		if (!canContinueToPayment) {
+			toast.error('Delivery requirements must be completed before payment can be requested.')
+			return
+		}
+
 		if (shippingData && sellers.length > 0 && specOrderIds.length === 0) {
 			setIsCreatingOrder(true)
 			try {
@@ -853,7 +958,13 @@ function RouteComponent() {
 						<div ref={animationParent} className="lg:h-full lg:min-h-full">
 							{currentStep === 'shipping' && (
 								<div className="h-full">
-									<ShippingAddressForm form={form} hasAllShippingMethods={hasAllShippingMethods} />
+									<ShippingAddressForm
+										form={form}
+										hasAllShippingMethods={hasAllShippingMethods}
+										deliveryRequirements={deliveryRequirements}
+										isDeliveryRequirementsLoading={isDeliveryRequirementsLoading}
+										deliveryRequirementsError={deliveryRequirementsError}
+									/>
 								</div>
 							)}
 
@@ -865,11 +976,16 @@ function RouteComponent() {
 											invoices={[]} // No invoices yet in summary step
 											totalInSats={totalInSats}
 											onNewOrder={goBackToShopping}
+											deliveryRequirements={deliveryRequirements}
 											// Note: onContinueToPayment moved to footer
 										/>
 									</div>
 									<div className="flex-shrink-0 bg-white border-t pt-4">
-										<Button onClick={handleContinueToPayment} className="w-full btn-black" disabled={isCreatingOrder}>
+										<Button
+											onClick={handleContinueToPayment}
+											className="w-full btn-black"
+											disabled={isCreatingOrder || !canContinueToPayment}
+										>
 											{isCreatingOrder ? (
 												<>
 													<Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -964,6 +1080,7 @@ function RouteComponent() {
 									totalInSats={totalInSats}
 									onNewOrder={goBackToShopping}
 									onViewOrders={goToOrders}
+									deliveryRequirements={deliveryRequirements}
 								/>
 							)}
 						</div>


### PR DESCRIPTION
## Summary

Closes #879.

This PR prevents digital-product checkout from advancing to payment unless the buyer provides a seller-visible digital delivery contact.

It also removes the unsafe fake fallback contact (`customer@example.com`) and adds defensive publish-time validation so unsafe digital orders cannot be created if UI validation is bypassed.

## What changed

- Added a checkout delivery-requirements helper for digital / pickup / physical delivery modes.
- Requires a valid digital delivery contact for digital carts before checkout can continue to payment.
- Fails closed when selected shipping/service data cannot be resolved.
- Adds buyer-facing privacy copy because order/contact metadata is currently public.
- Removes the fake `customer@example.com` fallback.
- Adds publish preflight validation for all seller groups before any order/payment event is published.
- Prevents partial multi-seller publishes if any seller group fails delivery validation.
- Updates order summary/detail copy to use settlement-aware digital delivery wording.
- Updates the stale e2e marketplace helper to provide a digital delivery contact.

## What this does not change

- No NIP-99 listing semantics changed.
- No new product listing tags.
- No NIP-15 migration.
- No NIP-17/NIP-44/NIP-59 encrypted delivery implementation.
- No file hosting or encrypted download flow.
- No payment-state redesign.
- No Add Product workflow refactor / #835 stacking.

## Validation

Passed:

- `bun run format:check`
- `bun prettier --check e2e-new/tests/marketplace.spec.ts`
- `bun test src/lib/checkout/deliveryRequirements.test.ts`
- `bun test src/publish/orders.test.ts`
- Combined focused test run: 16 pass / 0 fail
- `git diff --check upstream/master...HEAD`
- `rg "<divp|</divp" src`

Manual validation:

- Digital product checkout shows “Digital Delivery Contact (Email)”.
- Contact field is required before continuing.
- Buyer-facing privacy warning is shown before payment.
- Checkout advances to review after a valid contact is entered.
- Review/order completion shows the delivery contact.
- Seller messages/order detail show the buyer-provided contact.
- Seller can confirm the order/payment state.

Final audit result:

- `APPROVE WITH SMALL FOLLOW-UPS`

## Known non-blocking notes

- `bun run test:unit` does not currently discover the new focused tests because the repo script only scans specific folders. The focused tests were run directly.
- `bun run build` currently fails during `tsr generate` inside `@tanstack/router-generator` / `zod`, before app code is built. This PR does not modify package files, lockfiles, router config, or dependency versions, so this appears unrelated to #879 and should be tracked separately.

## Review focus

- Digital delivery contact requirement and privacy copy.
- Fail-closed unresolved delivery requirements.
- Publish preflight before any order/payment side effects.
- No partial publish in multi-seller checkout.
- Physical and pickup checkout behavior preserved.