### PR TITLE
fix(cart): scope cart shipping options to product refs

### DIFF
--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -29,7 +29,6 @@ interface CartItemProps {
 
 export default function CartItem({ productId, sellerPubkey, amount, onQuantityChange, onRemove, hideShipping = false }: CartItemProps) {
 	const [quantity, setQuantity] = useState(amount)
-	const [showShipping, setShowShipping] = useState(false)
 
 	// Fetch product data - pass sellerPubkey to support d-tag lookups
 	const { data: title, isLoading: isTitleLoading } = useProductTitle(productId, sellerPubkey)
@@ -86,6 +85,11 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 		[productShippingSelections, sellerShippingOptions],
 	)
 
+	const selectedShippingOption = useMemo(() => {
+		if (!currentShippingId) return null
+		return productShippingOptions.find((option) => option.shippingRef === currentShippingId || option.id === currentShippingId) ?? null
+	}, [currentShippingId, productShippingOptions])
+
 	const hasResolvedSellerShippingState = sellerShippingOptionsQuery.isSuccess || sellerShippingOptionsQuery.data !== undefined
 	const isShippingOptionsLoading = productQuery.isLoading || (productShippingSelections.length > 0 && !hasResolvedSellerShippingState)
 	const isShippingOptionsUnavailable = productQuery.isError || (!hasResolvedSellerShippingState && sellerShippingOptionsQuery.isError)
@@ -125,15 +129,42 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 		setQuantity(amount)
 	}, [amount])
 
