### PR TITLE
fix(cart): prevent cart sheet layout from being clipped

### DIFF
--- a/src/components/sheet-contents/cart/CartContent.tsx
+++ b/src/components/sheet-contents/cart/CartContent.tsx
@@ -97,7 +97,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 	}
 
 	return (
-		<div className={`flex flex-col h-full overflow-hidden px-4 sm:px-6 ${className}`}>
+		<div className={`flex min-h-0 flex-1 flex-col overflow-hidden px-4 sm:px-6 ${className}`}>
 			{missingShippingCount > 0 && (
 				<div className="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-4">
 					<div className="flex">
@@ -110,7 +110,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 				</div>
 			)}
 
-			<ScrollArea className="flex-1 overflow-y-auto py-2 min-h-0">
+			<ScrollArea className="min-h-0 flex-1 overflow-y-auto py-2">
 				<div className="space-y-6" ref={parent}>
 					{Object.entries(productsBySeller)
 						.filter(([sellerPubkey]) => sellerPubkey && sellerPubkey.length > 0 && sellerPubkey !== 'unknown')
@@ -202,7 +202,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 				</div>
 			</ScrollArea>
 
-			<div className="pt-4 pb-6 sm:pb-4 mt-auto flex-shrink-0">
+			<div className="mt-auto shrink-0 pt-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:pb-4">
 				<div className="space-y-3 w-full">
 					<div className="space-y-1 mb-2">
 						<div className="flex justify-between">

--- a/src/components/sheet-contents/cart/index.tsx
+++ b/src/components/sheet-contents/cart/index.tsx
@@ -4,6 +4,9 @@ import { useStore } from '@tanstack/react-store'
 import { CartContent } from './CartContent'
 import { EmptyCartScreen } from './EmptyCartScreen'
 
+const cartSheetContentClassName =
+	'flex h-dvh max-h-dvh w-[100vw] flex-col gap-0 overflow-hidden p-0 sm:w-[85vw] sm:max-w-none md:w-[55vw] xl:w-[35vw]'
+
 export default function CartSheetContent({
 	title = 'YOUR CART',
 	description = 'Review and manage your cart items',
@@ -16,15 +19,15 @@ export default function CartSheetContent({
 
 	if (isCartEmpty) {
 		return (
-			<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
+			<SheetContent side="right" className={cartSheetContentClassName}>
 				<EmptyCartScreen />
 			</SheetContent>
 		)
 	}
 
 	return (
-		<SheetContent side="right" className="flex flex-col max-h-screen w-[100vw] sm:w-[85vw] md:w-[55vw] xl:w-[35vw]">
-			<SheetHeader>
+		<SheetContent side="right" className={cartSheetContentClassName}>
+			<SheetHeader className="shrink-0 pr-12">
 				<SheetTitle>{title}</SheetTitle>
 				<SheetDescription className="hidden">{description}</SheetDescription>
 			</SheetHeader>


### PR DESCRIPTION
## Summary

Fixes #883 by tightening the cart drawer layout so the cart UI is not clipped on current master.

This is a layout-only fix. It does not change cart state, checkout behavior, shipping selection, Nostr event behavior, payment flow, or product identity semantics.

## What changed

- Added a cart-specific sheet class for the cart drawer.
- Overrode the shared `sm:max-w-sm` sheet constraint with `sm:max-w-none`.
- Made the cart sheet own viewport height with `h-dvh` / `max-h-dvh`.
- Removed inherited sheet spacing from the cart drawer with `gap-0` and `p-0`.
- Changed `CartContent` from nested `h-full` layout to `min-h-0 flex-1`.
- Kept cart items inside the scrollable area while preserving the footer/actions at the bottom.
- Added safe-area-aware bottom padding for the cart footer.

## Why

The shared sheet primitive applies a default right-side max width. The cart drawer sets wider responsive widths, but without overriding the shared max-width, the cart can still be constrained and appear cut off.

The cart body also rendered as a full-height child under a separate sheet header, which can cause clipping in constrained viewports. This patch makes the sheet/header/body/footer height ownership explicit.

## Acceptance criteria

- Cart drawer is not visually cut off.
- Cart item list scrolls when content is long.
- Subtotal, shipping, total, Clear, and Checkout controls remain visible.
- Empty cart state still renders correctly.
- Checkout navigation behavior is unchanged.
- No cart store, checkout, payment, shipping, or Nostr protocol behavior is changed.

## Test plan

- [x] `bun prettier --write src/components/sheet-contents/cart/index.tsx src/components/sheet-contents/cart/CartContent.tsx`
- [x] `bun run format:check`
- [x] `git diff --check`
- [x] Manual responsive verification at common breakpoints:
  - 1200px
  - 992px
  - 768px
  - 480px
- [x] Verified cart footer/actions remain visible while cart items scroll.
- [x] Verified cart drawer is not visually cut off.

## Screenshots

<img width="1898" height="1032" alt="Screenshot 2026-05-06 153748" src="https://github.com/user-attachments/assets/00443c60-426d-4c37-9cae-9a3df45b05a8" />
<img width="1898" height="1032" alt="Screenshot 2026-05-06 153808" src="https://github.com/user-attachments/assets/e602ba63-b8de-4c33-81f0-9e286048b6df" />
<img width="1898" height="1032" alt="Screenshot 2026-05-06 153831" src="https://github.com/user-attachments/assets/dc1ad6e9-19ba-4b16-b983-310b83c18810" />
<img width="1898" height="1032" alt="Screenshot 2026-05-06 153907" src="https://github.com/user-attachments/assets/7188f4de-a3cf-4573-b5f7-a79a9bcf7713" />
