### PR TITLE
Fix: constant "websocket error"

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -93,7 +93,7 @@ export const CURRENCIES = [
 	'NGN', // Nigerian Naira
 ] as const
 
-const CURRENCY_CVM_RELAYS = ['wss://relay.contextvm.org', 'wss://relay2.contextvm.org']
+const CURRENCY_CVM_RELAYS = ['wss://relay.contextvm.org']
 
 export function getCurrencyServerRelays(): string[] {
 	const env = process.env.NODE_ENV || 'development'

--- a/src/queries/external.tsx
+++ b/src/queries/external.tsx
@@ -3,6 +3,7 @@ import { currencyKeys } from './queryKeyFactory'
 import { CURRENCIES } from '@/lib/constants'
 import { CVM_SERVER_PUBKEY, getCurrencyServerRelays } from '@/lib/constants'
 import { configStore } from '@/lib/stores/config'
+import { PlebianCurrencyClient } from '@/lib/ctxcn-client'
 
 const numSatsInBtc = 100000000
 export type SupportedCurrency = (typeof CURRENCIES)[number]
@@ -14,17 +15,15 @@ export const CURRENCY_CACHE_CONFIG = {
 	RESOLVE_TIMEOUT: 5000,
 } as const
 
-let currencyClient: InstanceType<typeof import('@/lib/ctxcn-client').PlebianCurrencyClient> | null = null
+let currencyClient: PlebianCurrencyClient | null = null
 let currencyClientInitPromise: Promise<any> | null = null
 
-async function getCurrencyClient() {
+async function getCurrencyClient(): Promise<PlebianCurrencyClient> {
 	if (currencyClient) return currencyClient
 	if (currencyClientInitPromise) return currencyClientInitPromise
 
 	currencyClientInitPromise = (async () => {
 		try {
-			const { PlebianCurrencyClient } = await import('@/lib/ctxcn-client')
-
 			const privateKey = crypto.getRandomValues(new Uint8Array(32))
 
 			const mainRelay = typeof window !== 'undefined' ? await getMainRelayFromConfig() : undefined
@@ -68,10 +67,14 @@ async function fetchFromContextVm(): Promise<Record<string, number> | null> {
 		const startedAt = Date.now()
 		console.info(`ContextVM BTC fetch starting (timeout ${CONTEXTVM_CALL_TIMEOUT}ms)`)
 		const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), CONTEXTVM_CALL_TIMEOUT))
-		const callPromise = client.callTool({
-			name: 'get_btc_price',
-			arguments: {},
-		})
+		const callPromise = client
+			.callTool({
+				name: 'get_btc_price',
+				arguments: {},
+			})
+			.catch((reason) => {
+				console.warn(reason)
+			})
 
 		const result = await Promise.race([callPromise, timeout])
 		if (result === null) {

--- a/src/queries/external.tsx
+++ b/src/queries/external.tsx
@@ -67,14 +67,10 @@ async function fetchFromContextVm(): Promise<Record<string, number> | null> {
 		const startedAt = Date.now()
 		console.info(`ContextVM BTC fetch starting (timeout ${CONTEXTVM_CALL_TIMEOUT}ms)`)
 		const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), CONTEXTVM_CALL_TIMEOUT))
-		const callPromise = client
-			.callTool({
-				name: 'get_btc_price',
-				arguments: {},
-			})
-			.catch((reason) => {
-				console.warn(reason)
-			})
+		const callPromise = client.callTool({
+			name: 'get_btc_price',
+			arguments: {},
+		})
 
 		const result = await Promise.race([callPromise, timeout])
 		if (result === null) {


### PR DESCRIPTION
The issue seemed to be caused by the ContextVM module trying to connect to `relay2.contextvm.org` which was non-existent. This was causing issues such as a persistent error pop-up (that wasn't being caught by error handlers) and all e2e tests failing when running in local development.

Removing the non-existent relay fixed the issue.

As a further improvement, we could investigate why the error was being surfaced to the app level, and not caught by the error handlers. I wasn't able to find the reason here.

I also provided a bit of clean-up using an import of the contextVM module from the `queries/external` file. Given that the file is bundled with the app, and is always used, I didn't see the reason to use a dynamic import, but correct me if I misunderstood the previous reasoning here. The change enabled cleaner type-checking throughout the file and the app.