### PR TITLE
feat: keep drafts for auction form content

### DIFF
--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,5 +1,6 @@
 import type { BrowserContext, Page } from '@playwright/test'
 import { getPublicKey, finalizeEvent, type UnsignedEvent } from 'nostr-tools/pure'
+import { encrypt as nip44Encrypt, decrypt as nip44Decrypt, getConversationKey } from 'nostr-tools/nip44'
 import { hexToBytes, bytesToHex } from '@noble/hashes/utils.js'
 
 export interface TestUser {
@@ -7,14 +8,7 @@ export interface TestUser {
 	pk: string // hex public key
 }
 
-/**
- * Sets up a browser context with a NIP-07 (window.nostr) mock that
- * enables automatic login. Signing happens in Node.js via exposeFunction
- * so we have full access to nostr-tools.
- */
 export async function setupAuthContext(context: BrowserContext, user: TestUser): Promise<void> {
-	// Expose the signing function to the browser.
-	// This runs in Node.js where we have nostr-tools available.
 	await context.exposeFunction('__nostrSignEvent', (eventJson: string): string => {
 		const event = JSON.parse(eventJson) as UnsignedEvent
 		const skBytes = hexToBytes(user.sk)
@@ -22,12 +16,21 @@ export async function setupAuthContext(context: BrowserContext, user: TestUser):
 		return JSON.stringify(signed)
 	})
 
-	// Expose getPublicKey as well (simpler than passing the pubkey)
 	await context.exposeFunction('__nostrGetPublicKey', (): string => {
 		return user.pk
 	})
 
-	// Inject window.nostr mock before any page scripts run
+	const skBytes = hexToBytes(user.sk)
+	await context.exposeFunction('__nostrNip44Encrypt', (pubkey: string, plaintext: string): string => {
+		const convKey = getConversationKey(skBytes, pubkey)
+		return nip44Encrypt(plaintext, convKey)
+	})
+
+	await context.exposeFunction('__nostrNip44Decrypt', (pubkey: string, ciphertext: string): string => {
+		const convKey = getConversationKey(skBytes, pubkey)
+		return nip44Decrypt(ciphertext, convKey)
+	})
+
 	await context.addInitScript(() => {
 		;(window as any).nostr = {
 			getPublicKey: async () => {
@@ -41,23 +44,27 @@ export async function setupAuthContext(context: BrowserContext, user: TestUser):
 
 			nip04: {
 				encrypt: async (_pubkey: string, plaintext: string) => {
-					// In tests, return plaintext wrapped to indicate "encrypted"
 					return `test_encrypted:${plaintext}`
 				},
 				decrypt: async (_pubkey: string, ciphertext: string) => {
-					// In tests, unwrap if it was our fake encryption
 					if (ciphertext.startsWith('test_encrypted:')) {
 						return ciphertext.slice('test_encrypted:'.length)
 					}
 					return ciphertext
 				},
 			},
+
+			nip44: {
+				encrypt: async (pubkey: string, plaintext: string) => {
+					return await (window as any).__nostrNip44Encrypt(pubkey, plaintext)
+				},
+				decrypt: async (pubkey: string, ciphertext: string) => {
+					return await (window as any).__nostrNip44Decrypt(pubkey, ciphertext)
+				},
+			},
 		}
 
-		// Enable auto-login so the app picks up our NIP-07 mock
 		localStorage.setItem('nostr_auto_login', 'true')
-
-		// Pre-accept Terms & Conditions so the dialog doesn't block tests
 		localStorage.setItem('plebeian_terms_accepted', 'true')
 	})
 }

--- a/e2e/scenarios/index.ts
+++ b/e2e/scenarios/index.ts
@@ -591,3 +591,62 @@ export async function seedV4VWithRecipients(skHex: string, recipients: Array<{ p
 		relay.close()
 	}
 }
+
+export async function seedAuction(
+	relay: Relay,
+	skHex: string,
+	opts: {
+		title?: string
+		description?: string
+		startingBid?: number
+		bidIncrement?: number
+		reserve?: number
+		shippingOptions?: Array<{ shippingRef: string; extraCost?: string }>
+	},
+): Promise<VerifiedEvent> {
+	const now = Math.floor(Date.now() / 1000)
+	const auctionId = `e2e-auction-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`
+	const startingBid = opts.startingBid ?? 1000
+	const bidIncrement = opts.bidIncrement ?? 100
+	const reserve = opts.reserve ?? 0
+
+	const shippingTags: string[][] = []
+	for (const so of opts.shippingOptions ?? []) {
+		if (so.extraCost) {
+			shippingTags.push(['shipping_option', so.shippingRef, so.extraCost])
+		} else {
+			shippingTags.push(['shipping_option', so.shippingRef])
+		}
+	}
+
+	const event = await publish(relay, skHex, {
+		kind: 30408,
+		created_at: now,
+		content: opts.description ?? 'E2E test auction description.',
+		tags: [
+			['d', auctionId],
+			['title', opts.title ?? `Test Auction ${auctionId}`],
+			['summary', 'E2E test auction'],
+			['auction_type', 'english'],
+			['start_at', String(now)],
+			['end_at', String(now + 86400)],
+			['currency', 'SAT'],
+			['price', String(startingBid), 'SAT'],
+			['starting_bid', String(startingBid), 'SAT'],
+			['bid_increment', String(bidIncrement)],
+			['reserve', String(reserve)],
+			['mint', 'https://nofees.testnut.cashu.space'],
+			['escrow_pubkey', '02' + '00'.repeat(32)],
+			['key_scheme', 'hd_p2pk'],
+			['p2pk_xpub', 'xpub' + '0'.repeat(100)],
+			['settlement_policy', 'cashu_p2pk_v1'],
+			['schema', 'auction_v1'],
+			['image', 'https://cdn.satellite.earth/f8f1513ec22f966626dc05342a3bb1f36096d28dd0e6eeae640b5df44f2c7c84.png'],
+			['t', 'Bitcoin'],
+			...shippingTags,
+		],
+	})
+
+	console.log(`    Published auction: ${opts.title ?? auctionId}`)
+	return event
+}

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect } from '../fixtures'
+import { RELAY_URL, TEST_APP_PUBLIC_KEY } from '../test-config'
+import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
+import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import WebSocket from 'ws'
+import { devUser1 } from '../../src/lib/fixtures'
+import path from 'node:path'
+
+useWebSocketImplementation(WebSocket)
+
+const D_TAG = 'e2e-auction-mint-test'
+const MINT_A = 'https://testnut.cashu.space'
+const SCREENSHOT_DIR = 'test-results'
+
+async function seedAuction(relay: Relay, overrides: { mints: string[]; dTag?: string }) {
+	const skBytes = hexToBytes(devUser1.sk)
+	const now = Math.floor(Date.now() / 1000)
+	const startAt = now - 60
+	const endAt = now + 3600
+	const maxEndAt = now + 7200
+
+	const event = finalizeEvent(
+		{
+			kind: 30408,
+			created_at: now,
+			content: 'E2E auction for mint selection testing',
+			tags: [
+				['d', overrides.dTag ?? D_TAG],
+				['title', 'E2E Mint Test Auction'],
+				['summary', 'Auction with multiple mints for e2e testing'],
+				['auction_type', 'english'],
+				['start_at', String(startAt)],
+				['end_at', String(endAt)],
+				['max_end_at', String(maxEndAt)],
+				['currency', 'SAT'],
+				['price', '100', 'SAT'],
+				['starting_bid', '100', 'SAT'],
+				['bid_increment', '50'],
+				['reserve', '0'],
+				['settlement_policy', 'cashu_p2pk_path_oracle_v1'],
+				['key_scheme', 'hd_p2pk'],
+				['path_issuer', TEST_APP_PUBLIC_KEY],
+				['settlement_grace', '7200'],
+				['extension_rule', 'none'],
+				['schema', 'auction_v1'],
+				...overrides.mints.map((mint) => ['mint', mint]),
+				['image', 'https://placehold.co/600x600', '600x600', '0'],
+			],
+		},
+		skBytes,
+	)
+	await relay.publish(event)
+	return event
+}
+
+async function waitForWalletReady(page: import('@playwright/test').Page, timeoutMs = 30_000) {
+	const start = Date.now()
+	while (Date.now() - start < timeoutMs) {
+		const status = await page.evaluate(() => {
+			const w = (window as any).__nip60
+			return w ? w.getStatus().status : 'unavailable'
+		})
+		if (status === 'ready' || status === 'no_wallet') return status
+		await page.waitForTimeout(500)
+	}
+	throw new Error('Wallet did not initialize within timeout')
+}
+
+async function fundWallet(page: import('@playwright/test').Page, amount: number, mintUrl: string) {
+	const result = await page.evaluate(
+		async ({ amount: amt, mintUrl: mint }) => {
+			const w = (window as any).__nip60
+			if (!w) throw new Error('__nip60 bridge not available')
+			return await w.mintTestEcash(amt, mint)
+		},
+		{ amount, mintUrl },
+	)
+	return result
+}
+
+async function waitForWalletBalance(page: import('@playwright/test').Page, minBalance: number, timeoutMs = 30_000) {
+	const start = Date.now()
+	while (Date.now() - start < timeoutMs) {
+		const status = await page.evaluate(() => {
+			const w = (window as any).__nip60
+			return w ? w.getStatus() : { balance: 0, status: 'unavailable' }
+		})
+		if (status.balance >= minBalance && status.status === 'ready') return status
+		await page.waitForTimeout(500)
+	}
+	throw new Error(`Wallet balance did not reach ${minBalance} within timeout`)
+}
+
+test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
+	test('auction detail page renders bid button for multi-mint auction', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A, 'https://nofees.testnut.cashu.space'],
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await expect(buyerPage.getByRole('button', { name: /bid|place bid|submitting/i }).first()).toBeVisible({ timeout: 10_000 })
+		} finally {
+			relay.close()
+		}
+	})
+
+	test('auction detail page renders for single-mint auction', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await expect(buyerPage.getByRole('button', { name: /bid|place bid|submitting/i }).first()).toBeVisible({ timeout: 10_000 })
+		} finally {
+			relay.close()
+		}
+	})
+
+	test('auction detail page renders minimum bid info', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await expect(buyerPage.getByText(/minimum allowed bid/i)).toBeVisible({ timeout: 10_000 })
+		} finally {
+			relay.close()
+		}
+	})
+
+	test('second mint renders in mint selector when present in trusted mints', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A, 'https://nofees.testnut.cashu.space'],
+				dTag: 'e2e-auction-second-mint-test',
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await expect(buyerPage.getByText('Minimum allowed bid')).toBeVisible({ timeout: 10_000 })
+		} finally {
+			relay.close()
+		}
+	})
+})
+
+test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
+	test.slow()
+
+	test('mint selector shows funded mint with balance', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+				dTag: 'e2e-funded-mint-test',
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 500, MINT_A)
+			await waitForWalletBalance(buyerPage, 400)
+			await buyerPage.reload()
+
+			await waitForWalletBalance(buyerPage, 400)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await expect(buyerPage.getByRole('button', { name: /bid|place bid/i }).first()).toBeVisible({ timeout: 10_000 })
+			await expect(buyerPage.getByRole('button', { name: /bid|place bid/i }).first()).toBeEnabled({ timeout: 5_000 })
+
+			await buyerPage.screenshot({
+				path: path.join(SCREENSHOT_DIR, 'pr886-funded-mint-selector.png'),
+				fullPage: true,
+			})
+		} finally {
+			relay.close()
+		}
+	})
+
+	test('funded mint shows balance and enables bid after wallet reload', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+				dTag: 'e2e-funded-mint-reload-test',
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 500, MINT_A)
+			await waitForWalletBalance(buyerPage, 400)
+
+			await buyerPage.screenshot({
+				path: path.join(SCREENSHOT_DIR, 'pr886-funded-mint-no-reload.png'),
+				fullPage: true,
+			})
+		} finally {
+			relay.close()
+		}
+	})
+})

--- a/e2e/tests/auction-mint-state.spec.ts
+++ b/e2e/tests/auction-mint-state.spec.ts
@@ -1,0 +1,86 @@
+import { DEFAULT_TRUSTED_MINTS } from '@/lib/constants'
+import { test, expect } from '../fixtures'
+
+test.use({ scenario: 'merchant' })
+
+function selectedMintLocator(page: import('@playwright/test').Page, mintUrl: string) {
+	return page
+		.locator('span[title]')
+		.filter({ hasText: mintUrl })
+		.locator('..')
+		.locator('button[title="Remove mint"]')
+}
+
+function unselectedMintLocator(page: import('@playwright/test').Page, mintUrl: string) {
+	return page.locator('button').filter({ has: page.locator(`span[title="${mintUrl}"]`) })
+}
+
+test.describe('Auction Mint State', () => {
+	test('trusted mints initialize with available mints', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		await merchantPage.goto('/auctions')
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('button', { name: /create.*auction/i }).click()
+
+		await merchantPage.getByRole('tab', { name: 'Auction' }).click()
+
+		for (const mint of DEFAULT_TRUSTED_MINTS) {
+			await expect(merchantPage.locator(`span[title="${mint}"]`)).toBeVisible({ timeout: 10_000 })
+		}
+	})
+
+	test('user can remove a mint and the form stays valid', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		await merchantPage.goto('/auctions')
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('button', { name: /create.*auction/i }).click()
+
+		await merchantPage.getByRole('tab', { name: 'Auction' }).click()
+
+		const removeButtons = merchantPage.getByTitle('Remove mint')
+		await expect(removeButtons.first()).toBeVisible({ timeout: 10_000 })
+
+		const initialCount = await removeButtons.count()
+
+		await removeButtons.first().click()
+
+		const afterCount = await removeButtons.count()
+		expect(afterCount).toBe(initialCount - 1)
+
+		await expect(
+			merchantPage.getByTitle('At least one mint is required').or(merchantPage.getByTitle('Remove mint')).first(),
+		).toBeVisible()
+	})
+
+	test('user can re-add a previously removed mint via unselected list', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		await merchantPage.goto('/auctions')
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('button', { name: /create.*auction/i }).click()
+
+		await merchantPage.getByRole('tab', { name: 'Auction' }).click()
+
+		const removeButtons = merchantPage.getByTitle('Remove mint')
+		await expect(removeButtons.first()).toBeVisible({ timeout: 10_000 })
+
+		const firstSelectedRow = removeButtons.first().locator('..')
+		const removedMintSpan = firstSelectedRow.locator('span[title]')
+		const removedMintUrl = (await removedMintSpan.getAttribute('title')) ?? ''
+
+		await removeButtons.first().click()
+
+		await expect(selectedMintLocator(merchantPage, removedMintUrl)).not.toBeVisible()
+
+		const addMintButton = unselectedMintLocator(merchantPage, removedMintUrl)
+		await expect(addMintButton).toBeVisible({ timeout: 10_000 })
+		await addMintButton.click()
+
+		await expect(selectedMintLocator(merchantPage, removedMintUrl)).toBeVisible({ timeout: 10_000 })
+	})
+})

