### PR TITLE
Fixed issue with invalid conversion

### DIFF
--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -17,6 +17,7 @@ import type { RichShippingInfo } from '@/lib/stores/cart'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { normalizePublishedProductShippingTags, resolvePublishedProductShippingOptions } from '@/lib/utils/productShippingSelections'
 import { useQuery } from '@tanstack/react-query'
+import { PriceDisplay } from '@/components/PriceDisplay'
 
 interface CartItemProps {
 	productId: string
@@ -226,11 +227,9 @@ export default function CartItem({
 				<div className="flex flex-1 flex-col justify-between">
 					<div>
 						<h3 className="text-base font-medium">{title || 'Untitled Product'}</h3>
-						<p className="mt-1 text-sm text-muted-foreground">
-							{currency.toLowerCase() === 'sats' || currency.toLowerCase() === 'sat'
-								? `${Math.round(price).toLocaleString()} sats`
-								: `${Math.round(price * 100).toLocaleString()} sats (${price.toFixed(2)} ${currency})`}
-						</p>
+						<div className="mt-1">
+							<PriceDisplay priceValue={price} originalCurrency={currency} showOriginalPrice={true} showSatsPrice={true} />
+						</div>
 					</div>
 
 					{/* Quantity Controls */}


### PR DESCRIPTION
Fixed an issue where the cart conversion is sats was invalidly set to "100xUSD" value for prices in USD, and similar for any other fiat currencies.

<img width="1179" height="533" alt="Screenshot 2026-05-19 at 13 59 17" src="https://github.com/user-attachments/assets/3beb9e26-71b0-43c6-b8d3-2ffb5edb10a0" />

The issue was also present in production:

<img width="986" height="740" alt="Screenshot 2026-05-19 at 14 15 14" src="https://github.com/user-attachments/assets/e9af9bff-5533-4e2d-94a6-79586726e8b9" />

The fix uses the same currency display component as the Product details page for consistency:

<img width="583" height="495" alt="Screenshot 2026-05-19 at 14 34 22" src="https://github.com/user-attachments/assets/fd55212e-3e40-4937-a4ae-c1e8a53fe1dc" />
