### PR TITLE
style(auctions): auctions countdown

### DIFF
--- a/contextvm/server.ts
+++ b/contextvm/server.ts
@@ -1,10 +1,4 @@
-import {
-	NostrServerTransport,
-	PrivateKeySigner,
-	ApplesauceRelayPool,
-	withCommonToolSchemas,
-	GiftWrapMode,
-} from '@contextvm/sdk'
+import { NostrServerTransport, PrivateKeySigner, ApplesauceRelayPool, withCommonToolSchemas, GiftWrapMode } from '@contextvm/sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { fetchAllSources, SUPPORTED_FIAT, type AggregatedRates, type FiatCode } from './tools/price-sources'
 import { getBtcPriceInputSchema, getBtcPriceOutputSchema, getBtcPriceSingleInputSchema, getBtcPriceSingleOutputSchema } from './schemas'
@@ -310,7 +304,7 @@ async function main() {
 		{
 			title: 'Get current auction state',
 			description:
-				'Read-only view of an auction\'s current floor, top bid, bid count, and registry health (paths issued vs locked). Public — no caller identity required.',
+				"Read-only view of an auction's current floor, top bid, bid count, and registry health (paths issued vs locked). Public — no caller identity required.",
 			inputSchema: getAuctionStateInputSchema,
 			outputSchema: getAuctionStateOutputSchema,
 		},

--- a/contextvm/tools/auction-path-oracle/submit-bid-token.ts
+++ b/contextvm/tools/auction-path-oracle/submit-bid-token.ts
@@ -1,10 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { AUCTION_BID_TOKEN_TOPIC, type AuctionBidTokenEnvelope } from '../../../src/lib/auctionTransfers'
-import {
-	buildAuctionPathRegistry,
-	findAuctionPathEntryByChildPubkey,
-	upsertAuctionPathEntry,
-} from '../../../src/lib/auctionPathOracle'
+import { buildAuctionPathRegistry, findAuctionPathEntryByChildPubkey, upsertAuctionPathEntry } from '../../../src/lib/auctionPathOracle'
 import { getAuctionMaxEndAt, getAuctionSettlementGrace, getAuctionTagValue } from '../../../src/lib/auctionSettlement'
 import type { AuctionContext } from '../../../src/server/auction/context'
 import { loadAuctionEvent } from '../../../src/server/auction/loadAuction'

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -252,7 +252,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				<Button
 					onClick={handleSubmitBid}
 					disabled={isDisabledBid}
-					variant={isOwnAuction ? 'secondary' : 'default'}
+					variant={ended ? 'ghost' : isOwnAuction ? 'secondary' : 'default'}
 					className={cn('whitespace-nowrap flex grow')}
 				>
 					{buttonText}

--- a/src/components/AuctionCountdown.tsx
+++ b/src/components/AuctionCountdown.tsx
@@ -1,10 +1,5 @@
 import { cn } from '@/lib/utils'
-import {
-	formatAuctionCountdownDetailed,
-	formatAuctionEndTimeLabel,
-	formatAuctionTimeLeft,
-	getAuctionCountdownLabels,
-} from '@/lib/auctionCountdownLabels'
+import { formatAuctionCountdownDetailed, formatAuctionEndTimeLabel, getAuctionCountdownLabels } from '@/lib/auctionCountdownLabels'
 import { useEffect, useMemo, useState } from 'react'
 import ProgressBar from './shared/ProgressBar'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -16,7 +11,6 @@ import {
 	getAuctionStartAt,
 	useAuctionBids,
 } from '@/queries/auctions'
-import { Badge } from './ui/badge'
 
 type AuctionCountdownUrgency = 'calm' | 'lastDay' | 'lastHour' | 'endingSoon' | 'finalBids' | 'ended'
 
@@ -56,24 +50,6 @@ function getProgressColor(urgency: AuctionCountdownUrgency): string {
 			return '#e7e3e8' // White/Light Grey
 		default:
 			return '#18b9fe'
-	}
-}
-
-// Map urgency to the new CSS class names
-function getBadgeClassName(urgency: AuctionCountdownUrgency): string {
-	switch (urgency) {
-		case 'calm':
-			return 'badge-info'
-		case 'lastDay':
-			return 'badge-warn'
-		case 'lastHour':
-			return 'badge-amber'
-		case 'endingSoon':
-			return 'badge-error'
-		case 'finalBids':
-			return 'badge-pink'
-		default:
-			return 'badge-neutral'
 	}
 }
 