--- a/e2e/tests/auction-mint-state.spec.ts
+++ b/e2e/tests/auction-mint-state.spec.ts
@@ -4,11 +4,7 @@ import { test, expect } from '../fixtures'
 test.use({ scenario: 'merchant' })
 
 function selectedMintLocator(page: import('@playwright/test').Page, mintUrl: string) {
-	return page
-		.locator('span[title]')
-		.filter({ hasText: mintUrl })
-		.locator('..')
-		.locator('button[title="Remove mint"]')
+	return page.locator('span[title]').filter({ hasText: mintUrl }).locator('..').locator('button[title="Remove mint"]')
 }
 
 function unselectedMintLocator(page: import('@playwright/test').Page, mintUrl: string) {
@@ -51,9 +47,7 @@ test.describe('Auction Mint State', () => {
 		const afterCount = await removeButtons.count()
 		expect(afterCount).toBe(initialCount - 1)
 
-		await expect(
-			merchantPage.getByTitle('At least one mint is required').or(merchantPage.getByTitle('Remove mint')).first(),
-		).toBeVisible()
+		await expect(merchantPage.getByTitle('At least one mint is required').or(merchantPage.getByTitle('Remove mint')).first()).toBeVisible()
 	})
 
 	test('user can re-add a previously removed mint via unselected list', async ({ merchantPage }) => {

--- a/e2e/tests/auction-shipping.spec.ts
+++ b/e2e/tests/auction-shipping.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '../fixtures'
+import { Relay } from 'nostr-tools/relay'
+import { useWebSocketImplementation } from 'nostr-tools/relay'
+import { RELAY_URL } from 'e2e-new/test-config'
+import { devUser1 } from '@/lib/fixtures'
+import { seedAuction } from 'e2e-new/scenarios'
+import WebSocket from 'ws'
+
+useWebSocketImplementation(WebSocket)
+
+test.use({ scenario: 'merchant' })
+
+test.describe('Auction Shipping Display', () => {
+	test('shows resolved shipping option details', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'Shipping Display Test',
+			shippingOptions: [{ shippingRef: `30406:${devUser1.pk}:worldwide-standard` }],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		await expect(merchantPage.getByText('Worldwide Standard')).toBeVisible({ timeout: 15_000 })
+		await expect(merchantPage.getByText('Base:')).toBeVisible()
+	})
+
+	test('deduplicates shipping refs by shippingRef, first occurrence wins', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const shippingRef = `30406:${devUser1.pk}:digital-delivery`
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'Dedup Test',
+			shippingOptions: [
+				{ shippingRef, extraCost: '0' },
+				{ shippingRef, extraCost: '500' },
+			],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		const shippingItems = merchantPage.locator('li').filter({ hasText: 'Digital Delivery' })
+		await expect(shippingItems).toHaveCount(1, { timeout: 15_000 })
+	})
+
+	test('shows unavailable for unresolvable shipping ref', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const relay = await Relay.connect(RELAY_URL)
+		const auctionEvent = await seedAuction(relay, devUser1.sk, {
+			title: 'NotFound Test',
+			shippingOptions: [{ shippingRef: '30406:deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678:nonexistent' }],
+		})
+		relay.close()
+
+		await merchantPage.goto(`/auctions/${auctionEvent.id}`)
+		await merchantPage.waitForLoadState('networkidle')
+
+		await merchantPage.getByRole('tab', { name: 'Description' }).click()
+
+		await expect(merchantPage.getByText('Shipping option unavailable')).toBeVisible({ timeout: 15_000 })
+	})
+})

--- a/e2e/tests/auction-shipping.spec.ts
+++ b/e2e/tests/auction-shipping.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '../fixtures'
 import { Relay } from 'nostr-tools/relay'
 import { useWebSocketImplementation } from 'nostr-tools/relay'
-import { RELAY_URL } from 'e2e-new/test-config'
+import { RELAY_URL } from '../test-config'
 import { devUser1 } from '@/lib/fixtures'
-import { seedAuction } from 'e2e-new/scenarios'
+import { seedAuction } from '../scenarios'
 import WebSocket from 'ws'
 
 useWebSocketImplementation(WebSocket)

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -402,7 +402,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 			{/* Minimum Bid Info */}
 			{!compact && !ended && <div className="text-xs text-foreground/80 pl-1">Minimum allowed bid: {minBid.toLocaleString()} sats</div>}
-
 		</div>
 	)
 }

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -17,16 +17,20 @@ import {
 	getAuctionMaxEndAt,
 	getAuctionSettlementGrace,
 	getAuctionCurrentPriceFromBids,
+	getBidAmount,
 } from '@/queries/auctions'
 import { computeAuctionBidFloor, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
-import { useMemo, useState, useEffect, useRef } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { useAuctionCountdown } from './AuctionCountdown'
 import { Pencil, Plus, Minus, X, CircleX, TheaterIcon } from 'lucide-react'
 import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group'
 import { cn } from '@/lib/utils'
 import { TooltipToggleGroupItem } from './shared/TooltipToggleGroupItem'
+import { useStore } from '@tanstack/react-store'
+import { nip60Store } from '@/lib/stores/nip60'
+import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
 
 interface AuctionBidderProps {
 	auction: NDKEvent
@@ -35,6 +39,51 @@ interface AuctionBidderProps {
 	currentUserPubkey?: string
 	onBidSuccess?: () => void
 	compact?: boolean
+}
+
+export function useAuctionMintSelection(trustedMints: string[], bidAmount: number, previousBidAmount: number = 0) {
+	const nip60State = useStore(nip60Store)
+	const [manualMint, setManualMint] = useState<string | null>(null)
+
+	const deltaAmount = Math.max(0, bidAmount - previousBidAmount)
+
+	const result = useMemo<MintSelectionResult>(
+		() =>
+			resolveAuctionMintSelection({
+				trustedMints,
+				walletMints: nip60State.mints ?? [],
+				mintBalances: nip60State.mintBalances ?? {},
+				bidAmount,
+				previousBidAmount,
+			}),
+		[trustedMints, nip60State.mints, nip60State.mintBalances, bidAmount, previousBidAmount],
+	)
+
+	const manualMintValid = manualMint ? result.availableMints.some((m) => m.mintUrl === manualMint) : false
+
+	const manualMintCanFund = manualMint ? (result.availableMints.find((m) => m.mintUrl === manualMint)?.balance ?? 0 >= deltaAmount) : false
+
+	const selectedMint = manualMintValid ? manualMint : result.selectedMint
+
+	const setSelectedMint = useCallback((mintUrl: string | null) => {
+		setManualMint(mintUrl)
+	}, [])
+
+	const eligibleMints = result.eligibleMints
+
+	return {
+		selectedMint,
+		availableMints: result.availableMints,
+		eligibleMints,
+		insufficientBalanceMints: result.insufficientBalanceMints,
+		mintError: result.error,
+		setSelectedMint,
+		showMintSelector: result.availableMints.filter((m) => m.balance > 0).length > 1,
+		canFund: selectedMint
+			? (result.availableMints.find((m) => m.mintUrl === selectedMint)?.balance ?? 0) >= deltaAmount
+			: eligibleMints.length > 0,
+		deltaAmount,
+	}
 }
 
 export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBidSuccess, compact = false }: AuctionBidderProps) {
@@ -70,6 +119,12 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const notStarted = startAt > 0 && countdown.now < startAt
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const previousBidAmount = useMemo(() => {
+		if (!currentUserPubkey) return 0
+		const myBids = bids.filter((b) => b.pubkey === currentUserPubkey)
+		if (!myBids.length) return 0
+		return Math.max(...myBids.map(getBidAmount))
+	}, [bids, currentUserPubkey])
 	// AUCTIONS.md §6.1 — bidder-side live floor. Display the floor at
 	// `client_now` (no inflation). The CVM server is more lenient by
 	// `BID_FLOOR_TIME_GRACE_SECONDS = 5`, so a click at the displayed
@@ -110,6 +165,12 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		const val = parseInt(bidAmountInput || '0', 10)
 		return Number.isFinite(val) ? val : NaN
 	}, [bidAmountInput])
+
+	const { selectedMint, availableMints, showMintSelector, mintError, setSelectedMint, canFund } = useAuctionMintSelection(
+		trustedMints,
+		Number.isFinite(parsedBidAmount) ? parsedBidAmount : 0,
+		previousBidAmount,
+	)
 
 	// Initialize input to min bid on mount or when min changes
 	useEffect(() => {
@@ -166,6 +227,14 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				toast.error('This auction is missing a p2pk_xpub and cannot accept bids.')
 				return
 			}
+			if (!selectedMint) {
+				toast.error(mintError || 'No suitable mint available for bidding.')
+				return
+			}
+			if (!canFund) {
+				toast.error('Insufficient balance on selected mint to cover the required delta.')
+				return
+			}
 			await bidMutation.mutateAsync({
 				auctionEventId: auctionRootEventId || auction.id,
 				auctionCoordinates,
@@ -177,13 +246,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				sellerPubkey: auction.pubkey,
 				pathIssuerPubkey,
 				p2pkXpub,
-				// Hand the lock flow ALL the seller's trusted mints in
-				// declared order. `lockAuctionBidFunds` picks the first
-				// one where this bidder's wallet has enough balance —
-				// previously we hard-coded `trustedMints[0]`, so a
-				// bidder with funds on mint #4 would get a "0 sats on
-				// minibits" error.
-				mintCandidates: trustedMints,
+				mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
 			})
 			toast.success('Bid placed successfully')
 			setIsEditing(false)
@@ -210,6 +273,35 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				</div>
 			)}
 
+			{!compact && showMintSelector && (
+				<div className="flex items-center gap-2">
+					<span className="text-xs text-foreground/60 whitespace-nowrap">Mint:</span>
+					<ToggleGroup
+						type="single"
+						value={selectedMint ?? ''}
+						onValueChange={(val) => {
+							if (val) setSelectedMint(val)
+						}}
+						className="flex flex-wrap gap-1"
+					>
+						{availableMints
+							.filter((m) => m.balance > 0)
+							.map((m) => (
+								<TooltipToggleGroupItem
+									key={m.mintUrl}
+									value={m.mintUrl}
+									variant="outline"
+									size="sm"
+									tooltip={`${m.mintUrl} — ${m.balance.toLocaleString()} sats`}
+									disabled={isDisabledInput || !m.hasSufficientBalance}
+									className={cn('cursor-pointer flex text-xs', !m.hasSufficientBalance && 'opacity-60')}
+								>
+									{m.hostname} <span className="text-foreground/50">({m.balance.toLocaleString()})</span>
+								</TooltipToggleGroupItem>
+							))}
+					</ToggleGroup>
+				</div>
+			)}
 			{/* Main Action Area */}
 			<div className={cn('flex flex-col sm:flex-row gap-2 items-stretch sm:items-center')}>
 				{!compact &&
@@ -310,6 +402,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 			{/* Minimum Bid Info */}
 			{!compact && !ended && <div className="text-xs text-foreground/80 pl-1">Minimum allowed bid: {minBid.toLocaleString()} sats</div>}
+
 		</div>
 	)
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -200,14 +200,14 @@ export function Header() {
 	const { data: config } = useConfigQuery()
 	const { isAuthenticated, isAuthenticating, user } = useStore(authStore)
 	const { mobileMenuOpen } = useStore(uiStore)
-	const { unseenOrders, unseenMessages, unseenPurchases } = useStore(notificationStore)
+	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
 	const location = useLocation()
 	const [scrollY, setScrollY] = useState(0)
 	const breakpoint = useBreakpoint()
 	const isMobile = breakpoint === 'sm' || breakpoint === 'md'
 
 	// Calculate total notification count for dashboard button
-	const totalNotifications = unseenOrders + unseenMessages + unseenPurchases
+	const totalNotifications = unseenOrders + unseenMessages + unseenPurchases + unseenAuctionBids + unseenBidUpdates
 
 	// Check if we're on any product page (index page or individual product) or homepage
 	const isProductPage = location.pathname === '/products' || location.pathname.startsWith('/products/')

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -34,16 +34,23 @@ import {
 } from '@/publish/auctions'
 import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import {
+	clearDraft,
+	isDraftMeaningful,
+	loadDraft,
+	saveDraft,
+	type AuctionFormDraft,
+	type AuctionImage,
+	type AuctionTab,
+	type EndMode,
+	type StartMode,
+} from '@/lib/utils/auctionFormDraft'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState, useEffect, useRef, type Dispatch, type FormEvent, type SetStateAction } from 'react'
-import { z } from 'zod'
 import { Slider } from '@/components/ui/slider'
 
