### PR TITLE
feat(auction): implement anti-snipe bid floor per AUCTIONS.md §6.1

### DIFF
--- a/AUCTIONS.md
+++ b/AUCTIONS.md
@@ -101,24 +101,40 @@ There is intentionally no product reference (`a` tag) in v1.
 - `key_scheme`: `hd_p2pk`.
 - `p2pk_xpub`: seller HD xpub used for per-bid seller child key derivation.
 - `max_end_at`: **hard bidding cutoff** in unix seconds. The second of the
-  three protocol timestamps (see §6.0). When anti-sniping is disabled this
-  MUST equal `end_at`; when anti-sniping is enabled this MUST equal
-  `end_at + max_extensions × extension_seconds`. Always required so the
-  Cashu locktime is computable from auction tags alone.
+  three protocol timestamps (see §6.0). Either equals `end_at` (no
+  anti-snipe window) or sits later — `max_end_at = end_at + window` where
+  `window` is the seller-chosen anti-snipe window (typically minutes).
+  Bids submitted in `[start_at, end_at]` pay the flat floor; bids in
+  `(end_at, max_end_at]` pay the curve floor (see `min_bid_curve` below).
+  Always required so the Cashu locktime is computable from auction tags
+  alone.
 - `settlement_grace`: seconds between `max_end_at` and the bid's Cashu
   locktime — i.e. the window in which the seller has to publish the
   settlement after bidding closes. Together with `max_end_at` this fully
   determines `T_unlock` (see §6.0):
-  `locktime = max_end_at + settlement_grace`. v1 default: `7200` (2 h).
-  Auctions MAY use shorter values (e.g. `30` for dev quick-settle test
-  fixtures); production deployments SHOULD use values comfortably above
-  the worst-case time required to fetch a path release, derive child
-  privkeys, swap each leg at the mint, and publish the kind-1024 event.
+  `locktime = max_end_at + settlement_grace`. v1 form presets: `300`
+  (5 min), `3600` (1 h), `10800` (3 h). Auctions MAY use shorter values
+  (e.g. `30` for dev quick-settle test fixtures); production
+  deployments SHOULD use values comfortably above the worst-case time
+  required to fetch a path release, derive child privkeys, swap each
+  leg at the mint, and publish the kind-1024 event.
+- `min_bid_curve`: anti-snipe floor curve applied in `(end_at, max_end_at]`.
+  Format `<shape>:<peak_multiplier>` where `shape ∈ {none, linear,
+  exponential}` and `peak_multiplier` is a decimal in `[1.0, 100.0]`.
+  Floor computed as `baseline × multiplier(t)`:
+  - `baseline = top_bid === 0 ? starting_bid : top_bid + bid_increment`
+  - `multiplier(t) = 1` when `t ≤ end_at` or `shape = none`
+  - `multiplier(t) = peak_multiplier` when `t ≥ max_end_at`
+  - In `(end_at, max_end_at)` with `t_norm = (t - end_at) / (max_end_at - end_at)`:
+    - `shape = linear` → `1 + (peak_multiplier - 1) × t_norm`
+    - `shape = exponential` → `peak_multiplier ^ t_norm`
+  v1 form presets for `peak_multiplier`: `2.0` / `5.0` / `10.0`. Default
+  when tag is missing: `none:1.0` (no curve, flat floor through the
+  whole bidding window). The path issuer enforces this floor at
+  `request_path` time and re-checks at settlement per-bid.
 
 ### Optional auction tags
 
-- `extension_rule`: `none` (v1 default),
-  `anti_sniping:<window_seconds>:<extension_seconds>`.
 - `vadium_ratio_bps`: default `10000` (100%).
 - `schema`: version marker, e.g. `auction_v1`.
 - `path_issuer`: Nostr pubkey of the path oracle (defaults to the app's
@@ -154,13 +170,19 @@ Immutable after first publish:
 - `mint` set
 - `p2pk_xpub`
 - `path_issuer`
-- `extension_rule`
 - `max_end_at`
 - `settlement_grace`
+- `min_bid_curve`
 - `settlement_policy`
 - `key_scheme`
 - `reserve`
 - `bid_increment`
+
+`extension_rule` was used in earlier drafts (v0) to describe a dynamic
+`end_at`-shifting anti-snipe scheme. v1 retires it: the curve in
+`min_bid_curve` replaces it, and `max_end_at` is now fixed at publish
+time. Implementations MAY emit `['extension_rule', 'none']` for
+backwards compatibility, but any non-`none` value MUST be ignored.
 
 Mutable:
 
@@ -188,8 +210,9 @@ Important:
 		["auction_type", "english"],
 		["start_at", "1766202000"],
 		["end_at", "1766288400"],
-		["max_end_at", "1766288400"], // == end_at when anti-sniping disabled
-		["settlement_grace", "7200"], // 2 h seller-settlement window
+		["max_end_at", "1766289000"], // end_at + 600s anti-snipe window
+		["settlement_grace", "3600"], // 1 h seller-settlement window
+		["min_bid_curve", "exponential:5.0"], // 5× floor at max_end_at
 		["currency", "SAT"],
 		["reserve", "50000"],
 		["bid_increment", "1000"],
@@ -199,7 +222,6 @@ Important:
 		["key_scheme", "hd_p2pk"],
 		["p2pk_xpub", "xpub6Bk...sellerAuctionXpub"],
 		["path_issuer", "<app-path-oracle-nostr-pubkey>"],
-		["extension_rule", "none"],
 		["schema", "auction_v1"],
 
 		// Product-shaped fields
@@ -592,11 +614,11 @@ Every path-oracle auction is parameterised by three monotonically ordered
 timestamps. Implementations MUST treat each as a separate concern; collapsing
 any two of them into one is unsafe.
 
-| Tag / value          | Symbol     | Meaning                                                                                                |
-| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------ |
-| `end_at`             | `T_end`    | Nominal close. Bidders compete up to (or near) this moment. Extendable via anti-sniping.               |
-| `max_end_at`         | `T_cutoff` | **Hard bidding cutoff.** No new bids accepted past this. Equals `T_end` when anti-sniping is off.      |
-| `locktime` (per bid) | `T_unlock` | Unix-seconds value embedded in every Cashu P2PK secret. The mint opens the refund path at this moment. |
+| Tag / value          | Symbol     | Meaning                                                                                                                                                                              |
+| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `end_at`             | `T_end`    | Nominal close. Floor stays flat in `[start_at, end_at]`. After this point the curve in `min_bid_curve` ramps the floor up.                                                           |
+| `max_end_at`         | `T_cutoff` | **Hard bidding cutoff.** No new bids accepted past this. Equals `T_end` when the seller chose no anti-snipe window; otherwise sits `(max_end_at − end_at)` seconds later by tag.    |
+| `locktime` (per bid) | `T_unlock` | Unix-seconds value embedded in every Cashu P2PK secret. The mint opens the refund path at this moment.                                                                               |
 
 The invariants:
 
@@ -622,36 +644,61 @@ If you collapse any two:
 
 `max_end_at` MUST therefore be present on every auction event:
 
-- Anti-sniping disabled → `max_end_at = end_at`.
-- Anti-sniping enabled with `n` extensions of `ext` seconds →
-  `max_end_at = end_at + n × ext`.
+- No anti-snipe window → `max_end_at = end_at`.
+- Anti-snipe window of `window` seconds (seller-chosen at publish time) →
+  `max_end_at = end_at + window`. The window is fixed at publish, not
+  dynamically extended.
 
-`settlement_grace` is a protocol parameter — currently a constant
-on the issuer and embedded into each bid's locktime via `locktime =
-max_end_at + grace`. Sub-minute values are unsafe on shared infrastructure;
-sub-10-minute values are questionable in production. Dev environments use a
-shorter value (≈ 30 s) for test velocity, not as a design example.
+`settlement_grace` is per-auction (see §4.1). v1 form presets:
+`300` (5 min), `3600` (1 h), `10800` (3 h). Sub-minute values are unsafe
+on shared infrastructure; sub-10-minute values are questionable in
+production. Dev environments use a shorter value (≈ 30 s) for test
+velocity, not as a design example.
 
-## 6.1 Effective end time (anti-sniping)
+## 6.1 Bid floor and the anti-snipe curve
 
-If `extension_rule=anti_sniping:<window_seconds>:<extension_seconds>` is
-enabled, clients/indexers compute `effective_end_at` deterministically and
-cap it at `max_end_at`:
+v1 retires the dynamic `extension_rule` model. There is no
+`effective_end_at` that shifts as bids land — `max_end_at` is fixed at
+publish time. Instead, the **bid floor rises** in `(end_at, max_end_at]`
+per the `min_bid_curve` tag (see §4.1). A path issuer enforces the
+floor at `request_path` time and a settlement check re-verifies each
+bid against the floor at its `created_at`.
 
 ```text
-effective_end_at = end_at
-for each valid bid ordered by (created_at, id):
-  remaining = effective_end_at - bid.created_at
-  if 0 < remaining < snipe_window_seconds:
-    effective_end_at = min(effective_end_at + snipe_extension_seconds, max_end_at)
+baseline(top_bid)      = top_bid === 0 ? starting_bid : top_bid + bid_increment
+multiplier(t):
+  if t ≤ end_at OR shape = none:   return 1
+  if t ≥ max_end_at:                return peak_multiplier
+  t_norm = (t - end_at) / (max_end_at - end_at)
+  if shape = linear:                return 1 + (peak_multiplier - 1) × t_norm
+  if shape = exponential:           return peak_multiplier ^ t_norm
+floor(top_bid, t)      = baseline(top_bid) × multiplier(t)
 ```
+
+**Lag tolerance.** A protocol constant `BID_FLOOR_TIME_GRACE_SECONDS = 5`
+is applied server-side in two places:
+
+- `request_path` computes `effective_t = max(server_now - GRACE, end_at)`
+  before evaluating the floor. Gives bidders ~5 s of latency budget
+  between clicking "Bid" and the server receiving the request.
+- `request_settlement` per-bid re-check uses
+  `effective_t = clamp(bid.created_at - GRACE, end_at, max_end_at)`.
+  Bidders whose kind-1023 takes a few seconds to propagate aren't
+  penalised. A bidder who delays publishing kind-1023 for > 5 s after
+  receiving a grant pays the curve at the actual publish time, so
+  grants can't be sat on as cheap snipe ammunition.
+
+The bidder client displays the floor at `client_now` (no inflation) —
+the server is more lenient than the displayed value, so a click at
+the displayed price is always accepted within the GRACE window.
 
 Critical policy:
 
-- Settlement MUST use `effective_end_at`, not raw `end_at`.
-- `max_end_at` is always present (see §6.0). With anti-sniping disabled it
-  equals `end_at` and acts as a no-op cap; with anti-sniping enabled it
-  caps the snipe extension.
+- Settlement MUST use `max_end_at`, not raw `end_at`, when deciding
+  whether the auction can be settled.
+- `max_end_at` is always present (see §6.0). With no anti-snipe window
+  it equals `end_at` and the curve has zero duration (effectively
+  disabled regardless of `min_bid_curve` shape).
 - Bid locktime MUST be fixed up front to
   `max_end_at + settlement_grace`, so existing bidders never need
   to re-sign bids when the auction is extended.
@@ -784,6 +831,16 @@ Issuer MUST:
 - Verify the auction exists and is in `Active` state.
 - Use `extra._meta.clientPubkey` (SDK-injected) as the authenticated
   bidder pubkey; reject if absent or malformed.
+- **Reject self-bids:** if `bidderPubkey === auctionEvent.pubkey`,
+  refuse the path request. Sellers MUST NOT bid on their own
+  auctions; allowing it would let a seller pump the floor against
+  honest bidders.
+- **Enforce the bid floor:** compute the curve-aware floor at
+  `effective_t = max(server_now - BID_FLOOR_TIME_GRACE_SECONDS, end_at)`
+  using `min_bid_curve`, the current `top_bid` on the relay, and the
+  auction's `bid_increment` / `starting_bid`. Reject if
+  `intendedAmount < floor`. Return the enforced floor as
+  `acceptedFloor` in the response so the bidder UI can surface it.
 - Deduplicate by `(auctionEventId, bidderPubkey, requestId)` — the
   request id is generated server-side from a per-call nonce.
 - Apply rate limiting per bidder per auction.

--- a/AUCTIONS.md
+++ b/AUCTIONS.md
@@ -120,7 +120,7 @@ There is intentionally no product reference (`a` tag) in v1.
   leg at the mint, and publish the kind-1024 event.
 - `min_bid_curve`: anti-snipe floor curve applied in `(end_at, max_end_at]`.
   Format `<shape>:<peak_multiplier>` where `shape ∈ {none, linear,
-  exponential}` and `peak_multiplier` is a decimal in `[1.0, 100.0]`.
+exponential}` and `peak_multiplier` is a decimal in `[1.0, 100.0]`.
   Floor computed as `baseline × multiplier(t)`:
   - `baseline = top_bid === 0 ? starting_bid : top_bid + bid_increment`
   - `multiplier(t) = 1` when `t ≤ end_at` or `shape = none`
@@ -128,10 +128,10 @@ There is intentionally no product reference (`a` tag) in v1.
   - In `(end_at, max_end_at)` with `t_norm = (t - end_at) / (max_end_at - end_at)`:
     - `shape = linear` → `1 + (peak_multiplier - 1) × t_norm`
     - `shape = exponential` → `peak_multiplier ^ t_norm`
-  v1 form presets for `peak_multiplier`: `2.0` / `5.0` / `10.0`. Default
-  when tag is missing: `none:1.0` (no curve, flat floor through the
-  whole bidding window). The path issuer enforces this floor at
-  `request_path` time and re-checks at settlement per-bid.
+      v1 form presets for `peak_multiplier`: `2.0` / `5.0` / `10.0`. Default
+      when tag is missing: `none:1.0` (no curve, flat floor through the
+      whole bidding window). The path issuer enforces this floor at
+      `request_path` time and re-checks at settlement per-bid.
 
 ### Optional auction tags
 
@@ -614,11 +614,11 @@ Every path-oracle auction is parameterised by three monotonically ordered
 timestamps. Implementations MUST treat each as a separate concern; collapsing
 any two of them into one is unsafe.
 
-| Tag / value          | Symbol     | Meaning                                                                                                                                                                              |
-| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `end_at`             | `T_end`    | Nominal close. Floor stays flat in `[start_at, end_at]`. After this point the curve in `min_bid_curve` ramps the floor up.                                                           |
-| `max_end_at`         | `T_cutoff` | **Hard bidding cutoff.** No new bids accepted past this. Equals `T_end` when the seller chose no anti-snipe window; otherwise sits `(max_end_at − end_at)` seconds later by tag.    |
-| `locktime` (per bid) | `T_unlock` | Unix-seconds value embedded in every Cashu P2PK secret. The mint opens the refund path at this moment.                                                                               |
+| Tag / value          | Symbol     | Meaning                                                                                                                                                                          |
+| -------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `end_at`             | `T_end`    | Nominal close. Floor stays flat in `[start_at, end_at]`. After this point the curve in `min_bid_curve` ramps the floor up.                                                       |
+| `max_end_at`         | `T_cutoff` | **Hard bidding cutoff.** No new bids accepted past this. Equals `T_end` when the seller chose no anti-snipe window; otherwise sits `(max_end_at − end_at)` seconds later by tag. |
+| `locktime` (per bid) | `T_unlock` | Unix-seconds value embedded in every Cashu P2PK secret. The mint opens the refund path at this moment.                                                                           |
 
 The invariants:
 

--- a/contextvm/server.ts
+++ b/contextvm/server.ts
@@ -1,10 +1,4 @@
-import {
-	NostrServerTransport,
-	PrivateKeySigner,
-	ApplesauceRelayPool,
-	withCommonToolSchemas,
-	GiftWrapMode,
-} from '@contextvm/sdk'
+import { NostrServerTransport, PrivateKeySigner, ApplesauceRelayPool, withCommonToolSchemas, GiftWrapMode } from '@contextvm/sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { fetchAllSources, SUPPORTED_FIAT, type AggregatedRates, type FiatCode } from './tools/price-sources'
 import { getBtcPriceInputSchema, getBtcPriceOutputSchema, getBtcPriceSingleInputSchema, getBtcPriceSingleOutputSchema } from './schemas'
@@ -310,7 +304,7 @@ async function main() {
 		{
 			title: 'Get current auction state',
 			description:
-				'Read-only view of an auction\'s current floor, top bid, bid count, and registry health (paths issued vs locked). Public — no caller identity required.',
+				"Read-only view of an auction's current floor, top bid, bid count, and registry health (paths issued vs locked). Public — no caller identity required.",
 			inputSchema: getAuctionStateInputSchema,
 			outputSchema: getAuctionStateOutputSchema,
 		},

--- a/contextvm/tools/auction-path-oracle/request-path.ts
+++ b/contextvm/tools/auction-path-oracle/request-path.ts
@@ -26,6 +26,7 @@ export const createRequestPathHandler = (ctx: AuctionContext) => {
 				auctionCoordinates: args.auctionCoordinates,
 				bidderPubkey,
 				bidderRefundPubkey: args.bidderRefundPubkey,
+				intendedAmount: args.intendedAmount,
 			})
 			return {
 				content: [],
@@ -37,10 +38,10 @@ export const createRequestPathHandler = (ctx: AuctionContext) => {
 					pathIssuerPubkey: grant.pathIssuerPubkey,
 					issuedAt: grant.issuedAt,
 					expiresAt: grant.expiresAt,
-					// `acceptedFloor` is the floor enforced for this grant.
-					// For now equals `intendedAmount`; the upcoming anti-
-					// snipe curve will override this server-side.
-					acceptedFloor: args.intendedAmount,
+					// AUCTIONS.md §6.1 — the curve-aware floor the issuer
+					// enforced at request time. Bidder UI surfaces this
+					// so the next click can be priced correctly.
+					acceptedFloor: grant.acceptedFloor,
 				},
 			}
 		} catch (error) {

--- a/contextvm/tools/auction-path-oracle/submit-bid-token.ts
+++ b/contextvm/tools/auction-path-oracle/submit-bid-token.ts
@@ -1,10 +1,6 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 import { AUCTION_BID_TOKEN_TOPIC, type AuctionBidTokenEnvelope } from '../../../src/lib/auctionTransfers'
-import {
-	buildAuctionPathRegistry,
-	findAuctionPathEntryByChildPubkey,
-	upsertAuctionPathEntry,
-} from '../../../src/lib/auctionPathOracle'
+import { buildAuctionPathRegistry, findAuctionPathEntryByChildPubkey, upsertAuctionPathEntry } from '../../../src/lib/auctionPathOracle'
 import { getAuctionMaxEndAt, getAuctionSettlementGrace, getAuctionTagValue } from '../../../src/lib/auctionSettlement'
 import type { AuctionContext } from '../../../src/server/auction/context'
 import { loadAuctionEvent } from '../../../src/server/auction/loadAuction'

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -76,10 +76,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// price is always accepted within the GRACE window. Recomputes
 	// every tick via `useAuctionCountdown.now`, so the bidder watches
 	// the floor rise in real time once the curve window opens.
-	const curveFloor = useMemo(
-		() => computeAuctionBidFloor(auction, currentPrice, countdown.now),
-		[auction, currentPrice, countdown.now],
-	)
+	const curveFloor = useMemo(() => computeAuctionBidFloor(auction, currentPrice, countdown.now), [auction, currentPrice, countdown.now])
 	const flatFloor = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
 	const minBid = Math.max(flatFloor, curveFloor)
 	const inCurveWindow = countdown.now > endAt && countdown.now < (getAuctionMaxEndAt(auction) || endAt)

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -18,6 +18,7 @@ import {
 	getAuctionSettlementGrace,
 	getAuctionCurrentPriceFromBids,
 } from '@/queries/auctions'
+import { computeAuctionBidFloor, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
 import { useMemo, useState, useEffect } from 'react'
@@ -69,7 +70,20 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const notStarted = startAt > 0 && countdown.now < startAt
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
-	const minBid = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
+	// AUCTIONS.md §6.1 — bidder-side live floor. Display the floor at
+	// `client_now` (no inflation). The CVM server is more lenient by
+	// `BID_FLOOR_TIME_GRACE_SECONDS = 5`, so a click at the displayed
+	// price is always accepted within the GRACE window. Recomputes
+	// every tick via `useAuctionCountdown.now`, so the bidder watches
+	// the floor rise in real time once the curve window opens.
+	const curveFloor = useMemo(
+		() => computeAuctionBidFloor(auction, currentPrice, countdown.now),
+		[auction, currentPrice, countdown.now],
+	)
+	const flatFloor = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
+	const minBid = Math.max(flatFloor, curveFloor)
+	const inCurveWindow = countdown.now > endAt && countdown.now < (getAuctionMaxEndAt(auction) || endAt)
+	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
 
 	const isOwnAuction = currentUserPubkey === auction.pubkey
 
@@ -149,7 +163,13 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				sellerPubkey: auction.pubkey,
 				pathIssuerPubkey,
 				p2pkXpub,
-				mint: trustedMints[0],
+				// Hand the lock flow ALL the seller's trusted mints in
+				// declared order. `lockAuctionBidFunds` picks the first
+				// one where this bidder's wallet has enough balance —
+				// previously we hard-coded `trustedMints[0]`, so a
+				// bidder with funds on mint #4 would get a "0 sats on
+				// minibits" error.
+				mintCandidates: trustedMints,
 			})
 			toast.success('Bid placed successfully')
 			setIsEditing(false)