@@ -142,12 +118,14 @@ export function AuctionCountdown({
 
 	const urgency = getUrgency(remaining)
 	const color = getProgressColor(urgency)
+	const isEnded = remaining <= 0
+	const centerLabel = isEnded ? formatAuctionEndTimeLabel(endTimeEffective, true) : `${formatAuctionCountdownDetailed(remaining)} left`
 
-	// 1. Calculate Inverse Progress
+	// 1. Calculate forward progress so the bar fills from left to right as time runs out.
 	let progress = 0
 	if (totalDuration > 0) {
 		const elapsed = totalDuration - remaining
-		progress = 1 - Math.min(Math.max(elapsed / totalDuration, 0), 1)
+		progress = Math.min(Math.max(elapsed / totalDuration, 0), 1)
 	}
 	if (remaining < 0) progress = 1
 
@@ -171,43 +149,23 @@ export function AuctionCountdown({
 		}
 	}, [urgency])
 
-	const badgeClass = getBadgeClassName(urgency)
-
 	return (
 		<div className={cn('flex flex-col items-start gap-2', className)}>
-			<div className="flex flex-row justify-between items-center w-full">
-				<div className="flex flex-row gap-4 items-center">
-					{/* Shadcn Badge Component */}
-					<Badge
-						variant="outline"
-						className={cn(
-							'px-3 py-1.5 text-xs font-semibold tracking-wide shadow-sm border-2',
-							badgeClass,
-							// Overrides for badge class (bg -> primary, fg -> primary fg, border -> primary border. No hover state)
-							' bg-primary hover:bg-primary text-primary-foreground hover:text-primary-foreground border-primary-border hover:border-primary-border',
-						)}
-					>
-						{formatAuctionTimeLeft(remaining)}
-					</Badge>
-					{!compact && (
-						<span className="text-foreground whitespace-nowrap text-base font-semibold">{formatAuctionCountdownDetailed(remaining)}</span>
-					)}
-				</div>
-
-				{/* Rightmost Element: "Absolute" end time */}
-				{compact ? (
-					<span className="text-foreground whitespace-nowrap text-base text-end font-semibold">
-						{formatAuctionCountdownDetailed(remaining)}
-					</span>
-				) : (
-					<span className="text-foreground/80 text-end">{formatAuctionEndTimeLabel(endTimeEffective, remaining <= 0)}</span>
-				)}
-			</div>
-
-			{/* Progress Bar */}
 			<div className="w-full">
-				<ProgressBar progress={progress} color={color} fillDuration={1} height={16} {...progressConfig} />
+				<div className="relative overflow-hidden rounded-md w-full">
+					<ProgressBar progress={progress} color={color} fillDuration={1} height={28} badgeStyle {...progressConfig} />
+					<div className="absolute inset-0 flex items-center justify-center px-2 pointer-events-none">
+						<span className={cn('text-foreground font-semibold max-w-full truncate', isEnded ? 'text-xs' : 'text-sm whitespace-nowrap')}>
+							{centerLabel}
+						</span>
+					</div>
+				</div>
 			</div>
+
+			{/* Non-compact metadata line sits below the badge to avoid squeezing the bar. */}
+			{compact || isEnded ? null : (
+				<span className="text-foreground/80 text-end w-full">{formatAuctionEndTimeLabel(endTimeEffective, false)}</span>
+			)}
 		</div>
 	)
 }

--- a/src/components/shared/ProgressBar.tsx
+++ b/src/components/shared/ProgressBar.tsx
@@ -22,6 +22,8 @@ interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
 	stripeSpeed?: number
 	/** Angle of the stripes in degrees (default: 45) */
 	stripeAngle?: number
