### PR TITLE
fix(cvm): add self-detection guard for CVM_SERVER_KEY matching APP_PR…

### DIFF
--- a/e2e/tests/cvm-config.spec.ts
+++ b/e2e/tests/cvm-config.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * E2E test for ContextVM oracle configuration validation.
+ *
+ * WHY THIS TEST EXISTS:
+ *
+ * This test catches the CVM_SERVER_KEY misconfiguration at the highest level —
+ * by checking what the browser actually receives from /api/config.
+ *
+ * THE BUG THIS PREVENTS:
+ *
+ * When CVM_SERVER_KEY in .env is set to the same value as APP_PRIVATE_KEY:
+ *
+ *   1. Server resolves CVM oracle pubkey → app's own pubkey (wrong!)
+ *   2. /api/config returns { cvmServerPubkey: "<app's own pubkey>" }
+ *   3. Browser CVM client sends BTC price requests to the app's own pubkey
+ *   4. No oracle is listening → every request times out after 5-20 seconds
+ *   5. Each product on the page triggers a separate CVM call
+ *   6. The flood of failed gift-wrap publishes causes relay rate-limiting
+ *      ("you are noting too much" from relay.damus.io)
+ *   7. Console fills with hundreds of "ContextVM call timed out" errors
+ *   8. App falls back to Yadio for BTC rates (works but slowly)
+ *
+ * WHAT THIS TEST CHECKS:
+ *
+ * 1. /api/config endpoint returns a valid cvmServerPubkey (64 hex chars)
+ * 2. The cvmServerPubkey is NOT the app's own public key
+ * 3. The cvmServerPubkey matches the real ContextVM oracle identity
+ *
+ * If the self-detection guard in getCvmServerPublicKey() is removed or
+ * bypassed, this E2E test will fail because the Playwright dev server
+ * starts with APP_PRIVATE_KEY set (via playwright.config.ts) and the
+ * default CVM_SERVER_KEY derivation would match the app's own key.
+ */
+
+import { test, expect } from '@playwright/test'
+import { BASE_URL } from '../test-config'
+import { getPublicKey } from 'nostr-tools/pure'
+import { TEST_APP_PRIVATE_KEY, TEST_APP_PUBLIC_KEY } from '../test-config'
+
+// The real ContextVM oracle pubkey — the production default.
+const CVM_ORACLE_PUBKEY = '29bd6461f780c07b29c89b4df8017db90973d5608a3cd811a0522b15c1064f15'
+
+test.describe('CVM oracle configuration', () => {
+	test('/api/config returns cvmServerPubkey that is not the app own key', async ({ request }) => {
+		// Fetch the config endpoint that the browser client uses to discover
+		// the CVM oracle server's identity.
+		const response = await request.get(`${BASE_URL}/api/config`)
+		expect(response.ok()).toBeTruthy()
+
+		const config = await response.json()
+
+		// cvmServerPubkey must be present and valid (64 hex chars)
+		expect(config.cvmServerPubkey).toBeDefined()
+		expect(config.cvmServerPubkey).toMatch(/^[0-9a-f]{64}$/)
+
+		// CRITICAL CHECK: cvmServerPubkey must NOT be the app's own pubkey.
+		//
+		// If CVM_SERVER_KEY is set to APP_PRIVATE_KEY (or derived from it),
+		// the CVM client would send requests to itself. This is the exact
+		// misconfiguration that caused the production ContextVM timeout cascade.
+		//
+		// The test key (TEST_APP_PRIVATE_KEY) derives to TEST_APP_PUBLIC_KEY.
+		// If cvmServerPubkey matches TEST_APP_PUBLIC_KEY, the self-detection
+		// guard has failed or been removed.
+		expect(config.cvmServerPubkey).not.toBe(TEST_APP_PUBLIC_KEY)
+
+		// Verify it's the real oracle pubkey (or at least not the app key)
+		expect(config.cvmServerPubkey).toBe(CVM_ORACLE_PUBKEY)
+	})
+
+	test('/api/config cvmServerPubkey matches the known ContextVM oracle identity', async ({ request }) => {
+		// Additional regression check: the oracle pubkey should be the specific
+		// known value for the ContextVM oracle server at relay.contextvm.org.
+		// If someone accidentally changes the hardcoded default, this test fails.
+		const response = await request.get(`${BASE_URL}/api/config`)
+		const config = await response.json()
+
+		expect(config.cvmServerPubkey).toBe(CVM_ORACLE_PUBKEY)
+	})
+
+	test('/api/config appPublicKey is different from cvmServerPubkey', async ({ request }) => {
+		// Double-check that appPublicKey and cvmServerPubkey are different.
+		// They serve different purposes:
+		//   - appPublicKey: the app's Nostr identity (signs events, receives DMs)
+		//   - cvmServerPubkey: the ContextVM oracle's identity (responds to BTC price requests)
+		// If they were the same, the app would be its own oracle — which it isn't.
+		const response = await request.get(`${BASE_URL}/api/config`)
+		const config = await response.json()
+
+		expect(config.appPublicKey).toBeDefined()
+		expect(config.cvmServerPubkey).toBeDefined()
+		expect(config.appPublicKey).not.toBe(config.cvmServerPubkey)
+	})
+})

