### PR TITLE
fix(auctions): add auction notification counts

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -200,14 +200,14 @@ export function Header() {
 	const { data: config } = useConfigQuery()
 	const { isAuthenticated, isAuthenticating, user } = useStore(authStore)
 	const { mobileMenuOpen } = useStore(uiStore)
-	const { unseenOrders, unseenMessages, unseenPurchases } = useStore(notificationStore)
+	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
 	const location = useLocation()
 	const [scrollY, setScrollY] = useState(0)
 	const breakpoint = useBreakpoint()
 	const isMobile = breakpoint === 'sm' || breakpoint === 'md'
 
 	// Calculate total notification count for dashboard button
-	const totalNotifications = unseenOrders + unseenMessages + unseenPurchases
+	const totalNotifications = unseenOrders + unseenMessages + unseenPurchases + unseenAuctionBids + unseenBidUpdates
 
 	// Check if we're on any product page (index page or individual product) or homepage
 	const isProductPage = location.pathname === '/products' || location.pathname.startsWith('/products/')

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -1,10 +1,116 @@
 import { useEffect, useRef } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { authStore } from '@/lib/stores/auth'
+import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
+import {
+	fetchAuctionBidsByBidder,
+	fetchAuctionsByPubkey,
+	getAuctionId,
+	getAuctionRootEventId,
+	getBidAmount,
+	getBidAuctionCoordinates,
+	getBidAuctionEventId,
+} from '@/queries/auctions'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
+
+const AUCTION_MONITOR_LIMIT = 500
+const AUCTION_FILTER_CHUNK_SIZE = 80
+const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
+
+const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
+
+const chunkValues = (values: string[], size: number): string[][] => {
+	const chunks: string[][] = []
+	for (let index = 0; index < values.length; index += size) {
+		chunks.push(values.slice(index, index + size))
+	}
+	return chunks
+}
+
+const dedupeEvents = (events: NDKEvent[]): NDKEvent[] => {
+	const seen = new Set<string>()
+	return events.filter((event) => {
+		if (!event.id || seen.has(event.id)) return false
+		seen.add(event.id)
+		return true
+	})
+}
+
+const getAuctionCoordinate = (auction: NDKEvent): string => {
+	const auctionDTag = getAuctionId(auction)
+	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
+}
+
+const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
+
+const getEventAuctionCoordinate = (event: NDKEvent): string => getBidAuctionCoordinates(event)
+
+const getAuctionBidStatus = (event: NDKEvent): string =>
+	event.tags
+		.find((tag) => tag[0] === 'status')?.[1]
+		?.trim()
+		.toLowerCase() || 'unknown'
+
+const isCountableAuctionBidEvent = (event: NDKEvent): boolean => {
+	const status = getAuctionBidStatus(event)
+	return !IGNORED_AUCTION_BID_STATUSES.has(status)
+}
+
+const makeTaggedAuctionFilters = ({
+	kind,
+	auctionRootEventIds,
+	auctionCoordinates,
+	since,
+}: {
+	kind: NonNullable<NDKFilter['kinds']>[number]
+	auctionRootEventIds: string[]
+	auctionCoordinates: string[]
+	since?: number
+}): NDKFilter[] => {
+	const filters: NDKFilter[] = []
+	const baseFilter = {
+		kinds: [kind],
+		limit: AUCTION_MONITOR_LIMIT,
+		...(typeof since === 'number' ? { since } : {}),
+	}
+
+	for (const eventIdChunk of chunkValues(auctionRootEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#e': eventIdChunk,
+		})
+	}
+
+	for (const coordinateChunk of chunkValues(auctionCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#a': coordinateChunk,
+		})
+	}
+
+	return filters
+}
+
+const fetchTaggedAuctionEvents = async ({
+	kind,
+	auctionRootEventIds,
+	auctionCoordinates,
+	since,
+}: {
+	kind: NonNullable<NDKFilter['kinds']>[number]
+	auctionRootEventIds: string[]
+	auctionCoordinates: string[]
+	since?: number
+}): Promise<NDKEvent[]> => {
+	const filters = makeTaggedAuctionFilters({ kind, auctionRootEventIds, auctionCoordinates, since })
+	if (filters.length === 0) return []
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	return dedupeEvents(Array.from(events))
+}
 
 /**
  * Monitor nostr events and update notification counts in real-time
@@ -24,6 +130,12 @@ export const useNotificationMonitor = () => {
 
 		const ndk = ndkActions.getNDK()
 		if (!ndk) return
+
+		let isCancelled = false
+		const subscriptionSince = Math.floor(Date.now() / 1000)
+		const seenAuctionEventIds = new Set<string>()
+		const seenBidEventIds = new Set<string>()
+		const seenSettlementEventIds = new Set<string>()
 
 		// Mark as monitoring to prevent duplicate subscriptions
 		isMonitoringRef.current = true
@@ -46,7 +158,56 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
-		// Initial fetch to calculate current unseen counts
+		const isNewAuctionBid = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionBids()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewBidUpdate = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenBidUpdates()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const subscribeToTaggedAuctionEvents = ({
+			kind,
+			tagName,
+			values,
+			onEvent,
+		}: {
+			kind: NonNullable<NDKFilter['kinds']>[number]
+			tagName: '#e' | '#a'
+			values: string[]
+			onEvent: (event: NDKEvent) => void
+		}) => {
+			if (isCancelled || values.length === 0) return
+
+			const filter = {
+				kinds: [kind],
+				[tagName]: values,
+				since: subscriptionSince,
+			} as NDKFilter
+
+			const subscription = ndk.subscribe(filter, {
+				closeOnEose: false,
+			})
+
+			subscription.on('event', onEvent)
+			subscriptionsRef.current.push(subscription)
+		}
+
+		const getHighestOwnBidAmountForAuction = (
+			event: NDKEvent,
+			highestOwnBidByRootId: Map<string, number>,
+			highestOwnBidByCoordinate: Map<string, number>,
+		): number => {
+			const auctionRootEventId = getEventAuctionRootId(event)
+			const auctionCoordinate = getEventAuctionCoordinate(event)
+			const rootAmount = auctionRootEventId ? (highestOwnBidByRootId.get(auctionRootEventId) ?? 0) : 0
+			const coordinateAmount = auctionCoordinate ? (highestOwnBidByCoordinate.get(auctionCoordinate) ?? 0) : 0
+			return Math.max(rootAmount, coordinateAmount)
+		}
+
+		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
 				// Fetch recent orders where user is seller (recipient)
@@ -107,20 +268,155 @@ export const useNotificationMonitor = () => {
 					return isUpdate && event.pubkey !== user.pubkey && isNewPurchaseUpdate(event)
 				})
 
+				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
+				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
+				const sellerBidEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					auctionRootEventIds: sellerAuctionRootEventIds,
+					auctionCoordinates: sellerAuctionCoordinates,
+					since: notificationActions.getLastSeenAuctionBids() + 1,
+				})
+
+				const newSellerBidEvents = sellerBidEvents.filter((event) => {
+					seenAuctionEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event)
+				})
+
+				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
+				const highestOwnBidByRootId = new Map<string, number>()
+				const highestOwnBidByCoordinate = new Map<string, number>()
+
+				for (const bid of ownBidEvents) {
+					const amount = getBidAmount(bid)
+					const auctionRootEventId = getBidAuctionEventId(bid)
+					const auctionCoordinate = getBidAuctionCoordinates(bid)
+
+					if (auctionRootEventId) {
+						highestOwnBidByRootId.set(auctionRootEventId, Math.max(highestOwnBidByRootId.get(auctionRootEventId) ?? 0, amount))
+					}
+					if (auctionCoordinate) {
+						highestOwnBidByCoordinate.set(auctionCoordinate, Math.max(highestOwnBidByCoordinate.get(auctionCoordinate) ?? 0, amount))
+					}
+				}
+
+				const watchedAuctionRootEventIds = Array.from(highestOwnBidByRootId.keys())
+				const watchedAuctionCoordinates = Array.from(highestOwnBidByCoordinate.keys())
+				const watchedBidEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					auctionRootEventIds: watchedAuctionRootEventIds,
+					auctionCoordinates: watchedAuctionCoordinates,
+					since: notificationActions.getLastSeenBidUpdates() + 1,
+				})
+				const watchedSettlementEvents = await fetchTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					auctionRootEventIds: watchedAuctionRootEventIds,
+					auctionCoordinates: watchedAuctionCoordinates,
+					since: notificationActions.getLastSeenBidUpdates() + 1,
+				})
+
+				const newHigherBidEvents = watchedBidEvents.filter((event) => {
+					seenBidEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewBidUpdate(event)) return false
+
+					const highestOwnBidAmount = getHighestOwnBidAmountForAuction(event, highestOwnBidByRootId, highestOwnBidByCoordinate)
+					return highestOwnBidAmount > 0 && getBidAmount(event) > highestOwnBidAmount
+				})
+
+				const newSettlementEvents = watchedSettlementEvents.filter((event) => {
+					seenSettlementEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewBidUpdate(event)
+				})
+
+				if (isCancelled) return
+
 				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
 					orderCount: newOrders.length,
 					messageCount: totalUnseenMessages,
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
+					auctionBidCount: newSellerBidEvents.length,
+					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
 				console.log('[NotificationMonitor] Initial counts:', {
 					orders: newOrders.length,
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
+					auctionBids: newSellerBidEvents.length,
+					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
+
+				const handleSellerBidEvent = (event: NDKEvent) => {
+					if (!event.id || seenAuctionEventIds.has(event.id)) return
+					seenAuctionEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event)) return
+
+					console.log('[NotificationMonitor] New auction bid received:', event.id)
+					notificationActions.incrementUnseenAuctionBids()
+				}
+
+				const handleWatchedBidEvent = (event: NDKEvent) => {
+					if (!event.id || seenBidEventIds.has(event.id)) return
+					seenBidEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewBidUpdate(event)) return
+
+					const highestOwnBidAmount = getHighestOwnBidAmountForAuction(event, highestOwnBidByRootId, highestOwnBidByCoordinate)
+					if (highestOwnBidAmount <= 0 || getBidAmount(event) <= highestOwnBidAmount) return
+
+					console.log('[NotificationMonitor] New higher bid on watched auction:', event.id)
+					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				const handleWatchedSettlementEvent = (event: NDKEvent) => {
+					if (!event.id || seenSettlementEventIds.has(event.id)) return
+					seenSettlementEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isNewBidUpdate(event)) return
+
+					console.log('[NotificationMonitor] New settlement on watched auction:', event.id)
+					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#e',
+					values: sellerAuctionRootEventIds,
+					onEvent: handleSellerBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#a',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#e',
+					values: watchedAuctionRootEventIds,
+					onEvent: handleWatchedBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_BID_KIND,
+					tagName: '#a',
+					values: watchedAuctionCoordinates,
+					onEvent: handleWatchedBidEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					tagName: '#e',
+					values: watchedAuctionRootEventIds,
+					onEvent: handleWatchedSettlementEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: AUCTION_SETTLEMENT_KIND,
+					tagName: '#a',
+					values: watchedAuctionCoordinates,
+					onEvent: handleWatchedSettlementEvent,
+				})
+
+				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
 			} catch (error) {
 				console.error('[NotificationMonitor] Failed to initialize notifications:', error)
 			}
@@ -136,7 +432,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000), // Only new events from now
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -162,7 +458,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_GENERAL_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000), // Only new events from now
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -186,7 +482,7 @@ export const useNotificationMonitor = () => {
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: Math.floor(Date.now() / 1000),
+				since: subscriptionSince,
 			},
 			{
 				closeOnEose: false,
@@ -219,11 +515,12 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(purchaseUpdateSubscription)
 
-		console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
+		console.log('[NotificationMonitor] Base subscriptions active:', subscriptionsRef.current.length)
 
 		// Cleanup function
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
+			isCancelled = true
 			subscriptionsRef.current.forEach((sub) => {
 				sub.stop()
 			})

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -12,12 +12,16 @@ export interface NotificationState {
 	unseenOrders: number // New orders where user is seller
 	unseenMessages: number // New messages in conversations
 	unseenPurchases: number // Updates to orders where user is buyer
+	unseenAuctionBids: number // New bids on auctions where user is seller
+	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
 	unseenByConversation: ConversationNotifications
 
 	// Last seen timestamps (unix timestamp in seconds)
 	lastSeenTimestamps: {
 		orders: number
 		purchases: number
+		auctionBids: number
+		bidUpdates: number
 		messages: Record<string, number> // pubkey -> timestamp
 	}
 
@@ -61,10 +65,14 @@ const createInitialState = (): NotificationState => {
 		unseenOrders: 0,
 		unseenMessages: 0,
 		unseenPurchases: 0,
+		unseenAuctionBids: 0,
+		unseenBidUpdates: 0,
 		unseenByConversation: {},
 		lastSeenTimestamps: {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
+			auctionBids: stored.lastSeenTimestamps?.auctionBids || 0,
+			bidUpdates: stored.lastSeenTimestamps?.bidUpdates || 0,
 			messages: stored.lastSeenTimestamps?.messages || {},
 		},
 		isInitialized: false,
@@ -118,6 +126,26 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Update unseen seller auction bid count
+	 */
+	setUnseenAuctionBids: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen bidder auction update count
+	 */
+	setUnseenBidUpdates: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenBidUpdates: Math.max(0, count),
+		}))
+	},
+
+	/**
 	 * Update unseen count for a specific conversation
 	 */
 	setUnseenForConversation: (pubkey: string, count: number) => {
@@ -161,6 +189,26 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenPurchases: state.unseenPurchases + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen seller auction bid count
+	 */
+	incrementUnseenAuctionBids: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: state.unseenAuctionBids + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen bidder auction update count
+	 */
+	incrementUnseenBidUpdates: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenBidUpdates: state.unseenBidUpdates + 1,
 		}))
 	},
 