@@ -161,6 +181,21 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	return (
 		<div className="flex flex-col gap-2 w-full">
+			{/* Anti-snipe curve banner — visible only when we're inside
+			    `(end_at, max_end_at]` AND the auction has a non-`none` curve.
+			    Tells the bidder why the floor is higher than they'd expect
+			    from the flat `currentPrice + bidIncrement`. AUCTIONS.md §6.1. */}
+			{inCurveWindow && auctionCurve.shape !== 'none' && (
+				<div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+					<p className="font-semibold">Anti-snipe window — minimum bid rising</p>
+					<p className="mt-0.5 text-amber-700">
+						The auction's nominal end has passed. Bids are still accepted until the absolute end, but the floor ramps up{' '}
+						<span className="font-semibold">{auctionCurve.shape}</span>ly to {auctionCurve.peakMultiplier}× by then. Floor right now:{' '}
+						<span className="font-semibold">{minBid.toLocaleString()} sats</span>.
+					</p>
+				</div>
+			)}
+
 			{/* Main Action Area */}
 			<div className={cn('flex flex-col sm:flex-row gap-2 items-stretch sm:items-center')}>
 				{!compact &&

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -133,7 +133,11 @@ export function AuctionCard({
 				sellerPubkey: auction.pubkey,
 				pathIssuerPubkey,
 				p2pkXpub,
-				mint: acceptedMints[0],
+				// See AuctionBidder.tsx for why this is a list, not a single
+				// mint: `lockAuctionBidFunds` walks it in seller-declared
+				// order and picks the first mint where the bidder has the
+				// balance for the delta amount.
+				mintCandidates: acceptedMints,
 			})
 		} catch {
 			// Error toast is handled by mutation onError.

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -270,15 +270,7 @@ function DateTimePicker({
  * where its inputs are. Keeping the ladder lean lets sellers reason
  * about the bid-amount mechanics without the timing axis muddling it.
  */
-function BidLadderViz({
-	startingBid,
-	bidIncrement,
-	reserve,
-}: {
-	startingBid: number
-	bidIncrement: number
-	reserve: number
-}) {
+function BidLadderViz({ startingBid, bidIncrement, reserve }: { startingBid: number; bidIncrement: number; reserve: number }) {
 	const validStart = Number.isFinite(startingBid) && startingBid >= 0
 	const validInc = Number.isFinite(bidIncrement) && bidIncrement > 0
 
@@ -486,14 +478,9 @@ function AuctionTimelinePreview({
 			    below. Anchored to keep edges in-card. */}
 			<div className="relative mt-3 h-7 text-[9px]">
 				{ticks.map((tick) => {
-					const translate =
-						tick.anchor === 'start' ? 'translate-x-0' : tick.anchor === 'end' ? '-translate-x-full' : '-translate-x-1/2'
+					const translate = tick.anchor === 'start' ? 'translate-x-0' : tick.anchor === 'end' ? '-translate-x-full' : '-translate-x-1/2'
 					return (
-						<div
-							key={tick.label}
-							className={`absolute top-0 ${translate} flex flex-col`}
-							style={{ left: `${tick.xPct}%` }}
-						>
+						<div key={tick.label} className={`absolute top-0 ${translate} flex flex-col`} style={{ left: `${tick.xPct}%` }}>
 							<span className="font-semibold leading-tight" style={{ color: tick.color }}>
 								{tick.label}
 							</span>
@@ -523,9 +510,7 @@ function AuctionTimelinePreview({
 
 				{/* Phase 2: curve in [end_at, max_end_at] when enabled */}
 				{curvePath && <path d={curvePath} fill="none" stroke="#10b981" strokeWidth="1.4" />}
-				{!curvePath && hasWindow && (
-					<line x1={endX} y1={flatY} x2={maxEndX} y2={flatY} stroke="#10b981" strokeWidth="1.4" />
-				)}
+				{!curvePath && hasWindow && <line x1={endX} y1={flatY} x2={maxEndX} y2={flatY} stroke="#10b981" strokeWidth="1.4" />}
 
 				{/* Phase 3: settlement window in [max_end_at, locktime] — dashed at
 				    whatever floor was reached. No bids accepted here; only the
@@ -664,7 +649,9 @@ function AntiSnipeCurveSettings({
 									)
 								}
 								className={`rounded-md border px-3 py-1.5 text-xs ${
-									isActive ? 'border-emerald-500 bg-emerald-50 text-emerald-800' : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
+									isActive
+										? 'border-emerald-500 bg-emerald-50 text-emerald-800'
+										: 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
 								}`}
 							>
 								{minutes === 0 ? 'No window' : `${minutes} min`}
@@ -697,9 +684,7 @@ function AntiSnipeCurveSettings({
 						)
 					})}
 				</div>
-				{windowDisabled && (
-					<p className="text-[11px] text-amber-700">Pick a window above to enable the curve.</p>
-				)}
+				{windowDisabled && <p className="text-[11px] text-amber-700">Pick a window above to enable the curve.</p>}
 			</div>
 
 			<div className="grid gap-1.5">
@@ -795,7 +780,9 @@ function SettlementGraceSettings({
 							type="button"
 							onClick={() => setFormData((prev) => ({ ...prev, settlementGracePreset: option.value }))}
 							className={`flex flex-col items-start rounded-md border px-3 py-1.5 text-left text-xs ${
-								isActive ? 'border-emerald-500 bg-emerald-50 text-emerald-800' : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
+								isActive
+									? 'border-emerald-500 bg-emerald-50 text-emerald-800'
+									: 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
 							}`}
 						>
 							<span className="font-semibold">{option.label}</span>

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -19,7 +19,18 @@ import { authStore } from '@/lib/stores/auth'
 import { configStore } from '@/lib/stores/config'
 import { isNip60WalletDevModeEnabled, NIP60_DEV_TEST_MINTS } from '@/lib/stores/nip60'
 import { normalizeProductShippingSelections, type ProductShippingSelection } from '@/lib/utils/productShippingSelections'
-import { usePublishAuctionMutation, type AuctionFormData, type AuctionSpecEntry } from '@/publish/auctions'
+import {
+	AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES,
+	AUCTION_MIN_BID_CURVE_PEAK_PRESETS,
+	AUCTION_SETTLEMENT_GRACE_PRESETS,
+	usePublishAuctionMutation,
+	type AuctionAntiSnipeWindowMinutesPreset,
+	type AuctionFormData,
+	type AuctionMinBidCurvePeakPreset,
+	type AuctionMinBidCurveShape,
+	type AuctionSettlementGracePreset,
+	type AuctionSpecEntry,
+} from '@/publish/auctions'
 import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useNavigate } from '@tanstack/react-router'
@@ -41,10 +52,13 @@ const INITIAL_FORM: AuctionFormData = {
 	reserve: '0',
 	startAt: '',
 	endAt: '',
-	antiSnipingEnabled: false,
-	antiSnipingWindowSeconds: '300',
-	antiSnipingExtensionSeconds: '300',
-	antiSnipingMaxExtensions: '12',
+	// Anti-snipe defaults: no window, no curve, 1h settlement grace.
+	// Defaults are conservative — sellers must opt into the curve
+	// explicitly. AUCTIONS.md §6.1.
+	antiSnipeWindowMinutes: 0,
+	minBidCurveShape: 'none',
+	minBidCurvePeakMultiplier: 2,
+	settlementGracePreset: '1h',
 	mainCategory: '',
 	categories: [],
 	imageUrls: [],
@@ -249,7 +263,22 @@ function DateTimePicker({
 	)
 }
 
-function BidLadderViz({ startingBid, bidIncrement, reserve }: { startingBid: number; bidIncrement: number; reserve: number }) {
+/**
+ * Bid-ladder preview — sats-only view of the price progression. The
+ * companion timeline preview (which includes the anti-snipe curve)
+ * now lives inside `AntiSnipeCurveSettings`, since that's the card
+ * where its inputs are. Keeping the ladder lean lets sellers reason
+ * about the bid-amount mechanics without the timing axis muddling it.
+ */
+function BidLadderViz({
+	startingBid,
+	bidIncrement,
+	reserve,
+}: {
+	startingBid: number
+	bidIncrement: number
+	reserve: number
+}) {
 	const validStart = Number.isFinite(startingBid) && startingBid >= 0
 	const validInc = Number.isFinite(bidIncrement) && bidIncrement > 0
 
@@ -310,6 +339,475 @@ function BidLadderViz({ startingBid, bidIncrement, reserve }: { startingBid: num
 	)
 }
 
+/**
+ * Time-axis preview embedded in the anti-snipe card.
+ *
+ * **Symbolic, NOT proportional x-axis.** Realistic auctions have a
+ * 24-hour bidding window and a 30-minute curve — a strictly
+ * proportional chart squashes the curve into a sliver. We use fixed
+ * segment widths:
+ *   - flat phase `[start_at, end_at]`    → 35 % (or 60 % when no window)
+ *   - curve phase `[end_at, max_end_at]` → 40 % (collapsed to 0 when window=0)
+ *   - locktime phase `[max_end_at, locktime]` → 25 % (or 40 % when no window)
+ *
+ * The chart is for shape recognition ("there's a steep ramp at the
+ * end"), not precise time-magnitude. Absolute times appear inline
+ * above the chart at each tick.
+ *
+ * **Baseline pick** (AUCTIONS.md §6.1 — `top_bid + bid_increment`):
+ * the form has no live top bid, so we substitute
+ * `previewTopBid = max(reserve, starting_bid)`. Reserve is the
+ * seller's own hint at where the auction is expected to land —
+ * using it gives a realistic preview (a 10× of a 70 000-sat reserve
+ * is 700 010 sats; a 10× of a 10-sat starting bid is a meaningless
+ * 100 sats). Falls back to starting_bid when no reserve.
+ */
+function AuctionTimelinePreview({
+	startingBid,
+	bidIncrement,
+	reserve,
+	curveShape,
+	curvePeakMultiplier,
+	startAtSeconds,
+	endAtSeconds,
+	maxEndAtSeconds,
+	settlementGraceSeconds,
+	showCurve,
+}: {
+	startingBid: number
+	bidIncrement: number
+	reserve: number
+	curveShape: 'none' | 'linear' | 'exponential'
+	curvePeakMultiplier: number
+	startAtSeconds: number
+	endAtSeconds: number
+	maxEndAtSeconds: number
+	settlementGraceSeconds: number
+	showCurve: boolean
+}) {
+	if (!endAtSeconds || !startAtSeconds) {
+		return (
+			<div className="mt-3 rounded-md border border-dashed border-zinc-300 bg-zinc-50 px-3 py-2 text-[11px] text-zinc-500">
+				Pick an end time to preview the bidding timeline.
+			</div>
+		)
+	}
+
+	// Baseline = (preview top + bid_increment) — see comment block above.
+	const hasReserve = reserve > startingBid
+	const previewTopBid = hasReserve ? reserve : startingBid
+	const baseline = Math.max(1, previewTopBid + bidIncrement)
+	const peakMultiplier = showCurve ? curvePeakMultiplier : 1
+	const peakFloor = Math.ceil(baseline * peakMultiplier)
+
+	const lockTimeSeconds = maxEndAtSeconds + settlementGraceSeconds
+	const hasWindow = maxEndAtSeconds > endAtSeconds
+
+	// Symbolic segment widths (percent of chart width). When no anti-snipe
+	// window, the middle segment collapses and the other two grow to fill.
+	const flatPct = hasWindow ? 35 : 60
+	const curvePct = hasWindow ? 40 : 0
+	const lockPct = hasWindow ? 25 : 40
+	const endX = flatPct
+	const maxEndX = flatPct + curvePct
+	const lockX = flatPct + curvePct + lockPct
+
+	// SVG geometry. y-axis: baseline at the bottom (multiplier=1 → y=H-4),
+	// peak at the top (multiplier=peak → y=4). Bound denominator to avoid
+	// div-by-zero when peak=1; the chart collapses to a single flat line
+	// in that case, which is the correct visualisation.
+	const W = 100
+	const H = 36
+	const yScaleMult = (mult: number) => {
+		const denom = Math.max(peakMultiplier - 1, 0.0001)
+		const t = (mult - 1) / denom
+		return H - 4 - t * (H - 8)
+	}
+	const flatY = yScaleMult(1)
+	const peakY = yScaleMult(peakMultiplier)
+
+	// 32-sample curve in [end_at, max_end_at]. `tNorm` walks 0→1 across
+	// the SYMBOLIC curve segment (not real time).
+	const curveSamples = 32
+	const curvePath = (() => {
+		if (!showCurve || !hasWindow) return ''
+		const segments: string[] = []
+		for (let i = 0; i <= curveSamples; i++) {
+			const tNorm = i / curveSamples
+			let mult = 1
+			if (curveShape === 'linear') mult = 1 + (peakMultiplier - 1) * tNorm
+			else mult = Math.pow(peakMultiplier, tNorm)
+			const x = endX + tNorm * curvePct
+			const y = yScaleMult(mult)
+			segments.push(`${i === 0 ? 'M' : 'L'} ${x.toFixed(3)} ${y.toFixed(3)}`)
+		}
+		return segments.join(' ')
+	})()
+
+	// Inline label config. Each tick: dashed vertical guide in the SVG +
+	// two-line text label (bold name on top, mono compact time below)
+	// positioned just above the chart and x-aligned by percentage.
+	// Anchors are tweaked so edge labels don't overflow the card.
+	const ticks: Array<{
+		xPct: number
+		color: string
+		label: string
+		sub: string
+		anchor: 'start' | 'middle' | 'end'
+	}> = [
+		{ xPct: 0, color: '#10b981', label: 'start', sub: formatAbsoluteCompact(startAtSeconds), anchor: 'start' },
+		{ xPct: endX, color: '#10b981', label: 'end', sub: formatAbsoluteCompact(endAtSeconds), anchor: 'middle' },
+		...(hasWindow
+			? [
+					{
+						xPct: maxEndX,
+						color: '#f59e0b',
+						label: 'abs. end',
+						sub: formatAbsoluteCompact(maxEndAtSeconds),
+						anchor: 'middle' as const,
+					},
+				]
+			: []),
+		{ xPct: lockX, color: '#6b7280', label: 'locktime', sub: formatAbsoluteCompact(lockTimeSeconds), anchor: 'end' },
+	]
+
+	return (
+		<div className="mt-3 rounded-md border border-zinc-200 bg-zinc-50 px-3 py-3">
+			<div className="flex items-baseline justify-between gap-2">
+				<p className="text-[11px] font-semibold uppercase tracking-wide text-zinc-500">Bidding timeline</p>
+				<p className="text-[10px] text-zinc-500">
+					Preview top bid <span className="font-mono text-zinc-700">{previewTopBid.toLocaleString()} sats</span>{' '}
+					<span className="text-zinc-400">({hasReserve ? 'from reserve' : 'no reserve, using starting bid'})</span>
+				</p>
+			</div>
+
+			{/* Label strip ABOVE the chart, x-aligned with the SVG below.
+			    Two lines per tick: bold name on top, mono compact time
+			    below. Anchored to keep edges in-card. */}
+			<div className="relative mt-3 h-7 text-[9px]">
+				{ticks.map((tick) => {
+					const translate =
+						tick.anchor === 'start' ? 'translate-x-0' : tick.anchor === 'end' ? '-translate-x-full' : '-translate-x-1/2'
+					return (
+						<div
+							key={tick.label}
+							className={`absolute top-0 ${translate} flex flex-col`}
+							style={{ left: `${tick.xPct}%` }}
+						>
+							<span className="font-semibold leading-tight" style={{ color: tick.color }}>
+								{tick.label}
+							</span>
+							<span className="font-mono text-[8px] text-zinc-500 leading-tight">{tick.sub}</span>
+						</div>
+					)
+				})}
+			</div>
+
+			<svg viewBox={`0 0 ${W} ${H}`} className="mt-1 w-full" preserveAspectRatio="none" height={H * 2}>
+				{/* dashed vertical guides at each checkpoint */}
+				{ticks.map((tick) => (
+					<line
+						key={tick.label}
+						x1={tick.xPct}
+						y1={0}
+						x2={tick.xPct}
+						y2={H}
+						stroke={tick.color}
+						strokeWidth="0.3"
+						strokeDasharray="0.6 0.6"
+					/>
+				))}
+
+				{/* Phase 1: flat floor in [start_at, end_at] */}
+				<line x1={0} y1={flatY} x2={endX} y2={flatY} stroke="#10b981" strokeWidth="1.4" />
+
+				{/* Phase 2: curve in [end_at, max_end_at] when enabled */}
+				{curvePath && <path d={curvePath} fill="none" stroke="#10b981" strokeWidth="1.4" />}
+				{!curvePath && hasWindow && (
+					<line x1={endX} y1={flatY} x2={maxEndX} y2={flatY} stroke="#10b981" strokeWidth="1.4" />
+				)}
+
+				{/* Phase 3: settlement window in [max_end_at, locktime] — dashed at
+				    whatever floor was reached. No bids accepted here; only the
+				    seller's kind-1024 publish and bidder timelock-refund. */}
+				<line
+					x1={maxEndX}
+					y1={showCurve ? peakY : flatY}
+					x2={lockX}
+					y2={showCurve ? peakY : flatY}
+					stroke="#9ca3af"
+					strokeWidth="0.9"
+					strokeDasharray="1.2 1.2"
+				/>
+			</svg>
+
+			<div className="mt-2 flex flex-wrap items-baseline justify-between gap-2 text-[11px] text-zinc-600">
+				<p>
+					Floor at <span className="font-semibold text-zinc-900">auction end</span>:{' '}
+					<span className="font-semibold">{baseline.toLocaleString()} sats</span>
+				</p>
+				<p>
+					Floor at <span className="font-semibold text-zinc-900">absolute end</span>:{' '}
+					<span className={`font-semibold ${showCurve ? 'text-emerald-700' : 'text-zinc-700'}`}>{peakFloor.toLocaleString()} sats</span>{' '}
+					{showCurve ? (
+						<span className="text-zinc-400">
+							({curvePeakMultiplier}×, {curveShape})
+						</span>
+					) : (
+						<span className="text-zinc-400">(no curve)</span>
+					)}
+				</p>
+			</div>
+			<p className="mt-2 text-[10px] italic text-zinc-400">Times shown on the chart are symbolic — segments aren't to scale.</p>
+		</div>
+	)
+}
+
+/**
+ * Compact absolute-time formatter for the inline tick labels. Returns
+ * `HH:MM` when the checkpoint is on the seller's current day,
+ * `MM/DD HH:MM` otherwise. The full locale-aware formatting still lives
+ * on `formatAbsolute()` for any hover / copy contexts that need it.
+ */
+function formatAbsoluteCompact(tsSeconds: number): string {
+	if (!tsSeconds) return ''
+	const d = new Date(tsSeconds * 1000)
+	const hh = String(d.getHours()).padStart(2, '0')
+	const mm = String(d.getMinutes()).padStart(2, '0')
+	const today = new Date()
+	const sameDay = d.toDateString() === today.toDateString()
+	if (sameDay) return `${hh}:${mm}`
+	const month = String(d.getMonth() + 1).padStart(2, '0')
+	const day = String(d.getDate()).padStart(2, '0')
+	return `${month}/${day} ${hh}:${mm}`
+}
+
+/**
+ * Anti-snipe window + curve picker. Single card on the auction form
+ * with three rows of preset buttons:
+ *
+ *   1. Anti-snipe window (0 / 5 / 15 / 30 minutes added to end_at).
+ *   2. Curve shape (none / linear / exponential).
+ *   3. Peak multiplier (2× / 5× / 10×) — disabled when shape = none.
+ *
+ * Picking shape ≠ none with window = 0 surfaces a validation hint via
+ * `getAuctionPublishValidationIssues` (the form's per-field message
+ * map). AUCTIONS.md §6.1.
+ */
+function AntiSnipeCurveSettings({
+	formData,
+	setFormData,
+	startAtSeconds,
+	endAtSeconds,
+	maxEndAtSeconds,
+	settlementGraceSeconds,
+	startingBid,
+	bidIncrement,
+	reserve,
+}: {
+	formData: AuctionFormData
+	setFormData: Dispatch<SetStateAction<AuctionFormData>>
+	/** Resolved unix seconds derived by the parent form. */
+	startAtSeconds: number
+	endAtSeconds: number
+	maxEndAtSeconds: number
+	settlementGraceSeconds: number
+	/** Parsed numeric form values for the timeline preview's baseline. */
+	startingBid: number
+	bidIncrement: number
+	reserve: number
+}) {
+	const windowOptions: AuctionAntiSnipeWindowMinutesPreset[] = [...AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES]
+	const shapeOptions: Array<{ value: AuctionMinBidCurveShape; label: string; sub: string }> = [
+		{ value: 'none', label: 'None', sub: 'flat floor' },
+		{ value: 'linear', label: 'Linear', sub: 'straight ramp' },
+		{ value: 'exponential', label: 'Exponential', sub: 'steep finish' },
+	]
+	const peakOptions: AuctionMinBidCurvePeakPreset[] = [...AUCTION_MIN_BID_CURVE_PEAK_PRESETS]
+
+	// `windowDisabled = true` when the seller picked "No window" —
+	// disables curve shape AND peak multiplier in one go. With no window,
+	// `max_end_at = end_at`, the curve has zero duration, and a non-`none`
+	// shape would have no effect anyway. Disabling the controls visually
+	// reinforces "this section is gated on having a window".
+	const windowDisabled = formData.antiSnipeWindowMinutes === 0
+	const curveDisabled = windowDisabled || formData.minBidCurveShape === 'none'
+
+	return (
+		<div className="grid w-full gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-4">
+			<div>
+				<Label className="text-zinc-950">Anti-snipe</Label>
+				<p className="mt-1 text-xs text-zinc-500">
+					After the auction end, late bids can still land in an extra window — but the minimum bid ramps up to make sniping expensive. The
+					absolute end is fixed at publish time.
+				</p>
+			</div>
+
+			<div className="grid gap-1.5">
+				<Label className="text-xs uppercase tracking-wide text-zinc-500">Window</Label>
+				<div className="flex flex-wrap gap-2">
+					{windowOptions.map((minutes) => {
+						const isActive = formData.antiSnipeWindowMinutes === minutes
+						return (
+							<button
+								key={minutes}
+								type="button"
+								onClick={() =>
+									// Setting window=0 also resets curve to `none` —
+									// keeps the form state coherent so a re-enable
+									// doesn't surface a leftover shape the seller
+									// can't see.
+									setFormData((prev) =>
+										minutes === 0
+											? { ...prev, antiSnipeWindowMinutes: minutes, minBidCurveShape: 'none' }
+											: { ...prev, antiSnipeWindowMinutes: minutes },
+									)
+								}
+								className={`rounded-md border px-3 py-1.5 text-xs ${
+									isActive ? 'border-emerald-500 bg-emerald-50 text-emerald-800' : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
+								}`}
+							>
+								{minutes === 0 ? 'No window' : `${minutes} min`}
+							</button>
+						)
+					})}
+				</div>
+			</div>
+
+			<div className="grid gap-1.5">
+				<Label className={`text-xs uppercase tracking-wide ${windowDisabled ? 'text-zinc-300' : 'text-zinc-500'}`}>Curve shape</Label>
+				<div className="flex flex-wrap gap-2">
+					{shapeOptions.map((option) => {
+						const isActive = formData.minBidCurveShape === option.value
+						return (
+							<button
+								key={option.value}
+								type="button"
+								disabled={windowDisabled}
+								onClick={() => setFormData((prev) => ({ ...prev, minBidCurveShape: option.value }))}
+								className={`flex flex-col items-start rounded-md border px-3 py-1.5 text-left text-xs disabled:cursor-not-allowed disabled:opacity-40 ${
+									isActive && !windowDisabled
+										? 'border-emerald-500 bg-emerald-50 text-emerald-800'
+										: 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400 disabled:hover:border-zinc-200'
+								}`}
+							>
+								<span className="font-semibold">{option.label}</span>
+								<span className="text-[10px] text-zinc-500">{option.sub}</span>
+							</button>
+						)
+					})}
+				</div>
+				{windowDisabled && (
+					<p className="text-[11px] text-amber-700">Pick a window above to enable the curve.</p>
+				)}
+			</div>
+
+			<div className="grid gap-1.5">
+				<Label className={`text-xs uppercase tracking-wide ${curveDisabled ? 'text-zinc-300' : 'text-zinc-500'}`}>Peak multiplier</Label>
+				<div className="flex flex-wrap gap-2">
+					{peakOptions.map((peak) => {
+						const isActive = formData.minBidCurvePeakMultiplier === peak
+						return (
+							<button
+								key={peak}
+								type="button"
+								disabled={curveDisabled}
+								onClick={() => setFormData((prev) => ({ ...prev, minBidCurvePeakMultiplier: peak }))}
+								className={`rounded-md border px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-40 ${
+									isActive && !curveDisabled
+										? 'border-emerald-500 bg-emerald-50 text-emerald-800'
+										: 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400 disabled:hover:border-zinc-200'
+								}`}
+							>
+								{peak}×
+							</button>
+						)
+					})}
+				</div>
+				{!curveDisabled && (
+					<p className="text-[11px] text-zinc-500">
+						Floor at the absolute end will be {formData.minBidCurvePeakMultiplier}× the floor at auction end.
+					</p>
+				)}
+			</div>
+
+			{/* Timeline preview lives INSIDE this card now — the chart's
+			    inputs (window, shape, multiplier) are all here, so the
+			    feedback belongs alongside them rather than in the bid
+			    ladder card. */}
+			<AuctionTimelinePreview
+				startingBid={startingBid}
+				bidIncrement={bidIncrement}
+				reserve={reserve}
+				curveShape={formData.minBidCurveShape}
+				curvePeakMultiplier={formData.minBidCurvePeakMultiplier}
+				startAtSeconds={startAtSeconds}
+				endAtSeconds={endAtSeconds}
+				maxEndAtSeconds={maxEndAtSeconds}
+				settlementGraceSeconds={settlementGraceSeconds}
+				showCurve={
+					formData.minBidCurveShape !== 'none' &&
+					formData.minBidCurvePeakMultiplier > 1 &&
+					maxEndAtSeconds > endAtSeconds &&
+					endAtSeconds > 0
+				}
+			/>
+		</div>
+	)
+}
+
+/**
+ * Settlement-grace picker — 5 min / 1 h / 3 h. AUCTIONS.md §4.1.
+ *
+ * The grace is the window the seller has between `max_end_at` and the
+ * Cashu locktime to publish the kind-1024 settlement. Long enough that
+ * a mint outage or relay flake doesn't cost the seller; short enough
+ * that losing bidders aren't stranded for days.
+ */
+function SettlementGraceSettings({
+	formData,
+	setFormData,
+}: {
+	formData: AuctionFormData
+	setFormData: Dispatch<SetStateAction<AuctionFormData>>
+}) {
+	const presets: Array<{ value: AuctionSettlementGracePreset; label: string; sub: string }> = [
+		{ value: '5min', label: '5 min', sub: 'tight, mint must be reliable' },
+		{ value: '1h', label: '1 hour', sub: 'recommended' },
+		{ value: '3h', label: '3 hours', sub: 'safest for losers' },
+	]
+
+	return (
+		<div className="grid w-full gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-4">
+			<div>
+				<Label className="text-zinc-950">Settlement grace</Label>
+				<p className="mt-1 text-xs text-zinc-500">
+					How long after the absolute end you have to publish the settlement before losing bidders can reclaim their funds. Bids carry the
+					same locktime regardless of how many bids land.
+				</p>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				{presets.map((option) => {
+					const isActive = formData.settlementGracePreset === option.value
+					return (
+						<button
+							key={option.value}
+							type="button"
+							onClick={() => setFormData((prev) => ({ ...prev, settlementGracePreset: option.value }))}
+							className={`flex flex-col items-start rounded-md border px-3 py-1.5 text-left text-xs ${
+								isActive ? 'border-emerald-500 bg-emerald-50 text-emerald-800' : 'border-zinc-200 bg-white text-zinc-700 hover:border-zinc-400'
+							}`}
+						>
+							<span className="font-semibold">{option.label}</span>
+							<span className="text-[10px] text-zinc-500">{option.sub}</span>
+						</button>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
+
 function AuctionTabContent({
 	formData,
 	setFormData,
@@ -348,9 +846,7 @@ function AuctionTabContent({
 	const startingBidNum = parseInt(formData.startingBid, 10)
 	const bidIncrementNum = parseInt(formData.bidIncrement, 10)
 	const reserveNum = parseInt(formData.reserve, 10)
-	const antiSnipingWindowSeconds = parseInt(formData.antiSnipingWindowSeconds, 10)
-	const antiSnipingExtensionSeconds = parseInt(formData.antiSnipingExtensionSeconds, 10)
-	const antiSnipingMaxExtensions = parseInt(formData.antiSnipingMaxExtensions, 10)
+	const antiSnipeWindowSeconds = formData.antiSnipeWindowMinutes * 60
 	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 
 	const effectiveStartSeconds = useMemo(() => {
@@ -370,13 +866,13 @@ function AuctionTabContent({
 		return Math.max(0, virtualEndSeconds - effectiveStartSeconds)
 	}, [endMode, durationSeconds, virtualEndSeconds, effectiveStartSeconds])
 
-	const antiSnipingHardStopSeconds = useMemo(() => {
-		if (!formData.antiSnipingEnabled) return 0
+	// `max_end_at` preview — when no anti-snipe window is set this equals
+	// `end_at` and the curve has zero duration. AUCTIONS.md §6.0.
+	const curveMaxEndSeconds = useMemo(() => {
 		if (!virtualEndSeconds) return 0
-		if (!Number.isFinite(antiSnipingExtensionSeconds) || antiSnipingExtensionSeconds <= 0) return 0
-		if (!Number.isFinite(antiSnipingMaxExtensions) || antiSnipingMaxExtensions <= 0) return 0
-		return virtualEndSeconds + antiSnipingExtensionSeconds * antiSnipingMaxExtensions
-	}, [formData.antiSnipingEnabled, virtualEndSeconds, antiSnipingExtensionSeconds, antiSnipingMaxExtensions])
+		if (antiSnipeWindowSeconds <= 0) return virtualEndSeconds
+		return virtualEndSeconds + antiSnipeWindowSeconds
+	}, [virtualEndSeconds, antiSnipeWindowSeconds])
 
 	const handleStartImmediate = () => {
 		setStartMode('immediate')
@@ -406,48 +902,11 @@ function AuctionTabContent({
 
 	return (
 		<div className="flex flex-col gap-4">
-			<div className="grid sm:grid-cols-2 gap-4">
-				<div className="grid w-full gap-1.5">
-					<Label htmlFor="auction-starting-bid">
-						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Starting Bid (sats)</span>
-					</Label>
-					<Input
-						id="auction-starting-bid"
-						type="number"
-						min="0"
-						value={formData.startingBid}
-						onChange={(e) => setFormData((prev) => ({ ...prev, startingBid: e.target.value }))}
-					/>
-					{validationMessages.startingBid && <p className="text-xs text-red-600">{validationMessages.startingBid}</p>}
-				</div>
-				<div className="grid w-full gap-1.5">
-					<Label htmlFor="auction-bid-increment">
-						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Bid Increment (sats)</span>
-					</Label>
-					<Input
-						id="auction-bid-increment"
-						type="number"
-						min="1"
-						value={formData.bidIncrement}
-						onChange={(e) => setFormData((prev) => ({ ...prev, bidIncrement: e.target.value }))}
-					/>
-					{validationMessages.bidIncrement && <p className="text-xs text-red-600">{validationMessages.bidIncrement}</p>}
-				</div>
-			</div>
-
-			<div className="grid w-full gap-1.5">
-				<Label htmlFor="auction-reserve">Reserve (sats)</Label>
-				<Input
-					id="auction-reserve"
-					type="number"
-					min="0"
-					value={formData.reserve}
-					onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
-				/>
-				{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
-			</div>
-
-			<BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />
+			{/* Section order: timing first (start + end), then bidding
+			    mechanics (amounts + ladder), then auction-end policy
+			    (anti-snipe curve + settlement grace). The curve preview
+			    is embedded inside the anti-snipe card so its visual
+			    feedback sits next to the inputs that drive it. */}
 
 			<div className="grid w-full gap-2 rounded-lg border border-zinc-200 bg-white px-4 py-4">
 				<div className="flex items-center justify-between gap-2">
@@ -567,85 +1026,61 @@ function AuctionTabContent({
 				)}
 			</div>
 
-			<div className="grid w-full gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-4">
-				<div className="flex items-start gap-3">
-					<Checkbox
-						id="auction-anti-sniping"
-						checked={formData.antiSnipingEnabled}
-						onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, antiSnipingEnabled: checked === true }))}
-						className="mt-0.5"
+			<div className="grid sm:grid-cols-2 gap-4">
+				<div className="grid w-full gap-1.5">
+					<Label htmlFor="auction-starting-bid">
+						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Starting Bid (sats)</span>
+					</Label>
+					<Input
+						id="auction-starting-bid"
+						type="number"
+						min="0"
+						value={formData.startingBid}
+						onChange={(e) => setFormData((prev) => ({ ...prev, startingBid: e.target.value }))}
 					/>
-					<div className="space-y-1">
-						<Label htmlFor="auction-anti-sniping" className="cursor-pointer">
-							Bounded anti-sniping
-						</Label>
-						<p className="text-xs text-zinc-500">
-							Extend the auction when a valid bid lands near the end, but cap the total extension so bidders know the worst-case lockup.
-						</p>
-					</div>
+					{validationMessages.startingBid && <p className="text-xs text-red-600">{validationMessages.startingBid}</p>}
 				</div>
-
-				{formData.antiSnipingEnabled && (
-					<>
-						<div className="grid gap-3 sm:grid-cols-3">
-							<div className="grid w-full gap-1.5">
-								<Label htmlFor="auction-anti-sniping-window">Window (seconds)</Label>
-								<Input
-									id="auction-anti-sniping-window"
-									type="number"
-									min="1"
-									value={formData.antiSnipingWindowSeconds}
-									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingWindowSeconds: e.target.value }))}
-								/>
-								{validationMessages.antiSnipingWindowSeconds && (
-									<p className="text-xs text-red-600">{validationMessages.antiSnipingWindowSeconds}</p>
-								)}
-							</div>
-							<div className="grid w-full gap-1.5">
-								<Label htmlFor="auction-anti-sniping-extension">Extension (seconds)</Label>
-								<Input
-									id="auction-anti-sniping-extension"
-									type="number"
-									min="1"
-									value={formData.antiSnipingExtensionSeconds}
-									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingExtensionSeconds: e.target.value }))}
-								/>
-								{validationMessages.antiSnipingExtensionSeconds && (
-									<p className="text-xs text-red-600">{validationMessages.antiSnipingExtensionSeconds}</p>
-								)}
-							</div>
-							<div className="grid w-full gap-1.5">
-								<Label htmlFor="auction-anti-sniping-max-extensions">Max extensions</Label>
-								<Input
-									id="auction-anti-sniping-max-extensions"
-									type="number"
-									min="1"
-									value={formData.antiSnipingMaxExtensions}
-									onChange={(e) => setFormData((prev) => ({ ...prev, antiSnipingMaxExtensions: e.target.value }))}
-								/>
-								{validationMessages.antiSnipingMaxExtensions && (
-									<p className="text-xs text-red-600">{validationMessages.antiSnipingMaxExtensions}</p>
-								)}
-							</div>
-						</div>
-
-						<div className="rounded-md bg-zinc-50 px-3 py-2 text-xs text-zinc-700">
-							<p>
-								<span className="font-semibold text-zinc-900">Rule:</span>{' '}
-								{Number.isFinite(antiSnipingWindowSeconds) && antiSnipingWindowSeconds > 0
-									? `extend by ${antiSnipingExtensionSeconds || 0}s when a bid arrives in the last ${antiSnipingWindowSeconds}s.`
-									: 'Enter a valid anti-sniping window.'}
-							</p>
-							<p className="mt-0.5">
-								<span className="font-semibold text-zinc-900">Hard stop:</span>{' '}
-								{antiSnipingHardStopSeconds
-									? formatAbsolute(antiSnipingHardStopSeconds)
-									: 'Waiting for a valid end time and extension policy.'}
-							</p>
-						</div>
-					</>
-				)}
+				<div className="grid w-full gap-1.5">
+					<Label htmlFor="auction-bid-increment">
+						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Bid Increment (sats)</span>
+					</Label>
+					<Input
+						id="auction-bid-increment"
+						type="number"
+						min="1"
+						value={formData.bidIncrement}
+						onChange={(e) => setFormData((prev) => ({ ...prev, bidIncrement: e.target.value }))}
+					/>
+					{validationMessages.bidIncrement && <p className="text-xs text-red-600">{validationMessages.bidIncrement}</p>}
+				</div>
 			</div>
+
+			<div className="grid w-full gap-1.5">
+				<Label htmlFor="auction-reserve">Reserve (sats)</Label>
+				<Input
+					id="auction-reserve"
+					type="number"
+					min="0"
+					value={formData.reserve}
+					onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
+				/>
+				{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
+			</div>
+
+			<BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />
+
+			<AntiSnipeCurveSettings
+				formData={formData}
+				setFormData={setFormData}
+				startAtSeconds={effectiveStartSeconds}
+				endAtSeconds={virtualEndSeconds}
+				maxEndAtSeconds={curveMaxEndSeconds}
+				settlementGraceSeconds={AUCTION_SETTLEMENT_GRACE_PRESETS[formData.settlementGracePreset]}
+				startingBid={startingBidNum}
+				bidIncrement={bidIncrementNum}
+				reserve={reserveNum}
+			/>
+			<SettlementGraceSettings formData={formData} setFormData={setFormData} />
 
 			<div className="grid w-full gap-1.5">
 				<Label>Trusted Mints</Label>
@@ -1113,9 +1548,10 @@ export function AuctionFormContent() {
 		!validationMessages.startAt &&
 		!validationMessages.endAt &&
 		!validationMessages.duration &&
-		!validationMessages.antiSnipingWindowSeconds &&
-		!validationMessages.antiSnipingExtensionSeconds &&
-		!validationMessages.antiSnipingMaxExtensions
+		!validationMessages.antiSnipeWindowMinutes &&
+		!validationMessages.minBidCurveShape &&
+		!validationMessages.minBidCurvePeakMultiplier &&
+		!validationMessages.settlementGracePreset
 	const hasValidImages = !validationMessages.imageUrls
 	const hasValidMints = !validationMessages.trustedMints
 

--- a/src/lib/__tests__/auctionPublishValidation.test.ts
+++ b/src/lib/__tests__/auctionPublishValidation.test.ts
@@ -14,10 +14,10 @@ const baseInput = {
 	reserve: '100',
 	startAt: at(NOW_SECONDS + 60),
 	endAt: at(NOW_SECONDS + 3_600),
-	antiSnipingEnabled: false,
-	antiSnipingWindowSeconds: '300',
-	antiSnipingExtensionSeconds: '300',
-	antiSnipingMaxExtensions: '12',
+	antiSnipeWindowMinutes: 0 as number,
+	minBidCurveShape: 'none' as 'none' | 'linear' | 'exponential',
+	minBidCurvePeakMultiplier: 2 as number,
+	settlementGracePreset: '1h' as '5min' | '1h' | '3h',
 	imageUrls: ['https://example.com/auction.png'],
 	shippings: [{ shippingRef: '30406:seller:standard', extraCost: '' }],
 	trustedMints: ['https://mint.example'],
@@ -81,10 +81,10 @@ describe('auction publish validation', () => {
 			startingBid: '00100',
 			bidIncrement: '0010',
 			reserve: '00120',
-			antiSnipingEnabled: true,
-			antiSnipingWindowSeconds: '0300',
-			antiSnipingExtensionSeconds: '0600',
-			antiSnipingMaxExtensions: '02',
+			antiSnipeWindowMinutes: 15,
+			minBidCurveShape: 'exponential',
+			minBidCurvePeakMultiplier: 5,
+			settlementGracePreset: '1h',
 			imageUrls: ['  https://example.com/auction.png  '],
 			shippings: [{ shippingRef: ' 30406:seller:standard ', extraCost: '0005' }],
 			trustedMints: ['  https://mint.example  '],
@@ -95,12 +95,13 @@ describe('auction publish validation', () => {
 		expect(validated.startingBid).toBe(100)
 		expect(validated.bidIncrement).toBe(10)
 		expect(validated.reserve).toBe(120)
-		expect(validated.antiSnipingWindowSeconds).toBe(300)
-		expect(validated.antiSnipingExtensionSeconds).toBe(600)
-		expect(validated.antiSnipingMaxExtensions).toBe(2)
+		expect(validated.antiSnipeWindowSeconds).toBe(15 * 60)
+		expect(validated.minBidCurveShape).toBe('exponential')
+		expect(validated.minBidCurvePeakMultiplier).toBe(5)
+		expect(validated.settlementGracePreset).toBe('1h')
 		expect(validated.imageUrls).toEqual(['https://example.com/auction.png'])
 		expect(validated.shippings).toEqual([{ shippingRef: '30406:seller:standard', extraCost: '5' }])
 		expect(validated.trustedMints).toEqual(['https://mint.example'])
-		expect(validated.maxEndAt).toBe(validated.endAt + 1_200)
+		expect(validated.maxEndAt).toBe(validated.endAt + 15 * 60)
 	})
 })

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -3,8 +3,11 @@ import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import {
 	buildActiveAuctionBidChains,
 	compareAuctionBidChainPriority,
+	computeAuctionBidFloor,
+	computeAuctionFloorMultiplier,
 	getAuctionCurrentPrice,
 	getAuctionEffectiveEndAt,
+	getAuctionMinBidCurve,
 	getAuctionRootEventId,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
@@ -46,6 +49,8 @@ const makeAuction = (params: {
 	rootEventId?: string
 	extensionRule?: string
 	maxEndAt?: number
+	/** `<shape>:<peak>` (e.g. `linear:5.0`). Omit for no curve. */
+	minBidCurve?: string
 }): NDKEvent =>
 	({
 		id: params.id,
@@ -74,6 +79,7 @@ const makeAuction = (params: {
 			// Mirror the production invariant: max_end_at is always present.
 			// Defaults to end_at when no anti-sniping is configured.
 			['max_end_at', String(params.maxEndAt ?? params.endAt)],
+			...(params.minBidCurve ? ([['min_bid_curve', params.minBidCurve]] as string[][]) : []),
 		],
 	}) as NDKEvent
 
@@ -177,5 +183,139 @@ describe('auctionSettlement helpers', () => {
 		expect(getAuctionEffectiveEndAt(auction, bids)).toBe(320)
 		expect(getAuctionWindowValidBids(auction, bids).map((bid) => bid.id)).toEqual(['bid-early', 'bid-snipe-1', 'bid-snipe-2'])
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(1300)
+	})
+})
+
+describe('min_bid_curve parsing + floor multiplier (AUCTIONS.md §6.1)', () => {
+	test('missing tag → none/1.0, no boost', () => {
+		const auction = makeAuction({ id: 'a', endAt: 200 })
+		expect(getAuctionMinBidCurve(auction).shape).toBe('none')
+		expect(getAuctionMinBidCurve(auction).peakMultiplier).toBe(1)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'none', peakMultiplier: 1 })).toBe(1)
+	})
+
+	test('shape=none is a no-op regardless of peak', () => {
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'none', peakMultiplier: 10 }),
+		).toBe(1)
+	})
+
+	test('zero-duration window disables the curve', () => {
+		// max_end_at == end_at — no anti-snipe window picked by seller.
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 200, shape: 'exponential', peakMultiplier: 5 }),
+		).toBe(1)
+	})
+
+	test('peak=1 is a no-op (no flat-floor regression)', () => {
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 1 }),
+		).toBe(1)
+	})
+
+	test('linear: midpoint = (1 + peak) / 2', () => {
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 5 }),
+		).toBeCloseTo(3, 10)
+	})
+
+	test('exponential: midpoint = sqrt(peak)', () => {
+		const result = computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 9 })
+		expect(result).toBeCloseTo(3, 10)
+	})
+
+	test('boundary: at exactly end_at → multiplier = 1', () => {
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 200, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 10 }),
+		).toBe(1)
+	})
+
+	test('boundary: at or beyond max_end_at → multiplier = peak', () => {
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 7 }),
+		).toBe(7)
+		expect(
+			computeAuctionFloorMultiplier({ atSeconds: 500, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 7 }),
+		).toBe(7)
+	})
+
+	test('parser clamps absurd peak to [1, 100]', () => {
+		const auction = makeAuction({ id: 'a', endAt: 200, minBidCurve: 'linear:9999.0' })
+		expect(getAuctionMinBidCurve(auction).peakMultiplier).toBe(100)
+	})
+
+	test('parser tolerates malformed tag → falls back to none/1', () => {
+		const auction = makeAuction({ id: 'a', endAt: 200, minBidCurve: 'jellybean:42' })
+		expect(getAuctionMinBidCurve(auction).shape).toBe('none')
+		expect(getAuctionMinBidCurve(auction).peakMultiplier).toBe(1)
+	})
+})
+
+describe('computeAuctionBidFloor (AUCTIONS.md §6.1)', () => {
+	test('first-bid case (top_bid=0): floor = starting_bid × multiplier', () => {
+		const auction = makeAuction({
+			id: 'a',
+			startAt: 100,
+			endAt: 200,
+			maxEndAt: 300,
+			startingBid: 1000,
+			bidIncrement: 50,
+			minBidCurve: 'linear:5.0',
+		})
+		// At end_at: multiplier=1 → floor = starting_bid
+		expect(computeAuctionBidFloor(auction, 0, 200)).toBe(1000)
+		// Midpoint of window: multiplier=3 → floor = 3000
+		expect(computeAuctionBidFloor(auction, 0, 250)).toBe(3000)
+		// At max_end_at: multiplier=5 → floor = 5000
+		expect(computeAuctionBidFloor(auction, 0, 300)).toBe(5000)
+	})
+
+	test('subsequent-bid case: floor = (top_bid + bid_increment) × multiplier', () => {
+		const auction = makeAuction({
+			id: 'a',
+			startAt: 100,
+			endAt: 200,
+			maxEndAt: 300,
+			startingBid: 1000,
+			bidIncrement: 50,
+			minBidCurve: 'linear:5.0',
+		})
+		// Before curve: floor = top + increment = 2050
+		expect(computeAuctionBidFloor(auction, 2000, 150)).toBe(2050)
+		// Midpoint: (top + inc) × 3 = 2050 × 3 = 6150
+		expect(computeAuctionBidFloor(auction, 2000, 250)).toBe(6150)
+	})
+
+	test('rounds up: fractional multiplier is never shaved by the bidder', () => {
+		const auction = makeAuction({
+			id: 'a',
+			startAt: 100,
+			endAt: 200,
+			maxEndAt: 300,
+			startingBid: 100,
+			bidIncrement: 1,
+			minBidCurve: 'exponential:2.0',
+		})
+		// At t=210 (10% into 100-second window) with exp+peak=2: multiplier = 2^0.1 ≈ 1.0718
+		// floor for first bid = ceil(100 × 1.0718) = 108
+		expect(computeAuctionBidFloor(auction, 0, 210)).toBe(108)
+	})
+
+	test('monotonic non-decreasing over time (no surprises for bidders)', () => {
+		const auction = makeAuction({
+			id: 'a',
+			startAt: 100,
+			endAt: 200,
+			maxEndAt: 300,
+			startingBid: 1000,
+			bidIncrement: 50,
+			minBidCurve: 'exponential:10.0',
+		})
+		let previous = -Infinity
+		for (let t = 150; t <= 320; t += 1) {
+			const floor = computeAuctionBidFloor(auction, 5000, t)
+			expect(floor).toBeGreaterThanOrEqual(previous)
+			previous = floor
+		}
 	})
 })

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -195,28 +195,23 @@ describe('min_bid_curve parsing + floor multiplier (AUCTIONS.md §6.1)', () => {
 	})
 
 	test('shape=none is a no-op regardless of peak', () => {
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'none', peakMultiplier: 10 }),
-		).toBe(1)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'none', peakMultiplier: 10 })).toBe(1)
 	})
 
 	test('zero-duration window disables the curve', () => {
 		// max_end_at == end_at — no anti-snipe window picked by seller.
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 200, shape: 'exponential', peakMultiplier: 5 }),
-		).toBe(1)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 200, shape: 'exponential', peakMultiplier: 5 })).toBe(1)
 	})
 
 	test('peak=1 is a no-op (no flat-floor regression)', () => {
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 1 }),
-		).toBe(1)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 1 })).toBe(1)
 	})
 
 	test('linear: midpoint = (1 + peak) / 2', () => {
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 5 }),
-		).toBeCloseTo(3, 10)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 250, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 5 })).toBeCloseTo(
+			3,
+			10,
+		)
 	})
 
 	test('exponential: midpoint = sqrt(peak)', () => {
@@ -225,18 +220,12 @@ describe('min_bid_curve parsing + floor multiplier (AUCTIONS.md §6.1)', () => {
 	})
 
 	test('boundary: at exactly end_at → multiplier = 1', () => {
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 200, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 10 }),
-		).toBe(1)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 200, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 10 })).toBe(1)
 	})
 
 	test('boundary: at or beyond max_end_at → multiplier = peak', () => {
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 7 }),
-		).toBe(7)
-		expect(
-			computeAuctionFloorMultiplier({ atSeconds: 500, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 7 }),
-		).toBe(7)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 300, endAt: 200, maxEndAt: 300, shape: 'linear', peakMultiplier: 7 })).toBe(7)
+		expect(computeAuctionFloorMultiplier({ atSeconds: 500, endAt: 200, maxEndAt: 300, shape: 'exponential', peakMultiplier: 7 })).toBe(7)
 	})
 
 	test('parser clamps absurd peak to [1, 100]', () => {

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -15,9 +15,10 @@ export type AuctionPublishValidationField =
 	| 'startAt'
 	| 'endAt'
 	| 'duration'
-	| 'antiSnipingWindowSeconds'
-	| 'antiSnipingExtensionSeconds'
-	| 'antiSnipingMaxExtensions'
+	| 'antiSnipeWindowMinutes'
+	| 'minBidCurveShape'
+	| 'minBidCurvePeakMultiplier'
+	| 'settlementGracePreset'
 	| 'shippingExtraCost'
 	| 'trustedMints'
 	| 'imageUrls'
@@ -37,10 +38,20 @@ export type AuctionPublishValidationInput = {
 	reserve?: string | number | null
 	startAt?: string | null
 	endAt?: string | null
-	antiSnipingEnabled?: boolean | null
-	antiSnipingWindowSeconds?: string | number | null
-	antiSnipingExtensionSeconds?: string | number | null
-	antiSnipingMaxExtensions?: string | number | null
+	/**
+	 * Anti-snipe window in minutes — added to `end_at` to compute
+	 * `max_end_at`. `0` (default) disables the curve entirely.
+	 * Allowed values are enforced by `AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES`
+	 * in `publish/auctions.tsx`; the validator just checks the integer
+	 * is non-negative.
+	 */
+	antiSnipeWindowMinutes?: number | null
+	/** `'none' | 'linear' | 'exponential'`. */
+	minBidCurveShape?: string | null
+	/** Peak multiplier preset: 2, 5, or 10. */
+	minBidCurvePeakMultiplier?: number | null
+	/** `'5min' | '1h' | '3h'`. */
+	settlementGracePreset?: string | null
 	imageUrls?: string[] | null
 	shippings?: ProductShippingSelectionInput[] | null
 	trustedMints?: string[] | null
@@ -56,10 +67,11 @@ export type ValidatedAuctionPublishData = {
 	startAt: number
 	endAt: number
 	durationSeconds: number
-	antiSnipingEnabled: boolean
-	antiSnipingWindowSeconds: number
-	antiSnipingExtensionSeconds: number
-	antiSnipingMaxExtensions: number
+	/** Anti-snipe window in seconds (`antiSnipeWindowMinutes × 60`). */
+	antiSnipeWindowSeconds: number
+	minBidCurveShape: 'none' | 'linear' | 'exponential'
+	minBidCurvePeakMultiplier: number
+	settlementGracePreset: '5min' | '1h' | '3h'
 	maxEndAt: number
 	imageUrls: string[]
 	shippings: ProductShippingSelection[]
@@ -224,16 +236,48 @@ const normalizeAuctionPublishInput = (
 		issues.push({ field: 'duration', message: 'Auction duration must be at least 30 minutes' })
 	}
 
-	const antiSnipingEnabled = input.antiSnipingEnabled === true
-	const antiSnipingWindowSeconds = antiSnipingEnabled
-		? parsePositiveInteger(input.antiSnipingWindowSeconds, 'antiSnipingWindowSeconds', 'Anti-sniping window', issues)
-		: 0
-	const antiSnipingExtensionSeconds = antiSnipingEnabled
-		? parsePositiveInteger(input.antiSnipingExtensionSeconds, 'antiSnipingExtensionSeconds', 'Anti-sniping extension', issues)
-		: 0
-	const antiSnipingMaxExtensions = antiSnipingEnabled
-		? parsePositiveInteger(input.antiSnipingMaxExtensions, 'antiSnipingMaxExtensions', 'Max anti-sniping extensions', issues)
-		: 0
+	// Anti-snipe window in minutes → seconds. `0` means no window
+	// (max_end_at = end_at, curve disabled regardless of shape).
+	// AUCTIONS.md §6.0 / §6.1.
+	const rawWindowMinutes = typeof input.antiSnipeWindowMinutes === 'number' ? input.antiSnipeWindowMinutes : 0
+	const antiSnipeWindowMinutes = Number.isFinite(rawWindowMinutes) && rawWindowMinutes >= 0 ? Math.floor(rawWindowMinutes) : 0
+	if (!Number.isFinite(rawWindowMinutes) || rawWindowMinutes < 0) {
+		issues.push({ field: 'antiSnipeWindowMinutes', message: 'Anti-snipe window must be a non-negative number of minutes' })
+	}
+	const antiSnipeWindowSeconds = antiSnipeWindowMinutes * 60
+
+	const minBidCurveShapeRaw = typeof input.minBidCurveShape === 'string' ? input.minBidCurveShape : 'none'
+	const minBidCurveShape: 'none' | 'linear' | 'exponential' =
+		minBidCurveShapeRaw === 'linear' || minBidCurveShapeRaw === 'exponential' ? minBidCurveShapeRaw : 'none'
+	if (minBidCurveShape !== minBidCurveShapeRaw && minBidCurveShapeRaw !== 'none') {
+		issues.push({ field: 'minBidCurveShape', message: 'Anti-snipe curve shape must be none, linear, or exponential' })
+	}
+
+	const peakRaw = typeof input.minBidCurvePeakMultiplier === 'number' ? input.minBidCurvePeakMultiplier : 2
+	const minBidCurvePeakMultiplier =
+		Number.isFinite(peakRaw) && peakRaw >= 1 && peakRaw <= 100 ? peakRaw : 2
+	if (!Number.isFinite(peakRaw) || peakRaw < 1 || peakRaw > 100) {
+		issues.push({
+			field: 'minBidCurvePeakMultiplier',
+			message: 'Anti-snipe peak multiplier must be a number in [1, 100]',
+		})
+	}
+	// If the seller chose a curve but no window, the curve has zero
+	// duration — surface that as a validation hint so the form can
+	// either nudge them to widen the window or pick 'none'.
+	if (minBidCurveShape !== 'none' && antiSnipeWindowMinutes === 0) {
+		issues.push({
+			field: 'antiSnipeWindowMinutes',
+			message: 'Pick an anti-snipe window so the curve has time to ramp, or set the curve shape to none.',
+		})
+	}
+
+	const settlementGraceRaw = typeof input.settlementGracePreset === 'string' ? input.settlementGracePreset : '1h'
+	const settlementGracePreset: '5min' | '1h' | '3h' =
+		settlementGraceRaw === '5min' || settlementGraceRaw === '1h' || settlementGraceRaw === '3h' ? settlementGraceRaw : '1h'
+	if (settlementGracePreset !== settlementGraceRaw) {
+		issues.push({ field: 'settlementGracePreset', message: 'Settlement grace must be 5min, 1h, or 3h' })
+	}
 
 	const imageUrls = normalizeImages(input.imageUrls)
 	if (imageUrls.length === 0) {
@@ -247,10 +291,8 @@ const normalizeAuctionPublishInput = (
 
 	const shippings = normalizeShippingSelections(input.shippings, issues)
 
-	const maxEndAt =
-		antiSnipingEnabled && antiSnipingExtensionSeconds !== null && antiSnipingMaxExtensions !== null
-			? endAt + antiSnipingExtensionSeconds * antiSnipingMaxExtensions
-			: endAt
+	// max_end_at = end_at + window (no dynamic shifting per AUCTIONS.md §6.1).
+	const maxEndAt = endAt + antiSnipeWindowSeconds
 
 	return {
 		value: {
@@ -263,10 +305,10 @@ const normalizeAuctionPublishInput = (
 			startAt,
 			endAt,
 			durationSeconds,
-			antiSnipingEnabled,
-			antiSnipingWindowSeconds: antiSnipingWindowSeconds ?? 0,
-			antiSnipingExtensionSeconds: antiSnipingExtensionSeconds ?? 0,
-			antiSnipingMaxExtensions: antiSnipingMaxExtensions ?? 0,
+			antiSnipeWindowSeconds,
+			minBidCurveShape,
+			minBidCurvePeakMultiplier,
+			settlementGracePreset,
 			maxEndAt,
 			imageUrls,
 			shippings,

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -254,8 +254,7 @@ const normalizeAuctionPublishInput = (
 	}
 
 	const peakRaw = typeof input.minBidCurvePeakMultiplier === 'number' ? input.minBidCurvePeakMultiplier : 2
-	const minBidCurvePeakMultiplier =
-		Number.isFinite(peakRaw) && peakRaw >= 1 && peakRaw <= 100 ? peakRaw : 2
+	const minBidCurvePeakMultiplier = Number.isFinite(peakRaw) && peakRaw >= 1 && peakRaw <= 100 ? peakRaw : 2
 	if (!Number.isFinite(peakRaw) || peakRaw < 1 || peakRaw > 100) {
 		issues.push({
 			field: 'minBidCurvePeakMultiplier',

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -20,9 +20,13 @@ const AUCTION_IMMUTABLE_SINGLE_TAGS = [
 	'path_issuer',
 	'key_scheme',
 	'p2pk_xpub',
+	// `extension_rule` is retired in v1 (AUCTIONS.md §6.1) but kept in the
+	// immutable list so that auctions which still emit it (legacy auctions
+	// or backwards-compatible publishers) can't switch its value post-publish.
 	'extension_rule',
 	'max_end_at',
 	'settlement_grace',
+	'min_bid_curve',
 	'settlement_policy',
 	'schema',
 ]
@@ -112,6 +116,136 @@ export const getAuctionMaxEndAt = (auctionEvent: NDKEvent): number =>
  */
 export const getAuctionSettlementGrace = (auctionEvent: NDKEvent): number =>
 	parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'settlement_grace'), 0)
+
+/**
+ * AUCTIONS.md §6.1 — Lag tolerance applied server-side when computing
+ * the bid floor. `request_path` evaluates the curve at
+ * `effective_t = max(server_now - GRACE, end_at)`; `request_settlement`
+ * per-bid re-check uses
+ * `effective_t = clamp(bid.created_at - GRACE, end_at, max_end_at)`.
+ *
+ * Single-sided (only the server is lenient) so the bidder client can
+ * display the floor at `client_now` without inflation and trust that a
+ * bid at the displayed price will be accepted within 5 s of click→relay
+ * latency.
+ */
+export const BID_FLOOR_TIME_GRACE_SECONDS = 5
+
+export const getAuctionStartingBid = (auctionEvent: NDKEvent): number =>
+	parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'starting_bid'), 0)
+
+export const getAuctionBidIncrement = (auctionEvent: NDKEvent): number =>
+	parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'bid_increment'), 0)
+
+export type AuctionMinBidCurveShape = 'none' | 'linear' | 'exponential'
+
+export interface AuctionMinBidCurve {
+	shape: AuctionMinBidCurveShape
+	/** Multiplier applied to the baseline floor at `t = max_end_at`. */
+	peakMultiplier: number
+	/** Raw tag value for diagnostics. `''` when the tag is missing. */
+	raw: string
+}
+
+const MIN_BID_CURVE_MIN_PEAK = 1
+const MIN_BID_CURVE_MAX_PEAK = 100
+
+const parseMinBidCurvePeak = (value: string): number => {
+	const parsed = Number.parseFloat(value)
+	if (!Number.isFinite(parsed)) return MIN_BID_CURVE_MIN_PEAK
+	if (parsed < MIN_BID_CURVE_MIN_PEAK) return MIN_BID_CURVE_MIN_PEAK
+	if (parsed > MIN_BID_CURVE_MAX_PEAK) return MIN_BID_CURVE_MAX_PEAK
+	return parsed
+}
+
+/**
+ * Parse the `min_bid_curve` tag value `<shape>:<peak_multiplier>`.
+ *
+ * Returns `shape: 'none'` (with multiplier `1`) for missing/unrecognised
+ * tags so callers can treat "no curve" as the safe default: floor stays
+ * flat through the whole bidding window. See AUCTIONS.md §4.1 / §6.1.
+ */
+export const getAuctionMinBidCurve = (auctionEvent: NDKEvent): AuctionMinBidCurve => {
+	const raw = getAuctionTagValue(auctionEvent, 'min_bid_curve')
+	if (!raw) return { shape: 'none', peakMultiplier: 1, raw: '' }
+	const [shapeRaw, peakRaw] = raw.split(':')
+	if (shapeRaw === 'none') return { shape: 'none', peakMultiplier: 1, raw }
+	if (shapeRaw === 'linear' || shapeRaw === 'exponential') {
+		return { shape: shapeRaw, peakMultiplier: parseMinBidCurvePeak(peakRaw ?? ''), raw }
+	}
+	// Unrecognised shape — treat as no curve. Be permissive (don't throw)
+	// because malformed tags shouldn't brick the bidder UI.
+	return { shape: 'none', peakMultiplier: 1, raw }
+}
+
+/**
+ * Compute the minimum acceptable bid amount for an auction at a given
+ * unix-seconds moment, per AUCTIONS.md §6.1.
+ *
+ * Pure function — same inputs always yield the same output. Used in three
+ * places:
+ *   - bidder UI: live display of "your bid floor right now is X sats"
+ *   - CVM `request_path`: enforced gate before issuing a derivation path
+ *   - CVM `request_settlement`: per-bid re-check
+ *
+ * Floor formula:
+ *   `baseline = topBid === 0 ? startingBid : topBid + bidIncrement`
+ *   `multiplier(t) = 1` outside the curve window or when shape='none'
+ *   `multiplier(t) = peakMultiplier` at or past `max_end_at`
+ *   `multiplier(t) = linearly/exponentially interpolated otherwise`
+ *   `floor = baseline × multiplier(t)`
+ *
+ * Returns a positive integer (rounded up — bidder must pay at least the
+ * computed floor; rounding down would let bidders shave a sat off).
+ */
+export const computeAuctionBidFloor = (
+	auctionEvent: NDKEvent,
+	topBid: number,
+	atSeconds: number,
+): number => {
+	const endAt = getAuctionEndAt(auctionEvent)
+	const maxEndAt = getAuctionMaxEndAt(auctionEvent) || endAt
+	const startingBid = getAuctionStartingBid(auctionEvent)
+	const bidIncrement = getAuctionBidIncrement(auctionEvent)
+	const curve = getAuctionMinBidCurve(auctionEvent)
+
+	const baseline = topBid > 0 ? topBid + bidIncrement : startingBid
+	const multiplier = computeAuctionFloorMultiplier({
+		atSeconds,
+		endAt,
+		maxEndAt,
+		shape: curve.shape,
+		peakMultiplier: curve.peakMultiplier,
+	})
+
+	// `Math.ceil` so a fractional multiplier still requires the bidder to
+	// pay AT LEAST the floor — never less. (E.g. baseline=100,
+	// multiplier=1.5 → floor=150 exactly; multiplier=1.501 → 151.)
+	return Math.max(0, Math.ceil(baseline * multiplier))
+}
+
+/**
+ * Floor multiplier at `atSeconds`. Extracted so the seller's
+ * curve-preview UI can plot the curve without a full auction event in
+ * hand. Same monotonic behaviour as `computeAuctionBidFloor`.
+ */
+export const computeAuctionFloorMultiplier = (params: {
+	atSeconds: number
+	endAt: number
+	maxEndAt: number
+	shape: AuctionMinBidCurveShape
+	peakMultiplier: number
+}): number => {
+	const { atSeconds, endAt, maxEndAt, shape, peakMultiplier } = params
+	if (shape === 'none' || peakMultiplier <= 1) return 1
+	if (maxEndAt <= endAt) return 1 // zero-duration window → curve disabled
+	if (atSeconds <= endAt) return 1
+	if (atSeconds >= maxEndAt) return peakMultiplier
+	const tNorm = (atSeconds - endAt) / (maxEndAt - endAt)
+	if (shape === 'linear') return 1 + (peakMultiplier - 1) * tNorm
+	// exponential
+	return Math.pow(peakMultiplier, tNorm)
+}
 export const getAuctionRootEventId = (auctionEvent: NDKEvent): string =>
 	getAuctionTagValue(auctionEvent, AUCTION_ROOT_EVENT_ID_TAG) || auctionEvent.id
 export const getAuctionCoordinate = (auctionEvent: NDKEvent): string => {

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -198,11 +198,7 @@ export const getAuctionMinBidCurve = (auctionEvent: NDKEvent): AuctionMinBidCurv
  * Returns a positive integer (rounded up — bidder must pay at least the
  * computed floor; rounding down would let bidders shave a sat off).
  */
-export const computeAuctionBidFloor = (
-	auctionEvent: NDKEvent,
-	topBid: number,
-	atSeconds: number,
-): number => {
+export const computeAuctionBidFloor = (auctionEvent: NDKEvent, topBid: number, atSeconds: number): number => {
 	const endAt = getAuctionEndAt(auctionEvent)
 	const maxEndAt = getAuctionMaxEndAt(auctionEvent) || endAt
 	const startingBid = getAuctionStartingBid(auctionEvent)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1508,9 +1508,7 @@ export const nip60Actions = {
 		} else if (params.preferredMints && params.preferredMints.length > 0) {
 			targetMint = params.preferredMints.find((mint) => (mintBalances[mint] ?? 0) >= amount)
 			if (!targetMint) {
-				const breakdown = params.preferredMints
-					.map((mint) => `${getMintHostname(mint)}: ${mintBalances[mint] ?? 0} sats`)
-					.join(', ')
+				const breakdown = params.preferredMints.map((mint) => `${getMintHostname(mint)}: ${mintBalances[mint] ?? 0} sats`).join(', ')
 				throw new Error(
 					`No trusted mint has ${amount} sats. ${breakdown}. Deposit to one of the auction's trusted mints (or move existing funds there) and try again.`,
 				)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -71,7 +71,20 @@ export type AuctionP2pkKeyScheme = 'hd_p2pk'
 
 export interface LockAuctionBidFundsParams {
 	amount: number
+	/**
+	 * Single mint URL — kept for backwards compatibility with non-auction
+	 * callers (e.g. legacy lock flows). If both `mint` and
+	 * `preferredMints` are provided, `mint` wins (interpreted as an
+	 * explicit override). Most call sites should pass `preferredMints`.
+	 */
 	mint?: string
+	/**
+	 * Ordered list of trusted mints (seller-declared). Walked in order;
+	 * the first mint where the bidder's wallet has at least `amount`
+	 * sats is used. When omitted, falls back to the wallet's default
+	 * mint or any mint with sufficient balance.
+	 */
+	preferredMints?: string[]
 	locktime: number
 	refundPubkey: string
 	/**
@@ -1478,9 +1491,33 @@ export const nip60Actions = {
 			throw new Error(`Lock pubkey is invalid: ${error instanceof Error ? error.message : String(error)}`)
 		}
 
+		// Mint selection order (AUCTIONS.md §4.1 + bid flow):
+		//   1. `params.mint` explicit override — legacy callers only.
+		//   2. `params.preferredMints` in order — auction's trusted mints
+		//      walked seller-declared first; pick the first one where the
+		//      bidder has enough balance for `amount` (delta).
+		//   3. wallet's `defaultMint` — only when no preferred list given.
+		//   4. any mint in the wallet with enough balance — last resort.
+		// Falling through all four with no match yields a clear error
+		// listing per-trusted-mint balances so the bidder knows where
+		// to top up.
 		const { totalBalance, mintBalances } = getBalancesFromState(wallet)
-		let targetMint = params.mint ?? state.defaultMint ?? undefined
-		if (!targetMint) {
+		let targetMint: string | undefined
+		if (params.mint) {
+			targetMint = params.mint
+		} else if (params.preferredMints && params.preferredMints.length > 0) {
+			targetMint = params.preferredMints.find((mint) => (mintBalances[mint] ?? 0) >= amount)
+			if (!targetMint) {
+				const breakdown = params.preferredMints
+					.map((mint) => `${getMintHostname(mint)}: ${mintBalances[mint] ?? 0} sats`)
+					.join(', ')
+				throw new Error(
+					`No trusted mint has ${amount} sats. ${breakdown}. Deposit to one of the auction's trusted mints (or move existing funds there) and try again.`,
+				)
+			}
+		} else if (state.defaultMint && (mintBalances[state.defaultMint] ?? 0) >= amount) {
+			targetMint = state.defaultMint
+		} else {
 			targetMint = Object.keys(mintBalances).find((mint) => mintBalances[mint] >= amount)
 		}
 		if (!targetMint) {

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -11,7 +11,7 @@ import { ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import { configStore } from '@/lib/stores/config'
 import { ndkActions } from '@/lib/stores/ndk'
 import { PlebeianAuctionClient, type RequestPathOutput, type RequestSettlementOutput } from '@/lib/ctxcn-clients/PlebeianAuctionClient'
-import { getAuctionSettlementGraceSeconds, nip60Actions, type AuctionP2pkKeyScheme } from '@/lib/stores/nip60'
+import { nip60Actions, type AuctionP2pkKeyScheme } from '@/lib/stores/nip60'
 import type { ProductShippingSelectionInput } from '@/lib/utils/productShippingSelections'
 import { verifyAuctionPathGrant } from '@/lib/auctionP2pk'
 import { rememberAuctionPathGrant } from '@/lib/auctionPathOracle'
@@ -27,6 +27,40 @@ export interface AuctionSpecEntry {
 	value: string
 }
 
+/**
+ * Settlement grace presets (AUCTIONS.md §4.1). Seconds between
+ * `max_end_at` and the bid's Cashu locktime — i.e. how long the seller
+ * has to publish the kind-1024 settlement after bidding closes.
+ */
+export const AUCTION_SETTLEMENT_GRACE_PRESETS = {
+	'5min': 300,
+	'1h': 3600,
+	'3h': 10800,
+} as const
+export type AuctionSettlementGracePreset = keyof typeof AUCTION_SETTLEMENT_GRACE_PRESETS
+
+/**
+ * Anti-snipe curve shapes (AUCTIONS.md §6.1). Controls how the bid
+ * floor scales in `(end_at, max_end_at]`.
+ */
+export type AuctionMinBidCurveShape = 'none' | 'linear' | 'exponential'
+
+/**
+ * Peak-multiplier presets for the anti-snipe curve. Applied as
+ * `floor = baseline × peak` at `t = max_end_at`. 1.0 is implicit when
+ * `shape = 'none'`.
+ */
+export const AUCTION_MIN_BID_CURVE_PEAK_PRESETS = [2, 5, 10] as const
+export type AuctionMinBidCurvePeakPreset = (typeof AUCTION_MIN_BID_CURVE_PEAK_PRESETS)[number]
+
+/**
+ * Anti-snipe window presets — minutes added to `end_at` to compute
+ * `max_end_at`. Drives the duration of the curve. `0` disables the
+ * window entirely (max_end_at = end_at, no curve regardless of shape).
+ */
+export const AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES = [0, 5, 15, 30] as const
+export type AuctionAntiSnipeWindowMinutesPreset = (typeof AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES)[number]
+
 export interface AuctionFormData {
 	title: string
 	summary: string
@@ -36,10 +70,22 @@ export interface AuctionFormData {
 	reserve: string
 	startAt?: string
 	endAt: string
-	antiSnipingEnabled: boolean
-	antiSnipingWindowSeconds: string
-	antiSnipingExtensionSeconds: string
-	antiSnipingMaxExtensions: string
+	/**
+	 * Seconds added to `end_at` to compute `max_end_at`. Zero = no
+	 * anti-snipe window. When zero the curve has zero duration and is
+	 * effectively disabled regardless of `minBidCurveShape`.
+	 */
+	antiSnipeWindowMinutes: AuctionAntiSnipeWindowMinutesPreset
+	/** Shape of the anti-snipe floor curve in the `(end_at, max_end_at]` window. */
+	minBidCurveShape: AuctionMinBidCurveShape
+	/** Floor multiplier applied at `t = max_end_at`. Only relevant when shape ≠ none. */
+	minBidCurvePeakMultiplier: AuctionMinBidCurvePeakPreset
+	/**
+	 * Settlement grace preset — chosen as `5min`/`1h`/`3h` in the UI,
+	 * mapped to seconds at publish time via
+	 * `AUCTION_SETTLEMENT_GRACE_PRESETS[preset]`.
+	 */
+	settlementGracePreset: AuctionSettlementGracePreset
 	mainCategory: string
 	categories: string[]
 	imageUrls: string[]
@@ -85,7 +131,18 @@ export interface AuctionBidFormData {
 	 */
 	pathIssuerPubkey: string
 	p2pkXpub: string
-	mint?: string
+	/**
+	 * Ordered list of the auction's trusted mints (`mint` tags on
+	 * kind 30408). The lock flow walks this list and picks the first
+	 * one where the bidder's NIP-60 wallet has enough balance for the
+	 * delta amount. Falls back to `DEFAULT_BID_MINT` only when the list
+	 * is empty (legacy bid forms that didn't pass mints).
+	 *
+	 * Replaces the older `mint?: string` field which always picked
+	 * the seller's first declared mint regardless of whether the
+	 * bidder actually had any sats there.
+	 */
+	mintCandidates: string[]
 }
 
 export interface AuctionPathGrantResponse {
@@ -255,16 +312,19 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 	const startingBid = String(validated.startingBid)
 	const bidIncrement = String(validated.bidIncrement)
 	const reserve = String(validated.reserve)
-	const extensionRule = validated.antiSnipingEnabled
-		? `anti_sniping:${validated.antiSnipingWindowSeconds}:${validated.antiSnipingExtensionSeconds}`
-		: 'none'
-	// `max_end_at` is the SECOND of the three protocol timestamps:
-	//   end_at      → nominal close (extendable via anti-sniping)
-	//   max_end_at  → hard bidding cutoff (this value)
-	//   locktime    → max_end_at + settlement_grace_seconds, mint-enforced refund opens
-	// We always emit it — even when anti-sniping is off — so the locktime
-	// computation downstream is unambiguous and bidders never have to guess
-	// from a missing tag. With anti-sniping off, it equals end_at.
+	// AUCTIONS.md §6.0 — the three timestamps:
+	//   end_at      → nominal close. Floor stays flat in [start_at, end_at].
+	//   max_end_at  → hard bidding cutoff. Equals end_at + window_seconds
+	//                 where window_seconds is the seller-chosen anti-snipe
+	//                 window (or 0 → max_end_at = end_at, no curve).
+	//   locktime    → max_end_at + settlement_grace, mint-enforced refund opens.
+	//
+	// `min_bid_curve` defines the floor ramp in `(end_at, max_end_at]`.
+	// AUCTIONS.md §6.1 — replaces the legacy `extension_rule:anti_sniping:*`
+	// scheme. Floor is monotonic over time; bidder UI displays the floor
+	// at `client_now`, server enforces with a 5 s grace.
+	const minBidCurveTagValue = formData.minBidCurveShape === 'none' ? 'none:1.0' : `${formData.minBidCurveShape}:${formData.minBidCurvePeakMultiplier}.0`
+	const settlementGraceSeconds = AUCTION_SETTLEMENT_GRACE_PRESETS[formData.settlementGracePreset]
 	const keyScheme: AuctionP2pkKeyScheme = 'hd_p2pk'
 	const pathIssuerPubkey = getAuctionPathIssuerPubkeyOrThrow(formData.pathIssuerPubkey)
 	const p2pkXpub = await nip60Actions.getAuctionP2pkXpub()
@@ -302,9 +362,9 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 		['reserve', reserve],
 		...validated.trustedMints.map((mint) => ['mint', mint] as NDKTag),
 		['path_issuer', pathIssuerPubkey],
-		['extension_rule', extensionRule],
 		['max_end_at', String(validated.maxEndAt)],
-		['settlement_grace', String(getAuctionSettlementGraceSeconds())],
+		['settlement_grace', String(settlementGraceSeconds)],
+		['min_bid_curve', minBidCurveTagValue],
 		['key_scheme', keyScheme],
 		['p2pk_xpub', p2pkXpub],
 		['settlement_policy', AUCTION_SETTLEMENT_POLICY],
@@ -520,7 +580,12 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 
 	const lockedBid = await nip60Actions.lockAuctionBidFunds({
 		amount: deltaAmount,
-		mint: formData.mint || DEFAULT_BID_MINT,
+		// Pass the auction's full trusted-mint list. `lockAuctionBidFunds`
+		// walks it in seller-declared order and picks the first mint
+		// where the bidder's wallet has enough balance for the delta —
+		// fixes the "wrong mint" failure when the bidder has funds at
+		// e.g. mint #4 but the seller listed minibits first.
+		preferredMints: formData.mintCandidates.length > 0 ? formData.mintCandidates : [DEFAULT_BID_MINT],
 		locktime,
 		refundPubkey: bidderWalletP2pk,
 		lockPubkey: grant.childPubkey,

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -323,7 +323,8 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 	// AUCTIONS.md §6.1 — replaces the legacy `extension_rule:anti_sniping:*`
 	// scheme. Floor is monotonic over time; bidder UI displays the floor
 	// at `client_now`, server enforces with a 5 s grace.
-	const minBidCurveTagValue = formData.minBidCurveShape === 'none' ? 'none:1.0' : `${formData.minBidCurveShape}:${formData.minBidCurvePeakMultiplier}.0`
+	const minBidCurveTagValue =
+		formData.minBidCurveShape === 'none' ? 'none:1.0' : `${formData.minBidCurveShape}:${formData.minBidCurvePeakMultiplier}.0`
 	const settlementGraceSeconds = AUCTION_SETTLEMENT_GRACE_PRESETS[formData.settlementGracePreset]
 	const keyScheme: AuctionP2pkKeyScheme = 'hd_p2pk'
 	const pathIssuerPubkey = getAuctionPathIssuerPubkeyOrThrow(formData.pathIssuerPubkey)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,994 +57,1063 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-	id: '/setup',
-	path: '/setup',
-	getParentRoute: () => rootRouteImport,
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-	id: '/checkout',
-	path: '/checkout',
-	getParentRoute: () => rootRouteImport,
+  id: '/checkout',
+  path: '/checkout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-	id: '/_dashboard-layout',
-	getParentRoute: () => rootRouteImport,
+  id: '/_dashboard-layout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-	id: '/$vanityName',
-	path: '/$vanityName',
-	getParentRoute: () => rootRouteImport,
+  id: '/$vanityName',
+  path: '/$vanityName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-	id: '/products/',
-	path: '/products/',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/',
+  path: '/products/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-	id: '/posts/',
-	path: '/posts/',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/',
+  path: '/posts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-	id: '/nostr/',
-	path: '/nostr/',
-	getParentRoute: () => rootRouteImport,
+  id: '/nostr/',
+  path: '/nostr/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-	id: '/community/',
-	path: '/community/',
-	getParentRoute: () => rootRouteImport,
+  id: '/community/',
+  path: '/community/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-	id: '/auctions/',
-	path: '/auctions/',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/',
+  path: '/auctions/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-	id: '/search/products',
-	path: '/search/products',
-	getParentRoute: () => rootRouteImport,
+  id: '/search/products',
+  path: '/search/products',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-	id: '/profile/$profileId',
-	path: '/profile/$profileId',
-	getParentRoute: () => rootRouteImport,
+  id: '/profile/$profileId',
+  path: '/profile/$profileId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-	id: '/products/$productId',
-	path: '/products/$productId',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/$productId',
+  path: '/products/$productId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-	id: '/posts/$postId',
-	path: '/posts/$postId',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/$postId',
+  path: '/posts/$postId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-	id: '/collection/$collectionId',
-	path: '/collection/$collectionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/collection/$collectionId',
+  path: '/collection/$collectionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-	id: '/auctions/$auctionId',
-	path: '/auctions/$auctionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/$auctionId',
+  path: '/auctions/$auctionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
-	id: '/dashboard/',
-	path: '/dashboard/',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
-	id: '/dashboard/about',
-	path: '/dashboard/about',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
-	id: '/dashboard/sales/sales',
-	path: '/dashboard/sales/sales',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
-	id: '/dashboard/sales/messages',
-	path: '/dashboard/sales/messages',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-	id: '/dashboard/sales/circular-economy',
-	path: '/dashboard/sales/circular-economy',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-	id: '/dashboard/products/shipping-options',
-	path: '/dashboard/products/shipping-options',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
-	id: '/dashboard/products/products',
-	path: '/dashboard/products/products',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-	id: '/dashboard/products/migration-tool',
-	path: '/dashboard/products/migration-tool',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-	id: '/dashboard/products/collections',
-	path: '/dashboard/products/collections',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
-	id: '/dashboard/products/bids',
-	path: '/dashboard/products/bids',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-	id: '/dashboard/products/auctions',
-	path: '/dashboard/products/auctions',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-	id: '/dashboard/orders/$orderId',
-	path: '/dashboard/orders/$orderId',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-	id: '/dashboard/app-settings/team',
-	path: '/dashboard/app-settings/team',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-	id: '/dashboard/app-settings/featured-items',
-	path: '/dashboard/app-settings/featured-items',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-	id: '/dashboard/app-settings/blacklists',
-	path: '/dashboard/app-settings/blacklists',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-	id: '/dashboard/app-settings/app-miscelleneous',
-	path: '/dashboard/app-settings/app-miscelleneous',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-	id: '/dashboard/account/your-purchases',
-	path: '/dashboard/account/your-purchases',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-	id: '/dashboard/account/vanity-url',
-	path: '/dashboard/account/vanity-url',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-	id: '/dashboard/account/receiving-payments',
-	path: '/dashboard/account/receiving-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
-	id: '/dashboard/account/profile',
-	path: '/dashboard/account/profile',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-	id: '/dashboard/account/preferences',
-	path: '/dashboard/account/preferences',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-	id: '/dashboard/account/nostr-address',
-	path: '/dashboard/account/nostr-address',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
-	id: '/dashboard/account/network',
-	path: '/dashboard/account/network',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-	id: '/dashboard/account/making-payments',
-	path: '/dashboard/account/making-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-	id: '/$pubkey',
-	path: '/$pubkey',
-	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-	id: '/$productId',
-	path: '/$productId',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-} as any)
+const DashboardLayoutDashboardIndexRoute =
+  DashboardLayoutDashboardIndexRouteImport.update({
+    id: '/dashboard/',
+    path: '/dashboard/',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAboutRoute =
+  DashboardLayoutDashboardAboutRouteImport.update({
+    id: '/dashboard/about',
+    path: '/dashboard/about',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesSalesRoute =
+  DashboardLayoutDashboardSalesSalesRouteImport.update({
+    id: '/dashboard/sales/sales',
+    path: '/dashboard/sales/sales',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesRoute =
+  DashboardLayoutDashboardSalesMessagesRouteImport.update({
+    id: '/dashboard/sales/messages',
+    path: '/dashboard/sales/messages',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute =
+  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+    id: '/dashboard/sales/circular-economy',
+    path: '/dashboard/sales/circular-economy',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute =
+  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+    id: '/dashboard/products/shipping-options',
+    path: '/dashboard/products/shipping-options',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsRoute =
+  DashboardLayoutDashboardProductsProductsRouteImport.update({
+    id: '/dashboard/products/products',
+    path: '/dashboard/products/products',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute =
+  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+    id: '/dashboard/products/migration-tool',
+    path: '/dashboard/products/migration-tool',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsRoute =
+  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+    id: '/dashboard/products/collections',
+    path: '/dashboard/products/collections',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsBidsRoute =
+  DashboardLayoutDashboardProductsBidsRouteImport.update({
+    id: '/dashboard/products/bids',
+    path: '/dashboard/products/bids',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsRoute =
+  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+    id: '/dashboard/products/auctions',
+    path: '/dashboard/products/auctions',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute =
+  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+    id: '/dashboard/orders/$orderId',
+    path: '/dashboard/orders/$orderId',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute =
+  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+    id: '/dashboard/app-settings/team',
+    path: '/dashboard/app-settings/team',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+    id: '/dashboard/app-settings/featured-items',
+    path: '/dashboard/app-settings/featured-items',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
+  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+    id: '/dashboard/app-settings/blacklists',
+    path: '/dashboard/app-settings/blacklists',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+    id: '/dashboard/app-settings/app-miscelleneous',
+    path: '/dashboard/app-settings/app-miscelleneous',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute =
+  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+    id: '/dashboard/account/your-purchases',
+    path: '/dashboard/account/your-purchases',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute =
+  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+    id: '/dashboard/account/vanity-url',
+    path: '/dashboard/account/vanity-url',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
+  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+    id: '/dashboard/account/receiving-payments',
+    path: '/dashboard/account/receiving-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountProfileRoute =
+  DashboardLayoutDashboardAccountProfileRouteImport.update({
+    id: '/dashboard/account/profile',
+    path: '/dashboard/account/profile',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountPreferencesRoute =
+  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+    id: '/dashboard/account/preferences',
+    path: '/dashboard/account/preferences',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute =
+  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+    id: '/dashboard/account/nostr-address',
+    path: '/dashboard/account/nostr-address',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNetworkRoute =
+  DashboardLayoutDashboardAccountNetworkRouteImport.update({
+    id: '/dashboard/account/network',
+    path: '/dashboard/account/network',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute =
+  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+    id: '/dashboard/account/making-payments',
+    path: '/dashboard/account/making-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
+  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+    id: '/$pubkey',
+    path: '/$pubkey',
+    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsNewRoute =
+  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute =
+  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+    id: '/$productId',
+    path: '/$productId',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute =
+  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-		id: '/$collectionId',
-		path: '/$collectionId',
-		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-	} as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-	id: '/$auctionId',
-	path: '/$auctionId',
-	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-} as any)
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+    id: '/$collectionId',
+    path: '/$collectionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+    id: '/$auctionId',
+    path: '/$auctionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions': typeof AuctionsIndexRoute
-	'/community': typeof CommunityIndexRoute
-	'/nostr': typeof NostrIndexRoute
-	'/posts': typeof PostsIndexRoute
-	'/products': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions': typeof AuctionsIndexRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/dashboard/about'
-		| '/dashboard/'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions'
-		| '/community'
-		| '/nostr'
-		| '/posts'
-		| '/products'
-		| '/dashboard/about'
-		| '/dashboard'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	id:
-		| '__root__'
-		| '/'
-		| '/$vanityName'
-		| '/_dashboard-layout'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/_dashboard-layout/dashboard/about'
-		| '/_dashboard-layout/dashboard/'
-		| '/_dashboard-layout/dashboard/account/making-payments'
-		| '/_dashboard-layout/dashboard/account/network'
-		| '/_dashboard-layout/dashboard/account/nostr-address'
-		| '/_dashboard-layout/dashboard/account/preferences'
-		| '/_dashboard-layout/dashboard/account/profile'
-		| '/_dashboard-layout/dashboard/account/receiving-payments'
-		| '/_dashboard-layout/dashboard/account/vanity-url'
-		| '/_dashboard-layout/dashboard/account/your-purchases'
-		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-		| '/_dashboard-layout/dashboard/app-settings/blacklists'
-		| '/_dashboard-layout/dashboard/app-settings/featured-items'
-		| '/_dashboard-layout/dashboard/app-settings/team'
-		| '/_dashboard-layout/dashboard/orders/$orderId'
-		| '/_dashboard-layout/dashboard/products/auctions'
-		| '/_dashboard-layout/dashboard/products/bids'
-		| '/_dashboard-layout/dashboard/products/collections'
-		| '/_dashboard-layout/dashboard/products/migration-tool'
-		| '/_dashboard-layout/dashboard/products/products'
-		| '/_dashboard-layout/dashboard/products/shipping-options'
-		| '/_dashboard-layout/dashboard/sales/circular-economy'
-		| '/_dashboard-layout/dashboard/sales/messages'
-		| '/_dashboard-layout/dashboard/sales/sales'
-		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
-		| '/_dashboard-layout/dashboard/products/collections/new'
-		| '/_dashboard-layout/dashboard/products/products/$productId'
-		| '/_dashboard-layout/dashboard/products/products/new'
-		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/dashboard/about'
+    | '/dashboard/'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  id:
+    | '__root__'
+    | '/'
+    | '/$vanityName'
+    | '/_dashboard-layout'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/_dashboard-layout/dashboard/about'
+    | '/_dashboard-layout/dashboard/'
+    | '/_dashboard-layout/dashboard/account/making-payments'
+    | '/_dashboard-layout/dashboard/account/network'
+    | '/_dashboard-layout/dashboard/account/nostr-address'
+    | '/_dashboard-layout/dashboard/account/preferences'
+    | '/_dashboard-layout/dashboard/account/profile'
+    | '/_dashboard-layout/dashboard/account/receiving-payments'
+    | '/_dashboard-layout/dashboard/account/vanity-url'
+    | '/_dashboard-layout/dashboard/account/your-purchases'
+    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+    | '/_dashboard-layout/dashboard/app-settings/blacklists'
+    | '/_dashboard-layout/dashboard/app-settings/featured-items'
+    | '/_dashboard-layout/dashboard/app-settings/team'
+    | '/_dashboard-layout/dashboard/orders/$orderId'
+    | '/_dashboard-layout/dashboard/products/auctions'
+    | '/_dashboard-layout/dashboard/products/bids'
+    | '/_dashboard-layout/dashboard/products/collections'
+    | '/_dashboard-layout/dashboard/products/migration-tool'
+    | '/_dashboard-layout/dashboard/products/products'
+    | '/_dashboard-layout/dashboard/products/shipping-options'
+    | '/_dashboard-layout/dashboard/sales/circular-economy'
+    | '/_dashboard-layout/dashboard/sales/messages'
+    | '/_dashboard-layout/dashboard/sales/sales'
+    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
+    | '/_dashboard-layout/dashboard/products/collections/new'
+    | '/_dashboard-layout/dashboard/products/products/$productId'
+    | '/_dashboard-layout/dashboard/products/products/new'
+    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	VanityNameRoute: typeof VanityNameRoute
-	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-	CheckoutRoute: typeof CheckoutRoute
-	SetupRoute: typeof SetupRoute
-	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-	PostsPostIdRoute: typeof PostsPostIdRoute
-	ProductsProductIdRoute: typeof ProductsProductIdRoute
-	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-	SearchProductsRoute: typeof SearchProductsRoute
-	AuctionsIndexRoute: typeof AuctionsIndexRoute
-	CommunityIndexRoute: typeof CommunityIndexRoute
-	NostrIndexRoute: typeof NostrIndexRoute
-	PostsIndexRoute: typeof PostsIndexRoute
-	ProductsIndexRoute: typeof ProductsIndexRoute
+  IndexRoute: typeof IndexRoute
+  VanityNameRoute: typeof VanityNameRoute
+  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+  CheckoutRoute: typeof CheckoutRoute
+  SetupRoute: typeof SetupRoute
+  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+  PostsPostIdRoute: typeof PostsPostIdRoute
+  ProductsProductIdRoute: typeof ProductsProductIdRoute
+  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+  SearchProductsRoute: typeof SearchProductsRoute
+  AuctionsIndexRoute: typeof AuctionsIndexRoute
+  CommunityIndexRoute: typeof CommunityIndexRoute
+  NostrIndexRoute: typeof NostrIndexRoute
+  PostsIndexRoute: typeof PostsIndexRoute
+  ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/setup': {
-			id: '/setup'
-			path: '/setup'
-			fullPath: '/setup'
-			preLoaderRoute: typeof SetupRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/checkout': {
-			id: '/checkout'
-			path: '/checkout'
-			fullPath: '/checkout'
-			preLoaderRoute: typeof CheckoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout': {
-			id: '/_dashboard-layout'
-			path: ''
-			fullPath: '/'
-			preLoaderRoute: typeof DashboardLayoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/$vanityName': {
-			id: '/$vanityName'
-			path: '/$vanityName'
-			fullPath: '/$vanityName'
-			preLoaderRoute: typeof VanityNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/': {
-			id: '/'
-			path: '/'
-			fullPath: '/'
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/': {
-			id: '/products/'
-			path: '/products'
-			fullPath: '/products/'
-			preLoaderRoute: typeof ProductsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/': {
-			id: '/posts/'
-			path: '/posts'
-			fullPath: '/posts/'
-			preLoaderRoute: typeof PostsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/nostr/': {
-			id: '/nostr/'
-			path: '/nostr'
-			fullPath: '/nostr/'
-			preLoaderRoute: typeof NostrIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/community/': {
-			id: '/community/'
-			path: '/community'
-			fullPath: '/community/'
-			preLoaderRoute: typeof CommunityIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/': {
-			id: '/auctions/'
-			path: '/auctions'
-			fullPath: '/auctions/'
-			preLoaderRoute: typeof AuctionsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/search/products': {
-			id: '/search/products'
-			path: '/search/products'
-			fullPath: '/search/products'
-			preLoaderRoute: typeof SearchProductsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/profile/$profileId': {
-			id: '/profile/$profileId'
-			path: '/profile/$profileId'
-			fullPath: '/profile/$profileId'
-			preLoaderRoute: typeof ProfileProfileIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/$productId': {
-			id: '/products/$productId'
-			path: '/products/$productId'
-			fullPath: '/products/$productId'
-			preLoaderRoute: typeof ProductsProductIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/$postId': {
-			id: '/posts/$postId'
-			path: '/posts/$postId'
-			fullPath: '/posts/$postId'
-			preLoaderRoute: typeof PostsPostIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/collection/$collectionId': {
-			id: '/collection/$collectionId'
-			path: '/collection/$collectionId'
-			fullPath: '/collection/$collectionId'
-			preLoaderRoute: typeof CollectionCollectionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/$auctionId': {
-			id: '/auctions/$auctionId'
-			path: '/auctions/$auctionId'
-			fullPath: '/auctions/$auctionId'
-			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout/dashboard/': {
-			id: '/_dashboard-layout/dashboard/'
-			path: '/dashboard'
-			fullPath: '/dashboard/'
-			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/about': {
-			id: '/_dashboard-layout/dashboard/about'
-			path: '/dashboard/about'
-			fullPath: '/dashboard/about'
-			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/sales': {
-			id: '/_dashboard-layout/dashboard/sales/sales'
-			path: '/dashboard/sales/sales'
-			fullPath: '/dashboard/sales/sales'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages': {
-			id: '/_dashboard-layout/dashboard/sales/messages'
-			path: '/dashboard/sales/messages'
-			fullPath: '/dashboard/sales/messages'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/circular-economy': {
-			id: '/_dashboard-layout/dashboard/sales/circular-economy'
-			path: '/dashboard/sales/circular-economy'
-			fullPath: '/dashboard/sales/circular-economy'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/shipping-options': {
-			id: '/_dashboard-layout/dashboard/products/shipping-options'
-			path: '/dashboard/products/shipping-options'
-			fullPath: '/dashboard/products/shipping-options'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/products': {
-			id: '/_dashboard-layout/dashboard/products/products'
-			path: '/dashboard/products/products'
-			fullPath: '/dashboard/products/products'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/migration-tool': {
-			id: '/_dashboard-layout/dashboard/products/migration-tool'
-			path: '/dashboard/products/migration-tool'
-			fullPath: '/dashboard/products/migration-tool'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections': {
-			id: '/_dashboard-layout/dashboard/products/collections'
-			path: '/dashboard/products/collections'
-			fullPath: '/dashboard/products/collections'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/bids': {
-			id: '/_dashboard-layout/dashboard/products/bids'
-			path: '/dashboard/products/bids'
-			fullPath: '/dashboard/products/bids'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions': {
-			id: '/_dashboard-layout/dashboard/products/auctions'
-			path: '/dashboard/products/auctions'
-			fullPath: '/dashboard/products/auctions'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/orders/$orderId': {
-			id: '/_dashboard-layout/dashboard/orders/$orderId'
-			path: '/dashboard/orders/$orderId'
-			fullPath: '/dashboard/orders/$orderId'
-			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/team': {
-			id: '/_dashboard-layout/dashboard/app-settings/team'
-			path: '/dashboard/app-settings/team'
-			fullPath: '/dashboard/app-settings/team'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/featured-items': {
-			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-			path: '/dashboard/app-settings/featured-items'
-			fullPath: '/dashboard/app-settings/featured-items'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/blacklists': {
-			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-			path: '/dashboard/app-settings/blacklists'
-			fullPath: '/dashboard/app-settings/blacklists'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-			path: '/dashboard/app-settings/app-miscelleneous'
-			fullPath: '/dashboard/app-settings/app-miscelleneous'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/your-purchases': {
-			id: '/_dashboard-layout/dashboard/account/your-purchases'
-			path: '/dashboard/account/your-purchases'
-			fullPath: '/dashboard/account/your-purchases'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/vanity-url': {
-			id: '/_dashboard-layout/dashboard/account/vanity-url'
-			path: '/dashboard/account/vanity-url'
-			fullPath: '/dashboard/account/vanity-url'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/receiving-payments': {
-			id: '/_dashboard-layout/dashboard/account/receiving-payments'
-			path: '/dashboard/account/receiving-payments'
-			fullPath: '/dashboard/account/receiving-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/profile': {
-			id: '/_dashboard-layout/dashboard/account/profile'
-			path: '/dashboard/account/profile'
-			fullPath: '/dashboard/account/profile'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/preferences': {
-			id: '/_dashboard-layout/dashboard/account/preferences'
-			path: '/dashboard/account/preferences'
-			fullPath: '/dashboard/account/preferences'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/nostr-address': {
-			id: '/_dashboard-layout/dashboard/account/nostr-address'
-			path: '/dashboard/account/nostr-address'
-			fullPath: '/dashboard/account/nostr-address'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/network': {
-			id: '/_dashboard-layout/dashboard/account/network'
-			path: '/dashboard/account/network'
-			fullPath: '/dashboard/account/network'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/making-payments': {
-			id: '/_dashboard-layout/dashboard/account/making-payments'
-			path: '/dashboard/account/making-payments'
-			fullPath: '/dashboard/account/making-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-			path: '/$pubkey'
-			fullPath: '/dashboard/sales/messages/$pubkey'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/new': {
-			id: '/_dashboard-layout/dashboard/products/products/new'
-			path: '/new'
-			fullPath: '/dashboard/products/products/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/$productId': {
-			id: '/_dashboard-layout/dashboard/products/products/$productId'
-			path: '/$productId'
-			fullPath: '/dashboard/products/products/$productId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/new': {
-			id: '/_dashboard-layout/dashboard/products/collections/new'
-			path: '/new'
-			fullPath: '/dashboard/products/collections/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
-			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-			path: '/$collectionId'
-			fullPath: '/dashboard/products/collections/$collectionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-			path: '/$auctionId'
-			fullPath: '/dashboard/products/auctions/$auctionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-		}
-	}
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/checkout': {
+      id: '/checkout'
+      path: '/checkout'
+      fullPath: '/checkout'
+      preLoaderRoute: typeof CheckoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout': {
+      id: '/_dashboard-layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DashboardLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$vanityName': {
+      id: '/$vanityName'
+      path: '/$vanityName'
+      fullPath: '/$vanityName'
+      preLoaderRoute: typeof VanityNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/': {
+      id: '/products/'
+      path: '/products'
+      fullPath: '/products/'
+      preLoaderRoute: typeof ProductsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/posts'
+      fullPath: '/posts/'
+      preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nostr/': {
+      id: '/nostr/'
+      path: '/nostr'
+      fullPath: '/nostr/'
+      preLoaderRoute: typeof NostrIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/community/': {
+      id: '/community/'
+      path: '/community'
+      fullPath: '/community/'
+      preLoaderRoute: typeof CommunityIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/': {
+      id: '/auctions/'
+      path: '/auctions'
+      fullPath: '/auctions/'
+      preLoaderRoute: typeof AuctionsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search/products': {
+      id: '/search/products'
+      path: '/search/products'
+      fullPath: '/search/products'
+      preLoaderRoute: typeof SearchProductsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile/$profileId': {
+      id: '/profile/$profileId'
+      path: '/profile/$profileId'
+      fullPath: '/profile/$profileId'
+      preLoaderRoute: typeof ProfileProfileIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/$productId': {
+      id: '/products/$productId'
+      path: '/products/$productId'
+      fullPath: '/products/$productId'
+      preLoaderRoute: typeof ProductsProductIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/posts/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collection/$collectionId': {
+      id: '/collection/$collectionId'
+      path: '/collection/$collectionId'
+      fullPath: '/collection/$collectionId'
+      preLoaderRoute: typeof CollectionCollectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/$auctionId': {
+      id: '/auctions/$auctionId'
+      path: '/auctions/$auctionId'
+      fullPath: '/auctions/$auctionId'
+      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout/dashboard/': {
+      id: '/_dashboard-layout/dashboard/'
+      path: '/dashboard'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/about': {
+      id: '/_dashboard-layout/dashboard/about'
+      path: '/dashboard/about'
+      fullPath: '/dashboard/about'
+      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/sales': {
+      id: '/_dashboard-layout/dashboard/sales/sales'
+      path: '/dashboard/sales/sales'
+      fullPath: '/dashboard/sales/sales'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages': {
+      id: '/_dashboard-layout/dashboard/sales/messages'
+      path: '/dashboard/sales/messages'
+      fullPath: '/dashboard/sales/messages'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/circular-economy': {
+      id: '/_dashboard-layout/dashboard/sales/circular-economy'
+      path: '/dashboard/sales/circular-economy'
+      fullPath: '/dashboard/sales/circular-economy'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/shipping-options': {
+      id: '/_dashboard-layout/dashboard/products/shipping-options'
+      path: '/dashboard/products/shipping-options'
+      fullPath: '/dashboard/products/shipping-options'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/products': {
+      id: '/_dashboard-layout/dashboard/products/products'
+      path: '/dashboard/products/products'
+      fullPath: '/dashboard/products/products'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/migration-tool': {
+      id: '/_dashboard-layout/dashboard/products/migration-tool'
+      path: '/dashboard/products/migration-tool'
+      fullPath: '/dashboard/products/migration-tool'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections': {
+      id: '/_dashboard-layout/dashboard/products/collections'
+      path: '/dashboard/products/collections'
+      fullPath: '/dashboard/products/collections'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/bids': {
+      id: '/_dashboard-layout/dashboard/products/bids'
+      path: '/dashboard/products/bids'
+      fullPath: '/dashboard/products/bids'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions': {
+      id: '/_dashboard-layout/dashboard/products/auctions'
+      path: '/dashboard/products/auctions'
+      fullPath: '/dashboard/products/auctions'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/orders/$orderId': {
+      id: '/_dashboard-layout/dashboard/orders/$orderId'
+      path: '/dashboard/orders/$orderId'
+      fullPath: '/dashboard/orders/$orderId'
+      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/team': {
+      id: '/_dashboard-layout/dashboard/app-settings/team'
+      path: '/dashboard/app-settings/team'
+      fullPath: '/dashboard/app-settings/team'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/featured-items': {
+      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+      path: '/dashboard/app-settings/featured-items'
+      fullPath: '/dashboard/app-settings/featured-items'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/blacklists': {
+      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+      path: '/dashboard/app-settings/blacklists'
+      fullPath: '/dashboard/app-settings/blacklists'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+      path: '/dashboard/app-settings/app-miscelleneous'
+      fullPath: '/dashboard/app-settings/app-miscelleneous'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/your-purchases': {
+      id: '/_dashboard-layout/dashboard/account/your-purchases'
+      path: '/dashboard/account/your-purchases'
+      fullPath: '/dashboard/account/your-purchases'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/vanity-url': {
+      id: '/_dashboard-layout/dashboard/account/vanity-url'
+      path: '/dashboard/account/vanity-url'
+      fullPath: '/dashboard/account/vanity-url'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/receiving-payments': {
+      id: '/_dashboard-layout/dashboard/account/receiving-payments'
+      path: '/dashboard/account/receiving-payments'
+      fullPath: '/dashboard/account/receiving-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/profile': {
+      id: '/_dashboard-layout/dashboard/account/profile'
+      path: '/dashboard/account/profile'
+      fullPath: '/dashboard/account/profile'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/preferences': {
+      id: '/_dashboard-layout/dashboard/account/preferences'
+      path: '/dashboard/account/preferences'
+      fullPath: '/dashboard/account/preferences'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/nostr-address': {
+      id: '/_dashboard-layout/dashboard/account/nostr-address'
+      path: '/dashboard/account/nostr-address'
+      fullPath: '/dashboard/account/nostr-address'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/network': {
+      id: '/_dashboard-layout/dashboard/account/network'
+      path: '/dashboard/account/network'
+      fullPath: '/dashboard/account/network'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/making-payments': {
+      id: '/_dashboard-layout/dashboard/account/making-payments'
+      path: '/dashboard/account/making-payments'
+      fullPath: '/dashboard/account/making-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+      path: '/$pubkey'
+      fullPath: '/dashboard/sales/messages/$pubkey'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/new': {
+      id: '/_dashboard-layout/dashboard/products/products/new'
+      path: '/new'
+      fullPath: '/dashboard/products/products/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/$productId': {
+      id: '/_dashboard-layout/dashboard/products/products/$productId'
+      path: '/$productId'
+      fullPath: '/dashboard/products/products/$productId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/new': {
+      id: '/_dashboard-layout/dashboard/products/collections/new'
+      path: '/new'
+      fullPath: '/dashboard/products/collections/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
+      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+      path: '/$collectionId'
+      fullPath: '/dashboard/products/collections/$collectionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+      path: '/$auctionId'
+      fullPath: '/dashboard/products/auctions/$auctionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+    }
+  }
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-}
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
+      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+  }
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsAuctionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
+  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsAuctionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
-}
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
+      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+    DashboardLayoutDashboardProductsCollectionsNewRoute:
+      DashboardLayoutDashboardProductsCollectionsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsCollectionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
+  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsCollectionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
-	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
-}
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsProductsProductIdRoute:
+      DashboardLayoutDashboardProductsProductsProductIdRoute,
+    DashboardLayoutDashboardProductsProductsNewRoute:
+      DashboardLayoutDashboardProductsProductsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsProductsRouteChildren,
-)
+const DashboardLayoutDashboardProductsProductsRouteWithChildren =
+  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsProductsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-}
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
+  {
+    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
+      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+  }
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-	DashboardLayoutDashboardSalesMessagesRouteChildren,
-)
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
+  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+    DashboardLayoutDashboardSalesMessagesRouteChildren,
+  )
 
 interface DashboardLayoutRouteChildren {
-	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
-	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
-	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
-	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
-	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
-	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
-	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
-	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
-	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
-	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
-	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
-	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
-	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
+  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+  DashboardLayoutDashboardAccountMakingPaymentsRoute:
+    DashboardLayoutDashboardAccountMakingPaymentsRoute,
+  DashboardLayoutDashboardAccountNetworkRoute:
+    DashboardLayoutDashboardAccountNetworkRoute,
+  DashboardLayoutDashboardAccountNostrAddressRoute:
+    DashboardLayoutDashboardAccountNostrAddressRoute,
+  DashboardLayoutDashboardAccountPreferencesRoute:
+    DashboardLayoutDashboardAccountPreferencesRoute,
+  DashboardLayoutDashboardAccountProfileRoute:
+    DashboardLayoutDashboardAccountProfileRoute,
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
+    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+  DashboardLayoutDashboardAccountVanityUrlRoute:
+    DashboardLayoutDashboardAccountVanityUrlRoute,
+  DashboardLayoutDashboardAccountYourPurchasesRoute:
+    DashboardLayoutDashboardAccountYourPurchasesRoute,
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
+    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
+    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
+    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+  DashboardLayoutDashboardAppSettingsTeamRoute:
+    DashboardLayoutDashboardAppSettingsTeamRoute,
+  DashboardLayoutDashboardOrdersOrderIdRoute:
+    DashboardLayoutDashboardOrdersOrderIdRoute,
+  DashboardLayoutDashboardProductsAuctionsRoute:
+    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+  DashboardLayoutDashboardProductsBidsRoute:
+    DashboardLayoutDashboardProductsBidsRoute,
+  DashboardLayoutDashboardProductsCollectionsRoute:
+    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+  DashboardLayoutDashboardProductsMigrationToolRoute:
+    DashboardLayoutDashboardProductsMigrationToolRoute,
+  DashboardLayoutDashboardProductsProductsRoute:
+    DashboardLayoutDashboardProductsProductsRouteWithChildren,
+  DashboardLayoutDashboardProductsShippingOptionsRoute:
+    DashboardLayoutDashboardProductsShippingOptionsRoute,
+  DashboardLayoutDashboardSalesCircularEconomyRoute:
+    DashboardLayoutDashboardSalesCircularEconomyRoute,
+  DashboardLayoutDashboardSalesMessagesRoute:
+    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+  DashboardLayoutDashboardSalesSalesRoute:
+    DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
+  DashboardLayoutRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	VanityNameRoute: VanityNameRoute,
-	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-	CheckoutRoute: CheckoutRoute,
-	SetupRoute: SetupRoute,
-	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-	PostsPostIdRoute: PostsPostIdRoute,
-	ProductsProductIdRoute: ProductsProductIdRoute,
-	ProfileProfileIdRoute: ProfileProfileIdRoute,
-	SearchProductsRoute: SearchProductsRoute,
-	AuctionsIndexRoute: AuctionsIndexRoute,
-	CommunityIndexRoute: CommunityIndexRoute,
-	NostrIndexRoute: NostrIndexRoute,
-	PostsIndexRoute: PostsIndexRoute,
-	ProductsIndexRoute: ProductsIndexRoute,
+  IndexRoute: IndexRoute,
+  VanityNameRoute: VanityNameRoute,
+  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+  CheckoutRoute: CheckoutRoute,
+  SetupRoute: SetupRoute,
+  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+  PostsPostIdRoute: PostsPostIdRoute,
+  ProductsProductIdRoute: ProductsProductIdRoute,
+  ProfileProfileIdRoute: ProfileProfileIdRoute,
+  SearchProductsRoute: SearchProductsRoute,
+  AuctionsIndexRoute: AuctionsIndexRoute,
+  CommunityIndexRoute: CommunityIndexRoute,
+  NostrIndexRoute: NostrIndexRoute,
+  PostsIndexRoute: PostsIndexRoute,
+  ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,1063 +57,994 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-  id: '/setup',
-  path: '/setup',
-  getParentRoute: () => rootRouteImport,
+	id: '/setup',
+	path: '/setup',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-  id: '/checkout',
-  path: '/checkout',
-  getParentRoute: () => rootRouteImport,
+	id: '/checkout',
+	path: '/checkout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-  id: '/_dashboard-layout',
-  getParentRoute: () => rootRouteImport,
+	id: '/_dashboard-layout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-  id: '/$vanityName',
-  path: '/$vanityName',
-  getParentRoute: () => rootRouteImport,
+	id: '/$vanityName',
+	path: '/$vanityName',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-  id: '/products/',
-  path: '/products/',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/',
+	path: '/products/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-  id: '/posts/',
-  path: '/posts/',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/',
+	path: '/posts/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-  id: '/nostr/',
-  path: '/nostr/',
-  getParentRoute: () => rootRouteImport,
+	id: '/nostr/',
+	path: '/nostr/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-  id: '/community/',
-  path: '/community/',
-  getParentRoute: () => rootRouteImport,
+	id: '/community/',
+	path: '/community/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-  id: '/auctions/',
-  path: '/auctions/',
-  getParentRoute: () => rootRouteImport,
+	id: '/auctions/',
+	path: '/auctions/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-  id: '/search/products',
-  path: '/search/products',
-  getParentRoute: () => rootRouteImport,
+	id: '/search/products',
+	path: '/search/products',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-  id: '/profile/$profileId',
-  path: '/profile/$profileId',
-  getParentRoute: () => rootRouteImport,
+	id: '/profile/$profileId',
+	path: '/profile/$profileId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-  id: '/products/$productId',
-  path: '/products/$productId',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/$productId',
+	path: '/products/$productId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-  id: '/posts/$postId',
-  path: '/posts/$postId',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/$postId',
+	path: '/posts/$postId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-  id: '/collection/$collectionId',
-  path: '/collection/$collectionId',
-  getParentRoute: () => rootRouteImport,
+	id: '/collection/$collectionId',
+	path: '/collection/$collectionId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-  id: '/auctions/$auctionId',
-  path: '/auctions/$auctionId',
-  getParentRoute: () => rootRouteImport,
+	id: '/auctions/$auctionId',
+	path: '/auctions/$auctionId',
+	getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute =
-  DashboardLayoutDashboardIndexRouteImport.update({
-    id: '/dashboard/',
-    path: '/dashboard/',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAboutRoute =
-  DashboardLayoutDashboardAboutRouteImport.update({
-    id: '/dashboard/about',
-    path: '/dashboard/about',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesSalesRoute =
-  DashboardLayoutDashboardSalesSalesRouteImport.update({
-    id: '/dashboard/sales/sales',
-    path: '/dashboard/sales/sales',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesRoute =
-  DashboardLayoutDashboardSalesMessagesRouteImport.update({
-    id: '/dashboard/sales/messages',
-    path: '/dashboard/sales/messages',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute =
-  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-    id: '/dashboard/sales/circular-economy',
-    path: '/dashboard/sales/circular-economy',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute =
-  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-    id: '/dashboard/products/shipping-options',
-    path: '/dashboard/products/shipping-options',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsRoute =
-  DashboardLayoutDashboardProductsProductsRouteImport.update({
-    id: '/dashboard/products/products',
-    path: '/dashboard/products/products',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute =
-  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-    id: '/dashboard/products/migration-tool',
-    path: '/dashboard/products/migration-tool',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsRoute =
-  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-    id: '/dashboard/products/collections',
-    path: '/dashboard/products/collections',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsBidsRoute =
-  DashboardLayoutDashboardProductsBidsRouteImport.update({
-    id: '/dashboard/products/bids',
-    path: '/dashboard/products/bids',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsAuctionsRoute =
-  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-    id: '/dashboard/products/auctions',
-    path: '/dashboard/products/auctions',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute =
-  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-    id: '/dashboard/orders/$orderId',
-    path: '/dashboard/orders/$orderId',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute =
-  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-    id: '/dashboard/app-settings/team',
-    path: '/dashboard/app-settings/team',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-    id: '/dashboard/app-settings/featured-items',
-    path: '/dashboard/app-settings/featured-items',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
-  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-    id: '/dashboard/app-settings/blacklists',
-    path: '/dashboard/app-settings/blacklists',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-    id: '/dashboard/app-settings/app-miscelleneous',
-    path: '/dashboard/app-settings/app-miscelleneous',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute =
-  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-    id: '/dashboard/account/your-purchases',
-    path: '/dashboard/account/your-purchases',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute =
-  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-    id: '/dashboard/account/vanity-url',
-    path: '/dashboard/account/vanity-url',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
-  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-    id: '/dashboard/account/receiving-payments',
-    path: '/dashboard/account/receiving-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountProfileRoute =
-  DashboardLayoutDashboardAccountProfileRouteImport.update({
-    id: '/dashboard/account/profile',
-    path: '/dashboard/account/profile',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountPreferencesRoute =
-  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-    id: '/dashboard/account/preferences',
-    path: '/dashboard/account/preferences',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute =
-  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-    id: '/dashboard/account/nostr-address',
-    path: '/dashboard/account/nostr-address',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNetworkRoute =
-  DashboardLayoutDashboardAccountNetworkRouteImport.update({
-    id: '/dashboard/account/network',
-    path: '/dashboard/account/network',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute =
-  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-    id: '/dashboard/account/making-payments',
-    path: '/dashboard/account/making-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
-  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-    id: '/$pubkey',
-    path: '/$pubkey',
-    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsNewRoute =
-  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute =
-  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-    id: '/$productId',
-    path: '/$productId',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute =
-  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
+const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
+	id: '/dashboard/',
+	path: '/dashboard/',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
+	id: '/dashboard/about',
+	path: '/dashboard/about',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
+	id: '/dashboard/sales/sales',
+	path: '/dashboard/sales/sales',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
+	id: '/dashboard/sales/messages',
+	path: '/dashboard/sales/messages',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+	id: '/dashboard/sales/circular-economy',
+	path: '/dashboard/sales/circular-economy',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+	id: '/dashboard/products/shipping-options',
+	path: '/dashboard/products/shipping-options',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
+	id: '/dashboard/products/products',
+	path: '/dashboard/products/products',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+	id: '/dashboard/products/migration-tool',
+	path: '/dashboard/products/migration-tool',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+	id: '/dashboard/products/collections',
+	path: '/dashboard/products/collections',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
+	id: '/dashboard/products/bids',
+	path: '/dashboard/products/bids',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+	id: '/dashboard/products/auctions',
+	path: '/dashboard/products/auctions',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+	id: '/dashboard/orders/$orderId',
+	path: '/dashboard/orders/$orderId',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+	id: '/dashboard/app-settings/team',
+	path: '/dashboard/app-settings/team',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+	id: '/dashboard/app-settings/featured-items',
+	path: '/dashboard/app-settings/featured-items',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+	id: '/dashboard/app-settings/blacklists',
+	path: '/dashboard/app-settings/blacklists',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+	id: '/dashboard/app-settings/app-miscelleneous',
+	path: '/dashboard/app-settings/app-miscelleneous',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+	id: '/dashboard/account/your-purchases',
+	path: '/dashboard/account/your-purchases',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+	id: '/dashboard/account/vanity-url',
+	path: '/dashboard/account/vanity-url',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+	id: '/dashboard/account/receiving-payments',
+	path: '/dashboard/account/receiving-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
+	id: '/dashboard/account/profile',
+	path: '/dashboard/account/profile',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+	id: '/dashboard/account/preferences',
+	path: '/dashboard/account/preferences',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+	id: '/dashboard/account/nostr-address',
+	path: '/dashboard/account/nostr-address',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
+	id: '/dashboard/account/network',
+	path: '/dashboard/account/network',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+	id: '/dashboard/account/making-payments',
+	path: '/dashboard/account/making-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+	id: '/$pubkey',
+	path: '/$pubkey',
+	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+	id: '/$productId',
+	path: '/$productId',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+} as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-    id: '/$collectionId',
-    path: '/$collectionId',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
-  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-    id: '/$auctionId',
-    path: '/$auctionId',
-    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-  } as any)
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+		id: '/$collectionId',
+		path: '/$collectionId',
+		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+	} as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+	id: '/$auctionId',
+	path: '/$auctionId',
+	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions/': typeof AuctionsIndexRoute
-  '/community/': typeof CommunityIndexRoute
-  '/nostr/': typeof NostrIndexRoute
-  '/posts/': typeof PostsIndexRoute
-  '/products/': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions/': typeof AuctionsIndexRoute
+	'/community/': typeof CommunityIndexRoute
+	'/nostr/': typeof NostrIndexRoute
+	'/posts/': typeof PostsIndexRoute
+	'/products/': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions': typeof AuctionsIndexRoute
-  '/community': typeof CommunityIndexRoute
-  '/nostr': typeof NostrIndexRoute
-  '/posts': typeof PostsIndexRoute
-  '/products': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions': typeof AuctionsIndexRoute
+	'/community': typeof CommunityIndexRoute
+	'/nostr': typeof NostrIndexRoute
+	'/posts': typeof PostsIndexRoute
+	'/products': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions/': typeof AuctionsIndexRoute
-  '/community/': typeof CommunityIndexRoute
-  '/nostr/': typeof NostrIndexRoute
-  '/posts/': typeof PostsIndexRoute
-  '/products/': typeof ProductsIndexRoute
-  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	__root__: typeof rootRouteImport
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions/': typeof AuctionsIndexRoute
+	'/community/': typeof CommunityIndexRoute
+	'/nostr/': typeof NostrIndexRoute
+	'/posts/': typeof PostsIndexRoute
+	'/products/': typeof ProductsIndexRoute
+	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions/'
-    | '/community/'
-    | '/nostr/'
-    | '/posts/'
-    | '/products/'
-    | '/dashboard/about'
-    | '/dashboard/'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/auctions'
-    | '/dashboard/products/bids'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/auctions/$auctionId'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions'
-    | '/community'
-    | '/nostr'
-    | '/posts'
-    | '/products'
-    | '/dashboard/about'
-    | '/dashboard'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/auctions'
-    | '/dashboard/products/bids'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/auctions/$auctionId'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  id:
-    | '__root__'
-    | '/'
-    | '/$vanityName'
-    | '/_dashboard-layout'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions/'
-    | '/community/'
-    | '/nostr/'
-    | '/posts/'
-    | '/products/'
-    | '/_dashboard-layout/dashboard/about'
-    | '/_dashboard-layout/dashboard/'
-    | '/_dashboard-layout/dashboard/account/making-payments'
-    | '/_dashboard-layout/dashboard/account/network'
-    | '/_dashboard-layout/dashboard/account/nostr-address'
-    | '/_dashboard-layout/dashboard/account/preferences'
-    | '/_dashboard-layout/dashboard/account/profile'
-    | '/_dashboard-layout/dashboard/account/receiving-payments'
-    | '/_dashboard-layout/dashboard/account/vanity-url'
-    | '/_dashboard-layout/dashboard/account/your-purchases'
-    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-    | '/_dashboard-layout/dashboard/app-settings/blacklists'
-    | '/_dashboard-layout/dashboard/app-settings/featured-items'
-    | '/_dashboard-layout/dashboard/app-settings/team'
-    | '/_dashboard-layout/dashboard/orders/$orderId'
-    | '/_dashboard-layout/dashboard/products/auctions'
-    | '/_dashboard-layout/dashboard/products/bids'
-    | '/_dashboard-layout/dashboard/products/collections'
-    | '/_dashboard-layout/dashboard/products/migration-tool'
-    | '/_dashboard-layout/dashboard/products/products'
-    | '/_dashboard-layout/dashboard/products/shipping-options'
-    | '/_dashboard-layout/dashboard/sales/circular-economy'
-    | '/_dashboard-layout/dashboard/sales/messages'
-    | '/_dashboard-layout/dashboard/sales/sales'
-    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
-    | '/_dashboard-layout/dashboard/products/collections/new'
-    | '/_dashboard-layout/dashboard/products/products/$productId'
-    | '/_dashboard-layout/dashboard/products/products/new'
-    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath
+	fullPaths:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions/'
+		| '/community/'
+		| '/nostr/'
+		| '/posts/'
+		| '/products/'
+		| '/dashboard/about'
+		| '/dashboard/'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/auctions'
+		| '/dashboard/products/bids'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/auctions/$auctionId'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	fileRoutesByTo: FileRoutesByTo
+	to:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions'
+		| '/community'
+		| '/nostr'
+		| '/posts'
+		| '/products'
+		| '/dashboard/about'
+		| '/dashboard'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/auctions'
+		| '/dashboard/products/bids'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/auctions/$auctionId'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	id:
+		| '__root__'
+		| '/'
+		| '/$vanityName'
+		| '/_dashboard-layout'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions/'
+		| '/community/'
+		| '/nostr/'
+		| '/posts/'
+		| '/products/'
+		| '/_dashboard-layout/dashboard/about'
+		| '/_dashboard-layout/dashboard/'
+		| '/_dashboard-layout/dashboard/account/making-payments'
+		| '/_dashboard-layout/dashboard/account/network'
+		| '/_dashboard-layout/dashboard/account/nostr-address'
+		| '/_dashboard-layout/dashboard/account/preferences'
+		| '/_dashboard-layout/dashboard/account/profile'
+		| '/_dashboard-layout/dashboard/account/receiving-payments'
+		| '/_dashboard-layout/dashboard/account/vanity-url'
+		| '/_dashboard-layout/dashboard/account/your-purchases'
+		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+		| '/_dashboard-layout/dashboard/app-settings/blacklists'
+		| '/_dashboard-layout/dashboard/app-settings/featured-items'
+		| '/_dashboard-layout/dashboard/app-settings/team'
+		| '/_dashboard-layout/dashboard/orders/$orderId'
+		| '/_dashboard-layout/dashboard/products/auctions'
+		| '/_dashboard-layout/dashboard/products/bids'
+		| '/_dashboard-layout/dashboard/products/collections'
+		| '/_dashboard-layout/dashboard/products/migration-tool'
+		| '/_dashboard-layout/dashboard/products/products'
+		| '/_dashboard-layout/dashboard/products/shipping-options'
+		| '/_dashboard-layout/dashboard/sales/circular-economy'
+		| '/_dashboard-layout/dashboard/sales/messages'
+		| '/_dashboard-layout/dashboard/sales/sales'
+		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
+		| '/_dashboard-layout/dashboard/products/collections/new'
+		| '/_dashboard-layout/dashboard/products/products/$productId'
+		| '/_dashboard-layout/dashboard/products/products/new'
+		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+	fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  VanityNameRoute: typeof VanityNameRoute
-  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-  CheckoutRoute: typeof CheckoutRoute
-  SetupRoute: typeof SetupRoute
-  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-  PostsPostIdRoute: typeof PostsPostIdRoute
-  ProductsProductIdRoute: typeof ProductsProductIdRoute
-  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-  SearchProductsRoute: typeof SearchProductsRoute
-  AuctionsIndexRoute: typeof AuctionsIndexRoute
-  CommunityIndexRoute: typeof CommunityIndexRoute
-  NostrIndexRoute: typeof NostrIndexRoute
-  PostsIndexRoute: typeof PostsIndexRoute
-  ProductsIndexRoute: typeof ProductsIndexRoute
+	IndexRoute: typeof IndexRoute
+	VanityNameRoute: typeof VanityNameRoute
+	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+	CheckoutRoute: typeof CheckoutRoute
+	SetupRoute: typeof SetupRoute
+	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+	PostsPostIdRoute: typeof PostsPostIdRoute
+	ProductsProductIdRoute: typeof ProductsProductIdRoute
+	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+	SearchProductsRoute: typeof SearchProductsRoute
+	AuctionsIndexRoute: typeof AuctionsIndexRoute
+	CommunityIndexRoute: typeof CommunityIndexRoute
+	NostrIndexRoute: typeof NostrIndexRoute
+	PostsIndexRoute: typeof PostsIndexRoute
+	ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/setup': {
-      id: '/setup'
-      path: '/setup'
-      fullPath: '/setup'
-      preLoaderRoute: typeof SetupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/checkout': {
-      id: '/checkout'
-      path: '/checkout'
-      fullPath: '/checkout'
-      preLoaderRoute: typeof CheckoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout': {
-      id: '/_dashboard-layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof DashboardLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/$vanityName': {
-      id: '/$vanityName'
-      path: '/$vanityName'
-      fullPath: '/$vanityName'
-      preLoaderRoute: typeof VanityNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/': {
-      id: '/products/'
-      path: '/products'
-      fullPath: '/products/'
-      preLoaderRoute: typeof ProductsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/': {
-      id: '/posts/'
-      path: '/posts'
-      fullPath: '/posts/'
-      preLoaderRoute: typeof PostsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/nostr/': {
-      id: '/nostr/'
-      path: '/nostr'
-      fullPath: '/nostr/'
-      preLoaderRoute: typeof NostrIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/community/': {
-      id: '/community/'
-      path: '/community'
-      fullPath: '/community/'
-      preLoaderRoute: typeof CommunityIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auctions/': {
-      id: '/auctions/'
-      path: '/auctions'
-      fullPath: '/auctions/'
-      preLoaderRoute: typeof AuctionsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/search/products': {
-      id: '/search/products'
-      path: '/search/products'
-      fullPath: '/search/products'
-      preLoaderRoute: typeof SearchProductsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/profile/$profileId': {
-      id: '/profile/$profileId'
-      path: '/profile/$profileId'
-      fullPath: '/profile/$profileId'
-      preLoaderRoute: typeof ProfileProfileIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/$productId': {
-      id: '/products/$productId'
-      path: '/products/$productId'
-      fullPath: '/products/$productId'
-      preLoaderRoute: typeof ProductsProductIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/$postId': {
-      id: '/posts/$postId'
-      path: '/posts/$postId'
-      fullPath: '/posts/$postId'
-      preLoaderRoute: typeof PostsPostIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/collection/$collectionId': {
-      id: '/collection/$collectionId'
-      path: '/collection/$collectionId'
-      fullPath: '/collection/$collectionId'
-      preLoaderRoute: typeof CollectionCollectionIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auctions/$auctionId': {
-      id: '/auctions/$auctionId'
-      path: '/auctions/$auctionId'
-      fullPath: '/auctions/$auctionId'
-      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout/dashboard/': {
-      id: '/_dashboard-layout/dashboard/'
-      path: '/dashboard'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/about': {
-      id: '/_dashboard-layout/dashboard/about'
-      path: '/dashboard/about'
-      fullPath: '/dashboard/about'
-      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/sales': {
-      id: '/_dashboard-layout/dashboard/sales/sales'
-      path: '/dashboard/sales/sales'
-      fullPath: '/dashboard/sales/sales'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages': {
-      id: '/_dashboard-layout/dashboard/sales/messages'
-      path: '/dashboard/sales/messages'
-      fullPath: '/dashboard/sales/messages'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/circular-economy': {
-      id: '/_dashboard-layout/dashboard/sales/circular-economy'
-      path: '/dashboard/sales/circular-economy'
-      fullPath: '/dashboard/sales/circular-economy'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/shipping-options': {
-      id: '/_dashboard-layout/dashboard/products/shipping-options'
-      path: '/dashboard/products/shipping-options'
-      fullPath: '/dashboard/products/shipping-options'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/products': {
-      id: '/_dashboard-layout/dashboard/products/products'
-      path: '/dashboard/products/products'
-      fullPath: '/dashboard/products/products'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/migration-tool': {
-      id: '/_dashboard-layout/dashboard/products/migration-tool'
-      path: '/dashboard/products/migration-tool'
-      fullPath: '/dashboard/products/migration-tool'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections': {
-      id: '/_dashboard-layout/dashboard/products/collections'
-      path: '/dashboard/products/collections'
-      fullPath: '/dashboard/products/collections'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/bids': {
-      id: '/_dashboard-layout/dashboard/products/bids'
-      path: '/dashboard/products/bids'
-      fullPath: '/dashboard/products/bids'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/auctions': {
-      id: '/_dashboard-layout/dashboard/products/auctions'
-      path: '/dashboard/products/auctions'
-      fullPath: '/dashboard/products/auctions'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/orders/$orderId': {
-      id: '/_dashboard-layout/dashboard/orders/$orderId'
-      path: '/dashboard/orders/$orderId'
-      fullPath: '/dashboard/orders/$orderId'
-      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/team': {
-      id: '/_dashboard-layout/dashboard/app-settings/team'
-      path: '/dashboard/app-settings/team'
-      fullPath: '/dashboard/app-settings/team'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/featured-items': {
-      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-      path: '/dashboard/app-settings/featured-items'
-      fullPath: '/dashboard/app-settings/featured-items'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/blacklists': {
-      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-      path: '/dashboard/app-settings/blacklists'
-      fullPath: '/dashboard/app-settings/blacklists'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-      path: '/dashboard/app-settings/app-miscelleneous'
-      fullPath: '/dashboard/app-settings/app-miscelleneous'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/your-purchases': {
-      id: '/_dashboard-layout/dashboard/account/your-purchases'
-      path: '/dashboard/account/your-purchases'
-      fullPath: '/dashboard/account/your-purchases'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/vanity-url': {
-      id: '/_dashboard-layout/dashboard/account/vanity-url'
-      path: '/dashboard/account/vanity-url'
-      fullPath: '/dashboard/account/vanity-url'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/receiving-payments': {
-      id: '/_dashboard-layout/dashboard/account/receiving-payments'
-      path: '/dashboard/account/receiving-payments'
-      fullPath: '/dashboard/account/receiving-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/profile': {
-      id: '/_dashboard-layout/dashboard/account/profile'
-      path: '/dashboard/account/profile'
-      fullPath: '/dashboard/account/profile'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/preferences': {
-      id: '/_dashboard-layout/dashboard/account/preferences'
-      path: '/dashboard/account/preferences'
-      fullPath: '/dashboard/account/preferences'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/nostr-address': {
-      id: '/_dashboard-layout/dashboard/account/nostr-address'
-      path: '/dashboard/account/nostr-address'
-      fullPath: '/dashboard/account/nostr-address'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/network': {
-      id: '/_dashboard-layout/dashboard/account/network'
-      path: '/dashboard/account/network'
-      fullPath: '/dashboard/account/network'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/making-payments': {
-      id: '/_dashboard-layout/dashboard/account/making-payments'
-      path: '/dashboard/account/making-payments'
-      fullPath: '/dashboard/account/making-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-      path: '/$pubkey'
-      fullPath: '/dashboard/sales/messages/$pubkey'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/new': {
-      id: '/_dashboard-layout/dashboard/products/products/new'
-      path: '/new'
-      fullPath: '/dashboard/products/products/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/$productId': {
-      id: '/_dashboard-layout/dashboard/products/products/$productId'
-      path: '/$productId'
-      fullPath: '/dashboard/products/products/$productId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/new': {
-      id: '/_dashboard-layout/dashboard/products/collections/new'
-      path: '/new'
-      fullPath: '/dashboard/products/collections/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
-      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-      path: '/$collectionId'
-      fullPath: '/dashboard/products/collections/$collectionId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-      path: '/$auctionId'
-      fullPath: '/dashboard/products/auctions/$auctionId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-    }
-  }
+	interface FileRoutesByPath {
+		'/setup': {
+			id: '/setup'
+			path: '/setup'
+			fullPath: '/setup'
+			preLoaderRoute: typeof SetupRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/checkout': {
+			id: '/checkout'
+			path: '/checkout'
+			fullPath: '/checkout'
+			preLoaderRoute: typeof CheckoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout': {
+			id: '/_dashboard-layout'
+			path: ''
+			fullPath: '/'
+			preLoaderRoute: typeof DashboardLayoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/$vanityName': {
+			id: '/$vanityName'
+			path: '/$vanityName'
+			fullPath: '/$vanityName'
+			preLoaderRoute: typeof VanityNameRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/': {
+			id: '/'
+			path: '/'
+			fullPath: '/'
+			preLoaderRoute: typeof IndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/': {
+			id: '/products/'
+			path: '/products'
+			fullPath: '/products/'
+			preLoaderRoute: typeof ProductsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/': {
+			id: '/posts/'
+			path: '/posts'
+			fullPath: '/posts/'
+			preLoaderRoute: typeof PostsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/nostr/': {
+			id: '/nostr/'
+			path: '/nostr'
+			fullPath: '/nostr/'
+			preLoaderRoute: typeof NostrIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/community/': {
+			id: '/community/'
+			path: '/community'
+			fullPath: '/community/'
+			preLoaderRoute: typeof CommunityIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/auctions/': {
+			id: '/auctions/'
+			path: '/auctions'
+			fullPath: '/auctions/'
+			preLoaderRoute: typeof AuctionsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/search/products': {
+			id: '/search/products'
+			path: '/search/products'
+			fullPath: '/search/products'
+			preLoaderRoute: typeof SearchProductsRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/profile/$profileId': {
+			id: '/profile/$profileId'
+			path: '/profile/$profileId'
+			fullPath: '/profile/$profileId'
+			preLoaderRoute: typeof ProfileProfileIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/$productId': {
+			id: '/products/$productId'
+			path: '/products/$productId'
+			fullPath: '/products/$productId'
+			preLoaderRoute: typeof ProductsProductIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/$postId': {
+			id: '/posts/$postId'
+			path: '/posts/$postId'
+			fullPath: '/posts/$postId'
+			preLoaderRoute: typeof PostsPostIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/collection/$collectionId': {
+			id: '/collection/$collectionId'
+			path: '/collection/$collectionId'
+			fullPath: '/collection/$collectionId'
+			preLoaderRoute: typeof CollectionCollectionIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/auctions/$auctionId': {
+			id: '/auctions/$auctionId'
+			path: '/auctions/$auctionId'
+			fullPath: '/auctions/$auctionId'
+			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout/dashboard/': {
+			id: '/_dashboard-layout/dashboard/'
+			path: '/dashboard'
+			fullPath: '/dashboard/'
+			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/about': {
+			id: '/_dashboard-layout/dashboard/about'
+			path: '/dashboard/about'
+			fullPath: '/dashboard/about'
+			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/sales': {
+			id: '/_dashboard-layout/dashboard/sales/sales'
+			path: '/dashboard/sales/sales'
+			fullPath: '/dashboard/sales/sales'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages': {
+			id: '/_dashboard-layout/dashboard/sales/messages'
+			path: '/dashboard/sales/messages'
+			fullPath: '/dashboard/sales/messages'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/circular-economy': {
+			id: '/_dashboard-layout/dashboard/sales/circular-economy'
+			path: '/dashboard/sales/circular-economy'
+			fullPath: '/dashboard/sales/circular-economy'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/shipping-options': {
+			id: '/_dashboard-layout/dashboard/products/shipping-options'
+			path: '/dashboard/products/shipping-options'
+			fullPath: '/dashboard/products/shipping-options'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/products': {
+			id: '/_dashboard-layout/dashboard/products/products'
+			path: '/dashboard/products/products'
+			fullPath: '/dashboard/products/products'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/migration-tool': {
+			id: '/_dashboard-layout/dashboard/products/migration-tool'
+			path: '/dashboard/products/migration-tool'
+			fullPath: '/dashboard/products/migration-tool'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections': {
+			id: '/_dashboard-layout/dashboard/products/collections'
+			path: '/dashboard/products/collections'
+			fullPath: '/dashboard/products/collections'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/bids': {
+			id: '/_dashboard-layout/dashboard/products/bids'
+			path: '/dashboard/products/bids'
+			fullPath: '/dashboard/products/bids'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/auctions': {
+			id: '/_dashboard-layout/dashboard/products/auctions'
+			path: '/dashboard/products/auctions'
+			fullPath: '/dashboard/products/auctions'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/orders/$orderId': {
+			id: '/_dashboard-layout/dashboard/orders/$orderId'
+			path: '/dashboard/orders/$orderId'
+			fullPath: '/dashboard/orders/$orderId'
+			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/team': {
+			id: '/_dashboard-layout/dashboard/app-settings/team'
+			path: '/dashboard/app-settings/team'
+			fullPath: '/dashboard/app-settings/team'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/featured-items': {
+			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+			path: '/dashboard/app-settings/featured-items'
+			fullPath: '/dashboard/app-settings/featured-items'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/blacklists': {
+			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+			path: '/dashboard/app-settings/blacklists'
+			fullPath: '/dashboard/app-settings/blacklists'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+			path: '/dashboard/app-settings/app-miscelleneous'
+			fullPath: '/dashboard/app-settings/app-miscelleneous'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/your-purchases': {
+			id: '/_dashboard-layout/dashboard/account/your-purchases'
+			path: '/dashboard/account/your-purchases'
+			fullPath: '/dashboard/account/your-purchases'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/vanity-url': {
+			id: '/_dashboard-layout/dashboard/account/vanity-url'
+			path: '/dashboard/account/vanity-url'
+			fullPath: '/dashboard/account/vanity-url'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/receiving-payments': {
+			id: '/_dashboard-layout/dashboard/account/receiving-payments'
+			path: '/dashboard/account/receiving-payments'
+			fullPath: '/dashboard/account/receiving-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/profile': {
+			id: '/_dashboard-layout/dashboard/account/profile'
+			path: '/dashboard/account/profile'
+			fullPath: '/dashboard/account/profile'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/preferences': {
+			id: '/_dashboard-layout/dashboard/account/preferences'
+			path: '/dashboard/account/preferences'
+			fullPath: '/dashboard/account/preferences'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/nostr-address': {
+			id: '/_dashboard-layout/dashboard/account/nostr-address'
+			path: '/dashboard/account/nostr-address'
+			fullPath: '/dashboard/account/nostr-address'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/network': {
+			id: '/_dashboard-layout/dashboard/account/network'
+			path: '/dashboard/account/network'
+			fullPath: '/dashboard/account/network'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/making-payments': {
+			id: '/_dashboard-layout/dashboard/account/making-payments'
+			path: '/dashboard/account/making-payments'
+			fullPath: '/dashboard/account/making-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+			path: '/$pubkey'
+			fullPath: '/dashboard/sales/messages/$pubkey'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/new': {
+			id: '/_dashboard-layout/dashboard/products/products/new'
+			path: '/new'
+			fullPath: '/dashboard/products/products/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/$productId': {
+			id: '/_dashboard-layout/dashboard/products/products/$productId'
+			path: '/$productId'
+			fullPath: '/dashboard/products/products/$productId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/new': {
+			id: '/_dashboard-layout/dashboard/products/collections/new'
+			path: '/new'
+			fullPath: '/dashboard/products/collections/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
+			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+			path: '/$collectionId'
+			fullPath: '/dashboard/products/collections/$collectionId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+			path: '/$auctionId'
+			fullPath: '/dashboard/products/auctions/$auctionId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+		}
+	}
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
-      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-  }
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
+	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+}
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
-  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsAuctionsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsAuctionsRouteChildren,
+)
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
-      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-    DashboardLayoutDashboardProductsCollectionsNewRoute:
-      DashboardLayoutDashboardProductsCollectionsNewRoute,
-  }
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
-  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsCollectionsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsCollectionsRouteChildren,
+)
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsProductsProductIdRoute:
-      DashboardLayoutDashboardProductsProductsProductIdRoute,
-    DashboardLayoutDashboardProductsProductsNewRoute:
-      DashboardLayoutDashboardProductsProductsNewRoute,
-  }
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
+	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
+	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren =
-  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsProductsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsProductsRouteChildren,
+)
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
-  {
-    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
-      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-  }
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+}
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
-  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-    DashboardLayoutDashboardSalesMessagesRouteChildren,
-  )
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+	DashboardLayoutDashboardSalesMessagesRouteChildren,
+)
 
 interface DashboardLayoutRouteChildren {
-  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-  DashboardLayoutDashboardAccountMakingPaymentsRoute:
-    DashboardLayoutDashboardAccountMakingPaymentsRoute,
-  DashboardLayoutDashboardAccountNetworkRoute:
-    DashboardLayoutDashboardAccountNetworkRoute,
-  DashboardLayoutDashboardAccountNostrAddressRoute:
-    DashboardLayoutDashboardAccountNostrAddressRoute,
-  DashboardLayoutDashboardAccountPreferencesRoute:
-    DashboardLayoutDashboardAccountPreferencesRoute,
-  DashboardLayoutDashboardAccountProfileRoute:
-    DashboardLayoutDashboardAccountProfileRoute,
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
-    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-  DashboardLayoutDashboardAccountVanityUrlRoute:
-    DashboardLayoutDashboardAccountVanityUrlRoute,
-  DashboardLayoutDashboardAccountYourPurchasesRoute:
-    DashboardLayoutDashboardAccountYourPurchasesRoute,
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
-    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
-    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
-    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-  DashboardLayoutDashboardAppSettingsTeamRoute:
-    DashboardLayoutDashboardAppSettingsTeamRoute,
-  DashboardLayoutDashboardOrdersOrderIdRoute:
-    DashboardLayoutDashboardOrdersOrderIdRoute,
-  DashboardLayoutDashboardProductsAuctionsRoute:
-    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-  DashboardLayoutDashboardProductsBidsRoute:
-    DashboardLayoutDashboardProductsBidsRoute,
-  DashboardLayoutDashboardProductsCollectionsRoute:
-    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-  DashboardLayoutDashboardProductsMigrationToolRoute:
-    DashboardLayoutDashboardProductsMigrationToolRoute,
-  DashboardLayoutDashboardProductsProductsRoute:
-    DashboardLayoutDashboardProductsProductsRouteWithChildren,
-  DashboardLayoutDashboardProductsShippingOptionsRoute:
-    DashboardLayoutDashboardProductsShippingOptionsRoute,
-  DashboardLayoutDashboardSalesCircularEconomyRoute:
-    DashboardLayoutDashboardSalesCircularEconomyRoute,
-  DashboardLayoutDashboardSalesMessagesRoute:
-    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-  DashboardLayoutDashboardSalesSalesRoute:
-    DashboardLayoutDashboardSalesSalesRoute,
+	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
+	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
+	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
+	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
+	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
+	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
+	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
+	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
+	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
+	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
+	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
+	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
+	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
-  DashboardLayoutRouteChildren,
-)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  VanityNameRoute: VanityNameRoute,
-  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-  CheckoutRoute: CheckoutRoute,
-  SetupRoute: SetupRoute,
-  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-  PostsPostIdRoute: PostsPostIdRoute,
-  ProductsProductIdRoute: ProductsProductIdRoute,
-  ProfileProfileIdRoute: ProfileProfileIdRoute,
-  SearchProductsRoute: SearchProductsRoute,
-  AuctionsIndexRoute: AuctionsIndexRoute,
-  CommunityIndexRoute: CommunityIndexRoute,
-  NostrIndexRoute: NostrIndexRoute,
-  PostsIndexRoute: PostsIndexRoute,
-  ProductsIndexRoute: ProductsIndexRoute,
+	IndexRoute: IndexRoute,
+	VanityNameRoute: VanityNameRoute,
+	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+	CheckoutRoute: CheckoutRoute,
+	SetupRoute: SetupRoute,
+	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+	PostsPostIdRoute: PostsPostIdRoute,
+	ProductsProductIdRoute: ProductsProductIdRoute,
+	ProfileProfileIdRoute: ProfileProfileIdRoute,
+	SearchProductsRoute: SearchProductsRoute,
+	AuctionsIndexRoute: AuctionsIndexRoute,
+	CommunityIndexRoute: CommunityIndexRoute,
+	NostrIndexRoute: NostrIndexRoute,
+	PostsIndexRoute: PostsIndexRoute,
+	ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()

--- a/src/server/auction/grants.ts
+++ b/src/server/auction/grants.ts
@@ -200,11 +200,7 @@ export async function buildAuctionPathGrant(
  * the current top": a bid that's structurally invalid is still
  * something a bidder might have committed to outbid.
  */
-async function fetchCurrentTopBidAmount(
-	ctx: AuctionContext,
-	auctionEventId: string,
-	auctionCoordinates: string,
-): Promise<number> {
+async function fetchCurrentTopBidAmount(ctx: AuctionContext, auctionEventId: string, auctionCoordinates: string): Promise<number> {
 	const filters = [
 		{
 			kinds: [AUCTION_BID_KIND],

--- a/src/server/auction/grants.ts
+++ b/src/server/auction/grants.ts
@@ -1,4 +1,10 @@
-import { getAuctionTagValue } from '../../lib/auctionSettlement'
+import {
+	AUCTION_BID_KIND,
+	BID_FLOOR_TIME_GRACE_SECONDS,
+	computeAuctionBidFloor,
+	getAuctionBidAmount,
+	getAuctionTagValue,
+} from '../../lib/auctionSettlement'
 import {
 	AUCTION_PATH_GRANT_DEFAULT_TTL_SECONDS,
 	AUCTION_PATH_REGISTRY_SCHEMA,
@@ -34,6 +40,13 @@ export interface AuctionPathGrant {
 	childPubkey: string
 	issuedAt: number
 	expiresAt: number
+	/**
+	 * Bid floor enforced for this grant at request time (AUCTIONS.md §6.1).
+	 * Lower bound on `intendedAmount`; the bidder's kind-1023 amount MUST
+	 * be ≥ this value, and settlement re-checks against the floor at the
+	 * bid's own `created_at`.
+	 */
+	acceptedFloor: number
 }
 
 export async function buildAuctionPathGrant(
@@ -44,6 +57,7 @@ export async function buildAuctionPathGrant(
 		auctionCoordinates: string
 		bidderPubkey: string
 		bidderRefundPubkey: string
+		intendedAmount: number
 	},
 ): Promise<AuctionPathGrant> {
 	// AUCTIONS.md §7.5.1 input validation. The transport (HTTP NIP-98 or
@@ -56,6 +70,9 @@ export async function buildAuctionPathGrant(
 	if (!COMPRESSED_SECP256K1_PUBKEY_HEX_RE.test(params.bidderRefundPubkey)) {
 		throw new Error('bidderRefundPubkey must be a compressed secp256k1 pubkey (33 bytes hex, 02/03 prefix)')
 	}
+	if (!Number.isFinite(params.intendedAmount) || params.intendedAmount <= 0) {
+		throw new Error('intendedAmount must be a positive integer (sats)')
+	}
 
 	ctx.stateStore.enforcePathRequestRateLimit({
 		issuerPubkey: ctx.issuerPubkey,
@@ -65,6 +82,16 @@ export async function buildAuctionPathGrant(
 	})
 
 	const auctionEvent = await loadAuctionEvent(ctx, params.auctionEventId)
+
+	// AUCTIONS.md §7.5.1 — seller self-bid block. A seller bidding on
+	// their own auction could pump the floor against honest bidders
+	// without ever paying out (the kind-1023 → submit_bid_token loop
+	// would still settle to themselves, but the curve would have
+	// inflated the cost for legitimate participants in the meantime).
+	if (params.bidderPubkey.toLowerCase() === auctionEvent.pubkey.toLowerCase()) {
+		throw new Error('Sellers MUST NOT bid on their own auction')
+	}
+
 	const issuerPubkey = getAuctionPathIssuerFromEvent(auctionEvent)
 	if (issuerPubkey !== ctx.issuerPubkey) {
 		throw new Error('Auction is not configured for this path issuer')
@@ -88,6 +115,20 @@ export async function buildAuctionPathGrant(
 	}
 	if (maxEndAt && now >= maxEndAt) {
 		throw new Error('Auction has reached its hard bidding cutoff')
+	}
+
+	// AUCTIONS.md §6.1 — anti-snipe curve enforcement. Compute the floor
+	// at `now - GRACE` (server is lenient by 5 s to absorb relay/network
+	// latency between the bidder clicking "Bid" and us receiving the
+	// kind-25910). The floor uses the relay-current top bid; we fetch a
+	// fresh slice rather than trusting any client-supplied state.
+	const topBidAmount = await fetchCurrentTopBidAmount(ctx, params.auctionEventId, params.auctionCoordinates)
+	const effectiveT = Math.max(now - BID_FLOOR_TIME_GRACE_SECONDS, endAt)
+	const acceptedFloor = computeAuctionBidFloor(auctionEvent, topBidAmount, effectiveT)
+	if (params.intendedAmount < acceptedFloor) {
+		throw new Error(
+			`intendedAmount ${params.intendedAmount} is below the current bid floor ${acceptedFloor} sats — wait for the next floor update or bid higher`,
+		)
 	}
 
 	const registry = (await fetchAuctionPathRegistry(ctx, params.auctionEventId)) ?? {
@@ -140,5 +181,60 @@ export async function buildAuctionPathGrant(
 		childPubkey: allocated.childPubkey,
 		issuedAt,
 		expiresAt,
+		acceptedFloor,
+	}
+}
+
+/**
+ * Fetch every kind-1023 bid event for the auction and return the highest
+ * `amount` we see. Used by `buildAuctionPathGrant` to compute the
+ * curve-aware floor.
+ *
+ * Returns `0` when no bids exist yet, which makes
+ * `computeAuctionBidFloor` fall back to `starting_bid` for the baseline
+ * (the "first bid" case in AUCTIONS.md §6.1).
+ *
+ * We deliberately don't enforce chain priority or any of settlement's
+ * stricter checks here — those guard the actual release. For floor
+ * enforcement we want the loosest possible interpretation of "what's
+ * the current top": a bid that's structurally invalid is still
+ * something a bidder might have committed to outbid.
+ */
+async function fetchCurrentTopBidAmount(
+	ctx: AuctionContext,
+	auctionEventId: string,
+	auctionCoordinates: string,
+): Promise<number> {
+	const filters = [
+		{
+			kinds: [AUCTION_BID_KIND],
+			'#e': [auctionEventId],
+			limit: 200,
+		},
+		...(auctionCoordinates
+			? [
+					{
+						kinds: [AUCTION_BID_KIND],
+						'#a': [auctionCoordinates],
+						limit: 200,
+					},
+				]
+			: []),
+	]
+	try {
+		const bidEvents = Array.from(await ctx.ndk.fetchEvents(filters.length === 1 ? filters[0] : filters))
+		let top = 0
+		for (const bid of bidEvents) {
+			const amount = getAuctionBidAmount(bid)
+			if (amount > top) top = amount
+		}
+		return top
+	} catch (error) {
+		// On relay error, fall back to "no top bid" — the floor degrades
+		// to `starting_bid × multiplier`. The bidder's UI shows the same
+		// number (it doesn't know about the failure), so behaviour stays
+		// consistent. Log so operators see persistent issues.
+		console.warn('[auction] fetchCurrentTopBidAmount failed; falling back to top=0', error)
+		return 0
 	}
 }

--- a/src/server/auction/settlement.ts
+++ b/src/server/auction/settlement.ts
@@ -1,8 +1,10 @@
 import {
 	AUCTION_BID_KIND,
 	AUCTION_SETTLEMENT_KIND,
+	BID_FLOOR_TIME_GRACE_SECONDS,
 	buildActiveAuctionBidChains,
 	compareAuctionBidChainPriority,
+	computeAuctionBidFloor,
 	getAuctionBidAmount,
 	getAuctionEffectiveEndAt,
 	getAuctionEndAt,
@@ -14,6 +16,7 @@ import {
 	type AuctionSettlementPlanResponse,
 	type AuctionSettlementPublishStatus,
 } from '../../lib/auctionSettlement'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { auctionP2pkPubkeysMatch, deriveAuctionChildP2pkPubkeyFromXpub, normalizeAuctionP2pkPubkey } from '../../lib/auctionP2pk'
 import { buildAuctionPathRegistry, findAuctionPathEntryByChildPubkey, type AuctionPathRegistryEntry } from '../../lib/auctionPathOracle'
 import type { AuctionContext } from './context'
@@ -102,7 +105,30 @@ export async function buildAuctionSettlementPlan(
 	// caused every settlement to resolve to `reserve_not_met` no matter
 	// what the bid amount was.
 	const registry = await fetchAuctionPathRegistry(ctx, params.auctionEventId)
-	const eligibleChains = buildActiveAuctionBidChains(getAuctionWindowValidBids(auctionEvent, bidEvents))
+
+	// AUCTIONS.md §6.1 — pre-compute the "top bid AT THE MOMENT just before
+	// this bid landed", per-bid. The floor for a bid B depends on the
+	// auction-wide top bid that B was trying to outbid, not the chain-
+	// internal predecessor. We walk bids in time order, keeping a running
+	// max and stamping each bid with the max-before-it.
+	const allWindowBids = getAuctionWindowValidBids(auctionEvent, bidEvents)
+	const bidsByTime = [...allWindowBids].sort((a, b) => (a.created_at || 0) - (b.created_at || 0))
+	const topBidBeforeByBidId = new Map<string, number>()
+	{
+		let runningMax = 0
+		for (const bid of bidsByTime) {
+			topBidBeforeByBidId.set(bid.id, runningMax)
+			const amount = getAuctionBidAmount(bid)
+			if (amount > runningMax) runningMax = amount
+		}
+	}
+	const computeBidFloorAtCreated = (bid: NDKEvent): number => {
+		const topBefore = topBidBeforeByBidId.get(bid.id) ?? 0
+		const effectiveT = (bid.created_at || 0) - BID_FLOOR_TIME_GRACE_SECONDS
+		return computeAuctionBidFloor(auctionEvent, topBefore, effectiveT)
+	}
+
+	const eligibleChains = buildActiveAuctionBidChains(allWindowBids)
 		.filter((group) =>
 			group.chain.every((bid) => {
 				const bidChildPubkey = getAuctionTagValue(bid, 'child_pubkey')
@@ -135,6 +161,13 @@ export async function buildAuctionSettlementPlan(
 					if (!Number.isFinite(bidLocktime) || bidLocktime !== expectedLocktime) return false
 					if (lockPayload.locktime !== expectedLocktime) return false
 				}
+				// §6.1 — bid amount must clear the curve-aware floor at its
+				// own `created_at` (minus GRACE). A bidder who got a grant
+				// early then delayed publishing into the curve window can't
+				// cheat: the floor at publish time is what counts.
+				const bidAmount = getAuctionBidAmount(bid)
+				const floorAtBid = computeBidFloorAtCreated(bid)
+				if (bidAmount < floorAtBid) return false
 				return true
 			}),
 		)


### PR DESCRIPTION
Full implementation of the anti-snipe bid floor system from AUCTIONS.md §6.1, including:
- Replace legacy dynamic anti-sniping extension logic with static max_end_at and min_bid_curve auction tags
- Add real-time client-side floor display and warning banner in the AuctionBidder UI
- Add server-side floor enforcement in path grants and final bid settlement checks
- Rework bid mint selection to use the full seller-declared trusted mints list instead of hardcoding the first entry, fixing cases where bidders with funds on non-first mints would fail bids
- Update auction publish validation, form fields, and all related test suites
- Update AUCTIONS.md documentation to reflect the v1 auction protocol rules
- Refactor lockAuctionBidFunds to support ordered mint candidates for improved bid flow