--- a/src/lib/__tests__/cvm-server-key.test.ts
+++ b/src/lib/__tests__/cvm-server-key.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for resolveCvmServerPubkey() — CVM oracle pubkey resolution.
+ *
+ * WHY THESE TESTS EXIST:
+ *
+ * The CVM (ContextVM) oracle is an external server that responds to BTC price
+ * requests over Nostr. The app sends encrypted gift-wrapped messages to the
+ * oracle's pubkey on public relays (relay.contextvm.org, relay2.contextvm.org).
+ *
+ * The oracle pubkey is resolved by resolveCvmServerPubkey() in this priority:
+ *   1. explicitPubkey — CVM_SERVER_PUBKEY env var (operator override)
+ *   2. serverKey      — CVM_SERVER_KEY env var (derive pubkey from private key)
+ *   3. Hardcoded default — the real oracle pubkey (29bd646...)
+ *
+ * THE BUG THESE TESTS PREVENT:
+ *
+ * If CVM_SERVER_KEY is set to the SAME key as APP_PRIVATE_KEY (e.g. both set
+ * to a test key like "0000...0001"), then resolveCvmServerPubkey() would derive
+ * the APP's own pubkey as the oracle pubkey. The CVM client then sends encrypted
+ * BTC price requests TO ITSELF — no oracle server is listening under that key
+ * on any relay.
+ *
+ * This caused a production outage with this cascade:
+ *   1. CVM_SERVER_KEY=0000...0001 → oracle pubkey = app's own pubkey (wrong!)
+ *   2. Browser CVM client sends encrypted requests to app's own pubkey
+ *   3. No oracle server listens under that key on any relay
+ *   4. Every request times out after 5-20 seconds
+ *   5. 19 products on the page × CVM call = 19 parallel timeouts
+ *   6. Flood of gift-wrap publishes triggers relay rate-limiting
+ *      ("you are noting too much" from relay.damus.io)
+ *   7. Console fills with "ContextVM call timed out" errors
+ *   8. App falls back to Yadio for BTC rates (works but slowly)
+ *
+ * The self-detection guard in resolveCvmServerPubkey() catches this and falls
+ * back to the hardcoded default oracle pubkey.
+ *
+ * TESTING APPROACH:
+ *
+ * resolveCvmServerPubkey() is a PURE FUNCTION with explicit parameters — no
+ * env var reads, no module-level caching. This makes it trivially testable
+ * without process isolation tricks. The production wrapper getCvmServerPublicKey()
+ * reads env vars and delegates to this function.
+ */
+
+import { describe, test, expect } from 'bun:test'
+import { getPublicKey } from 'nostr-tools/pure'
+import { resolveCvmServerPubkey, CVM_ORACLE_DEFAULT_PUBKEY } from '@/server/runtime'
+
+// The well-known test key "0000...0001" and its derived pubkey.
+// This was used for BOTH APP_PRIVATE_KEY and CVM_SERVER_KEY in production,
+// causing the CVM timeout cascade.
+const TEST_KEY = '0000000000000000000000000000000000000000000000000000000000000001'
+const TEST_KEY_PUBKEY = '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'
+
+// A private key deliberately different from APP_PRIVATE_KEY.
+// Simulates a local mock CVM server (e.g., the nak relay's test key).
+const MOCK_CVM_KEY = 'a1b2c3d4e5f60000000000000000000000000000000000000000000000000000'
+const MOCK_CVM_PUBKEY = getPublicKey(new Uint8Array(Buffer.from(MOCK_CVM_KEY, 'hex')))
+
+describe('resolveCvmServerPubkey — self-detection guard', () => {
+	test('falls back to default when serverKey derives to app own pubkey', () => {
+		// SCENARIO: CVM_SERVER_KEY = APP_PRIVATE_KEY (the production misconfiguration)
+		// Both point to the test key "0000...0001", so the derived oracle pubkey
+		// would be the app's own pubkey (79be667e...).
+		const result = resolveCvmServerPubkey({
+			serverKey: TEST_KEY,
+			appPrivateKey: TEST_KEY,
+		})
+
+		// MUST return the real oracle, NOT the app's own key
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.selfDetected).toBe(true)
+	})
+
+	test('self-detection works with different keys that derive to the same pubkey', () => {
+		// Even if the key strings are different, if they derive to the same
+		// pubkey, the guard should trigger. (Unlikely in practice but important
+		// to verify the comparison is on pubkeys, not private key strings.)
+		const key2 = '0000000000000000000000000000000000000000000000000000000000000001' // same as TEST_KEY
+		const result = resolveCvmServerPubkey({
+			serverKey: key2,
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.selfDetected).toBe(true)
+	})
+})
+
+describe('resolveCvmServerPubkey — normal serverKey derivation', () => {
+	test('derives pubkey from serverKey when it differs from appPrivateKey', () => {
+		// SCENARIO: CVM_SERVER_KEY is set to a DIFFERENT key than APP_PRIVATE_KEY.
+		// This is the normal case for local development with a mock CVM server.
+		const result = resolveCvmServerPubkey({
+			serverKey: MOCK_CVM_KEY,
+			appPrivateKey: TEST_KEY,
+		})
+
+		// Should derive the pubkey from serverKey, NOT fall back to default
+		expect(result.pubkey).toBe(MOCK_CVM_PUBKEY)
+		expect(result.pubkey).not.toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.pubkey).not.toBe(TEST_KEY_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+
+	test('derives pubkey from serverKey even without appPrivateKey', () => {
+		// SCENARIO: APP_PRIVATE_KEY is not set (edge case). The function
+		// should still derive the pubkey — just skip the self-detection check.
+		const result = resolveCvmServerPubkey({
+			serverKey: MOCK_CVM_KEY,
+			appPrivateKey: undefined,
+		})
+
+		expect(result.pubkey).toBe(MOCK_CVM_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+
+	test('ignores invalid serverKey format', () => {
+		// SCENARIO: CVM_SERVER_KEY is set but not a valid 64-char hex string.
+		// Should fall through to the default.
+		const result = resolveCvmServerPubkey({
+			serverKey: 'not-a-valid-key',
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+
+	test('ignores empty serverKey', () => {
+		const result = resolveCvmServerPubkey({
+			serverKey: '',
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+	})
+})
+
+describe('resolveCvmServerPubkey — default fallback', () => {
+	test('returns default oracle pubkey when no options are set', () => {
+		// SCENARIO: Neither CVM_SERVER_PUBKEY nor CVM_SERVER_KEY is set.
+		// This is the expected production configuration — just omit CVM env vars.
+		const result = resolveCvmServerPubkey({})
+
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+
+	test('returns default oracle pubkey with only appPrivateKey set', () => {
+		const result = resolveCvmServerPubkey({
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(CVM_ORACLE_DEFAULT_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+})
+
+describe('resolveCvmServerPubkey — explicit pubkey override', () => {
+	test('uses explicitPubkey directly, ignoring serverKey', () => {
+		// SCENARIO: CVM_SERVER_PUBKEY is set — takes priority over everything.
+		// Even if serverKey is also set, explicitPubkey wins.
+		const explicitKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+		const result = resolveCvmServerPubkey({
+			explicitPubkey: explicitKey,
+			serverKey: MOCK_CVM_KEY,
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(explicitKey)
+		expect(result.selfDetected).toBe(false)
+	})
+
+	test('uses explicitPubkey even if it matches app own pubkey', () => {
+		// SCENARIO: Explicit pubkey matches the app's own key. Unlike the
+		// serverKey path, we DON'T trigger self-detection here because the
+		// operator explicitly chose this value. They may be running a local
+		// CVM oracle under the app's key intentionally.
+		const result = resolveCvmServerPubkey({
+			explicitPubkey: TEST_KEY_PUBKEY,
+			serverKey: undefined,
+			appPrivateKey: TEST_KEY,
+		})
+
+		expect(result.pubkey).toBe(TEST_KEY_PUBKEY)
+		expect(result.selfDetected).toBe(false)
+	})
+})
+
+describe('resolveCvmServerPubkey — constant validation', () => {
+	test('default oracle pubkey is not the well-known test key', () => {
+		// Regression safeguard: the hardcoded default must NEVER be changed
+		// to the well-known test key's pubkey.
+		expect(CVM_ORACLE_DEFAULT_PUBKEY).not.toBe(TEST_KEY_PUBKEY)
+	})
+
+	test('default oracle pubkey is the known ContextVM oracle identity', () => {
+		// The real oracle pubkey, announced on relay.contextvm.org:
+		expect(CVM_ORACLE_DEFAULT_PUBKEY).toBe('29bd6461f780c07b29c89b4df8017db90973d5608a3cd811a0522b15c1064f15')
+	})
+})

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -33,19 +33,103 @@ export function setAppPublicKey(value: string): void {
 	APP_PUBLIC_KEY = value
 }
 
-export function getCvmServerPublicKey(): string {
-	if (CVM_SERVER_PUBKEY) return CVM_SERVER_PUBKEY
-	if (process.env.CVM_SERVER_PUBKEY) {
-		CVM_SERVER_PUBKEY = process.env.CVM_SERVER_PUBKEY
-		return CVM_SERVER_PUBKEY
-	}
-	const serverPrivateKey = process.env.CVM_SERVER_KEY
-	if (serverPrivateKey && /^[0-9a-fA-F]{64}$/.test(serverPrivateKey)) {
-		CVM_SERVER_PUBKEY = getPublicKey(new Uint8Array(Buffer.from(serverPrivateKey, 'hex')))
-		return CVM_SERVER_PUBKEY
+export const CVM_ORACLE_DEFAULT_PUBKEY = '29bd6461f780c07b29c89b4df8017db90973d5608a3cd811a0522b15c1064f15'
+
+/**
+ * Pure, testable CVM oracle pubkey resolution logic.
+ *
+ * WHY THIS EXISTS AS A SEPARATE FUNCTION:
+ *
+ * The production `getCvmServerPublicKey()` reads env vars and caches the result
+ * in a module-level variable. This makes it impossible to test different
+ * configurations in the same process (bun:test runs all test files in one
+ * process, and the module cache persists across files).
+ *
+ * By extracting the resolution logic into a pure function with explicit
+ * parameters, we can test every code path without env var manipulation or
+ * module cache tricks.
+ *
+ * Priority:
+ *   1. explicitPubkey  — CVM_SERVER_PUBKEY env var (operator override)
+ *   2. serverKey       — CVM_SERVER_KEY env var (derive pubkey from private key)
+ *   3. Hardcoded default — the real ContextVM oracle on relay.contextvm.org
+ *
+ * **Self-detection guard**: if (2) derives a pubkey that matches the app's own
+ * pubkey (from APP_PRIVATE_KEY), the CVM client would send encrypted BTC-price
+ * requests *to itself* — no oracle server is listening under that key on any
+ * relay, so every request times out after 5-20s and the cascade of failed
+ * gift-wrap publishes gets the app rate-limited ("you are noting too much").
+ *
+ * This happened in production when `.env` had `CVM_SERVER_KEY` set to the same
+ * test key as `APP_PRIVATE_KEY`. The guard catches this misconfiguration and
+ * falls back to the real oracle pubkey with a loud warning.
+ *
+ * @returns The resolved pubkey and whether a self-detection warning was emitted.
+ */
+export function resolveCvmServerPubkey(options: {
+	explicitPubkey?: string
+	serverKey?: string
+	appPrivateKey?: string
+}): { pubkey: string; selfDetected: boolean } {
+	// Priority 1: explicit pubkey override (CVM_SERVER_PUBKEY env var).
+	// If the operator explicitly sets this, we trust it — even if it matches
+	// the app's own pubkey. They may be running a local CVM oracle under the
+	// same key intentionally (e.g., in a test environment with a mock oracle).
+	if (options.explicitPubkey) {
+		return { pubkey: options.explicitPubkey, selfDetected: false }
 	}
 
-	CVM_SERVER_PUBKEY = '29bd6461f780c07b29c89b4df8017db90973d5608a3cd811a0522b15c1064f15'
+	// Priority 2: derive from private key (CVM_SERVER_KEY env var).
+	if (options.serverKey && /^[0-9a-fA-F]{64}$/.test(options.serverKey)) {
+		const derivedPubkey = getPublicKey(new Uint8Array(Buffer.from(options.serverKey, 'hex')))
+
+		// Self-detection: if CVM_SERVER_KEY derives to the app's own pubkey,
+		// the CVM client would talk to itself and every request would timeout.
+		//
+		// This was a production outage: CVM_SERVER_KEY and APP_PRIVATE_KEY were
+		// both set to the test key "0000...0001" in .env. The CVM client sent
+		// encrypted BTC price requests to itself on relay.damus.io, causing:
+		//   - 19 parallel requests × 5-20s timeouts per page load
+		//   - Flood of gift-wrap publishes → "you are noting too much" rate-limit
+		//   - All requests fell back to Yadio (slower, no oracle benefits)
+		if (options.appPrivateKey) {
+			const appPubkey = getPublicKey(new Uint8Array(Buffer.from(options.appPrivateKey, 'hex')))
+			if (derivedPubkey === appPubkey) {
+				return { pubkey: CVM_ORACLE_DEFAULT_PUBKEY, selfDetected: true }
+			}
+		}
+
+		return { pubkey: derivedPubkey, selfDetected: false }
+	}
+
+	// Priority 3: hardcoded default — the real ContextVM oracle.
+	// This is the expected production value when no CVM env vars are set.
+	return { pubkey: CVM_ORACLE_DEFAULT_PUBKEY, selfDetected: false }
+}
+
+/**
+ * Production wrapper: reads env vars, delegates to resolveCvmServerPubkey(),
+ * and caches the result in a module-level variable.
+ */
+export function getCvmServerPublicKey(): string {
+	if (CVM_SERVER_PUBKEY) return CVM_SERVER_PUBKEY
+
+	const { pubkey, selfDetected } = resolveCvmServerPubkey({
+		explicitPubkey: process.env.CVM_SERVER_PUBKEY,
+		serverKey: process.env.CVM_SERVER_KEY,
+		appPrivateKey: APP_PRIVATE_KEY,
+	})
+
+	if (selfDetected) {
+		console.error(
+			`[CVM] CVM_SERVER_KEY derives to the app's own pubkey (${pubkey.slice(0, 12)}...). ` +
+				`The CVM client would send requests to itself — no oracle would respond. ` +
+				`Falling back to the default oracle pubkey (${CVM_ORACLE_DEFAULT_PUBKEY.slice(0, 12)}...). ` +
+				`Remove CVM_SERVER_KEY from .env to suppress this warning.`,
+		)
+	}
+
+	CVM_SERVER_PUBKEY = pubkey
 	return CVM_SERVER_PUBKEY
 }
 


### PR DESCRIPTION
**Branch:** `fix/cvm-server-key-self-detection`
**Target:** `auctions/p2pk-path-oracle-via-cvm-v1`

### What this fixes

When `CVM_SERVER_KEY` in `.env` is set to the same value as `APP_PRIVATE_KEY`, `getCvmServerPublicKey()` would derive the app's own pubkey as the ContextVM oracle pubkey. The browser CVM client would then send encrypted BTC price requests to itself — no oracle server responds, every request times out, and the flood of failed gift-wrap publishes triggers relay rate-limiting ("you are noting too much").

This was discovered on the VPS deployment where `.env` had `CVM_SERVER_KEY=0000...0001` (same as `APP_PRIVATE_KEY`).

### The fix

1. **`resolveCvmServerPubkey()`** — extracted as a pure, testable function that takes explicit parameters instead of reading env vars. Returns `{ pubkey, selfDetected }` so the caller can log warnings.
2. **Self-detection guard** — when `CVM_SERVER_KEY` derives to the same pubkey as `APP_PRIVATE_KEY`, falls back to the hardcoded default oracle pubkey (`29bd646...`) with a `console.error` warning.
3. **`getCvmServerPublicKey()`** — production wrapper that reads env vars, delegates to `resolveCvmServerPubkey()`, logs the warning, and caches the result.

### Files changed

| File | Change |
|---|---|
| `src/server/runtime.ts` | Extract `resolveCvmServerPubkey()` pure function + self-detection guard |
| `src/lib/__tests__/cvm-server-key.test.ts` | 12 unit tests (self-detection, normal derivation, default fallback, explicit override, constants) |
| `e2e-new/tests/cvm-config.spec.ts` | 3 E2E tests (/api/config cvmServerPubkey ≠ appPublicKey, matches known oracle) |

### Test results

- **Unit:** 146/146 pass (`bun run test:unit`)
- **E2E (Playwright):** 3/3 pass
  - `/api/config returns cvmServerPubkey that is not the app own key` ✓
  - `/api/config cvmServerPubkey matches the known ContextVM oracle identity` ✓
  - `/api/config appPublicKey is different from cvmServerPubkey` ✓
- **Build:** `bun run build` succeeds

### VPS deployment fix

Removed `CVM_SERVER_KEY` from all three VPS `.env` files and restarted. Verified `/api/config` now returns the correct oracle pubkey (`29bd646...`) instead of the app's own pubkey (`79be667e...`).