+	/** Render with badge-like visuals (pill corners + lighter border weight). */
+	badgeStyle?: boolean
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({
@@ -35,6 +37,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 	stripeOpacity = 0.3,
 	stripeSpeed = 1,
 	stripeAngle = 45,
+	badgeStyle = false,
 	className,
 	style,
 	...props
@@ -77,11 +80,12 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 	const containerStyle: React.CSSProperties = {
 		padding: '2px',
 		width: '100%',
-		border: `3px solid ${color}`,
+		border: `${badgeStyle ? 2 : 3}px solid ${color}`,
 		height: `${height}px`,
-		borderRadius: '4px',
+		borderRadius: badgeStyle ? '9999px' : '4px',
 		overflow: 'hidden',
 		position: 'relative',
+		backgroundColor: badgeStyle ? 'rgba(255, 255, 255, 0.08)' : undefined,
 		// Apply glow animation if enabled
 		animation: glow ? `pulse-glow-${instanceId} 2s ease-in-out infinite` : 'none',
 	}
@@ -90,6 +94,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 		height: '100%',
 		width: `${progressPct}%`,
 		backgroundColor: color,
+		borderRadius: badgeStyle ? '9999px' : undefined,
 
 		// Dynamic Gradient
 		backgroundImage: `repeating-linear-gradient(

--- a/src/lib/auctionCountdownLabels.ts
+++ b/src/lib/auctionCountdownLabels.ts
@@ -81,7 +81,7 @@ export function formatAuctionEndTimeLabel(endTimestamp: number, isEnded: boolean
 	const timeStr = endDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
 	if (isEnded) {
-		return `Ended on ${endDate.toLocaleDateString()} at ${timeStr}`
+		return `Ended on ${endDate.toLocaleDateString()} ${timeStr}`
 	}
 
 	if (endDateStr === todayStr) {

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import { AuctionCountdown } from '@/components/AuctionCountdown'
 import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Button } from '@/components/ui/button'
@@ -207,13 +208,23 @@ function AuctionListItem({
 					<Gavel className="w-5 h-5 text-gray-400" />
 				</div>
 			)}
-			<div className="min-w-0">
-				<div className="flex flex-wrap items-center gap-2">
-					<p className="font-semibold truncate">{getAuctionTitle(auction)}</p>
-					<AuctionCountdown auction={auction} compact className="px-2 py-1 text-[10px]" />
+			<div className="min-w-0 flex-1">
+				<div className="flex items-start justify-between gap-3 min-w-0">
+					<p className="font-semibold text-sm truncate text-foreground">{getAuctionTitle(auction)}</p>
 				</div>
-				<div className="mt-1 text-xs text-muted-foreground">
-					<span>{status}</span>
+				<div className="mt-2 flex flex-wrap items-center gap-2">
+					<span
+						className={cn(
+							'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
+							status === 'Live'
+								? 'bg-emerald-100 text-emerald-800'
+								: status === 'Scheduled'
+									? 'bg-sky-100 text-sky-800'
+									: 'bg-zinc-100 text-zinc-800',
+						)}
+					>
+						{status}
+					</span>
 				</div>
 			</div>
 		</div>
@@ -221,6 +232,9 @@ function AuctionListItem({
 
 	const actions = (
 		<>
+			<div className="w-52 md:w-56">
+				<AuctionCountdown auction={auction} compact className="w-full" />
+			</div>
 			<Link
 				to="/dashboard/products/auctions/$auctionId"
 				params={{ auctionId: auction.id }}


### PR DESCRIPTION
This PR 
- Styles auctions countdown the auctions card and auctions dashboard route.
- Removes button styling for ended auctions
- Makes progress bar move from the right to the left


<img width="1023" height="139" alt="auctions-basic-info" src="https://github.com/user-attachments/assets/7c128e4c-63a7-4457-b4d9-f3f39d99b2fa" />

<img width="1023" height="142" alt="auctions-basic-info-live" src="https://github.com/user-attachments/assets/0c8a4270-aef8-41f8-bb0e-ba83f0bbd809" />

<img width="1680" height="565" alt="auctions-card-styling" src="https://github.com/user-attachments/assets/85b49c95-bc0a-4f67-a9b6-e0829af1fae3" />