-	// Get shipping cost from the cart state
-	const getSelectedShipping = () => {
-		const cart = cartStore.state.cart
-		const product = cart.products[productId]
-		return {
-			cost: product?.shippingCost || 0,
-			currency: product?.shippingCostCurrency || currency,
-		}
+	const formatShippingCost = (cost: number | null | undefined): string => {
+		return typeof cost === 'number' && Number.isFinite(cost) ? cost.toLocaleString() : ''
 	}
+
+	const formatShippingAmount = (cost: number | null | undefined, shippingCurrency?: string | null): string => {
+		return [formatShippingCost(cost), shippingCurrency?.trim()].filter(Boolean).join(' ')
+	}
+
+	const cartSelectedShipping = (() => {
+		const product = cartStore.state.cart.products[productId]
+		if (!product || typeof product.shippingCost !== 'number' || !Number.isFinite(product.shippingCost)) return null
+		return {
+			cost: product.shippingCost,
+			currency: product.shippingCostCurrency,
+		}
+	})()
+
+	const selectedShippingCost = selectedShippingOption
+		? {
+				cost: selectedShippingOption.cost,
+				currency: selectedShippingOption.currency,
+			}
+		: cartSelectedShipping
+
+	const selectedShippingCostText = selectedShippingCost
+		? formatShippingAmount(selectedShippingCost.cost, selectedShippingCost.currency)
+		: ''
+	const hasAdditiveShippingMetadata =
+		selectedShippingOption && Number.isFinite(selectedShippingOption.baseCost) && Number.isFinite(selectedShippingOption.extraCostAmount)
+	const selectedShippingBreakdownText =
+		hasAdditiveShippingMetadata && selectedShippingOption.extraCostAmount !== 0
+			? `${formatShippingAmount(selectedShippingOption.baseCost, selectedShippingOption.currency)} base cost + ${formatShippingAmount(
+					selectedShippingOption.extraCostAmount,
+					selectedShippingOption.currency,
+				)} product cost`
+			: ''
 
 	if (isLoading) {
 		return (
@@ -229,45 +260,27 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 			{/* Shipping Section - only show if not hidden */}
 			{!hideShipping && (
 				<div className="sm:ml-24 ml-0 mt-3 flex flex-col gap-2">
-					<button
-						className={`text-sm ${
-							!hasShipping ? 'text-red-600 hover:text-red-800 font-medium' : 'text-blue-600 hover:text-blue-800'
-						} text-left w-fit flex items-center gap-2`}
-						onClick={() => setShowShipping(!showShipping)}
-					>
-						{!hasShipping && <span className="i-warning w-4 h-4" />}
-						{showShipping ? 'Hide shipping options' : hasShipping ? 'Change shipping' : 'Select shipping (required)'}
-					</button>
-
-					{showShipping && (
-						<div className={`flex flex-col gap-2 ${!hasShipping ? 'border-l-2 border-yellow-400 pl-2' : ''}`}>
-							{isShippingOptionsLoading ? (
-								<div className="text-sm text-muted-foreground">Loading shipping options...</div>
-							) : isShippingOptionsUnavailable ? (
-								<div className="text-sm text-red-500">Shipping options unavailable</div>
-							) : (
-								<ShippingSelector
-									productId={productId}
-									options={productShippingOptions}
-									selectedId={currentShippingId ?? undefined}
-									className="w-full max-w-xs"
-									onSelect={() => {}} // No-op since ShippingSelector updates cart when productId is provided
-								/>
-							)}
-
-							{getSelectedShipping().cost > 0 && (
-								<div className="text-sm text-muted-foreground">
-									Shipping cost: {getSelectedShipping().cost} {getSelectedShipping().currency}
-								</div>
-							)}
-						</div>
+					{isShippingOptionsLoading ? (
+						<div className="text-sm text-muted-foreground">Loading shipping options...</div>
+					) : isShippingOptionsUnavailable ? (
+						<div className="text-sm text-red-500">Shipping options unavailable</div>
+					) : (
+						<ShippingSelector
+							productId={productId}
+							options={productShippingOptions}
+							selectedId={currentShippingId ?? undefined}
+							className="w-full max-w-xs"
+							onSelect={() => {}} // No-op since ShippingSelector updates cart when productId is provided
+						/>
 					)}
 
-					{!showShipping && currentShippingId && getSelectedShipping().cost > 0 && (
-						<div className="text-sm text-muted-foreground">
-							Shipping: {getSelectedShipping().cost} {getSelectedShipping().currency}
-						</div>
+					{!hasShipping && <div className="text-sm font-medium text-red-600">Select a shipping option before continuing.</div>}
+
+					{hasShipping && selectedShippingCostText && (
+						<div className="text-sm text-muted-foreground">Shipping cost: {selectedShippingCostText}</div>
 					)}
+
+					{selectedShippingBreakdownText && <div className="text-xs text-muted-foreground">{selectedShippingBreakdownText}</div>}
 				</div>
 			)}
 		</li>

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -1,11 +1,22 @@
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Minus, Plus, Trash2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useProductTitle, useProductPrice, useProductImages, useProductStock } from '@/queries/products'
+import { useEffect, useMemo, useState } from 'react'
+import {
+	getProductShippingOptions,
+	productSmartQueryOptions,
+	useProductTitle,
+	useProductPrice,
+	useProductImages,
+	useProductStock,
+} from '@/queries/products'
 import { Skeleton } from '@/components/ui/skeleton'
 import { ShippingSelector } from '@/components/ShippingSelector'
+import { createShippingReference, getShippingInfo, useShippingOptionsByPubkey } from '@/queries/shipping'
+import type { RichShippingInfo } from '@/lib/stores/cart'
 import { cartActions, cartStore } from '@/lib/stores/cart'
+import { normalizePublishedProductShippingTags, resolvePublishedProductShippingOptions } from '@/lib/utils/productShippingSelections'
+import { useQuery } from '@tanstack/react-query'
 
 interface CartItemProps {
 	productId: string
@@ -25,6 +36,8 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 	const { data: priceTag, isLoading: isPriceLoading } = useProductPrice(productId, sellerPubkey)
 	const { data: images, isLoading: isImagesLoading } = useProductImages(productId, sellerPubkey)
 	const { data: stockTag, isLoading: isStockLoading } = useProductStock(productId, sellerPubkey)
+	const productQuery = useQuery(productSmartQueryOptions(productId, sellerPubkey))
+	const sellerShippingOptionsQuery = useShippingOptionsByPubkey(sellerPubkey)
 
 	const isLoading = isTitleLoading || isPriceLoading || isImagesLoading || isStockLoading
 
@@ -37,6 +50,45 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 	// Get current shipping method
 	const currentShippingId = cartActions.getShippingMethod(productId)
 	const hasShipping = Boolean(currentShippingId)
+
+	const sellerShippingOptions = useMemo<RichShippingInfo[]>(() => {
+		if (!sellerShippingOptionsQuery.data || !sellerPubkey) return []
+
+		return sellerShippingOptionsQuery.data
+			.map((event) => {
+				const info = getShippingInfo(event)
+				if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return null
+
+				return {
+					id: createShippingReference(sellerPubkey, info.id),
+					name: info.title,
+					cost: parseFloat(info.price.amount),
+					currency: info.price.currency,
+					countries: info.countries,
+					service: info.service,
+					carrier: info.carrier,
+				}
+			})
+			.filter((option): option is RichShippingInfo => option !== null)
+	}, [sellerPubkey, sellerShippingOptionsQuery.data])
+
+	const productShippingSelections = useMemo(
+		() => normalizePublishedProductShippingTags(getProductShippingOptions(productQuery.data ?? null)),
+		[productQuery.data],
+	)
+
+	const productShippingOptions = useMemo(
+		() =>
+			resolvePublishedProductShippingOptions({
+				publishedSelections: productShippingSelections,
+				availableOptions: sellerShippingOptions,
+			}),
+		[productShippingSelections, sellerShippingOptions],
+	)
+
+	const hasResolvedSellerShippingState = sellerShippingOptionsQuery.isSuccess || sellerShippingOptionsQuery.data !== undefined
+	const isShippingOptionsLoading = productQuery.isLoading || (productShippingSelections.length > 0 && !hasResolvedSellerShippingState)
+	const isShippingOptionsUnavailable = productQuery.isError || (!hasResolvedSellerShippingState && sellerShippingOptionsQuery.isError)
 
 	// Handle quantity input change
 	const handleQuantityChange = (value: string) => {
@@ -74,10 +126,13 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 	}, [amount])
 
 	// Get shipping cost from the cart state
-	const getShippingCost = () => {
+	const getSelectedShipping = () => {
 		const cart = cartStore.state.cart
 		const product = cart.products[productId]
-		return product?.shippingCost || 0
+		return {
+			cost: product?.shippingCost || 0,
+			currency: product?.shippingCostCurrency || currency,
+		}
 	}
 
 	if (isLoading) {
@@ -186,23 +241,31 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 
 					{showShipping && (
 						<div className={`flex flex-col gap-2 ${!hasShipping ? 'border-l-2 border-yellow-400 pl-2' : ''}`}>
-							<ShippingSelector
-								productId={productId}
-								className="w-full max-w-xs"
-								onSelect={() => {}} // No-op since we handle selection inside ShippingSelector
-							/>
+							{isShippingOptionsLoading ? (
+								<div className="text-sm text-muted-foreground">Loading shipping options...</div>
+							) : isShippingOptionsUnavailable ? (
+								<div className="text-sm text-red-500">Shipping options unavailable</div>
+							) : (
+								<ShippingSelector
+									productId={productId}
+									options={productShippingOptions}
+									selectedId={currentShippingId ?? undefined}
+									className="w-full max-w-xs"
+									onSelect={() => {}} // No-op since ShippingSelector updates cart when productId is provided
+								/>
+							)}
 
-							{getShippingCost() > 0 && (
+							{getSelectedShipping().cost > 0 && (
 								<div className="text-sm text-muted-foreground">
-									Shipping cost: {getShippingCost()} {currency}
+									Shipping cost: {getSelectedShipping().cost} {getSelectedShipping().currency}
 								</div>
 							)}
 						</div>
 					)}
 
-					{!showShipping && currentShippingId && getShippingCost() > 0 && (
+					{!showShipping && currentShippingId && getSelectedShipping().cost > 0 && (
 						<div className="text-sm text-muted-foreground">
-							Shipping: {getShippingCost()} {currency}
+							Shipping: {getSelectedShipping().cost} {getSelectedShipping().currency}
 						</div>
 					)}
 				</div>

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -54,12 +54,12 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 	const sellerShippingOptions = useMemo<RichShippingInfo[]>(() => {
 		if (!sellerShippingOptionsQuery.data || !sellerPubkey) return []
 
-		return sellerShippingOptionsQuery.data
-			.map((event) => {
-				const info = getShippingInfo(event)
-				if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return null
+		return sellerShippingOptionsQuery.data.flatMap((event) => {
+			const info = getShippingInfo(event)
+			if (!info || !info.id || typeof info.id !== 'string' || info.id.trim().length === 0) return []
 
-				return {
+			return [
+				{
 					id: createShippingReference(sellerPubkey, info.id),
 					name: info.title,
 					cost: parseFloat(info.price.amount),
@@ -67,9 +67,9 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 					countries: info.countries,
 					service: info.service,
 					carrier: info.carrier,
-				}
-			})
-			.filter((option): option is RichShippingInfo => option !== null)
+				},
+			]
+		})
 	}, [sellerPubkey, sellerShippingOptionsQuery.data])
 
 	const productShippingSelections = useMemo(

--- a/src/components/CartSummary.tsx
+++ b/src/components/CartSummary.tsx
@@ -1,7 +1,5 @@
 import CartItem from '@/components/CartItem'
-import { ShippingSelector } from '@/components/ShippingSelector'
 import { Separator } from '@/components/ui/separator'
-import type { RichShippingInfo } from '@/lib/stores/cart'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useStore } from '@tanstack/react-store'
@@ -22,19 +20,9 @@ export function CartSummary({
 	allowShippingChanges = true,
 	showExpandedDetails = false,
 }: CartSummaryProps) {
-	const {
-		cart,
-		sellerData,
-		productsBySeller,
-		totalInSats,
-		totalShippingInSats,
-		totalByCurrency,
-		shippingByCurrency,
-		sellerShippingOptions,
-	} = useStore(cartStore)
+	const { cart, sellerData, productsBySeller, totalInSats, totalShippingInSats, totalByCurrency, shippingByCurrency } = useStore(cartStore)
 
 	const [parent, enableAnimations] = useAutoAnimate()
-	const [selectedShippingByUser, setSelectedShippingByUser] = useState<Record<string, string>>({})
 	const [detailsExpanded, setDetailsExpanded] = useState(showExpandedDetails)
 
 	const totalItems = useMemo(() => {
@@ -57,16 +45,7 @@ export function CartSummary({
 		if (Object.keys(cart.products).length > 0) {
 			cartActions.groupProductsBySeller()
 			cartActions.updateSellerData()
-			cartActions.fetchAndSetSellerShippingOptions()
 		}
-
-		const initialSelected: Record<string, string> = {}
-		Object.values(cart.products).forEach((product) => {
-			if (product.sellerPubkey && product.shippingMethodId && !initialSelected[product.sellerPubkey]) {
-				initialSelected[product.sellerPubkey] = product.shippingMethodId
-			}
-		})
-		setSelectedShippingByUser(initialSelected)
 	}, [cart.products])
 
 	useEffect(() => {
@@ -83,21 +62,6 @@ export function CartSummary({
 		if (allowQuantityChanges) {
 			cartActions.handleProductUpdate('remove', productId)
 		}
-	}
-
-	const handleShippingSelect = async (sellerPubkey: string, shippingOption: RichShippingInfo) => {
-		if (!allowShippingChanges) return
-
-		setSelectedShippingByUser((prev) => ({
-			...prev,
-			[sellerPubkey]: shippingOption.id,
-		}))
-
-		const products = productsBySeller[sellerPubkey] || []
-		for (const product of products) {
-			await cartActions.setShippingMethod(product.id, shippingOption)
-		}
-		await cartActions.updateSellerData()
 	}
 
 	return (
@@ -123,8 +87,6 @@ export function CartSummary({
 						shippingSats: 0,
 					}
 
-					const optionsForThisSeller = sellerShippingOptions[sellerPubkey] || []
-
 					return (
 						<div key={sellerPubkey} className="p-4 rounded-lg border shadow-md bg-white">
 							<div className="mb-4">
@@ -140,22 +102,11 @@ export function CartSummary({
 											amount={product.amount}
 											onQuantityChange={allowQuantityChanges ? handleQuantityChange : () => {}}
 											onRemove={allowQuantityChanges ? handleRemoveProduct : () => {}}
-											hideShipping={true}
+											hideShipping={!allowShippingChanges}
 										/>
 									</div>
 								))}
 							</ul>
-
-							{allowShippingChanges && (
-								<div className="mt-4">
-									<ShippingSelector
-										options={optionsForThisSeller}
-										selectedId={selectedShippingByUser[sellerPubkey]}
-										onSelect={(option) => handleShippingSelect(sellerPubkey, option)}
-										className="w-full"
-									/>
-								</div>
-							)}
 
 							{Object.entries(data.currencyTotals).map(([currency, amount]) => (
 								<div key={`${sellerPubkey}-${currency}`} className="flex justify-between mt-4">

--- a/src/components/ShippingSelector.tsx
+++ b/src/components/ShippingSelector.tsx
@@ -36,6 +36,17 @@ const getBestShippingOptions = (options: RichShippingInfo[], selectedId?: string
 	return limitedOptions
 }
 
+const hasAdditiveShippingMetadata = (
+	option: RichShippingInfo,
+): option is RichShippingInfo & { baseCost: number; extraCostAmount: number } => {
+	return Number.isFinite(option.baseCost) && Number.isFinite(option.extraCostAmount)
+}
+
+const formatShippingCost = (cost: number | undefined): string => {
+	if (!Number.isFinite(cost)) return '0'
+	return Number(cost).toLocaleString()
+}
+
 export function ShippingSelector({
 	productId,
 	options: propOptions,
@@ -141,7 +152,16 @@ export function ShippingSelector({
 						<SelectLabel>Shipping Options</SelectLabel>
 						{options.map((option: RichShippingInfo) => (
 							<SelectItem key={option.id} value={option.id} className="break-all">
-								{option.name} - {option.cost} {option.currency}
+								<div className="flex flex-col">
+									<span>
+										{option.name} - {formatShippingCost(option.cost)} {option.currency}
+									</span>
+									{hasAdditiveShippingMetadata(option) && option.extraCostAmount !== 0 && (
+										<span className="text-xs text-muted-foreground">
+											{formatShippingCost(option.baseCost)} base + {formatShippingCost(option.extraCostAmount)} product extra
+										</span>
+									)}
+								</div>
 							</SelectItem>
 						))}
 					</SelectGroup>

--- a/src/components/ShippingSelector.tsx
+++ b/src/components/ShippingSelector.tsx
@@ -36,15 +36,13 @@ const getBestShippingOptions = (options: RichShippingInfo[], selectedId?: string
 	return limitedOptions
 }
 
-const hasAdditiveShippingMetadata = (
-	option: RichShippingInfo,
-): option is RichShippingInfo & { baseCost: number; extraCostAmount: number } => {
-	return Number.isFinite(option.baseCost) && Number.isFinite(option.extraCostAmount)
-}
-
 const formatShippingCost = (cost: number | undefined): string => {
 	if (!Number.isFinite(cost)) return '0'
 	return Number(cost).toLocaleString()
+}
+
+const formatShippingAmount = (cost: number | undefined, currency?: string): string => {
+	return [formatShippingCost(cost), currency?.trim()].filter(Boolean).join(' ')
 }
 
 export function ShippingSelector({
@@ -151,17 +149,8 @@ export function ShippingSelector({
 					<SelectGroup>
 						<SelectLabel>Shipping Options</SelectLabel>
 						{options.map((option: RichShippingInfo) => (
-							<SelectItem key={option.id} value={option.id} className="break-all">
-								<div className="flex flex-col">
-									<span>
-										{option.name} - {formatShippingCost(option.cost)} {option.currency}
-									</span>
-									{hasAdditiveShippingMetadata(option) && option.extraCostAmount !== 0 && (
-										<span className="text-xs text-muted-foreground">
-											{formatShippingCost(option.baseCost)} base + {formatShippingCost(option.extraCostAmount)} product extra
-										</span>
-									)}
-								</div>
+							<SelectItem key={option.id} value={option.id} className="whitespace-normal">
+								{option.name} - {formatShippingAmount(option.cost, option.currency)}
 							</SelectItem>
 						))}
 					</SelectGroup>

--- a/src/components/sheet-contents/cart/CartContent.tsx
+++ b/src/components/sheet-contents/cart/CartContent.tsx
@@ -1,31 +1,19 @@
 import CartItem from '@/components/CartItem'
-import { ShippingSelector } from '@/components/ShippingSelector'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import type { RichShippingInfo } from '@/lib/stores/cart'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { uiActions } from '@/lib/stores/ui'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { EmptyCartScreen } from './EmptyCartScreen'
 import { UserCard } from '@/components/UserCard'
 
 export function CartContent({ className = '' }: { className?: string }) {
-	const {
-		cart,
-		sellerData,
-		productsBySeller,
-		totalInSats,
-		totalShippingInSats,
-		totalByCurrency,
-		shippingByCurrency,
-		sellerShippingOptions,
-	} = useStore(cartStore)
+	const { cart, sellerData, productsBySeller, totalInSats, totalShippingInSats, totalByCurrency, shippingByCurrency } = useStore(cartStore)
 
 	const [parent, enableAnimations] = useAutoAnimate()
-	const [selectedShippingByUser, setSelectedShippingByUser] = useState<Record<string, string>>({})
 	const navigate = useNavigate()
 
 	const totalItems = useMemo(() => {
@@ -56,17 +44,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 		if (Object.keys(cart.products).length > 0) {
 			cartActions.groupProductsBySeller()
 			cartActions.updateSellerData()
-
-			cartActions.fetchAndSetSellerShippingOptions()
 		}
-
-		const initialSelected: Record<string, string> = {}
-		Object.values(cart.products).forEach((product) => {
-			if (product.sellerPubkey && product.shippingMethodId && !initialSelected[product.sellerPubkey]) {
-				initialSelected[product.sellerPubkey] = product.shippingMethodId
-			}
-		})
-		setSelectedShippingByUser(initialSelected)
 	}, [cart.products])
 
 	const handleQuantityChange = (productId: string, newAmount: number) => {
@@ -77,19 +55,6 @@ export function CartContent({ className = '' }: { className?: string }) {
 	const handleRemoveProduct = (productId: string) => {
 		// Updated function signature - no longer needs buyerPubkey
 		cartActions.handleProductUpdate('remove', productId)
-	}
-
-	const handleShippingSelect = async (sellerPubkey: string, shippingOption: RichShippingInfo) => {
-		setSelectedShippingByUser((prev) => ({
-			...prev,
-			[sellerPubkey]: shippingOption.id,
-		}))
-
-		const products = productsBySeller[sellerPubkey] || []
-		for (const product of products) {
-			await cartActions.setShippingMethod(product.id, shippingOption)
-		}
-		await cartActions.updateSellerData()
 	}
 
 	if (isCartEmpty) {
@@ -122,8 +87,6 @@ export function CartContent({ className = '' }: { className?: string }) {
 								shippingSats: 0,
 							}
 
-							const optionsForThisSeller = sellerShippingOptions[sellerPubkey] || []
-
 							return (
 								<div key={sellerPubkey} className="p-4 rounded-lg border shadow-md bg-white">
 									<div className="mb-3">
@@ -139,20 +102,10 @@ export function CartContent({ className = '' }: { className?: string }) {
 													amount={product.amount}
 													onQuantityChange={handleQuantityChange}
 													onRemove={handleRemoveProduct}
-													hideShipping={true}
 												/>
 											</div>
 										))}
 									</ul>
-
-									<div className={`mt-4 ${!selectedShippingByUser[sellerPubkey] ? 'border-l-4 border-yellow-400 pl-2' : ''}`}>
-										<ShippingSelector
-											options={optionsForThisSeller}
-											selectedId={selectedShippingByUser[sellerPubkey]}
-											onSelect={(option) => handleShippingSelect(sellerPubkey, option)}
-											className="w-full"
-										/>
-									</div>
 
 									{Object.entries(data.currencyTotals).map(([currency, amount]) => (
 										<div key={`${sellerPubkey}-${currency}`} className="flex justify-between mt-4">

--- a/src/components/sheet-contents/cart/CartContent.tsx
+++ b/src/components/sheet-contents/cart/CartContent.tsx
@@ -20,10 +20,6 @@ export function CartContent({ className = '' }: { className?: string }) {
 		return Object.values(cart.products).reduce((sum, product) => sum + product.amount, 0)
 	}, [cart.products])
 
-	const hasAllShippingMethods = useMemo(() => {
-		return Object.values(cart.products).every((product) => product.shippingMethodId !== null)
-	}, [cart.products])
-
 	const missingShippingCount = useMemo(() => {
 		return Object.values(cart.products).filter((product) => !product.shippingMethodId).length
 	}, [cart.products])
@@ -68,7 +64,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 					<div className="flex">
 						<div className="ml-3">
 							<p className="text-sm text-yellow-700">
-								Please select shipping options for {missingShippingCount} {missingShippingCount === 1 ? 'item' : 'items'} before checkout.
+								Select shipping at checkout for {missingShippingCount} {missingShippingCount === 1 ? 'item' : 'items'}.
 							</p>
 						</div>
 					</div>
@@ -102,7 +98,20 @@ export function CartContent({ className = '' }: { className?: string }) {
 													amount={product.amount}
 													onQuantityChange={handleQuantityChange}
 													onRemove={handleRemoveProduct}
+													hideShipping={true}
 												/>
+												<div className="mt-2 text-sm text-muted-foreground">
+													{product.shippingMethodId ? (
+														<span>
+															Shipping: {product.shippingMethodName || 'Selected'}
+															{product.shippingCost > 0 && product.shippingCostCurrency
+																? ` - ${product.shippingCost} ${product.shippingCostCurrency}`
+																: ''}
+														</span>
+													) : (
+														<span>Select shipping at checkout</span>
+													)}
+												</div>
 											</div>
 										))}
 									</ul>
@@ -187,8 +196,7 @@ export function CartContent({ className = '' }: { className?: string }) {
 
 							<Button
 								className="flex-1 btn-product-banner"
-								disabled={!hasAllShippingMethods || totalItems === 0}
-								title={!hasAllShippingMethods ? 'Please select shipping options for all items' : ''}
+								disabled={totalItems === 0}
 								onClick={() => {
 									uiActions.closeDrawer('cart')
 									navigate({ to: '/checkout' })

--- a/src/lib/stores/cart.ts
+++ b/src/lib/stores/cart.ts
@@ -15,6 +15,12 @@ import { v4VForUserQuery } from '@/queries/v4v'
 import { publishCartSnapshot } from '@/publish/cart'
 import type { PersistedCartContent } from '@/lib/schemas/cartPersistence'
 import { ndkActions } from '@/lib/stores/ndk'
+import {
+	findReusablePublishedShippingSelection,
+	normalizePublishedProductShippingTags,
+	resolvePublishedProductShippingOptions,
+	type ProductShippingSelection,
+} from '@/lib/utils/productShippingSelections'
 import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { QueryClient } from '@tanstack/react-query'
 import { useStore } from '@tanstack/react-store'
@@ -389,6 +395,36 @@ const getProductEvent = async (id: string, sellerPubkey?: string): Promise<NDKEv
 export const getShippingEvent = async (shippingReferenceId: string): Promise<NDKEvent | null> =>
 	cartSyncDependencies.getShippingEvent(shippingReferenceId)
 
+const resolveCartProductShippingOptions = async (sellerPubkey: string, productShippingSelections: ProductShippingSelection[]) => {
+	const availableOptions: RichShippingInfo[] = []
+
+	for (const selection of productShippingSelections) {
+		const shippingCoords = parseCoordinateRef(selection.shippingRef, String(SHIPPING_KIND))
+		if (!shippingCoords || shippingCoords.pubkey !== sellerPubkey) continue
+
+		const shippingEvent = await getShippingEvent(selection.shippingRef)
+		if (!shippingEvent || shippingEvent.pubkey !== shippingCoords.pubkey) continue
+
+		const info = getShippingInfo(shippingEvent)
+		if (!info || !info.id || typeof info.id !== 'string' || info.id.trim() !== shippingCoords.identifier) continue
+
+		availableOptions.push({
+			id: selection.shippingRef,
+			name: info.title,
+			cost: parseFloat(info.price.amount),
+			currency: info.price.currency,
+			countries: info.countries,
+			service: info.service,
+			carrier: info.carrier,
+		})
+	}
+
+	return resolvePublishedProductShippingOptions({
+		publishedSelections: productShippingSelections,
+		availableOptions,
+	})
+}
+
 export const cartActions = {
 	saveToStorage: async (cart: NormalizedCart, updatedAt: number | null = cartStore.state.lastCartIntentUpdatedAt) => {
 		if (typeof sessionStorage !== 'undefined') {
@@ -599,6 +635,7 @@ export const cartActions = {
 		let productId: string
 		let sellerPubkey: string
 		let amount = 1
+		let productEventForShippingRefs: NDKEvent | null = null
 		const updatedAt = cartSyncDependencies.now()
 
 		if (typeof productData === 'string') {
@@ -611,6 +648,7 @@ export const cartActions = {
 				return
 			}
 		} else if (productData instanceof NDKEvent) {
+			productEventForShippingRefs = productData
 			// Use the product's d-tag as the ID, not the event.id
 			// This ensures correct product references in orders (30402:pubkey:dTag format)
 			const productDTag = getProductId(productData)
@@ -630,6 +668,25 @@ export const cartActions = {
 			return
 		}
 
+		const existingProducts = Object.values(cartStore.state.cart.products)
+		const isNewProduct = !cartStore.state.cart.products[productId]
+		let reusableShippingSelection: ReturnType<typeof findReusablePublishedShippingSelection> = null
+		if (isNewProduct) {
+			if (!productEventForShippingRefs) {
+				productEventForShippingRefs = await getProductEvent(productId, sellerPubkey)
+			}
+
+			const productShippingSelections = normalizePublishedProductShippingTags(productEventForShippingRefs?.tags ?? [])
+			const resolvedShippingOptions = await resolveCartProductShippingOptions(sellerPubkey, productShippingSelections)
+
+			reusableShippingSelection = findReusablePublishedShippingSelection({
+				currentProductId: productId,
+				sellerPubkey,
+				products: existingProducts,
+				resolvedShippingOptions,
+			})
+		}
+
 		cartStore.setState((state) => {
 			const cart = { ...state.cart }
 			const seller = cartActions.findOrCreateSeller(cart, sellerPubkey)
@@ -640,10 +697,10 @@ export const cartActions = {
 				cart.products[productId] = {
 					id: productId,
 					amount: amount,
-					shippingMethodId: null,
-					shippingMethodName: null,
-					shippingCost: 0,
-					shippingCostCurrency: null,
+					shippingMethodId: reusableShippingSelection?.shippingMethodId ?? null,
+					shippingMethodName: reusableShippingSelection?.shippingMethodName ?? null,
+					shippingCost: reusableShippingSelection?.shippingCost ?? 0,
+					shippingCostCurrency: reusableShippingSelection?.shippingCostCurrency ?? null,
 					sellerPubkey,
 				}
 				seller.productIds.push(productId)

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -108,7 +108,9 @@ describe('product shipping selection normalization', () => {
 				cost: 12,
 				currency: 'USD',
 				shippingRef: '30406:merchant:standard',
+				baseCost: 10,
 				extraCost: '2',
+				extraCostAmount: 2,
 				isResolved: true,
 			},
 			{
@@ -117,9 +119,51 @@ describe('product shipping selection normalization', () => {
 				cost: 0,
 				currency: 'USD',
 				shippingRef: '30406:merchant:pickup',
+				baseCost: 0,
 				extraCost: '',
+				extraCostAmount: 0,
 				isResolved: true,
 			},
+		])
+	})
+
+	test('invalid or missing product extra cost resolves as zero while preserving final cost compatibility', () => {
+		const resolvedOptions = resolvePublishedProductShippingOptions({
+			publishedSelections: normalizePublishedProductShippingTags([
+				['shipping_option', '30406:merchant:standard', 'not-a-number'],
+				['shipping_option', '30406:merchant:pickup'],
+			]),
+			availableOptions: [
+				{
+					id: '30406:merchant:standard',
+					name: 'Worldwide Standard',
+					cost: 10,
+					currency: 'USD',
+				},
+				{
+					id: '30406:merchant:pickup',
+					name: 'Local Pickup',
+					cost: 0,
+					currency: 'USD',
+				},
+			],
+		})
+
+		expect(resolvedOptions).toEqual([
+			expect.objectContaining({
+				id: '30406:merchant:standard',
+				baseCost: 10,
+				extraCost: 'not-a-number',
+				extraCostAmount: 0,
+				cost: 10,
+			}),
+			expect.objectContaining({
+				id: '30406:merchant:pickup',
+				baseCost: 0,
+				extraCost: '',
+				extraCostAmount: 0,
+				cost: 0,
+			}),
 		])
 	})
 })

--- a/src/lib/utils/productShippingSelections.test.ts
+++ b/src/lib/utils/productShippingSelections.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test'
 import {
+	findReusablePublishedShippingSelection,
 	normalizeProductShippingSelections,
 	normalizePublishedProductShippingTags,
 	resolveProductShippingSelections,
@@ -165,5 +166,128 @@ describe('product shipping selection normalization', () => {
 				cost: 0,
 			}),
 		])
+	})
+})
+
+describe('findReusablePublishedShippingSelection', () => {
+	const sellerPubkey = 'seller-a'
+	const reusableShippingRef = '30406:seller-a:standard'
+	const reusableProduct = {
+		id: 'existing-product',
+		sellerPubkey,
+		shippingMethodId: reusableShippingRef,
+	}
+	const resolvedShippingOption = {
+		id: reusableShippingRef,
+		shippingRef: reusableShippingRef,
+		name: 'Standard Shipping',
+		cost: 25,
+		currency: 'USD',
+	}
+
+	test('inherits same-seller shipping when the new product resolves the selected ref', () => {
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [reusableProduct],
+				resolvedShippingOptions: [resolvedShippingOption],
+			}),
+		).toEqual({
+			shippingMethodId: reusableShippingRef,
+			shippingMethodName: 'Standard Shipping',
+			shippingCost: 25,
+			shippingCostCurrency: 'USD',
+		})
+	})
+
+	test('inherits the method but uses the new product resolved cost for a different product extra cost', () => {
+		const productWithOldStoredCost = {
+			...reusableProduct,
+			shippingMethodName: 'Old Product Shipping',
+			shippingCost: 40,
+			shippingCostCurrency: 'USD',
+		}
+
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [productWithOldStoredCost],
+				resolvedShippingOptions: [{ ...resolvedShippingOption, cost: 30 }],
+			}),
+		).toEqual({
+			shippingMethodId: reusableShippingRef,
+			shippingMethodName: 'Standard Shipping',
+			shippingCost: 30,
+			shippingCostCurrency: 'USD',
+		})
+	})
+
+	test('does not inherit when the selected ref is not resolved for the new product', () => {
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [reusableProduct],
+				resolvedShippingOptions: [{ ...resolvedShippingOption, id: '30406:seller-a:pickup', shippingRef: '30406:seller-a:pickup' }],
+			}),
+		).toBeNull()
+	})
+
+	test('does not inherit from a different seller', () => {
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [{ ...reusableProduct, sellerPubkey: 'seller-b' }],
+				resolvedShippingOptions: [resolvedShippingOption],
+			}),
+		).toBeNull()
+	})
+
+	test('does not inherit incomplete selected shipping ref state', () => {
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [{ ...reusableProduct, shippingMethodId: null }],
+				resolvedShippingOptions: [resolvedShippingOption],
+			}),
+		).toBeNull()
+	})
+
+	test('does not inherit when no matching option is resolved for the new product', () => {
+		expect(
+			findReusablePublishedShippingSelection({
+				currentProductId: 'new-product',
+				sellerPubkey,
+				products: [reusableProduct],
+				resolvedShippingOptions: [],
+			}),
+		).toBeNull()
+	})
+
+	test('uses the new resolved option name, cost, and currency instead of old cart product values', () => {
+		const productWithOldStoredValues = {
+			...reusableProduct,
+			shippingMethodName: 'Old Product Shipping',
+			shippingCost: 999,
+			shippingCostCurrency: 'OLD',
+		}
+
+		const selection = findReusablePublishedShippingSelection({
+			currentProductId: 'new-product',
+			sellerPubkey,
+			products: [productWithOldStoredValues],
+			resolvedShippingOptions: [{ ...resolvedShippingOption, name: 'New Product Shipping', cost: 5, currency: 'SATS' }],
+		})
+
+		expect(selection).toEqual({
+			shippingMethodId: reusableShippingRef,
+			shippingMethodName: 'New Product Shipping',
+			shippingCost: 5,
+			shippingCostCurrency: 'SATS',
+		})
 	})
 })

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -26,6 +26,77 @@ export type ResolvedProductPageShippingOption = RichShippingInfo & {
 	isResolved: true
 }
 
+export type ReusableShippingSelectionCandidate = {
+	id: string
+	sellerPubkey?: string | null
+	shippingMethodId?: string | null
+}
+
+export type ReusableResolvedShippingOption = {
+	id: string
+	shippingRef?: string | null
+	name?: string | null
+	cost?: number | null
+	currency?: string | null
+}
+
+export type ReusablePublishedShippingSelection = {
+	shippingMethodId: string
+	shippingMethodName: string | null
+	shippingCost: number
+	shippingCostCurrency: string
+}
+
+const nonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.trim().length > 0
+
+export const findReusablePublishedShippingSelection = ({
+	currentProductId,
+	sellerPubkey,
+	products,
+	resolvedShippingOptions,
+}: {
+	currentProductId: string
+	sellerPubkey: string
+	products: ReusableShippingSelectionCandidate[]
+	resolvedShippingOptions: ReusableResolvedShippingOption[]
+}): ReusablePublishedShippingSelection | null => {
+	const resolvedOptionsByRef = new Map(
+		resolvedShippingOptions
+			.map((option) => {
+				const shippingRef = nonEmptyString(option.shippingRef)
+					? option.shippingRef.trim()
+					: nonEmptyString(option.id)
+						? option.id.trim()
+						: ''
+				return [shippingRef, option] as const
+			})
+			.filter(([shippingRef]) => shippingRef.length > 0),
+	)
+	if (resolvedOptionsByRef.size === 0) return null
+
+	for (const product of products) {
+		if (product.id === currentProductId) continue
+		if (product.sellerPubkey !== sellerPubkey) continue
+
+		const shippingMethodId = nonEmptyString(product.shippingMethodId) ? product.shippingMethodId.trim() : ''
+		const matchingOption = shippingMethodId ? resolvedOptionsByRef.get(shippingMethodId) : null
+		if (!matchingOption) continue
+		if (typeof matchingOption.cost !== 'number' || !Number.isFinite(matchingOption.cost)) continue
+
+		const shippingCostCurrency = nonEmptyString(matchingOption.currency) ? matchingOption.currency.trim() : ''
+		if (!shippingCostCurrency) continue
+
+		return {
+			shippingMethodId,
+			shippingMethodName: nonEmptyString(matchingOption.name) ? matchingOption.name : null,
+			shippingCost: matchingOption.cost,
+			shippingCostCurrency,
+		}
+	}
+
+	return null
+}
+
 export const normalizeProductShippingSelection = (input: ProductShippingSelectionInput): ProductShippingSelection | null => {
 	const shippingRef =
 		(typeof input.shippingRef === 'string' && input.shippingRef.trim()) ||

--- a/src/lib/utils/productShippingSelections.ts
+++ b/src/lib/utils/productShippingSelections.ts
@@ -20,7 +20,9 @@ export type ResolvedProductShippingSelection = ProductShippingSelection & {
 
 export type ResolvedProductPageShippingOption = RichShippingInfo & {
 	shippingRef: string
+	baseCost: number
 	extraCost: string
+	extraCostAmount: number
 	isResolved: true
 }
 
@@ -102,7 +104,9 @@ export const resolvePublishedProductShippingOptions = ({
 				id: selection.option.id,
 				cost: baseCost + extraCost,
 				shippingRef: selection.shippingRef,
+				baseCost,
 				extraCost: selection.extraCost,
+				extraCostAmount: extraCost,
 				isResolved: true,
 			}
 		})


### PR DESCRIPTION
## Summary

Partially addresses #831 and #888.

This PR fixes the cart/checkout selector side of #831 by making each product's published `shipping_option` refs the source of truth for selectable shipping options.

It also adds a narrow #888 fix: newly-added products from the same seller inherit an already-selected shipping option only when the new product publishes and resolves that same `shipping_option` ref.

It does not change order metadata, payment requests, V4V/community split, product publishing, product-page behavior, or checkout layout.

## What changed

- Resolves selectable cart shipping options from product `shipping_option` tags.
- Uses seller shipping events only as lookup templates.
- Removes seller-wide cart and checkout selectors that applied one shipping option to every product from a seller.
- Keeps the cart drawer compact by showing shipping status only.
- Preserves product-scoped shipping selection in checkout.
- Shows additive shipping metadata as base cost plus product extra where available.
- Preserves final selected `cost` as base + extra for existing cart behavior.
- Displays selected shipping with `shippingCostCurrency` instead of product price currency.
- Fixes the `CartItem` TypeScript predicate issue reported in review.
- Safely inherits an already-selected same-seller shipping option for newly-added products only when the new product publishes and resolves the same `shipping_option` ref.
- Uses the existing cart selection only as the candidate shipping ref; inherited name, final cost, and currency come from the newly-added product’s resolved shipping option.

## Source of truth / boundaries

Canonical source of truth:

- Product kind `30402` `shipping_option` tags define which shipping options are valid for a product.
- Seller shipping options are reusable lookup templates only.
- Canonical shipping identity remains `30406:<sellerPubkey>:<shippingDTag>`.

For #888 inheritance:

- Existing cart product supplies only the candidate `shippingMethodId`.
- Newly-added product’s resolved shipping option supplies `shippingMethodName`, `shippingCost`, and `shippingCostCurrency`.
- Seller-wide shipping is not reintroduced.

Boundaries preserved:

- No changes to order publishing.
- No changes to payment request flow.
- No changes to V4V/community split logic.
- No changes to product publishing.
- No changes to product-page selector behavior from PR #841.
- No checkout layout redesign.

## Out of scope

- Checkout shipping-step redesign.
- Checkout-time order shipping metadata.
- Chat/order/sales shipping display fixes.
- V4V/community split regression fix.
- Fiat conversion improvements.
- NIP/product schema changes.
- Empty-options behavior in already-open buyer sessions, which may require separate query/cache/relay freshness work.

## Validation

- [x] `bun test src/lib/utils/productShippingSelections.test.ts`
- [x] `bun prettier --check <touched files>`
- [x] `bun run format:check`
- [x] `git diff --check`
- [x] `bun run build`
- [x] GitHub CI: Unit and Integration Tests
- [x] GitHub CI: Prettier Check
- [x] GitHub CI: E2E Tests / e2e-pricing

## Manual validation recommended

Please verify with one seller that has two products using different product-published shipping refs:

- Product A should only show its published shipping option.
- Product B should only show its published shipping option.
- The cart drawer should not show a seller-wide selector.
- Checkout summary should not apply one seller shipping option to all products.
- Additive shipping should display as final cost plus base + product extra.
- Selected shipping should display using the shipping currency.
- Adding another same-seller product should inherit the existing shipping selection only when that new product publishes and resolves the same shipping ref.

## Follow-ups

Recommended follow-up PRs:

1. Preserve checkout-time shipping amount metadata for order/chat/sales display.
2. Add focused regression around V4V/community split excluding shipping if still reproducible.
3. Investigate empty-options behavior in already-open buyer sessions as query/cache/relay freshness work.
4. Add fiat conversion display for shipping if desired by maintainers.
5. Explore a dedicated checkout shipping-step UX grouped by product.