-type AuctionImage = { imageUrl: string; imageOrder: number }
-
-type AuctionTab = 'name' | 'auction' | 'category' | 'spec' | 'images' | 'shipping'
 type ValidationMessages = Partial<Record<AuctionPublishValidationField, string>>
 
 const INITIAL_FORM: AuctionFormData = {
@@ -161,111 +168,6 @@ function NameTab({ formData, setFormData }: TabProps) {
 			</div>
 		</div>
 	)
-}
-
-type StartMode = 'immediate' | 'scheduled'
-type EndMode = 'duration' | 'absolute'
-
-interface AuctionFormDraft {
-	formData: AuctionFormData
-	images: AuctionImage[]
-	subCategoryInput: string
-	startMode: StartMode
-	endMode: EndMode
-	durationSeconds: number
-	activeTab: AuctionTab
-}
-
-const DRAFT_VERSION = 1 as const
-
-const auctionDraftEnvelopeSchema = z.object({
-	version: z.literal(DRAFT_VERSION),
-	ownerPubkey: z.string().min(1),
-	savedAt: z.number().int().positive(),
-	draft: z.object({
-		formData: z.object({
-			title: z.string(),
-			summary: z.string(),
-			description: z.string(),
-			startingBid: z.string(),
-			bidIncrement: z.string(),
-			reserve: z.string().optional(),
-			startAt: z.string().optional(),
-			endAt: z.string(),
-			antiSnipeWindowMinutes: z.number(),
-			minBidCurveShape: z.string(),
-			minBidCurvePeakMultiplier: z.number(),
-			settlementGracePreset: z.string(),
-			mainCategory: z.string(),
-			categories: z.array(z.string()),
-			imageUrls: z.array(z.string()),
-			specs: z.array(z.object({ key: z.string(), value: z.string() })),
-			shippings: z.array(z.record(z.string(), z.unknown())),
-			trustedMints: z.array(z.string()),
-			isNSFW: z.boolean(),
-			pathIssuerPubkey: z.string(),
-		}),
-		images: z.array(z.object({ imageUrl: z.string(), imageOrder: z.number() })),
-		subCategoryInput: z.string(),
-		startMode: z.enum(['immediate', 'scheduled']),
-		endMode: z.enum(['duration', 'absolute']),
-		durationSeconds: z.number().positive(),
-		activeTab: z.enum(['name', 'auction', 'category', 'spec', 'images', 'shipping']),
-	}),
-})
-
-type AuctionDraftEnvelope = z.infer<typeof auctionDraftEnvelopeSchema>
-
-function isDraftMeaningful({ formData, images, subCategoryInput }: AuctionFormDraft): boolean {
-	const { summary, description, startingBid, reserve, startAt, endAt, mainCategory, categories, imageUrls, specs, shippings } = formData
-	return (
-		[summary, description, startingBid, reserve ?? '', startAt ?? '', endAt, mainCategory, subCategoryInput].some(
-			(s) => s.trim().length > 0,
-		) ||
-		[categories, imageUrls, specs, shippings, images].some((a) => a.length > 0)
-	)
-}
-
-function getAuctionDraftKey(pubkey: string | undefined): string | null {
-	return pubkey ? `auction-form-draft:v1:${pubkey}` : null
-}
-
-function saveDraft(pubkey: string | undefined, draft: AuctionFormDraft): void {
-	const key = getAuctionDraftKey(pubkey)
-	if (!key || !pubkey) return
-	const envelope: AuctionDraftEnvelope = {
-		version: DRAFT_VERSION,
-		ownerPubkey: pubkey,
-		savedAt: Date.now(),
-		draft,
-	}
-	try {
-		localStorage.setItem(key, JSON.stringify(envelope))
-	} catch {}
-}
-
-function loadDraft(pubkey: string | undefined): AuctionFormDraft | null {
-	const key = getAuctionDraftKey(pubkey)
-	if (!key || !pubkey) return null
-	try {
-		const raw = localStorage.getItem(key)
-		if (!raw) return null
-		const parsed: unknown = JSON.parse(raw)
-		const result = auctionDraftEnvelopeSchema.safeParse(parsed)
-		if (!result.success) return null
-		if (result.data.ownerPubkey !== pubkey) return null
-		return result.data.draft as AuctionFormDraft
-	} catch {
-		return null
-	}
-}
-
-function clearDraft(pubkey: string | undefined): void {
-	const key = getAuctionDraftKey(pubkey)
-	if (!key) return
-	try {
-		localStorage.removeItem(key)
-	} catch {}
 }
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Checkbox } from '@/components/ui/checkbox'
 import { ImageUploader } from '@/components/ui/image-uploader/ImageUploader'
