### PR TITLE
fix(auctions): prompt deposit when bidder has insufficient balance

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
 import { usePublishAuctionBidMutation } from '@/publish/auctions'
 import {
 	getAuctionEndAt,
@@ -29,6 +30,9 @@ import { cn } from '@/lib/utils'
 import { TooltipToggleGroupItem } from './shared/TooltipToggleGroupItem'
 import { useStore } from '@tanstack/react-store'
 import { nip60Store } from '@/lib/stores/nip60'
+import { authStore } from '@/lib/stores/auth'
+import { uiActions } from '@/lib/stores/ui'
+import { normalizeMintUrl } from '@/lib/wallet'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
 
 interface AuctionBidderProps {
@@ -60,9 +64,12 @@ export function useAuctionMintSelection(trustedMints: string[], bidAmount: numbe
 
 	const manualMintValid = manualMint ? result.availableMints.some((m) => m.mintUrl === manualMint) : false
 
-	const manualMintCanFund = manualMint ? (result.availableMints.find((m) => m.mintUrl === manualMint)?.balance ?? 0 >= deltaAmount) : false
-
 	const selectedMint = manualMintValid ? manualMint : result.selectedMint
+	const walletMintSet = new Set((nip60State.mints ?? []).map(normalizeMintUrl))
+	const unfundedWalletMint = result.unfundedTrustedMints.find((mint) => walletMintSet.has(normalizeMintUrl(mint))) ?? null
+	const depositMint = manualMintValid
+		? manualMint
+		: (result.insufficientBalanceMints[0]?.mintUrl ?? result.availableMints[0]?.mintUrl ?? unfundedWalletMint)
 
 	const setSelectedMint = useCallback((mintUrl: string | null) => {
 		setManualMint(mintUrl)
@@ -72,6 +79,7 @@ export function useAuctionMintSelection(trustedMints: string[], bidAmount: numbe
 
 	return {
 		selectedMint,
+		depositMint,
 		availableMints: result.availableMints,
 		eligibleMints,
 		insufficientBalanceMints: result.insufficientBalanceMints,
@@ -87,6 +95,8 @@ export function useAuctionMintSelection(trustedMints: string[], bidAmount: numbe
 
 export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBidSuccess, compact = false }: AuctionBidderProps) {
 	const bidMutation = usePublishAuctionBidMutation()
+	const { status: nip60Status } = useStore(nip60Store)
+	const { isAuthenticated, user } = useStore(authStore)
 
 	// Derive auction state
 	const auctionId = auction.id
@@ -117,12 +127,16 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const notStarted = startAt > 0 && countdown.now < startAt
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const signedInBidderPubkey = isAuthenticated ? user?.pubkey || currentUserPubkey || '' : ''
+	const hasSignedInBidder = !!signedInBidderPubkey
+	const isNip60Ready = nip60Status === 'ready'
+	const isNip60Loading = nip60Status === 'idle' || nip60Status === 'initializing'
 	const previousBidAmount = useMemo(() => {
-		if (!currentUserPubkey) return 0
-		const myBids = bids.filter((b) => b.pubkey === currentUserPubkey)
+		if (!signedInBidderPubkey) return 0
+		const myBids = bids.filter((b) => b.pubkey === signedInBidderPubkey)
 		if (!myBids.length) return 0
 		return Math.max(...myBids.map(getBidAmount))
-	}, [bids, currentUserPubkey])
+	}, [bids, signedInBidderPubkey])
 	// AUCTIONS.md §6.1 — bidder-side live floor. Display the floor at
 	// `client_now` (no inflation). The CVM server is more lenient by
 	// `BID_FLOOR_TIME_GRACE_SECONDS = 5`, so a click at the displayed
@@ -152,11 +166,14 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const inCurveWindow = countdown.now > endAt && countdown.now < (getAuctionMaxEndAt(auction) || endAt)
 	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
 
-	const isOwnAuction = currentUserPubkey === auction.pubkey
+	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
 	const [isEditing, setIsEditing] = useState(false)
+	const [isDepositOpen, setIsDepositOpen] = useState(false)
+	const [depositAmount, setDepositAmount] = useState(0)
+	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -164,11 +181,19 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		return Number.isFinite(val) ? val : NaN
 	}, [bidAmountInput])
 
-	const { selectedMint, availableMints, showMintSelector, mintError, setSelectedMint, canFund } = useAuctionMintSelection(
-		trustedMints,
-		Number.isFinite(parsedBidAmount) ? parsedBidAmount : 0,
-		previousBidAmount,
-	)
+	const { selectedMint, depositMint, availableMints, showMintSelector, mintError, setSelectedMint, canFund, deltaAmount } =
+		useAuctionMintSelection(trustedMints, Number.isFinite(parsedBidAmount) ? parsedBidAmount : 0, previousBidAmount)
+
+	const hasInsufficientBidFunds =
+		hasSignedInBidder &&
+		isNip60Ready &&
+		!ended &&
+		!notStarted &&
+		!isOwnAuction &&
+		Number.isFinite(parsedBidAmount) &&
+		parsedBidAmount >= minBid &&
+		deltaAmount > 0 &&
+		!canFund
 
 	// Initialize input to min bid on mount or when min changes
 	useEffect(() => {
@@ -202,10 +227,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		if (ended) return 'Auction Ended'
 		if (notStarted) return 'Bidding not started'
 		if (bidMutation.isPending) return 'Submitting...'
+		if (!hasSignedInBidder) return 'Sign in to bid'
 		const selectedValue = getSelectedValue()
 		if (compact || selectedValue === 'edit' || selectedValue === 'mult2') return 'Bid ' + parsedBidAmount.toLocaleString() + ' sats'
 		return 'Place Bid'
-	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, parsedBidAmount])
+	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
 
 	const handleSubmitBid = async () => {
 		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return
@@ -213,6 +239,28 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		const parsedAmount = parseInt(bidAmountInput || '0', 10)
 		if (!Number.isFinite(parsedAmount) || parsedAmount < minBid) {
 			toast.error(`Bid must be at least ${minBid.toLocaleString()} sats`)
+			return
+		}
+
+		if (!hasSignedInBidder) {
+			uiActions.openDialog('login')
+			return
+		}
+
+		if (isNip60Loading) {
+			toast.info('Wallet is still loading. Try again in a moment.')
+			return
+		}
+
+		if (hasInsufficientBidFunds) {
+			if (!depositMint) {
+				toast.error(mintError || 'No suitable mint available for bidding.')
+				return
+			}
+
+			setDepositAmount(Math.ceil(deltaAmount))
+			setPreferredDepositMint(depositMint)
+			setIsDepositOpen(true)
 			return
 		}
 
@@ -256,6 +304,12 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	return (
 		<div className="flex flex-col gap-2 w-full">
+			<DepositLightningModal
+				open={isDepositOpen}
+				onClose={() => setIsDepositOpen(false)}
+				initialAmount={depositAmount}
+				preferredMint={preferredDepositMint}
+			/>
 			{/* Anti-snipe curve banner — visible only when we're inside
 			    `(end_at, max_end_at]` AND the auction has a non-`none` curve.
 			    Tells the bidder why the floor is higher than they'd expect

--- a/src/feature/wallet/components/DepositLightningModal.tsx
+++ b/src/feature/wallet/components/DepositLightningModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Dialog, DialogContent, DialogTitle, DialogHeader, DialogDescription } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { nip60Actions, nip60Store } from '@/lib/stores/nip60'
@@ -6,25 +6,41 @@ import { useStore } from '@tanstack/react-store'
 import { Loader2, Copy, Check, Zap } from 'lucide-react'
 import { toast } from 'sonner'
 import { QRCodeSVG } from 'qrcode.react'
+import { normalizeMintUrl } from '@/lib/wallet'
 
 interface DepositLightningModalProps {
 	open: boolean
 	onClose: () => void
+	initialAmount?: number
+	preferredMint?: string
 }
 
-export function DepositLightningModal({ open, onClose }: DepositLightningModalProps) {
+export function DepositLightningModal({ open, onClose, initialAmount, preferredMint }: DepositLightningModalProps) {
 	const { mints, defaultMint, depositInvoice, depositStatus } = useStore(nip60Store)
 	const [amount, setAmount] = useState('')
 	const [selectedMint, setSelectedMint] = useState<string>('')
 	const [isGenerating, setIsGenerating] = useState(false)
 	const [copied, setCopied] = useState(false)
 
-	// Sync selectedMint with defaultMint when modal opens or defaultMint changes
+	// Sync defaults once when the modal opens so user edits are not overwritten.
+	const wasOpenRef = useRef(false)
+
 	useEffect(() => {
-		if (open) {
-			setSelectedMint(defaultMint ?? mints[0] ?? '')
+		if (!open) {
+			wasOpenRef.current = false
+			return
 		}
-	}, [open, defaultMint, mints])
+
+		if (wasOpenRef.current) return
+		wasOpenRef.current = true
+
+		const preferred = preferredMint ? mints.find((mint) => normalizeMintUrl(mint) === normalizeMintUrl(preferredMint)) : ''
+		setSelectedMint(preferred || defaultMint || mints[0] || '')
+
+		if (typeof initialAmount === 'number' && Number.isFinite(initialAmount) && initialAmount > 0) {
+			setAmount(String(Math.ceil(initialAmount)))
+		}
+	}, [open, defaultMint, mints, initialAmount, preferredMint])
 
 	const handleGenerateInvoice = async () => {
 		const amountNum = parseInt(amount, 10)

--- a/src/lib/auctionMintSelection.ts
+++ b/src/lib/auctionMintSelection.ts
@@ -1,4 +1,4 @@
-import { getMintHostname } from '@/lib/wallet'
+import { getMintHostname, normalizeMintUrl } from '@/lib/wallet'
 
 export interface AvailableMint {
 	mintUrl: string
@@ -23,8 +23,6 @@ export interface MintSelectionResult {
 	unfundedTrustedMints: string[]
 	error: string | null
 }
-
-const normalizeMintUrl = (url: string): string => url.trim().replace(/\/+$/, '')
 
 export function resolveAuctionMintSelection(input: MintSelectionInput): MintSelectionResult {
 	const { trustedMints, walletMints, mintBalances, bidAmount, previousBidAmount = 0 } = input

--- a/src/lib/wallet/display.ts
+++ b/src/lib/wallet/display.ts
@@ -21,3 +21,11 @@ export function getMintHostname(mintUrl: string): string {
 export function formatSats(sats: number): string {
 	return sats.toLocaleString()
 }
+
+/**
+ * Normalize a mint URL for stable comparisons.
+ * Trims whitespace and removes trailing slashes.
+ */
+export function normalizeMintUrl(mintUrl: string): string {
+	return mintUrl.trim().replace(/\/+$/, '')
+}

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -8,4 +8,4 @@ export { extractProofsByMint, getProofsForMint } from './proofs'
 export { loadUserData, saveUserData, removeUserData } from './storage'
 
 // Display utilities
-export { getMintHostname, formatSats } from './display'
+export { getMintHostname, formatSats, normalizeMintUrl } from './display'


### PR DESCRIPTION
## Summary

Addresses #765 by improving the auction bidding UX when a bidder is logged out or does not have enough NIP-60 balance to cover the required bid delta.

This PR:

* shows `Sign in to bid` for logged-out users
* opens the existing login dialog from the auction bid action
* keeps the auction action focused on bidding intent (`Bid … sats` / `Place Bid`) instead of changing the button to deposit/add-mint labels
* gates insufficient-balance preflight on NIP-60 wallet readiness so an initializing wallet is not treated as a real zero-balance state
* opens the existing Lightning deposit modal when the bidder needs to top up before bidding
* prefills the deposit modal with the missing bid delta
* selects a suitable `depositMint` top-up target when available, including zero-balance trusted mints already present in the wallet
* keeps `selectedMint` as the publish-path funding target and uses `depositMint` only for deposit modal UX
* moves `normalizeMintUrl` into the shared wallet display utility
* prevents deposit modal defaults from overwriting a user-edited amount/mint while the modal is already open

This is a UX preflight only. The publish/lock path remains authoritative.

## Architecture / protocol notes

* No Nostr event semantics change.
* No Cashu proof semantics change.
* No P2PK custody semantics change.
* No settlement or reclaim behavior change.
* The current buyer-path `p2pk_xpub` flow is preserved.
* `selectedMint` remains the mint candidate used by the bid publish path.
* `depositMint` is only a UI target for topping up before retrying the bid.

## Manual verification checklist

Recommended UI checks after pulling this branch:

* Logged out, auctions list/detail:

  * button says `Sign in to bid`
  * click opens login modal
  * deposit modal does not open
  * bid mutation does not run

* Logged in, wallet initializing:

  * insufficient-balance deposit preflight does not treat initial `0` balance as authoritative
  * submit path shows a wallet-loading message instead of a misleading no-mint/insufficient-balance error

* Logged in with insufficient balance on a trusted mint:

  * bid button remains focused on bidding intent
  * click opens the Lightning deposit modal
  * amount is prefilled with the missing bid delta
  * modal prefers the relevant auction/trusted mint when available
  * editing the modal amount/mint is not overwritten while the modal stays open

* Logged in with sufficient balance:

  * existing bid submit path is unchanged

Note: invoice generation may still fail in the existing deposit flow for some local/dev mints. This PR only changes the auction bid preflight and deposit handoff, not mint invoice generation.

## Validation

Ran locally after rebasing onto `auctions/p2pk-buyer-path-custody-v1`:

* `bun test src/lib/__tests__/auctionSettlement.test.ts` — pass
* `bun test src/lib/__tests__/auctionP2pk.test.ts` — pass
* `bun test src/lib/__tests__/auctionShippingRefs.test.ts` — pass
* `bun run test:unit` — 339 pass / 0 fail
* `bun run format:check` — pass
* `git diff --check` — pass

Note: `src/lib/__tests__/auctionPathOracle.test.ts` no longer appears to exist/match a Bun test path on this branch, so it was not counted as a passing targeted test. The full unit suite passed.
