### PR TITLE
fix(checkout): lock cart edits after delivery step

### DIFF
--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -25,9 +25,18 @@ interface CartItemProps {
 	onQuantityChange: (productId: string, newAmount: number) => void
 	onRemove: (productId: string) => void
 	hideShipping?: boolean
+	isEditable?: boolean
 }
 
-export default function CartItem({ productId, sellerPubkey, amount, onQuantityChange, onRemove, hideShipping = false }: CartItemProps) {
+export default function CartItem({
+	productId,
+	sellerPubkey,
+	amount,
+	onQuantityChange,
+	onRemove,
+	hideShipping = false,
+	isEditable = true,
+}: CartItemProps) {
 	const [quantity, setQuantity] = useState(amount)
 
 	// Fetch product data - pass sellerPubkey to support d-tag lookups
@@ -96,6 +105,7 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 
 	// Handle quantity input change
 	const handleQuantityChange = (value: string) => {
+		if (!isEditable) return
 		const newQuantity = parseInt(value)
 		if (!isNaN(newQuantity)) {
 			setQuantity(newQuantity)
@@ -104,6 +114,7 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 
 	// Handle quantity blur to update cart
 	const handleQuantityBlur = () => {
+		if (!isEditable) return
 		if (quantity !== amount) {
 			onQuantityChange(productId, quantity)
 		}
@@ -111,6 +122,7 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 
 	// Handle immediate button-based quantity changes
 	const handleIncrementClick = () => {
+		if (!isEditable) return
 		const newAmount = Math.min(amount + 1, stockQuantity)
 		if (newAmount !== amount) {
 			onQuantityChange(productId, newAmount)
@@ -118,6 +130,7 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 	}
 
 	const handleDecrementClick = () => {
+		if (!isEditable) return
 		const newAmount = Math.max(1, amount - 1)
 		if (newAmount !== amount) {
 			onQuantityChange(productId, newAmount)
@@ -223,7 +236,13 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 					{/* Quantity Controls */}
 					<div className="flex items-center mt-2">
 						<div className="flex items-center space-x-2">
-							<Button variant="outline" size="icon" className="h-8 w-8" onClick={handleDecrementClick} disabled={amount <= 1}>
+							<Button
+								variant="outline"
+								size="icon"
+								className="h-8 w-8"
+								onClick={handleDecrementClick}
+								disabled={!isEditable || amount <= 1}
+							>
 								<Minus size={14} />
 							</Button>
 
@@ -235,9 +254,16 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 								onBlur={handleQuantityBlur}
 								min={1}
 								max={stockQuantity}
+								disabled={!isEditable}
 							/>
 
-							<Button variant="outline" size="icon" className="h-8 w-8" onClick={handleIncrementClick} disabled={amount >= stockQuantity}>
+							<Button
+								variant="outline"
+								size="icon"
+								className="h-8 w-8"
+								onClick={handleIncrementClick}
+								disabled={!isEditable || amount >= stockQuantity}
+							>
 								<Plus size={14} />
 							</Button>
 						</div>
@@ -247,7 +273,11 @@ export default function CartItem({ productId, sellerPubkey, amount, onQuantityCh
 							variant="ghost"
 							size="icon"
 							className="h-8 w-8 text-red-500 hover:text-red-700 hover:bg-red-50 sm:self-center sm:ml-auto self-start"
-							onClick={() => onRemove(productId)}
+							onClick={() => {
+								if (!isEditable) return
+								onRemove(productId)
+							}}
+							disabled={!isEditable}
 						>
 							<Trash2 size={16} />
 						</Button>

--- a/src/components/CartSummary.tsx
+++ b/src/components/CartSummary.tsx
@@ -100,9 +100,10 @@ export function CartSummary({
 											productId={product.id}
 											sellerPubkey={product.sellerPubkey}
 											amount={product.amount}
-											onQuantityChange={allowQuantityChanges ? handleQuantityChange : () => {}}
-											onRemove={allowQuantityChanges ? handleRemoveProduct : () => {}}
+											onQuantityChange={handleQuantityChange}
+											onRemove={handleRemoveProduct}
 											hideShipping={!allowShippingChanges}
+											isEditable={allowQuantityChanges}
 										/>
 									</div>
 								))}

--- a/src/components/checkout/CheckoutProgress.tsx
+++ b/src/components/checkout/CheckoutProgress.tsx
@@ -8,14 +8,25 @@ interface CheckoutProgressProps {
 	progress: number
 	stepDescription: string
 	onBackClick: () => void
+	showBackButton?: boolean
 }
 
-export function CheckoutProgress({ currentStepNumber, totalSteps, progress, stepDescription, onBackClick }: CheckoutProgressProps) {
+export function CheckoutProgress({
+	currentStepNumber,
+	totalSteps,
+	progress,
+	stepDescription,
+	onBackClick,
+	showBackButton = true,
+}: CheckoutProgressProps) {
 	return (
 		<div className="sticky top-0 z-50 bg-white flex flex-row items-center gap-3 px-4 py-3 lg:gap-4 lg:p-4">
-			<Button variant="ghost" size="icon" onClick={onBackClick} className="flex-shrink-0 h-8 w-8 lg:h-10 lg:w-10">
-				<ChevronLeft className="h-4 w-4" />
-			</Button>
+			{showBackButton && (
+				<Button variant="ghost" onClick={onBackClick} className="flex-shrink-0 h-8 px-2 lg:h-10 lg:px-3" aria-label="Go back in checkout">
+					<ChevronLeft className="h-4 w-4" />
+					<span className="ml-1 text-sm">Back</span>
+				</Button>
+			)}
 			<div className="flex-1 min-w-0">
 				<div className="flex items-center justify-between text-xs lg:text-sm text-gray-600 mb-1 lg:mb-2">
 					<span className="font-medium">

--- a/src/components/checkout/ShippingAddressForm.tsx
+++ b/src/components/checkout/ShippingAddressForm.tsx
@@ -444,15 +444,15 @@ export function ShippingAddressForm({
 			</div>
 			<div className="flex-shrink-0 bg-white border-t pt-4">
 				<form.Subscribe
-					selector={(state: any) => [state.canSubmit, state.isSubmitting]}
-					children={([canSubmit, isSubmitting]: [boolean, boolean]) => (
+					selector={(state: any) => state.isSubmitting}
+					children={(isSubmitting: boolean) => (
 						<Button
 							form="shipping-form"
 							type="submit"
 							className="w-full btn-black"
-							disabled={!canSubmit || !hasAllShippingMethods || deliveryRequirementsBlocked || isSubmitting}
+							disabled={!hasAllShippingMethods || deliveryRequirementsBlocked || isSubmitting}
 						>
-							{isSubmitting ? 'Processing...' : 'Continue to Payment'}
+							{isSubmitting ? 'Processing...' : 'Continue to Review'}
 						</Button>
 					)}
 				/>

--- a/src/routes/checkout.tsx
+++ b/src/routes/checkout.tsx
@@ -145,6 +145,8 @@ function RouteComponent() {
 
 	const [orderInvoiceSets, setOrderInvoiceSets] = useState<Record<string, OrderInvoiceSet>>({})
 	const [specOrderIds, setSpecOrderIds] = useState<string[]>([])
+	const hasCheckoutArtifacts = specOrderIds.length > 0 || invoices.length > 0
+	const isCartEditable = currentStep === 'shipping' && !hasCheckoutArtifacts
 	// Use auto-animate with error handling to prevent DOM manipulation errors
 	const [animationParent] = (() => {
 		try {
@@ -763,6 +765,10 @@ function RouteComponent() {
 
 	const goBackToPreviousStep = () => {
 		if (currentStep === 'summary') {
+			if (hasCheckoutArtifacts) {
+				toast.info('Cart edits are locked after order creation.')
+				return
+			}
 			setCurrentStep('shipping')
 		} else if (currentStep === 'payment') {
 			if (currentInvoiceIndex > 0) {
@@ -851,6 +857,7 @@ function RouteComponent() {
 					progress={progress}
 					stepDescription={stepDescription}
 					onBackClick={handleBackClick}
+					showBackButton={currentStep !== 'complete'}
 				/>
 			</div>
 
@@ -912,11 +919,7 @@ function RouteComponent() {
 									</>
 								) : (
 									<div className="max-h-[50vh] overflow-y-auto">
-										<CartSummary
-											allowQuantityChanges={currentStep === 'shipping'}
-											allowShippingChanges={currentStep === 'shipping'}
-											showExpandedDetails={false}
-										/>
+										<CartSummary allowQuantityChanges={isCartEditable} allowShippingChanges={isCartEditable} showExpandedDetails={false} />
 									</div>
 								)}
 							</CardContent>
@@ -1139,8 +1142,8 @@ function RouteComponent() {
 							<ScrollArea className="h-full">
 								<CartSummary
 									className="pb-6"
-									allowQuantityChanges={currentStep === 'shipping'}
-									allowShippingChanges={currentStep === 'shipping'}
+									allowQuantityChanges={isCartEditable}
+									allowShippingChanges={isCartEditable}
 									showExpandedDetails={false}
 								/>
 							</ScrollArea>


### PR DESCRIPTION
## Summary

Fixes #898.

Locks checkout cart mutation after the delivery/details step and clarifies checkout navigation.

## Changes

- Allows cart mutation only on the shipping/details step before order or invoice artifacts exist.
- Disables quantity controls and item removal after step 1.
- Hides shipping mutation after step 1 through existing `CartSummary` props.
- Adds visible Back text to the checkout progress control.
- Hides the checkout Back button on the complete step.
- Changes step 1 CTA from “Continue to Payment” to “Continue to Review”.
- Fixes a submit-state regression where returning from review could leave “Continue to Review” stuck disabled.

## Validation

- `bun run format:check`
- `bun run build`
- `git diff --check`
- Manual checkout flow with shipping + local pickup
- Manual back/resubmit validation
- Manual payment/complete flow validation