+import { InfoTooltip } from '@/components/shared/InfoTooltip'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -37,6 +38,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState, useEffect, useRef, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { Slider } from '@/components/ui/slider'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 
@@ -163,8 +165,6 @@ function NameTab({ formData, setFormData }: TabProps) {
 type StartMode = 'immediate' | 'scheduled'
 type EndMode = 'duration' | 'absolute'
 
-const AUCTION_DRAFT_KEY = 'auction-form-draft'
-
 interface AuctionFormDraft {
 	formData: AuctionFormData
 	images: AuctionImage[]
@@ -175,24 +175,34 @@ interface AuctionFormDraft {
 	activeTab: AuctionTab
 }
 
-function saveDraft(draft: AuctionFormDraft): void {
+function getAuctionDraftKey(pubkey: string | undefined): string | null {
+	return pubkey ? `auction-form-draft:v1:${pubkey}` : null
+}
+
+function saveDraft(pubkey: string | undefined, draft: AuctionFormDraft): void {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key) return
 	try {
-		localStorage.setItem(AUCTION_DRAFT_KEY, JSON.stringify(draft))
+		localStorage.setItem(key, JSON.stringify(draft))
 	} catch {}
 }
 
-function loadDraft(): AuctionFormDraft | null {
+function loadDraft(pubkey: string | undefined): AuctionFormDraft | null {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key) return null
 	try {
-		const raw = localStorage.getItem(AUCTION_DRAFT_KEY)
+		const raw = localStorage.getItem(key)
 		return raw ? (JSON.parse(raw) as AuctionFormDraft) : null
 	} catch {
 		return null
 	}
 }
 
-function clearDraft(): void {
+function clearDraft(pubkey: string | undefined): void {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key) return
 	try {
-		localStorage.removeItem(AUCTION_DRAFT_KEY)
+		localStorage.removeItem(key)
 	} catch {}
 }
 
@@ -1552,7 +1562,7 @@ export function AuctionFormContent() {
 		[walletDevMode],
 	)
 
-	const draft = useMemo(() => loadDraft(), [])
+	const draft = useMemo(() => loadDraft(userPubkey), [])
 
 	const [formData, setFormData] = useState<AuctionFormData>(() => draft?.formData ?? { ...INITIAL_FORM, trustedMints: [...availableMints] })
 	const [images, setImages] = useState<AuctionImage[]>(() => draft?.images ?? [])
@@ -1569,12 +1579,12 @@ export function AuctionFormContent() {
 			isMounted.current = true
 			return
 		}
-		saveDraft({ formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab })
+		saveDraft(userPubkey, { formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab })
 		setHasDraft(true)
 	}, [formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab])
 
 	const handleClearDraft = () => {
-		clearDraft()
+		clearDraft(userPubkey)
 		isMounted.current = false
 		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
 		setImages([])
@@ -1646,7 +1656,7 @@ export function AuctionFormContent() {
 			const publishedEventId = await publishMutation.mutateAsync(nextFormData)
 			if (!publishedEventId) return
 
-			clearDraft()
+			clearDraft(userPubkey)
 			document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 			navigate({ to: '/auctions/$auctionId', params: { auctionId: publishedEventId } })
 		} catch (error) {

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -15,6 +15,7 @@ import {
 	type AuctionPublishValidationField,
 	type AuctionPublishValidationIssue,
 } from '@/lib/auctionPublishValidation'
+import { syncMintSelection } from '@/lib/auctionMintSync'
 import { DEFAULT_TRUSTED_MINTS, PRODUCT_CATEGORIES } from '@/lib/constants'
 import { authStore } from '@/lib/stores/auth'
 import { configStore } from '@/lib/stores/config'
@@ -50,6 +51,8 @@ import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState, useEffect, useRef, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { Slider } from '@/components/ui/slider'
+import { CalendarIcon, Plus, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 
 type ValidationMessages = Partial<Record<AuctionPublishValidationField, string>>
 
@@ -59,7 +62,7 @@ const INITIAL_FORM: AuctionFormData = {
 	description: '',
 	startingBid: '',
 	bidIncrement: '1',
-	reserve: undefined,
+	reserve: '0',
 	startAt: '',
 	endAt: '',
 	// Anti-snipe defaults: no window, no curve, 1h settlement grace.
@@ -171,49 +174,24 @@ function NameTab({ formData, setFormData }: TabProps) {
 }
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [
-	{ label: '1m', seconds: 1 * 60 },
-	{ label: '2m', seconds: 2 * 60 },
-	{ label: '3m', seconds: 3 * 60 },
-	{ label: '4m', seconds: 4 * 60 },
-	{ label: '5m', seconds: 5 * 60 },
-	{ label: '10m', seconds: 10 * 60 },
-	{ label: '15m', seconds: 15 * 60 },
-	{ label: '30m', seconds: 30 * 60 },
-	{ label: '45m', seconds: 45 * 60 },
 	{ label: '1h', seconds: 3600 },
-	{ label: '2h', seconds: 2 * 3600 },
-	{ label: '3h', seconds: 3 * 3600 },
-	{ label: '4h', seconds: 4 * 3600 },
-	{ label: '5h', seconds: 5 * 3600 },
 	{ label: '6h', seconds: 6 * 3600 },
-	{ label: '12h', seconds: 12 * 3600 },
-	{ label: '18h', seconds: 18 * 3600 },
 	{ label: '1d', seconds: 86400 },
-	{ label: '2d', seconds: 2 * 86400 },
 	{ label: '3d', seconds: 3 * 86400 },
-	{ label: '4d', seconds: 4 * 86400 },
-	{ label: '5d', seconds: 5 * 86400 },
-	{ label: '6d', seconds: 6 * 86400 },
 	{ label: '7d', seconds: 7 * 86400 },
-	{ label: '8d', seconds: 8 * 86400 },
-	{ label: '9d', seconds: 9 * 86400 },
-	{ label: '10d', seconds: 10 * 86400 },
-	{ label: '11d', seconds: 11 * 86400 },
-	{ label: '12d', seconds: 12 * 86400 },
-	{ label: '13d', seconds: 13 * 86400 },
 	{ label: '14d', seconds: 14 * 86400 },
-	{ label: '15d', seconds: 15 * 86400 },
-	{ label: '20d', seconds: 20 * 86400 },
-	{ label: '25d', seconds: 25 * 86400 },
 	{ label: '30d', seconds: 30 * 86400 },
 ]
+
+const MIN_DURATION_HOURS = 1
+const MAX_DURATION_HOURS = 30 * 24
 
 function pad2(n: number): string {
 	return n.toString().padStart(2, '0')
 }
 
 function toDatetimeLocal(date: Date): string {
-	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
+	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
 }
 
 function parseDatetimeLocalSeconds(value: string): number | null {
@@ -838,6 +816,8 @@ function AuctionTabContent({
 	durationSeconds,
 	setDurationSeconds,
 	validationMessages,
+	userRemovedMints,
+	onUserRemovedMintsChange,
 }: TabProps & {
 	availableMints: readonly string[]
 	startMode: StartMode
@@ -847,10 +827,9 @@ function AuctionTabContent({
 	durationSeconds: number
 	setDurationSeconds: Dispatch<SetStateAction<number>>
 	validationMessages: ValidationMessages
+	userRemovedMints: Set<string>
+	onUserRemovedMintsChange: (next: Set<string>) => void
 }) {
-	const [useReserve, setUseReserve] = useState(false)
-	const [inputSliderValue, setInputSliderValue] = useState<number>(16) // Default value: 1 day (24 hours)
-
 	const selectedMints = formData.trustedMints
 	const unselectedMints = availableMints.filter((mint) => !selectedMints.includes(mint))
 	const canRemoveMint = selectedMints.length > 1
@@ -858,16 +837,22 @@ function AuctionTabContent({
 	const removeMint = (mint: string) => {
 		if (!canRemoveMint) return
 		setFormData((prev) => ({ ...prev, trustedMints: prev.trustedMints.filter((m) => m !== mint) }))
+		onUserRemovedMintsChange(new Set(userRemovedMints).add(mint))
 	}
 
 	const addMint = (mint: string) => {
 		if (selectedMints.includes(mint)) return
 		setFormData((prev) => ({ ...prev, trustedMints: [...prev.trustedMints, mint] }))
+		if (userRemovedMints.has(mint)) {
+			const next = new Set(userRemovedMints)
+			next.delete(mint)
+			onUserRemovedMintsChange(next)
+		}
 	}
 
 	const startingBidNum = parseInt(formData.startingBid, 10)
 	const bidIncrementNum = parseInt(formData.bidIncrement, 10)
-	const reserveNum = parseInt(formData.reserve ?? '', 10)
+	const reserveNum = parseInt(formData.reserve, 10)
 	const antiSnipeWindowSeconds = formData.antiSnipeWindowMinutes * 60
 	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 
@@ -919,6 +904,8 @@ function AuctionTabContent({
 			return { ...prev, endAt: toDatetimeLocal(initial) }
 		})
 	}
+
+	const durationHours = Math.max(MIN_DURATION_HOURS, Math.round(durationSeconds / 3600))
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -985,24 +972,38 @@ function AuctionTabContent({
 
 				{endMode === 'duration' ? (
 					<div className="space-y-3">
-						<div>
-							<Slider
-								min={1}
-								max={DURATION_PRESETS.length}
-								value={[inputSliderValue]}
-								onValueChange={(val) => {
-									const sliderValue = val?.at(0)
-									if (sliderValue) {
-										const value = DURATION_PRESETS[sliderValue - 1]
+						<div className="flex flex-wrap gap-1.5">
+							{DURATION_PRESETS.map((preset) => {
+								const isActive = durationSeconds === preset.seconds
+								return (
+									<button
+										key={preset.label}
+										type="button"
+										onClick={() => setDurationSeconds(preset.seconds)}
+										className={`rounded-full px-3 py-1 text-xs font-semibold border ${
+											isActive
+												? 'border-secondary bg-secondary text-white'
+												: 'border-zinc-300 bg-white text-zinc-700 hover:border-secondary'
+										}`}
+									>
+										{preset.label}
+									</button>
+								)
+							})}
+						</div>
 
-										setInputSliderValue(sliderValue)
-										setDurationSeconds(value.seconds)
-									}
-								}}
+						<div>
+							<input
+								type="range"
+								min={MIN_DURATION_HOURS}
+								max={MAX_DURATION_HOURS}
+								step={1}
+								value={durationHours}
+								onChange={(e) => setDurationSeconds(parseInt(e.target.value, 10) * 3600)}
 								className="w-full accent-secondary"
 							/>
 							<div className="flex items-center justify-between text-[10px] text-zinc-500">
-								<span>1m</span>
+								<span>1h</span>
 								<span>30d</span>
 							</div>
 						</div>
@@ -1032,7 +1033,7 @@ function AuctionTabContent({
 				)}
 			</div>
 
-			<div className="grid sm:grid-cols-2 gap-4 items-start">
+			<div className="grid sm:grid-cols-2 gap-4">
 				<div className="grid w-full gap-1.5">
 					<Label htmlFor="auction-starting-bid">
 						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Starting Bid (sats)</span>
@@ -1061,37 +1062,17 @@ function AuctionTabContent({
 				</div>
 			</div>
 
-			<div className="flex items-center space-x-2">
-				<Checkbox
-					id="use-reserve"
-					checked={!!formData.reserve || useReserve}
-					onCheckedChange={(checked) => {
-						if (checked === true) {
-							setUseReserve(true)
-							setFormData((prev) => ({ ...prev, reserve: formData.startingBid }))
-						} else {
-							setUseReserve(false)
-							setFormData((prev) => ({ ...prev, reserve: undefined }))
-						}
-					}}
+			<div className="grid w-full gap-1.5">
+				<Label htmlFor="auction-reserve">Reserve (sats)</Label>
+				<Input
+					id="auction-reserve"
+					type="number"
+					min="0"
+					value={formData.reserve}
+					onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
 				/>
-				<Label htmlFor="use-reserve">Set Reserve Price</Label>
-				<InfoTooltip content="A reserve price sets a minimum bid amount that must be met for the auction to be successful. If the highest bid is below the reserve, the auction ends with no winner." />
+				{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
 			</div>
-
-			{(!!formData.reserve || useReserve) && (
-				<div className="grid w-full gap-1.5">
-					<Label htmlFor="auction-reserve">Reserve (sats)</Label>
-					<Input
-						id="auction-reserve"
-						type="number"
-						min="0"
-						value={formData.reserve}
-						onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
-					/>
-					{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
-				</div>
-			)}
 
 			<BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />
 
@@ -1526,6 +1507,25 @@ export function AuctionFormContent() {
 		[walletDevMode],
 	)
 
+	const prevAvailableMintsRef = useRef(availableMints)
+	const userRemovedMintsRef = useRef<Set<string>>(new Set())
+
+	const setUserRemovedMints = (next: Set<string>) => {
+		userRemovedMintsRef.current = next
+	}
+
+	useEffect(() => {
+		const prev = prevAvailableMintsRef.current
+		if (prev === availableMints) return
+
+		setFormData((prevForm) => ({
+			...prevForm,
+			trustedMints: syncMintSelection(prev, availableMints, prevForm.trustedMints, userRemovedMintsRef.current),
+		}))
+
+		prevAvailableMintsRef.current = availableMints
+	}, [availableMints])
+
 	const draft = useMemo(() => loadDraft(userPubkey), [])
 
 	const [formData, setFormData] = useState<AuctionFormData>(() => draft?.formData ?? { ...INITIAL_FORM, trustedMints: [...availableMints] })
@@ -1598,6 +1598,7 @@ export function AuctionFormContent() {
 	const hasValidBidding =
 		!validationMessages.startingBid &&
 		!validationMessages.bidIncrement &&
+		!validationMessages.reserve &&
 		!validationMessages.startAt &&
 		!validationMessages.endAt &&
 		!validationMessages.duration &&
@@ -1624,7 +1625,7 @@ export function AuctionFormContent() {
 
 			clearDraft(userPubkey)
 			document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
-			navigate({ to: '/auctions/$auctionId', params: { auctionId: publishedEventId } })
+			navigate({ to: '/auctions' })
 		} catch (error) {
 			console.error('Failed to submit auction form:', error)
 		}
@@ -1676,6 +1677,8 @@ export function AuctionFormContent() {
 								durationSeconds={durationSeconds}
 								setDurationSeconds={setDurationSeconds}
 								validationMessages={validationMessages}
+								userRemovedMints={userRemovedMintsRef.current}
+								onUserRemovedMintsChange={setUserRemovedMints}
 							/>
 						</TabsContent>
 						<TabsContent value="category" className="mt-4">

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -35,10 +35,8 @@ import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { CalendarIcon, Plus, X } from 'lucide-react'
-import { useMemo, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
-import { InfoTooltip } from '@/components/shared/InfoTooltip'
-import { Slider } from '@/components/ui/slider'
+import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
+import { useMemo, useState, useEffect, useRef, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 
@@ -164,6 +162,39 @@ function NameTab({ formData, setFormData }: TabProps) {
 
 type StartMode = 'immediate' | 'scheduled'
 type EndMode = 'duration' | 'absolute'
+
+const AUCTION_DRAFT_KEY = 'auction-form-draft'
+
+interface AuctionFormDraft {
+	formData: AuctionFormData
+	images: AuctionImage[]
+	subCategoryInput: string
+	startMode: StartMode
+	endMode: EndMode
+	durationSeconds: number
+	activeTab: AuctionTab
+}
+
+function saveDraft(draft: AuctionFormDraft): void {
+	try {
+		localStorage.setItem(AUCTION_DRAFT_KEY, JSON.stringify(draft))
+	} catch {}
+}
+
+function loadDraft(): AuctionFormDraft | null {
+	try {
+		const raw = localStorage.getItem(AUCTION_DRAFT_KEY)
+		return raw ? (JSON.parse(raw) as AuctionFormDraft) : null
+	} catch {
+		return null
+	}
+}
+
+function clearDraft(): void {
+	try {
+		localStorage.removeItem(AUCTION_DRAFT_KEY)
+	} catch {}
+}
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [
 	{ label: '1m', seconds: 1 * 60 },
@@ -1521,13 +1552,39 @@ export function AuctionFormContent() {
 		[walletDevMode],
 	)
 
-	const [formData, setFormData] = useState<AuctionFormData>(() => ({ ...INITIAL_FORM, trustedMints: [...availableMints] }))
-	const [images, setImages] = useState<AuctionImage[]>([])
-	const [activeTab, setActiveTab] = useState<AuctionTab>('name')
-	const [subCategoryInput, setSubCategoryInput] = useState('')
-	const [startMode, setStartMode] = useState<StartMode>('immediate')
-	const [endMode, setEndMode] = useState<EndMode>('duration')
-	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
+	const draft = useMemo(() => loadDraft(), [])
+
+	const [formData, setFormData] = useState<AuctionFormData>(() => draft?.formData ?? { ...INITIAL_FORM, trustedMints: [...availableMints] })
+	const [images, setImages] = useState<AuctionImage[]>(() => draft?.images ?? [])
+	const [activeTab, setActiveTab] = useState<AuctionTab>(() => draft?.activeTab ?? 'name')
+	const [subCategoryInput, setSubCategoryInput] = useState<string>(() => draft?.subCategoryInput ?? '')
+	const [startMode, setStartMode] = useState<StartMode>(() => draft?.startMode ?? 'immediate')
+	const [endMode, setEndMode] = useState<EndMode>(() => draft?.endMode ?? 'duration')
+	const [durationSeconds, setDurationSeconds] = useState<number>(() => draft?.durationSeconds ?? 24 * 60 * 60)
+	const [hasDraft, setHasDraft] = useState<boolean>(() => !!draft)
+	const isMounted = useRef(false)
+
+	useEffect(() => {
+		if (!isMounted.current) {
+			isMounted.current = true
+			return
+		}
+		saveDraft({ formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab })
+		setHasDraft(true)
+	}, [formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab])
+
+	const handleClearDraft = () => {
+		clearDraft()
+		isMounted.current = false
+		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
+		setImages([])
+		setActiveTab('name')
+		setSubCategoryInput('')
+		setStartMode('immediate')
+		setEndMode('duration')
+		setDurationSeconds(24 * 60 * 60)
+		setHasDraft(false)
+	}
 
 	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')
@@ -1589,6 +1646,7 @@ export function AuctionFormContent() {
 			const publishedEventId = await publishMutation.mutateAsync(nextFormData)
 			if (!publishedEventId) return
 
+			clearDraft()
 			document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 			navigate({ to: '/auctions/$auctionId', params: { auctionId: publishedEventId } })
 		} catch (error) {
@@ -1670,7 +1728,20 @@ export function AuctionFormContent() {
 				</Tabs>
 			</div>
 
-			<div className="bg-white border-t pt-4 pb-2 mt-2">
+			<div className="bg-white border-t pt-4 pb-2 mt-2 space-y-2">
+				{hasDraft && (
+					<div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+						<span className="flex-1">Draft saved</span>
+						<button
+							type="button"
+							onClick={handleClearDraft}
+							className="flex items-center gap-1 font-semibold text-amber-900 hover:text-red-700 shrink-0"
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+							Clear draft
+						</button>
+					</div>
+				)}
 				<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
 					{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 				</Button>

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -38,6 +38,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState, useEffect, useRef, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { z } from 'zod'
 import { Slider } from '@/components/ui/slider'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
@@ -175,24 +176,75 @@ interface AuctionFormDraft {
 	activeTab: AuctionTab
 }
 
+const DRAFT_VERSION = 1 as const
+
+const auctionDraftEnvelopeSchema = z.object({
+	version: z.literal(DRAFT_VERSION),
+	ownerPubkey: z.string().min(1),
+	savedAt: z.number().int().positive(),
+	draft: z.object({
+		formData: z.object({
+			title: z.string(),
+			summary: z.string(),
+			description: z.string(),
+			startingBid: z.string(),
+			bidIncrement: z.string(),
+			reserve: z.string().optional(),
+			startAt: z.string().optional(),
+			endAt: z.string(),
+			antiSnipeWindowMinutes: z.number(),
+			minBidCurveShape: z.string(),
+			minBidCurvePeakMultiplier: z.number(),
+			settlementGracePreset: z.string(),
+			mainCategory: z.string(),
+			categories: z.array(z.string()),
+			imageUrls: z.array(z.string()),
+			specs: z.array(z.object({ key: z.string(), value: z.string() })),
+			shippings: z.array(z.record(z.string(), z.unknown())),
+			trustedMints: z.array(z.string()),
+			isNSFW: z.boolean(),
+			pathIssuerPubkey: z.string(),
+		}),
+		images: z.array(z.object({ imageUrl: z.string(), imageOrder: z.number() })),
+		subCategoryInput: z.string(),
+		startMode: z.enum(['immediate', 'scheduled']),
+		endMode: z.enum(['duration', 'absolute']),
+		durationSeconds: z.number().positive(),
+		activeTab: z.enum(['name', 'auction', 'category', 'spec', 'images', 'shipping']),
+	}),
+})
+
+type AuctionDraftEnvelope = z.infer<typeof auctionDraftEnvelopeSchema>
+
 function getAuctionDraftKey(pubkey: string | undefined): string | null {
 	return pubkey ? `auction-form-draft:v1:${pubkey}` : null
 }
 
 function saveDraft(pubkey: string | undefined, draft: AuctionFormDraft): void {
 	const key = getAuctionDraftKey(pubkey)
-	if (!key) return
+	if (!key || !pubkey) return
+	const envelope: AuctionDraftEnvelope = {
+		version: DRAFT_VERSION,
+		ownerPubkey: pubkey,
+		savedAt: Date.now(),
+		draft,
+	}
 	try {
-		localStorage.setItem(key, JSON.stringify(draft))
+		localStorage.setItem(key, JSON.stringify(envelope))
 	} catch {}
 }
 
 function loadDraft(pubkey: string | undefined): AuctionFormDraft | null {
 	const key = getAuctionDraftKey(pubkey)
-	if (!key) return null
+	if (!key || !pubkey) return null
 	try {
 		const raw = localStorage.getItem(key)
-		return raw ? (JSON.parse(raw) as AuctionFormDraft) : null
+		if (!raw) return null
+		const parsed: unknown = JSON.parse(raw)
+		const result = auctionDraftEnvelopeSchema.safeParse(parsed)
+		if (!result.success) return null
+		if (result.data.ownerPubkey !== pubkey) return null
+		return result.data.draft as AuctionFormDraft
 	} catch {
 		return null
 	}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -216,6 +216,16 @@ const auctionDraftEnvelopeSchema = z.object({
 
 type AuctionDraftEnvelope = z.infer<typeof auctionDraftEnvelopeSchema>
 
+function isDraftMeaningful({ formData, images, subCategoryInput }: AuctionFormDraft): boolean {
+	const { summary, description, startingBid, reserve, startAt, endAt, mainCategory, categories, imageUrls, specs, shippings } = formData
+	return (
+		[summary, description, startingBid, reserve ?? '', startAt ?? '', endAt, mainCategory, subCategoryInput].some(
+			(s) => s.trim().length > 0,
+		) ||
+		[categories, imageUrls, specs, shippings, images].some((a) => a.length > 0)
+	)
+}
+
 function getAuctionDraftKey(pubkey: string | undefined): string | null {
 	return pubkey ? `auction-form-draft:v1:${pubkey}` : null
 }
@@ -1631,7 +1641,9 @@ export function AuctionFormContent() {
 			isMounted.current = true
 			return
 		}
-		saveDraft(userPubkey, { formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab })
+		const candidate = { formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab }
+		if (!isDraftMeaningful(candidate)) return
+		saveDraft(userPubkey, candidate)
 		setHasDraft(true)
 	}, [formData, images, subCategoryInput, startMode, endMode, durationSeconds, activeTab])
 

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -1,10 +1,116 @@
 import { useEffect, useRef } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { authStore } from '@/lib/stores/auth'
+import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
+import {
+	fetchAuctionBidsByBidder,
+	fetchAuctionsByPubkey,
+	getAuctionId,
+	getAuctionRootEventId,
+	getBidAmount,
+	getBidAuctionCoordinates,
+	getBidAuctionEventId,
+} from '@/queries/auctions'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
+
+const AUCTION_MONITOR_LIMIT = 500
+const AUCTION_FILTER_CHUNK_SIZE = 80
+const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
+
+const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
+
+const chunkValues = (values: string[], size: number): string[][] => {
+	const chunks: string[][] = []
+	for (let index = 0; index < values.length; index += size) {
+		chunks.push(values.slice(index, index + size))
+	}
+	return chunks
+}
+
+const dedupeEvents = (events: NDKEvent[]): NDKEvent[] => {
+	const seen = new Set<string>()
+	return events.filter((event) => {
+		if (!event.id || seen.has(event.id)) return false
+		seen.add(event.id)
+		return true
+	})
+}
+
+const getAuctionCoordinate = (auction: NDKEvent): string => {
+	const auctionDTag = getAuctionId(auction)
+	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
+}
+
+const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
+
+const getEventAuctionCoordinate = (event: NDKEvent): string => getBidAuctionCoordinates(event)
+
+const getAuctionBidStatus = (event: NDKEvent): string =>
+	event.tags
+		.find((tag) => tag[0] === 'status')?.[1]
+		?.trim()
+		.toLowerCase() || 'unknown'
+
+const isCountableAuctionBidEvent = (event: NDKEvent): boolean => {
+	const status = getAuctionBidStatus(event)
+	return !IGNORED_AUCTION_BID_STATUSES.has(status)
+}
+
+const makeTaggedAuctionFilters = ({
+	kind,
+	auctionRootEventIds,
+	auctionCoordinates,
+	since,
+}: {
+	kind: NonNullable<NDKFilter['kinds']>[number]
+	auctionRootEventIds: string[]
+	auctionCoordinates: string[]
+	since?: number
+}): NDKFilter[] => {
+	const filters: NDKFilter[] = []
+	const baseFilter = {
+		kinds: [kind],
+		limit: AUCTION_MONITOR_LIMIT,
+		...(typeof since === 'number' ? { since } : {}),
+	}
+
+	for (const eventIdChunk of chunkValues(auctionRootEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#e': eventIdChunk,
+		})
+	}
+
+	for (const coordinateChunk of chunkValues(auctionCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#a': coordinateChunk,
+		})
+	}
+
+	return filters
+}
+
+const fetchTaggedAuctionEvents = async ({
+	kind,
+	auctionRootEventIds,
+	auctionCoordinates,
+	since,
+}: {
+	kind: NonNullable<NDKFilter['kinds']>[number]
+	auctionRootEventIds: string[]
+	auctionCoordinates: string[]
+	since?: number
+}): Promise<NDKEvent[]> => {
+	const filters = makeTaggedAuctionFilters({ kind, auctionRootEventIds, auctionCoordinates, since })
+	if (filters.length === 0) return []
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	return dedupeEvents(Array.from(events))
+}
 
 /**
  * Monitor nostr events and update notification counts in real-time
@@ -24,6 +130,12 @@ export const useNotificationMonitor = () => {
 
 		const ndk = ndkActions.getNDK()
 		if (!ndk) return
+
+		let isCancelled = false
+		const subscriptionSince = Math.floor(Date.now() / 1000)
+		const seenAuctionEventIds = new Set<string>()
+		const seenBidEventIds = new Set<string>()
+		const seenSettlementEventIds = new Set<string>()
 
 		// Mark as monitoring to prevent duplicate subscriptions
 		isMonitoringRef.current = true
@@ -46,7 +158,56 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
-		// Initial fetch to calculate current unseen counts
+		const isNewAuctionBid = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionBids()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewBidUpdate = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenBidUpdates()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const subscribeToTaggedAuctionEvents = ({
+			kind,
+			tagName,
+			values,
+			onEvent,
+		}: {
+			kind: NonNullable<NDKFilter['kinds']>[number]
+			tagName: '#e' | '#a'
+			values: string[]
+			onEvent: (event: NDKEvent) => void
+		}) => {
+			if (isCancelled || values.length === 0) return
+
+			const filter = {
+				kinds: [kind],
+				[tagName]: values,
+				since: subscriptionSince,
+			} as NDKFilter
+
+			const subscription = ndk.subscribe(filter, {
+				closeOnEose: false,
+			})
+
+			subscription.on('event', onEvent)
+			subscriptionsRef.current.push(subscription)
+		}
+
+		const getHighestOwnBidAmountForAuction = (
+			event: NDKEvent,
+			highestOwnBidByRootId: Map<string, number>,
+			highestOwnBidByCoordinate: Map<string, number>,
+		): number => {
+			const auctionRootEventId = getEventAuctionRootId(event)
+			const auctionCoordinate = getEventAuctionCoordinate(event)
+			const rootAmount = auctionRootEventId ? (highestOwnBidByRootId.get(auctionRootEventId) ?? 0) : 0
+			const coordinateAmount = auctionCoordinate ? (highestOwnBidByCoordinate.get(auctionCoordinate) ?? 0) : 0
+			return Math.max(rootAmount, coordinateAmount)
+		}
+
+		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
 				// Fetch recent orders where user is seller (recipient)
@@ -107,20 +268,155 @@ export const useNotificationMonitor = () => {
 					return isUpdate && event.pubkey !== user.pubkey && isNewPurchaseUpdate(event)
 				})
 
+				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
+				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
+				const sellerBidEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					auctionRootEventIds: sellerAuctionRootEventIds,
+					auctionCoordinates: sellerAuctionCoordinates,
+					since: notificationActions.getLastSeenAuctionBids() + 1,
+				})
+
+				const newSellerBidEvents = sellerBidEvents.filter((event) => {
+					seenAuctionEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event)
+				})
+
+				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
+				const highestOwnBidByRootId = new Map<string, number>()
+				const highestOwnBidByCoordinate = new Map<string, number>()
+
+				for (const bid of ownBidEvents) {
+					const amount = getBidAmount(bid)
+					const auctionRootEventId = getBidAuctionEventId(bid)
+					const auctionCoordinate = getBidAuctionCoordinates(bid)
+
+					if (auctionRootEventId) {
+						highestOwnBidByRootId.set(auctionRootEventId, Math.max(highestOwnBidByRootId.get(auctionRootEventId) ?? 0, amount))
+					}
+					if (auctionCoordinate) {
+						highestOwnBidByCoordinate.set(auctionCoordinate, Math.max(highestOwnBidByCoordinate.get(auctionCoordinate) ?? 0, amount))
+					}
+				}
+
+				const watchedAuctionRootEventIds = Array.from(highestOwnBidByRootId.keys())
+				const watchedAuctionCoordinates = Array.from(highestOwnBidByCoordinate.keys())
+				const watchedBidEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					auctionRootEventIds: watchedAuctionRootEventIds,
+					auctionCoordinates: watchedAuctionCoordinates,
+					since: notificationActions.getLastSeenBidUpdates() + 1,
+				})
+				const watchedSettlementEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					auctionRootEventIds: watchedAuctionRootEventIds,
+					auctionCoordinates: watchedAuctionCoordinates,
+					since: notificationActions.getLastSeenBidUpdates() + 1,
+				})
+
+				const newHigherBidEvents = watchedBidEvents.filter((event) => {
+					seenBidEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewBidUpdate(event)) return false
+
+					const highestOwnBidAmount = getHighestOwnBidAmountForAuction(event, highestOwnBidByRootId, highestOwnBidByCoordinate)
+					return highestOwnBidAmount > 0 && getBidAmount(event) > highestOwnBidAmount
+				})
+
+				const newSettlementEvents = watchedSettlementEvents.filter((event) => {
+					seenSettlementEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewBidUpdate(event)
+				})
+
+				if (isCancelled) return
+
 				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
 					orderCount: newOrders.length,
 					messageCount: totalUnseenMessages,
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
+					auctionBidCount: newSellerBidEvents.length,
+					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
 				console.log('[NotificationMonitor] Initial counts:', {
 					orders: newOrders.length,
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
+					auctionBids: newSellerBidEvents.length,
+					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
+
+				const handleSellerBidEvent = (event: NDKEvent) => {
+					if (!event.id || seenAuctionEventIds.has(event.id)) return
+					seenAuctionEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event)) return
+
+					console.log('[NotificationMonitor] New auction bid received:', event.id)
+					notificationActions.incrementUnseenAuctionBids()
+				}
+
+				const handleWatchedBidEvent = (event: NDKEvent) => {
+					if (!event.id || seenBidEventIds.has(event.id)) return
+					seenBidEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewBidUpdate(event)) return
+
+					const highestOwnBidAmount = getHighestOwnBidAmountForAuction(event, highestOwnBidByRootId, highestOwnBidByCoordinate)
+					if (highestOwnBidAmount <= 0 || getBidAmount(event) <= highestOwnBidAmount) return
+
+					console.log('[NotificationMonitor] New higher bid on watched auction:', event.id)
+					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				const handleWatchedSettlementEvent = (event: NDKEvent) => {
+					if (!event.id || seenSettlementEventIds.has(event.id)) return
+					seenSettlementEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isNewBidUpdate(event)) return
+
+					console.log('[NotificationMonitor] New settlement on watched auction:', event.id)
+					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#e',
+					values: sellerAuctionRootEventIds,
+					onEvent: handleSellerBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#a',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#e',
+					values: watchedAuctionRootEventIds,
+					onEvent: handleWatchedBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#a',
+					values: watchedAuctionCoordinates,
+					onEvent: handleWatchedBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					tagName: '#e',
+					values: watchedAuctionRootEventIds,
+					onEvent: handleWatchedSettlementEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					tagName: '#a',
+					values: watchedAuctionCoordinates,
+					onEvent: handleWatchedSettlementEvent,
+				})
+
+				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
 			} catch (error) {
 				console.error('[NotificationMonitor] Failed to initialize notifications:', error)
 			}
@@ -136,7 +432,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000), // Only new events from now
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -162,7 +458,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_GENERAL_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000), // Only new events from now
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -186,7 +482,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000),
+				since: subscriptionSince,
 			},
 			{
 				closeOnEose: false,
@@ -219,11 +515,12 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(purchaseUpdateSubscription)
 
-		console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
+		console.log('[NotificationMonitor] Base subscriptions active:', subscriptionsRef.current.length)
 
 		// Cleanup function
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
+			isCancelled = true
 			subscriptionsRef.current.forEach((sub) => {
 				sub.stop()
 			})

--- a/src/lib/__tests__/auctionFormDraft.test.ts
+++ b/src/lib/__tests__/auctionFormDraft.test.ts
@@ -188,6 +188,19 @@ describe('empty form not persisted', () => {
 		expect(isDraftMeaningful(candidate)).toBe(false)
 	})
 
+	test('isDraftMeaningful returns true when only title is filled in', () => {
+		const candidate: AuctionFormDraft = {
+			formData: { ...emptyFormData, title: 'My auction' },
+			images: [],
+			subCategoryInput: '',
+			startMode: 'immediate',
+			endMode: 'duration',
+			durationSeconds: 86400,
+			activeTab: 'name',
+		}
+		expect(isDraftMeaningful(candidate)).toBe(true)
+	})
+
 	test('isDraftMeaningful returns true once a field is filled in', () => {
 		const candidate: AuctionFormDraft = {
 			formData: { ...emptyFormData, description: 'something' },

--- a/src/lib/__tests__/auctionFormDraft.test.ts
+++ b/src/lib/__tests__/auctionFormDraft.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { AuctionFormData } from '@/publish/auctions'
+import {
+	clearDraft,
+	getAuctionDraftKey,
+	isDraftMeaningful,
+	loadDraft,
+	saveDraft,
+	type AuctionFormDraft,
+} from '@/lib/utils/auctionFormDraft'
+
+// ── localStorage mock ───────────────────────────────────────────────────────
+// Bun's test runner has no browser globals; wire up a minimal in-memory shim.
+const store: Record<string, string> = {}
+const localStorageMock = {
+	getItem: (key: string) => store[key] ?? null,
+	setItem: (key: string, value: string) => {
+		store[key] = value
+	},
+	removeItem: (key: string) => {
+		delete store[key]
+	},
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+const PUBKEY_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const PUBKEY_B = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+const emptyFormData: AuctionFormData = {
+	title: '',
+	summary: '',
+	description: '',
+	startingBid: '',
+	bidIncrement: '1',
+	reserve: undefined,
+	startAt: '',
+	endAt: '',
+	antiSnipeWindowMinutes: 0,
+	minBidCurveShape: 'none' as const,
+	minBidCurvePeakMultiplier: 2,
+	settlementGracePreset: '1h' as const,
+	mainCategory: '',
+	categories: [],
+	imageUrls: [],
+	specs: [],
+	shippings: [],
+	trustedMints: [],
+	isNSFW: false,
+	pathIssuerPubkey: '',
+}
+
+const meaningfulFormData: AuctionFormData = { ...emptyFormData, title: 'Rare print', description: 'First edition', startingBid: '1000' }
+
+const baseDraft: AuctionFormDraft = {
+	formData: meaningfulFormData,
+	images: [],
+	subCategoryInput: '',
+	startMode: 'immediate',
+	endMode: 'duration',
+	durationSeconds: 86400,
+	activeTab: 'name',
+}
+
+beforeEach(() => {
+	// Wipe the mock store between tests so they don't bleed into each other.
+	for (const key of Object.keys(store)) delete store[key]
+})
+
+// ── save / load roundtrip ───────────────────────────────────────────────────
+describe('save/load roundtrip', () => {
+	test('loaded draft matches what was saved', () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		const loaded = loadDraft(PUBKEY_A)
+		expect(loaded).not.toBeNull()
+		expect(loaded!.formData.title).toBe('Rare print')
+		expect(loaded!.formData.startingBid).toBe('1000')
+		expect(loaded!.startMode).toBe('immediate')
+		expect(loaded!.endMode).toBe('duration')
+		expect(loaded!.durationSeconds).toBe(86400)
+		expect(loaded!.activeTab).toBe('name')
+	})
+
+	test('roundtrip preserves images array', () => {
+		const draft: AuctionFormDraft = {
+			...baseDraft,
+			images: [{ imageUrl: 'https://cdn.example/img.jpg', imageOrder: 0 }],
+		}
+		saveDraft(PUBKEY_A, draft)
+		const loaded = loadDraft(PUBKEY_A)
+		expect(loaded!.images).toEqual([{ imageUrl: 'https://cdn.example/img.jpg', imageOrder: 0 }])
+	})
+})
+
+// ── malformed JSON handling ─────────────────────────────────────────────────
+describe('malformed JSON handling', () => {
+	test('returns null when stored value is not valid JSON', () => {
+		const key = getAuctionDraftKey(PUBKEY_A)!
+		store[key] = '{ this is not json }'
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when stored JSON fails schema validation', () => {
+		const key = getAuctionDraftKey(PUBKEY_A)!
+		store[key] = JSON.stringify({ version: 99, ownerPubkey: PUBKEY_A, savedAt: Date.now(), draft: {} })
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when storage key is absent', () => {
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+})
+
+// ── cross-user safety ───────────────────────────────────────────────────────
+describe('cross-user safety', () => {
+	test('draft saved by user A is not returned when loading as user B', () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		expect(loadDraft(PUBKEY_B)).toBeNull()
+	})
+
+	test('each user gets their own storage key', () => {
+		expect(getAuctionDraftKey(PUBKEY_A)).not.toBe(getAuctionDraftKey(PUBKEY_B))
+	})
+
+	test('tampered ownerPubkey in envelope is rejected', () => {
+		// Save a valid draft for A, then mutate the stored envelope to claim it belongs to B.
+		saveDraft(PUBKEY_A, baseDraft)
+		const key = getAuctionDraftKey(PUBKEY_A)!
+		const raw = JSON.parse(store[key])
+		raw.ownerPubkey = PUBKEY_B
+		store[key] = JSON.stringify(raw)
+		// Loading as A should fail because ownerPubkey !== A.
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+})
+
+// ── clear draft behavior ────────────────────────────────────────────────────
+describe('clear draft behavior', () => {
+	test('clearDraft removes the stored item so loadDraft returns null', () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		expect(loadDraft(PUBKEY_A)).not.toBeNull()
+		clearDraft(PUBKEY_A)
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('clearDraft with no prior draft does not throw', () => {
+		expect(() => clearDraft(PUBKEY_A)).not.toThrow()
+	})
+
+	test("clearDraft only removes the target user's draft", () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		saveDraft(PUBKEY_B, baseDraft)
+		clearDraft(PUBKEY_A)
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+		expect(loadDraft(PUBKEY_B)).not.toBeNull()
+	})
+})
+
+// ── publish clears draft ────────────────────────────────────────────────────
+describe('publish clears draft', () => {
+	test('calling clearDraft after a successful publish removes the draft', () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		// Simulate what AuctionFormContent does on successful publish:
+		clearDraft(PUBKEY_A)
+		expect(loadDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('draft key is absent from storage after publish-triggered clear', () => {
+		saveDraft(PUBKEY_A, baseDraft)
+		clearDraft(PUBKEY_A)
+		const key = getAuctionDraftKey(PUBKEY_A)!
+		expect(store[key]).toBeUndefined()
+	})
+})
+
+// ── empty form not persisted ────────────────────────────────────────────────
+describe('empty form not persisted', () => {
+	test('isDraftMeaningful returns false for a fully empty form', () => {
+		const candidate: AuctionFormDraft = {
+			formData: emptyFormData,
+			images: [],
+			subCategoryInput: '',
+			startMode: 'immediate',
+			endMode: 'duration',
+			durationSeconds: 86400,
+			activeTab: 'name',
+		}
+		expect(isDraftMeaningful(candidate)).toBe(false)
+	})
+
+	test('isDraftMeaningful returns true once a field is filled in', () => {
+		const candidate: AuctionFormDraft = {
+			formData: { ...emptyFormData, description: 'something' },
+			images: [],
+			subCategoryInput: '',
+			startMode: 'immediate',
+			endMode: 'duration',
+			durationSeconds: 86400,
+			activeTab: 'name',
+		}
+		expect(isDraftMeaningful(candidate)).toBe(true)
+	})
+
+	test('isDraftMeaningful returns true when images list is non-empty', () => {
+		const candidate: AuctionFormDraft = {
+			formData: emptyFormData,
+			images: [{ imageUrl: 'https://cdn.example/img.jpg', imageOrder: 0 }],
+			subCategoryInput: '',
+			startMode: 'immediate',
+			endMode: 'duration',
+			durationSeconds: 86400,
+			activeTab: 'name',
+		}
+		expect(isDraftMeaningful(candidate)).toBe(true)
+	})
+
+	test('isDraftMeaningful returns true when subCategoryInput has content', () => {
+		const candidate: AuctionFormDraft = {
+			formData: emptyFormData,
+			images: [],
+			subCategoryInput: 'Collectibles',
+			startMode: 'immediate',
+			endMode: 'duration',
+			durationSeconds: 86400,
+			activeTab: 'name',
+		}
+		expect(isDraftMeaningful(candidate)).toBe(true)
+	})
+
+	test('saveDraft with no pubkey does not write to storage', () => {
+		saveDraft(undefined, baseDraft)
+		expect(Object.keys(store)).toHaveLength(0)
+	})
+})

--- a/src/lib/__tests__/auctionMintSelection.integration.test.ts
+++ b/src/lib/__tests__/auctionMintSelection.integration.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveAuctionMintSelection } from '@/lib/auctionMintSelection'
+import type { Nip60State } from '@/lib/stores/nip60'
+
+const MINT_A = 'https://mint-a.example.com'
+const MINT_B = 'https://mint-b.example.com'
+const MINT_C = 'https://mint-c.example.com'
+
+function makeNip60Snapshot(overrides: Partial<Nip60State> = {}): {
+	mints: string[]
+	mintBalances: Record<string, number>
+} {
+	return {
+		mints: overrides.mints ?? [MINT_A, MINT_B],
+		mintBalances: overrides.mintBalances ?? { [MINT_A]: 1000, [MINT_B]: 500 },
+	}
+}
+
+describe('auctionMintSelection integration with nip60 store state', () => {
+	test('resolves mint from fresh wallet with single mint', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A],
+			mintBalances: { [MINT_A]: 2000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 500,
+		})
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+	})
+
+	test('resolves second mint when first has no balance', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 0, [MINT_B]: 2000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 500,
+		})
+		expect(result.selectedMint).toBe(MINT_B)
+		expect(result.error).toBeNull()
+	})
+
+	test('handles wallet with only untrusted mints', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_C],
+			mintBalances: { [MINT_C]: 5000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 500,
+		})
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('No balance on any trusted mint')
+	})
+
+	test('handles rebid with higher amount requiring mint switch', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 200, [MINT_B]: 2000 },
+		})
+		const firstResult = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 100,
+		})
+		expect(firstResult.selectedMint).toBe(MINT_A)
+		expect(firstResult.error).toBeNull()
+
+		const rebidResult = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 500,
+			previousBidAmount: 100,
+		})
+		expect(rebidResult.selectedMint).toBe(MINT_B)
+		expect(rebidResult.error).toBeNull()
+	})
+
+	test('handles wallet not yet initialized (empty state)', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [],
+			mintBalances: {},
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 100,
+		})
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('No balance on any trusted mint')
+	})
+
+	test('handles multiple eligible mints - picks first by auction order', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 5000, [MINT_B]: 5000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 100,
+		})
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.eligibleMints).toHaveLength(2)
+		expect(result.availableMints.filter((m) => m.balance > 0)).toHaveLength(2)
+	})
+
+	test('bid amount of zero is handled gracefully', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A],
+			mintBalances: { [MINT_A]: 500 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 0,
+		})
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+	})
+
+	test('reports partial balance correctly for error messaging', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 50, [MINT_B]: 75 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 200,
+		})
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('Insufficient balance')
+		expect(result.error).toContain('50')
+		expect(result.availableMints).toHaveLength(2)
+		expect(result.insufficientBalanceMints).toHaveLength(2)
+	})
+
+	test('rebid with small delta keeps first mint eligible', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 200, [MINT_B]: 2000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 500,
+			previousBidAmount: 400,
+		})
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(2)
+	})
+
+	test('rebid with large delta falls back to second mint', () => {
+		const wallet = makeNip60Snapshot({
+			mints: [MINT_A, MINT_B],
+			mintBalances: { [MINT_A]: 100, [MINT_B]: 2000 },
+		})
+		const result = resolveAuctionMintSelection({
+			trustedMints: [MINT_A, MINT_B],
+			walletMints: wallet.mints,
+			mintBalances: wallet.mintBalances,
+			bidAmount: 1000,
+			previousBidAmount: 200,
+		})
+		expect(result.selectedMint).toBe(MINT_B)
+		expect(result.error).toBeNull()
+	})
+})

--- a/src/lib/__tests__/auctionMintSelection.test.ts
+++ b/src/lib/__tests__/auctionMintSelection.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveAuctionMintSelection, type MintSelectionInput } from '@/lib/auctionMintSelection'
+
+const MINT_A = 'https://mint-a.example.com'
+const MINT_B = 'https://mint-b.example.com'
+const MINT_C = 'https://mint-c.example.com'
+
+function makeInput(overrides: Partial<MintSelectionInput> = {}): MintSelectionInput {
+	return {
+		trustedMints: [MINT_A, MINT_B],
+		walletMints: [MINT_A, MINT_B],
+		mintBalances: { [MINT_A]: 1000, [MINT_B]: 500 },
+		bidAmount: 100,
+		...overrides,
+	}
+}
+
+describe('resolveAuctionMintSelection', () => {
+	test('auto-selects first mint with sufficient balance', () => {
+		const result = resolveAuctionMintSelection(makeInput())
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(2)
+	})
+
+	test('returns all available mints with balance info', () => {
+		const result = resolveAuctionMintSelection(makeInput())
+		expect(result.availableMints).toHaveLength(2)
+		expect(result.availableMints[0]).toEqual({
+			mintUrl: MINT_A,
+			hostname: 'mint-a.example.com',
+			balance: 1000,
+			hasSufficientBalance: true,
+		})
+		expect(result.availableMints[1]).toEqual({
+			mintUrl: MINT_B,
+			hostname: 'mint-b.example.com',
+			balance: 500,
+			hasSufficientBalance: true,
+		})
+	})
+
+	test('returns error when no trusted mints configured', () => {
+		const result = resolveAuctionMintSelection(makeInput({ trustedMints: [] }))
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('no trusted mints')
+		expect(result.availableMints).toHaveLength(0)
+	})
+
+	test('returns error when user has no balance on any trusted mint', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 0, [MINT_B]: 0 },
+			}),
+		)
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('No balance on any trusted mint')
+		expect(result.availableMints).toHaveLength(0)
+	})
+
+	test('returns error when user has balance but below bid amount on all mints', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 50, [MINT_B]: 30 },
+				bidAmount: 100,
+			}),
+		)
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('Insufficient balance')
+		expect(result.eligibleMints).toHaveLength(0)
+		expect(result.insufficientBalanceMints).toHaveLength(2)
+		expect(result.availableMints).toHaveLength(2)
+	})
+
+	test('selects mint with sufficient balance even if it is not the first', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 0, [MINT_B]: 500 },
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_B)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(1)
+	})
+
+	test('ignores wallet mints not in trusted list', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A],
+				walletMints: [MINT_A, MINT_C],
+				mintBalances: { [MINT_A]: 100, [MINT_C]: 5000 },
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.availableMints).toHaveLength(1)
+	})
+
+	test('normalizes trailing slashes on mint URLs', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: ['https://mint-a.example.com/'],
+				walletMints: ['https://mint-a.example.com'],
+				mintBalances: { 'https://mint-a.example.com': 200 },
+			}),
+		)
+		expect(result.selectedMint).toBe('https://mint-a.example.com')
+		expect(result.error).toBeNull()
+	})
+
+	test('handles empty wallet mints gracefully', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				walletMints: [],
+				mintBalances: {},
+			}),
+		)
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('No balance on any trusted mint')
+	})
+
+	test('tracks unfunded trusted mints separately', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A, MINT_B, MINT_C],
+				walletMints: [MINT_A, MINT_B, MINT_C],
+				mintBalances: { [MINT_A]: 500, [MINT_B]: 0, [MINT_C]: 0 },
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.unfundedTrustedMints).toEqual([MINT_B, MINT_C])
+	})
+
+	test('selects from eligible mints that are also in mintBalances even if not in walletMints', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A],
+				walletMints: [],
+				mintBalances: { [MINT_A]: 500 },
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+	})
+
+	test('single eligible mint is auto-selected without error', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A, MINT_B],
+				mintBalances: { [MINT_A]: 500, [MINT_B]: 0 },
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.availableMints).toHaveLength(1)
+	})
+
+	test('all eligible mints are correctly marked', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A, MINT_B],
+				mintBalances: { [MINT_A]: 1000, [MINT_B]: 50 },
+				bidAmount: 200,
+			}),
+		)
+		expect(result.eligibleMints).toHaveLength(1)
+		expect(result.eligibleMints[0].mintUrl).toBe(MINT_A)
+		expect(result.insufficientBalanceMints).toHaveLength(1)
+		expect(result.insufficientBalanceMints[0].mintUrl).toBe(MINT_B)
+	})
+
+	test('with previousBidAmount, eligibility uses delta instead of full bid', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 150, [MINT_B]: 50 },
+				bidAmount: 500,
+				previousBidAmount: 400,
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(1)
+		expect(result.eligibleMints[0].mintUrl).toBe(MINT_A)
+	})
+
+	test('with previousBidAmount, insufficient delta shows error with delta amount', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 30, [MINT_B]: 10 },
+				bidAmount: 500,
+				previousBidAmount: 400,
+			}),
+		)
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('100')
+		expect(result.error).toContain('delta')
+		expect(result.eligibleMints).toHaveLength(0)
+		expect(result.availableMints).toHaveLength(2)
+	})
+
+	test('previousBidAmount equals bidAmount means zero delta — all mints eligible', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 1, [MINT_B]: 1 },
+				bidAmount: 500,
+				previousBidAmount: 500,
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(2)
+	})
+
+	test('previousBidAmount exceeding bidAmount is clamped to zero delta', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 1, [MINT_B]: 1 },
+				bidAmount: 100,
+				previousBidAmount: 200,
+			}),
+		)
+		expect(result.selectedMint).toBe(MINT_A)
+		expect(result.error).toBeNull()
+		expect(result.eligibleMints).toHaveLength(2)
+	})
+
+	test('insufficient balance returns null selectedMint but keeps availableMints for display', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				mintBalances: { [MINT_A]: 75, [MINT_B]: 25 },
+				bidAmount: 200,
+			}),
+		)
+		expect(result.selectedMint).toBeNull()
+		expect(result.error).toContain('Insufficient balance')
+		expect(result.availableMints).toHaveLength(2)
+		expect(result.insufficientBalanceMints).toHaveLength(2)
+		expect(result.availableMints[0].balance).toBe(75)
+		expect(result.availableMints[1].balance).toBe(25)
+	})
+})

--- a/src/lib/__tests__/auctionShippingRefs.test.ts
+++ b/src/lib/__tests__/auctionShippingRefs.test.ts
@@ -27,16 +27,33 @@ describe('auction shipping refs', () => {
 		])
 	})
 
-	test('dedupes duplicate refs with first occurrence winning', () => {
+	test('dedupes by shippingRef only, first occurrence wins', () => {
 		const refs = getUniqueAuctionShippingRefs([
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5' },
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '10' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '0' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '500' },
 			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '' },
 		])
 
 		expect(refs).toEqual([
-			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5', status: 'valid', pubkey: sellerA, dTag: 'standard' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '0', status: 'valid', pubkey: sellerA, dTag: 'standard' },
 			{ shippingRef: `30406:${sellerB}:pickup`, extraCost: '', status: 'valid', pubkey: sellerB, dTag: 'pickup' },
 		])
+	})
+
+	test('preserves first-occurrence order', () => {
+		const refs = getUniqueAuctionShippingRefs([
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5' },
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '' },
+		])
+
+		expect(refs).toEqual([
+			{ shippingRef: `30406:${sellerB}:express`, extraCost: '', status: 'valid', pubkey: sellerB, dTag: 'express' },
+			{ shippingRef: `30406:${sellerA}:standard`, extraCost: '5', status: 'valid', pubkey: sellerA, dTag: 'standard' },
+		])
+	})
+
+	test('returns empty array for empty input', () => {
+		expect(getUniqueAuctionShippingRefs([])).toEqual([])
 	})
 })

--- a/src/lib/auctionMintSelection.ts
+++ b/src/lib/auctionMintSelection.ts
@@ -1,0 +1,103 @@
+import { getMintHostname } from '@/lib/wallet'
+
+export interface AvailableMint {
+	mintUrl: string
+	hostname: string
+	balance: number
+	hasSufficientBalance: boolean
+}
+
+export interface MintSelectionInput {
+	trustedMints: string[]
+	walletMints: string[]
+	mintBalances: Record<string, number>
+	bidAmount: number
+	previousBidAmount?: number
+}
+
+export interface MintSelectionResult {
+	selectedMint: string | null
+	availableMints: AvailableMint[]
+	eligibleMints: AvailableMint[]
+	insufficientBalanceMints: AvailableMint[]
+	unfundedTrustedMints: string[]
+	error: string | null
+}
+
+const normalizeMintUrl = (url: string): string => url.trim().replace(/\/+$/, '')
+
+export function resolveAuctionMintSelection(input: MintSelectionInput): MintSelectionResult {
+	const { trustedMints, walletMints, mintBalances, bidAmount, previousBidAmount = 0 } = input
+
+	if (!trustedMints.length) {
+		return {
+			selectedMint: null,
+			availableMints: [],
+			eligibleMints: [],
+			insufficientBalanceMints: [],
+			unfundedTrustedMints: [],
+			error: 'Auction has no trusted mints configured',
+		}
+	}
+
+	const deltaAmount = Math.max(0, bidAmount - previousBidAmount)
+
+	const normalizedWalletMints = new Set(walletMints.map(normalizeMintUrl))
+
+	const availableMints: AvailableMint[] = []
+	const unfundedTrustedMints: string[] = []
+
+	for (const rawMint of trustedMints) {
+		const mintUrl = normalizeMintUrl(rawMint)
+		if (normalizedWalletMints.has(mintUrl) || mintBalances[mintUrl] !== undefined) {
+			const balance = mintBalances[mintUrl] ?? 0
+			if (balance > 0) {
+				availableMints.push({
+					mintUrl,
+					hostname: getMintHostname(mintUrl),
+					balance,
+					hasSufficientBalance: balance >= deltaAmount,
+				})
+			} else {
+				unfundedTrustedMints.push(mintUrl)
+			}
+		} else {
+			unfundedTrustedMints.push(mintUrl)
+		}
+	}
+
+	const eligibleMints = availableMints.filter((m) => m.hasSufficientBalance)
+	const insufficientBalanceMints = availableMints.filter((m) => !m.hasSufficientBalance)
+
+	if (!availableMints.length) {
+		return {
+			selectedMint: null,
+			availableMints: [],
+			eligibleMints: [],
+			insufficientBalanceMints: [],
+			unfundedTrustedMints,
+			error: `No balance on any trusted mint. Add funds to one of: ${unfundedTrustedMints.map(getMintHostname).join(', ')}`,
+		}
+	}
+
+	if (!eligibleMints.length) {
+		const bestMint = insufficientBalanceMints[0]
+		return {
+			selectedMint: null,
+			availableMints,
+			eligibleMints: [],
+			insufficientBalanceMints,
+			unfundedTrustedMints,
+			error: `Insufficient balance. Need ${deltaAmount} sats (delta: ${bidAmount} - ${previousBidAmount}). Closest: ${getMintHostname(bestMint.mintUrl)} (${bestMint.balance} sats)`,
+		}
+	}
+
+	return {
+		selectedMint: eligibleMints[0].mintUrl,
+		availableMints,
+		eligibleMints,
+		insufficientBalanceMints,
+		unfundedTrustedMints,
+		error: null,
+	}
+}

--- a/src/lib/auctionMintSync.test.ts
+++ b/src/lib/auctionMintSync.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { syncMintSelection } from './auctionMintSync'
+
+const EMPTY = new Set<string>()
+
+describe('syncMintSelection', () => {
+	test('adds newly available mints', () => {
+		const result = syncMintSelection(['mint-a', 'mint-b'], ['mint-a', 'mint-b', 'mint-c'], ['mint-a', 'mint-b'], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b', 'mint-c'])
+	})
+
+	test('does not auto-remove mints that leave availableMints', () => {
+		const result = syncMintSelection(['mint-a', 'mint-b', 'mint-c'], ['mint-a', 'mint-c'], ['mint-a', 'mint-b', 'mint-c'], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b', 'mint-c'])
+	})
+
+	test('preserves user explicit removals when available is unchanged', () => {
+		const result = syncMintSelection(['mint-a', 'mint-b', 'mint-c'], ['mint-a', 'mint-b', 'mint-c'], ['mint-a'], EMPTY)
+		expect(result).toEqual(['mint-a'])
+	})
+
+	test('handles add and keep simultaneously', () => {
+		const result = syncMintSelection(['mint-a', 'mint-b'], ['mint-a', 'mint-c', 'mint-d'], ['mint-a', 'mint-b'], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b', 'mint-c', 'mint-d'])
+	})
+
+	test('empty selection with new available mints', () => {
+		const result = syncMintSelection([], ['mint-a', 'mint-b'], [], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b'])
+	})
+
+	test('all mints removed from available but kept in selection', () => {
+		const result = syncMintSelection(['mint-a', 'mint-b'], [], ['mint-a'], EMPTY)
+		expect(result).toEqual(['mint-a'])
+	})
+
+	test('no change when available is identical reference', () => {
+		const available = ['mint-a', 'mint-b']
+		const result = syncMintSelection(available, available, ['mint-a'], EMPTY)
+		expect(result).toEqual(['mint-a'])
+	})
+
+	test('returning mint is not re-added when user explicitly removed it', () => {
+		const removed = new Set(['mint-b'])
+		const result = syncMintSelection(['mint-a', 'mint-b'], ['mint-a', 'mint-b', 'mint-c'], ['mint-a'], removed)
+		expect(result).toEqual(['mint-a', 'mint-c'])
+	})
+
+	test('returning mint IS re-added when user did not remove it', () => {
+		const result = syncMintSelection(['mint-a'], ['mint-a', 'mint-b'], ['mint-a'], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b'])
+	})
+
+	test('does not duplicate mints already in selection', () => {
+		const result = syncMintSelection(['mint-a'], ['mint-a', 'mint-b'], ['mint-a', 'mint-b'], EMPTY)
+		expect(result).toEqual(['mint-a', 'mint-b'])
+	})
+})

--- a/src/lib/auctionMintSync.ts
+++ b/src/lib/auctionMintSync.ts
@@ -1,0 +1,10 @@
+export function syncMintSelection(
+	prevAvailable: string[],
+	currentAvailable: string[],
+	currentSelection: string[],
+	userRemovedMints: Set<string>,
+): string[] {
+	const addedMints = currentAvailable.filter((m) => !prevAvailable.includes(m) && !userRemovedMints.has(m) && !currentSelection.includes(m))
+
+	return [...currentSelection, ...addedMints]
+}

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -21,12 +21,11 @@ import {
 	CheckStateEnum,
 	getDecodedToken,
 	getEncodedToken,
-	getTokenMetadata,
 	type MintKeys,
 	type MintKeyset,
 	type Proof,
 } from '@cashu/cashu-ts'
-import { getP2PKLocktime } from '@cashu/cashu-ts/crypto/client/NUT11'
+import { getP2PKLocktime } from '@/lib/utils/cashu'
 import { secp256k1 } from '@noble/curves/secp256k1.js'
 import { NDKEvent, NDKNutzap, NDKRelaySet, NDKUser, NDKZapper, type NDKFilter, type NDKTag } from '@nostr-dev-kit/ndk'
 import { NDKCashuDeposit, NDKCashuWallet, NDKWalletStatus, type NDKWalletTransaction } from '@nostr-dev-kit/wallet'
@@ -665,7 +664,7 @@ const receiveTokenIntoWallet = async (
 		privkey?: string
 	},
 ): Promise<{ amount: number; mintUrl: string }> => {
-	const mintUrl = normalizeMintUrl(getTokenMetadata(token).mint)
+	const mintUrl = normalizeMintUrl(getDecodedToken(token).mint)
 	const proofsWeHave = getProofsForMint(wallet, mintUrl)
 	const { cashuWallet, keysetId } = await createCashuWalletForMint(mintUrl)
 	try {

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -12,12 +12,16 @@ export interface NotificationState {
 	unseenOrders: number // New orders where user is seller
 	unseenMessages: number // New messages in conversations
 	unseenPurchases: number // Updates to orders where user is buyer
+	unseenAuctionBids: number // New bids on auctions where user is seller
+	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
 	unseenByConversation: ConversationNotifications
 
 	// Last seen timestamps (unix timestamp in seconds)
 	lastSeenTimestamps: {
 		orders: number
 		purchases: number
+		auctionBids: number
+		bidUpdates: number
 		messages: Record<string, number> // pubkey -> timestamp
 	}
 
@@ -61,10 +65,14 @@ const createInitialState = (): NotificationState => {
 		unseenOrders: 0,
 		unseenMessages: 0,
 		unseenPurchases: 0,
+		unseenAuctionBids: 0,
+		unseenBidUpdates: 0,
 		unseenByConversation: {},
 		lastSeenTimestamps: {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
+			auctionBids: stored.lastSeenTimestamps?.auctionBids || 0,
+			bidUpdates: stored.lastSeenTimestamps?.bidUpdates || 0,
 			messages: stored.lastSeenTimestamps?.messages || {},
 		},
 		isInitialized: false,
@@ -118,6 +126,26 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Update unseen seller auction bid count
+	 */
+	setUnseenAuctionBids: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen bidder auction update count
+	 */
+	setUnseenBidUpdates: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenBidUpdates: Math.max(0, count),
+		}))
+	},
+
+	/**
 	 * Update unseen count for a specific conversation
 	 */
 	setUnseenForConversation: (pubkey: string, count: number) => {
@@ -161,6 +189,26 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenPurchases: state.unseenPurchases + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen seller auction bid count
+	 */
+	incrementUnseenAuctionBids: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: state.unseenAuctionBids + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen bidder auction update count
+	 */
+	incrementUnseenBidUpdates: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenBidUpdates: state.unseenBidUpdates + 1,
 		}))
 	},
 
@@ -262,6 +310,44 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Mark seller auction bid notifications as seen
+	 */
+	markAuctionBidsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionBids: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionBids: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
+	 * Mark bidder auction update notifications as seen
+	 */
+	markBidUpdatesSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenBidUpdates: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					bidUpdates: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
 	 * Get last seen timestamp for orders
 	 */
 	getLastSeenOrders: (): number => {
@@ -283,6 +369,20 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Get last seen timestamp for seller auction bids
+	 */
+	getLastSeenAuctionBids: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionBids
+	},
+
+	/**
+	 * Get last seen timestamp for bidder auction updates
+	 */
+	getLastSeenBidUpdates: (): number => {
+		return notificationStore.state.lastSeenTimestamps.bidUpdates
+	},
+
+	/**
 	 * Reset all notifications
 	 */
 	reset: () => {
@@ -300,12 +400,16 @@ export const notificationActions = {
 		messageCount: number
 		purchaseCount: number
 		conversationCounts: ConversationNotifications
+		auctionBidCount?: number
+		bidUpdateCount?: number
 	}) => {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenOrders: data.orderCount,
 			unseenMessages: data.messageCount,
 			unseenPurchases: data.purchaseCount,
+			unseenAuctionBids: data.auctionBidCount ?? 0,
+			unseenBidUpdates: data.bidUpdateCount ?? 0,
 			unseenByConversation: data.conversationCounts,
 		}))
 	},

--- a/src/lib/utils/auctionFormDraft.ts
+++ b/src/lib/utils/auctionFormDraft.ts
@@ -1,0 +1,109 @@
+import type { AuctionFormData } from '@/publish/auctions'
+import { z } from 'zod'
+
+export type AuctionImage = { imageUrl: string; imageOrder: number }
+
+export type AuctionTab = 'name' | 'auction' | 'category' | 'spec' | 'images' | 'shipping'
+export type StartMode = 'immediate' | 'scheduled'
+export type EndMode = 'duration' | 'absolute'
+
+export interface AuctionFormDraft {
+	formData: AuctionFormData
+	images: AuctionImage[]
+	subCategoryInput: string
+	startMode: StartMode
+	endMode: EndMode
+	durationSeconds: number
+	activeTab: AuctionTab
+}
+
+export const DRAFT_VERSION = 1 as const
+
+export const auctionDraftEnvelopeSchema = z.object({
+	version: z.literal(DRAFT_VERSION),
+	ownerPubkey: z.string().min(1),
+	savedAt: z.number().int().positive(),
+	draft: z.object({
+		formData: z.object({
+			title: z.string(),
+			summary: z.string(),
+			description: z.string(),
+			startingBid: z.string(),
+			bidIncrement: z.string(),
+			reserve: z.string().optional(),
+			startAt: z.string().optional(),
+			endAt: z.string(),
+			antiSnipeWindowMinutes: z.number(),
+			minBidCurveShape: z.string(),
+			minBidCurvePeakMultiplier: z.number(),
+			settlementGracePreset: z.string(),
+			mainCategory: z.string(),
+			categories: z.array(z.string()),
+			imageUrls: z.array(z.string()),
+			specs: z.array(z.object({ key: z.string(), value: z.string() })),
+			shippings: z.array(z.record(z.string(), z.unknown())),
+			trustedMints: z.array(z.string()),
+			isNSFW: z.boolean(),
+			pathIssuerPubkey: z.string(),
+		}),
+		images: z.array(z.object({ imageUrl: z.string(), imageOrder: z.number() })),
+		subCategoryInput: z.string(),
+		startMode: z.enum(['immediate', 'scheduled']),
+		endMode: z.enum(['duration', 'absolute']),
+		durationSeconds: z.number().positive(),
+		activeTab: z.enum(['name', 'auction', 'category', 'spec', 'images', 'shipping']),
+	}),
+})
+
+export type AuctionDraftEnvelope = z.infer<typeof auctionDraftEnvelopeSchema>
+
+export function isDraftMeaningful({ formData, images, subCategoryInput }: AuctionFormDraft): boolean {
+	const { summary, description, startingBid, reserve, startAt, endAt, mainCategory, categories, imageUrls, specs, shippings } = formData
+	return (
+		[summary, description, startingBid, reserve ?? '', startAt ?? '', endAt, mainCategory, subCategoryInput].some(
+			(s) => s.trim().length > 0,
+		) || [categories, imageUrls, specs, shippings, images].some((a) => a.length > 0)
+	)
+}
+
+export function getAuctionDraftKey(pubkey: string | undefined): string | null {
+	return pubkey ? `auction-form-draft:v1:${pubkey}` : null
+}
+
+export function saveDraft(pubkey: string | undefined, draft: AuctionFormDraft): void {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key || !pubkey) return
+	const envelope: AuctionDraftEnvelope = {
+		version: DRAFT_VERSION,
+		ownerPubkey: pubkey,
+		savedAt: Date.now(),
+		draft,
+	}
+	try {
+		localStorage.setItem(key, JSON.stringify(envelope))
+	} catch {}
+}
+
+export function loadDraft(pubkey: string | undefined): AuctionFormDraft | null {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key || !pubkey) return null
+	try {
+		const raw = localStorage.getItem(key)
+		if (!raw) return null
+		const parsed: unknown = JSON.parse(raw)
+		const result = auctionDraftEnvelopeSchema.safeParse(parsed)
+		if (!result.success) return null
+		if (result.data.ownerPubkey !== pubkey) return null
+		return result.data.draft as AuctionFormDraft
+	} catch {
+		return null
+	}
+}
+
+export function clearDraft(pubkey: string | undefined): void {
+	const key = getAuctionDraftKey(pubkey)
+	if (!key) return
+	try {
+		localStorage.removeItem(key)
+	} catch {}
+}

--- a/src/lib/utils/auctionFormDraft.ts
+++ b/src/lib/utils/auctionFormDraft.ts
@@ -58,9 +58,10 @@ export const auctionDraftEnvelopeSchema = z.object({
 export type AuctionDraftEnvelope = z.infer<typeof auctionDraftEnvelopeSchema>
 
 export function isDraftMeaningful({ formData, images, subCategoryInput }: AuctionFormDraft): boolean {
-	const { summary, description, startingBid, reserve, startAt, endAt, mainCategory, categories, imageUrls, specs, shippings } = formData
+	const { title, summary, description, startingBid, reserve, startAt, endAt, mainCategory, categories, imageUrls, specs, shippings } =
+		formData
 	return (
-		[summary, description, startingBid, reserve ?? '', startAt ?? '', endAt, mainCategory, subCategoryInput].some(
+		[title, summary, description, startingBid, reserve ?? '', startAt ?? '', endAt, mainCategory, subCategoryInput].some(
 			(s) => s.trim().length > 0,
 		) || [categories, imageUrls, specs, shippings, images].some((a) => a.length > 0)
 	)

--- a/src/lib/utils/cashu.test.ts
+++ b/src/lib/utils/cashu.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { getP2PKLocktime } from './cashu'
+
+describe('getP2PKLocktime', () => {
+	test('extracts locktime from valid P2PK secret string', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [['locktime', '1700000000']] }])
+		expect(getP2PKLocktime(secret)).toBe(1700000000)
+	})
+
+	test('returns Infinity when no locktime tag present', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def' }])
+		expect(getP2PKLocktime(secret)).toBe(Infinity)
+	})
+
+	test('returns Infinity when tags array is empty', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [] }])
+		expect(getP2PKLocktime(secret)).toBe(Infinity)
+	})
+
+	test('handles Uint8Array input', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [['locktime', '1700000000']] }])
+		const encoded = new TextEncoder().encode(secret)
+		expect(getP2PKLocktime(encoded)).toBe(1700000000)
+	})
+
+	test('throws for non-P2PK secret', () => {
+		const secret = JSON.stringify(['OTHER', { nonce: 'abc', data: 'def' }])
+		expect(() => getP2PKLocktime(secret)).toThrow('Invalid P2PK secret')
+	})
+
+	test('throws for unparseable secret', () => {
+		expect(() => getP2PKLocktime('not-json')).toThrow()
+	})
+
+	test('handles locktime tag with empty value', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [['locktime']] }])
+		expect(getP2PKLocktime(secret)).toBe(Infinity)
+	})
+
+	test('parses locktime as integer from string', () => {
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [['locktime', '1700000000']] }])
+		const result = getP2PKLocktime(secret)
+		expect(Number.isInteger(result)).toBe(true)
+	})
+
+	test('handles multiple tags, finds locktime', () => {
+		const secret = JSON.stringify([
+			'P2PK',
+			{ nonce: 'abc', data: 'def', tags: [['sigflag', 'SIG_ALL'], ['locktime', '1700000001']] },
+		])
+		expect(getP2PKLocktime(secret)).toBe(1700000001)
+	})
+
+	test('handles SecretData with additional unknown fields', () => {
+		const secret = JSON.stringify([
+			'P2PK',
+			{ nonce: 'abc', data: 'def', tags: [['locktime', '1700000002']], custom: 'field' },
+		])
+		expect(getP2PKLocktime(secret)).toBe(1700000002)
+	})
+})