@@ -262,6 +310,44 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Mark seller auction bid notifications as seen
+	 */
+	markAuctionBidsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionBids: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionBids: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
+	 * Mark bidder auction update notifications as seen
+	 */
+	markBidUpdatesSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenBidUpdates: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					bidUpdates: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
 	 * Get last seen timestamp for orders
 	 */
 	getLastSeenOrders: (): number => {
@@ -283,6 +369,20 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Get last seen timestamp for seller auction bids
+	 */
+	getLastSeenAuctionBids: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionBids
+	},
+
+	/**
+	 * Get last seen timestamp for bidder auction updates
+	 */
+	getLastSeenBidUpdates: (): number => {
+		return notificationStore.state.lastSeenTimestamps.bidUpdates
+	},
+
+	/**
 	 * Reset all notifications
 	 */
 	reset: () => {
@@ -300,12 +400,16 @@ export const notificationActions = {
 		messageCount: number
 		purchaseCount: number
 		conversationCounts: ConversationNotifications
+		auctionBidCount?: number
+		bidUpdateCount?: number
 	}) => {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenOrders: data.orderCount,
 			unseenMessages: data.messageCount,
 			unseenPurchases: data.purchaseCount,
+			unseenAuctionBids: data.auctionBidCount ?? 0,
+			unseenBidUpdates: data.bidUpdateCount ?? 0,
 			unseenByConversation: data.conversationCounts,
 		}))
 	},