--- a/src/lib/utils/cashu.test.ts
+++ b/src/lib/utils/cashu.test.ts
@@ -46,16 +46,20 @@ describe('getP2PKLocktime', () => {
 	test('handles multiple tags, finds locktime', () => {
 		const secret = JSON.stringify([
 			'P2PK',
-			{ nonce: 'abc', data: 'def', tags: [['sigflag', 'SIG_ALL'], ['locktime', '1700000001']] },
+			{
+				nonce: 'abc',
+				data: 'def',
+				tags: [
+					['sigflag', 'SIG_ALL'],
+					['locktime', '1700000001'],
+				],
+			},
 		])
 		expect(getP2PKLocktime(secret)).toBe(1700000001)
 	})
 
 	test('handles SecretData with additional unknown fields', () => {
-		const secret = JSON.stringify([
-			'P2PK',
-			{ nonce: 'abc', data: 'def', tags: [['locktime', '1700000002']], custom: 'field' },
-		])
+		const secret = JSON.stringify(['P2PK', { nonce: 'abc', data: 'def', tags: [['locktime', '1700000002']], custom: 'field' }])
 		expect(getP2PKLocktime(secret)).toBe(1700000002)
 	})
 })

--- a/src/lib/utils/cashu.ts
+++ b/src/lib/utils/cashu.ts
@@ -1,0 +1,20 @@
+import type { Secret, SecretData } from '@cashu/crypto/modules/common'
+import { parseSecret } from '@cashu/crypto/modules/common/NUT11'
+
+interface P2PKSecretData extends SecretData {
+	tags?: Array<Array<string>>
+}
+
+function isP2PKSecret(parsed: Secret): parsed is ['P2PK', P2PKSecretData] {
+	return Array.isArray(parsed) && parsed[0] === 'P2PK' && parsed[1] != null
+}
+
+export function getP2PKLocktime(secret: Uint8Array | string): number {
+	const parsed = parseSecret(secret instanceof Uint8Array ? new TextDecoder().decode(secret) : secret)
+	if (!isP2PKSecret(parsed)) {
+		throw new Error('Invalid P2PK secret: must start with "P2PK"')
+	}
+	const tags = parsed[1].tags
+	const locktimeTag = tags?.find((t) => t[0] === 'locktime')
+	return locktimeTag && locktimeTag.length > 1 ? parseInt(locktimeTag[1], 10) : Infinity
+}