--- a/src/routes/_dashboard-layout.tsx
+++ b/src/routes/_dashboard-layout.tsx
@@ -116,7 +116,14 @@ function getCurrentEmoji(showSidebar: boolean, currentPath: string): string | nu
 }
 
 // Helper to get notification count for a navigation item
-function getNotificationCount(path: string, unseenOrders: number, unseenMessages: number, unseenPurchases: number): number {
+function getNotificationCount(
+	path: string,
+	unseenOrders: number,
+	unseenMessages: number,
+	unseenPurchases: number,
+	unseenAuctionBids: number,
+	unseenBidUpdates: number,
+): number {
 	if (path === '/dashboard/sales/sales') {
 		return unseenOrders
 	}
@@ -125,6 +132,12 @@ function getNotificationCount(path: string, unseenOrders: number, unseenMessages
 	}
 	if (path === '/dashboard/account/your-purchases') {
 		return unseenPurchases
+	}
+	if (path === '/dashboard/products/auctions') {
+		return unseenAuctionBids
+	}
+	if (path === '/dashboard/products/bids') {
+		return unseenBidUpdates
 	}
 	return 0
 }
@@ -157,7 +170,7 @@ function DashboardLayout() {
 	const [parent] = useAutoAnimate()
 	const { dashboardTitle, dashboardHeaderAction } = useStore(uiStore)
 	const { isAuthenticated } = useStore(authStore)
-	const { unseenOrders, unseenMessages, unseenPurchases, unseenByConversation } = useStore(notificationStore)
+	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
 	const isMessageDetailView =
 		location.pathname.startsWith('/dashboard/sales/messages/') && location.pathname !== '/dashboard/sales/messages'
 	// Admin checking
@@ -319,7 +332,14 @@ function DashboardLayout() {
 										<nav className="space-y-2 p-4 lg:p-0 lg:text-base text-xl">
 											{section.items.map((item) => {
 												const isActive = matchRoute({ to: item.path, fuzzy: true })
-												const notificationCount = getNotificationCount(item.path, unseenOrders, unseenMessages, unseenPurchases)
+												const notificationCount = getNotificationCount(
+													item.path,
+													unseenOrders,
+													unseenMessages,
+													unseenPurchases,
+													unseenAuctionBids,
+													unseenBidUpdates,
+												)
 												return (
 													<Link
 														key={item.path}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -4,6 +4,7 @@ import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
+import { notificationActions } from '@/lib/stores/notifications'
 import { uiActions } from '@/lib/stores/ui'
 import { usePublishAuctionSettlementMutation } from '@/publish/auctions'
 import {
@@ -32,7 +33,7 @@ import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { Clock, Eye, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
 	defaultAuctionFilters,
@@ -295,6 +296,12 @@ function AuctionsOverviewComponent() {
 	})
 
 	useDashboardTitle(isOnChildRoute ? 'Auction Details' : 'Auctions')
+
+	useEffect(() => {
+		if (isAuthenticated && user?.pubkey) {
+			notificationActions.markAuctionBidsSeen()
+		}
+	}, [isAuthenticated, user?.pubkey])
 
 	const {
 		data: auctions,

--- a/src/routes/_dashboard-layout/dashboard/products/bids.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/bids.tsx
@@ -5,6 +5,7 @@ import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { authStore } from '@/lib/stores/auth'
+import { notificationActions } from '@/lib/stores/notifications'
 import { formatReclaimWaitSeconds, getAuctionReclaimReadyAt, nip60Actions, nip60Store, type PendingNip60Token } from '@/lib/stores/nip60'
 import { getMintHostname } from '@/lib/wallet'
 import {
@@ -236,6 +237,12 @@ function BidsOverviewComponent() {
 	const [animationParent] = useAutoAnimate()
 
 	const { data: myBids, isLoading, error } = useAuctionBidsByBidder(user?.pubkey ?? '', 500)
+
+	useEffect(() => {
+		if (isAuthenticated && user?.pubkey) {
+			notificationActions.markBidUpdatesSeen()
+		}
+	}, [isAuthenticated, user?.pubkey])
 
 	// Pending tokens are kept in localStorage scoped to the bidder's pubkey, so
 	// they survive relay resets. When a lock succeeds at the mint but the


### PR DESCRIPTION
Addresses #766 

## Summary

Adds auction-related notification counts to the existing local notification system.

This PR adds:
- Seller-facing auction bid notifications on `Dashboard > Products > Auctions`
- Bidder-facing higher-bid / settlement update notifications on `Dashboard > Products > Bids`
- Header badge aggregation for the new auction notification counts
- Seen-state clearing when opening the relevant dashboard pages

## Notes

This is UX-only notification tracking.

Outbid notifications are based on newer visible higher bids on watched auctions and are not canonical bid-validity logic. #907 remains separate.

## Manual testing

- Seller receives a new bid:
  - header badge increments
  - Products > Auctions badge appears
  - reopening Products > Auctions clears the badge

- Bidder gets a higher visible bid on a watched auction:
  - header badge increments
  - Products > Bids badge appears
  - reopening Products > Bids clears the badge
  

## Screenshots

<img width="1536" height="1032" alt="Screenshot 2026-05-19 215919" src="https://github.com/user-attachments/assets/04e97516-d673-4fe0-bb61-95891fb40683" />

<img width="1533" height="1032" alt="Screenshot 2026-05-19 221010" src="https://github.com/user-attachments/assets/a5ede3d3-4a79-4fdf-9843-9fe64f54bbbd" />

<img width="1536" height="1032" alt="Screenshot 2026-05-19 222605" src="https://github.com/user-attachments/assets/f6c3c5e1-8215-4ebf-92fb-60cb7d99a35f" />

<img width="1536" height="1032" alt="Screenshot 2026-05-19 222620" src="https://github.com/user-attachments/assets/60746802-6614-4363-93a9-896b104d456d" />

<img width="1536" height="1032" alt="Screenshot 2026-05-19 222702" src="https://github.com/user-attachments/assets/94b1fd2a-e08e-406f-b8c6-4622b44aaf1b" />

<img width="1536" height="1032" alt="Screenshot 2026-05-19 222714" src="https://github.com/user-attachments/assets/d36cd16a-42f2-42cd-a3c2-2ece9ee0cc3b" />

## Tests

- `bun run build.ts`
- `git diff --check`
- auction-focused unit tests passed during implementation