--- a/src/routes/_dashboard-layout.tsx
+++ b/src/routes/_dashboard-layout.tsx
@@ -116,7 +116,14 @@ function getCurrentEmoji(showSidebar: boolean, currentPath: string): string | nu
 }
 
 // Helper to get notification count for a navigation item
-function getNotificationCount(path: string, unseenOrders: number, unseenMessages: number, unseenPurchases: number): number {
+function getNotificationCount(
+	path: string,
+	unseenOrders: number,
+	unseenMessages: number,
+	unseenPurchases: number,
+	unseenAuctionBids: number,
+	unseenBidUpdates: number,
+): number {
 	if (path === '/dashboard/sales/sales') {
 		return unseenOrders
 	}
@@ -125,6 +132,12 @@ function getNotificationCount(path: string, unseenOrders: number, unseenMessages
 	}
 	if (path === '/dashboard/account/your-purchases') {
 		return unseenPurchases
+	}
+	if (path === '/dashboard/products/auctions') {
+		return unseenAuctionBids
+	}
+	if (path === '/dashboard/products/bids') {
+		return unseenBidUpdates
 	}
 	return 0
 }
@@ -157,7 +170,7 @@ function DashboardLayout() {
 	const [parent] = useAutoAnimate()
 	const { dashboardTitle, dashboardHeaderAction } = useStore(uiStore)
 	const { isAuthenticated } = useStore(authStore)
-	const { unseenOrders, unseenMessages, unseenPurchases, unseenByConversation } = useStore(notificationStore)
+	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
 	const isMessageDetailView =
 		location.pathname.startsWith('/dashboard/sales/messages/') && location.pathname !== '/dashboard/sales/messages'
 	// Admin checking
@@ -319,7 +332,14 @@ function DashboardLayout() {
 										<nav className="space-y-2 p-4 lg:p-0 lg:text-base text-xl">
 											{section.items.map((item) => {
 												const isActive = matchRoute({ to: item.path, fuzzy: true })
-												const notificationCount = getNotificationCount(item.path, unseenOrders, unseenMessages, unseenPurchases)
+												const notificationCount = getNotificationCount(
+													item.path,
+													unseenOrders,
+													unseenMessages,
+													unseenPurchases,
+													unseenAuctionBids,
+													unseenBidUpdates,
+												)
 												return (
 													<Link
 														key={item.path}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -4,6 +4,7 @@ import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
+import { notificationActions } from '@/lib/stores/notifications'
 import { uiActions } from '@/lib/stores/ui'
 import { usePublishAuctionSettlementMutation } from '@/publish/auctions'
 import {
@@ -32,7 +33,7 @@ import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { Clock, Eye, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
 	defaultAuctionFilters,
@@ -295,6 +296,12 @@ function AuctionsOverviewComponent() {
 	})
 
 	useDashboardTitle(isOnChildRoute ? 'Auction Details' : 'Auctions')
+
+	useEffect(() => {
+		if (isAuthenticated && user?.pubkey) {
+			notificationActions.markAuctionBidsSeen()
+		}
+	}, [isAuthenticated, user?.pubkey])
 
 	const {
 		data: auctions,

--- a/src/routes/_dashboard-layout/dashboard/products/bids.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/bids.tsx
@@ -5,6 +5,7 @@ import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { authStore } from '@/lib/stores/auth'
+import { notificationActions } from '@/lib/stores/notifications'
 import { formatReclaimWaitSeconds, getAuctionReclaimReadyAt, nip60Actions, nip60Store, type PendingNip60Token } from '@/lib/stores/nip60'
 import { getMintHostname } from '@/lib/wallet'
 import {
@@ -236,6 +237,12 @@ function BidsOverviewComponent() {
 	const [animationParent] = useAutoAnimate()
 
 	const { data: myBids, isLoading, error } = useAuctionBidsByBidder(user?.pubkey ?? '', 500)
+
+	useEffect(() => {
+		if (isAuthenticated && user?.pubkey) {
+			notificationActions.markBidUpdatesSeen()
+		}
+	}, [isAuthenticated, user?.pubkey])
 
 	// Pending tokens are kept in localStorage scoped to the bidder's pubkey, so
 	// they survive relay resets. When a lock succeeds at the mint but the

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -203,28 +203,32 @@ function AuctionDetailRoute() {
 	const auctionCoordinates = auctionDTag && auction ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 
 	const parsedShippingRefs = useMemo(() => getUniqueAuctionShippingRefs(shippingOptions), [shippingOptions])
-	const validShippingRefs = useMemo(() => parsedShippingRefs.filter((entry) => entry.status === 'valid'), [parsedShippingRefs])
 
 	const shippingQueryResults = useQueries({
-		queries: validShippingRefs.map(({ pubkey, dTag }) => ({
-			...shippingOptionByCoordinatesQueryOptions(pubkey, dTag),
-			enabled: true,
+		queries: parsedShippingRefs.map((entry) => ({
+			...shippingOptionByCoordinatesQueryOptions(entry.pubkey, entry.dTag),
+			enabled: entry.status === 'valid',
 		})),
 	})
 
-	const resolvedShippingOptions = useMemo(() => {
-		const shippingInfoByRef = new Map<string, ReturnType<typeof getShippingInfo> | null>()
-		validShippingRefs.forEach((entry, index) => {
-			const event = shippingQueryResults[index]?.data ?? null
-			const info = event ? getShippingInfo(event) : null
-			shippingInfoByRef.set(entry.shippingRef, info)
-		})
-
-		return parsedShippingRefs.map((entry) => ({
-			...entry,
-			info: entry.status === 'valid' ? (shippingInfoByRef.get(entry.shippingRef) ?? null) : null,
-		}))
-	}, [parsedShippingRefs, validShippingRefs, shippingQueryResults])
+	const resolvedShippingOptions = useMemo(
+		() =>
+			parsedShippingRefs.map((entry, index) => {
+				if (entry.status !== 'valid') {
+					return { ...entry, info: null as ReturnType<typeof getShippingInfo> | null, isLoading: false, isNotFound: false }
+				}
+				const queryResult = shippingQueryResults[index]
+				const event = queryResult?.data ?? null
+				const info = event ? getShippingInfo(event) : null
+				return {
+					...entry,
+					info,
+					isLoading: (queryResult?.isLoading ?? false) && !queryResult?.data,
+					isNotFound: !queryResult?.isLoading && !queryResult?.data,
+				}
+			}),
+		[parsedShippingRefs, shippingQueryResults],
+	)
 
 	const bidsQuery = useAuctionBids(auctionRootEventId || auctionId, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
@@ -624,6 +628,8 @@ function AuctionDetailRoute() {
 																	<p className="font-medium text-zinc-900">Invalid shipping reference</p>
 																	<p className="break-all text-xs text-zinc-500">{option.shippingRef}</p>
 																</div>
+															) : option.isLoading ? (
+																<p className="text-sm text-zinc-400">Loading shipping details...</p>
 															) : option.info ? (
 																<div className="space-y-1">
 																	<p className="font-medium text-zinc-900">{option.info.title}</p>

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -399,7 +399,7 @@ function AuctionDetailRoute() {
 								)}
 								{!ended && <span className="text-foreground/80 text-end">{formatAuctionEndTimeLabel(effectiveEndAt, false)}</span>}
 							</div>
-							<AuctionBidder auction={auction} />
+							<AuctionBidder auction={auction} currentUserPubkey={activeUserPubkey} bids={bids} />
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Description

This PR adds support for saving auctions drafts to the local storage to prevent them from clearing when the user closes the sheet form or navigates to another url.

## Screenshots

https://github.com/user-attachments/assets/9467b84a-e44b-40f5-8dce-b488c9566b27

closes #909 
