### PR TITLE
feat(ndk,server,queries): add app-relay event fetching and live subsc…

### DIFF
--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -134,6 +134,43 @@ export function getWriteRelaySet(): NDKRelaySet | undefined {
 }
 
 /**
+ * Get an NDKRelaySet pinned to ONLY the app's main relay.
+ * Use for reads of app-config events (kind 31990 handler info, kind 30000 d=admins/editors,
+ * kind 10000 mute list, NIP-51 featured lists). Prevents stale copies on user-added
+ * NIP-65 relays or public relays from racing the canonical answer.
+ *
+ * Returns undefined if NDK or the app relay isn't ready yet — callers should treat
+ * that as "config not available yet" rather than falling back to all relays.
+ */
+export function getAppRelaySet(): NDKRelaySet | undefined {
+	const ndk = ndkStore.state.ndk
+	const mainRelay = getMainRelay()
+	if (!ndk || !mainRelay) return undefined
+	return NDKRelaySet.fromRelayUrls([mainRelay], ndk)
+}
+
+/**
+ * Filter shape accepted by fetchLatestAppEvent. Kinds is widened to plain number[]
+ * so call sites can use literal kinds (e.g. NIP-99 30402, featured-products 30405)
+ * that aren't members of NDK's NDKKind enum.
+ */
+export type AppEventFilter = Omit<NDKFilter, 'kinds'> & { kinds?: number[] }
+
+/**
+ * Fetch the latest event (highest created_at) matching the filter from the app relay only.
+ * Returns null if NDK isn't ready, the app relay isn't known yet, or no event was found.
+ */
+export async function fetchLatestAppEvent(filter: AppEventFilter): Promise<NDKEvent | null> {
+	const ndk = ndkStore.state.ndk
+	const relaySet = getAppRelaySet()
+	if (!ndk || !relaySet) return null
+	const events = await ndk.fetchEvents(filter as NDKFilter, undefined, relaySet)
+	const arr = Array.from(events)
+	if (arr.length === 0) return null
+	return arr.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
+}
+
+/**
  * Determine which relays to use based on config and environment
  */
 function getRelayUrls(overrideRelays?: string[]): string[] {

--- a/src/queries/app-settings.tsx
+++ b/src/queries/app-settings.tsx
@@ -1,5 +1,4 @@
-import { ndkActions } from '@/lib/stores/ndk'
-import { naddrFromAddress } from '@/lib/nostr/naddr'
+import { fetchLatestAppEvent, getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -32,8 +31,11 @@ export const fetchAdminSettings = async (appPubkey?: string): Promise<AdminSetti
 		throw new Error('App pubkey is required')
 	}
 
-	const naddr = naddrFromAddress(30000, targetPubkey, 'admins')
-	const latestEvent = await ndk.fetchEvent(naddr)
+	const latestEvent = await fetchLatestAppEvent({
+		kinds: [30000],
+		authors: [targetPubkey],
+		'#d': ['admins'],
+	})
 
 	if (!latestEvent) {
 		console.log(`No admin settings found for app pubkey: ${targetPubkey}`)
@@ -75,9 +77,13 @@ export const useAdminSettings = (appPubkey?: string) => {
 		let latestEventTime = 0
 		let receivedEose = false
 
-		const subscription = ndk.subscribe(adminListFilter, {
-			closeOnEose: false, // Keep subscription open
-		})
+		const subscription = ndk.subscribe(
+			adminListFilter,
+			{
+				closeOnEose: false, // Keep subscription open
+			},
+			getAppRelaySet(),
+		)
 
 		// Event handler for admin list updates - only react to newer events after EOSE
 		subscription.on('event', (newEvent) => {
@@ -175,8 +181,11 @@ export const fetchEditorSettings = async (appPubkey?: string): Promise<EditorSet
 		throw new Error('App pubkey is required')
 	}
 
-	const naddr = naddrFromAddress(30000, targetPubkey, 'editors')
-	const latestEvent = await ndk.fetchEvent(naddr)
+	const latestEvent = await fetchLatestAppEvent({
+		kinds: [30000],
+		authors: [targetPubkey],
+		'#d': ['editors'],
+	})
 
 	if (!latestEvent) {
 		console.log(`No editor settings found for app pubkey: ${targetPubkey}`)
@@ -219,9 +228,13 @@ export const useEditorSettings = (appPubkey?: string) => {
 		let latestEventTime = 0
 		let receivedEose = false
 
-		const subscription = ndk.subscribe(editorListFilter, {
-			closeOnEose: false, // Keep subscription open
-		})
+		const subscription = ndk.subscribe(
+			editorListFilter,
+			{
+				closeOnEose: false, // Keep subscription open
+			},
+			getAppRelaySet(),
+		)
 
 		// Event handler for editor list updates - only react to newer events after EOSE
 		subscription.on('event', (newEvent) => {

--- a/src/queries/blacklist.tsx
+++ b/src/queries/blacklist.tsx
@@ -1,5 +1,5 @@
-import { ndkActions } from '@/lib/stores/ndk'
-import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
+import { fetchLatestAppEvent, getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { configKeys } from './queryKeyFactory'
@@ -16,9 +16,6 @@ export interface BlacklistSettings {
  * Fetches blacklist settings (kind 10000) for the app
  */
 export const fetchBlacklistSettings = async (appPubkey?: string): Promise<BlacklistSettings | null> => {
-	const ndk = ndkActions.getNDK()
-	if (!ndk) throw new Error('NDK not initialized')
-
 	// If no app pubkey provided, try to get it from config
 	let targetPubkey = appPubkey
 	if (!targetPubkey) {
@@ -26,16 +23,12 @@ export const fetchBlacklistSettings = async (appPubkey?: string): Promise<Blackl
 		throw new Error('App pubkey is required')
 	}
 
-	const blacklistFilter: NDKFilter = {
+	const latestEvent = await fetchLatestAppEvent({
 		kinds: [10000], // NIP-51 mute list
 		authors: [targetPubkey],
-		limit: 1,
-	}
+	})
 
-	const events = await ndk.fetchEvents(blacklistFilter)
-	const eventArray = Array.from(events)
-
-	if (eventArray.length === 0) {
+	if (!latestEvent) {
 		console.log(`No blacklist settings found for app pubkey: ${targetPubkey}`)
 		// Return empty blacklist instead of null for consistency
 		return {
@@ -46,9 +39,6 @@ export const fetchBlacklistSettings = async (appPubkey?: string): Promise<Blackl
 			event: null,
 		}
 	}
-
-	// Get the latest blacklist event
-	const latestEvent = eventArray.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
 
 	// Extract blacklisted pubkeys from 'p' tags
 	const blacklistedPubkeys = latestEvent.tags.filter((tag) => tag[0] === 'p' && tag[1]).map((tag) => tag[1])
@@ -86,13 +76,30 @@ export const useBlacklistSettings = (appPubkey?: string) => {
 			authors: [appPubkey],
 		}
 
-		const subscription = ndk.subscribe(blacklistFilter, {
-			closeOnEose: false, // Keep subscription open
+		let latestEventTime = 0
+		let receivedEose = false
+
+		const subscription = ndk.subscribe(
+			blacklistFilter,
+			{
+				closeOnEose: false, // Keep subscription open
+			},
+			getAppRelaySet(),
+		)
+
+		// Event handler for blacklist updates - only react to newer events after EOSE
+		subscription.on('event', (newEvent) => {
+			const eventTime = newEvent.created_at ?? 0
+			if (receivedEose && eventTime > latestEventTime) {
+				queryClient.invalidateQueries({ queryKey: configKeys.blacklist(appPubkey) })
+			}
+			if (eventTime > latestEventTime) {
+				latestEventTime = eventTime
+			}
 		})
 
-		// Event handler for blacklist updates
-		subscription.on('event', (newEvent) => {
-			queryClient.invalidateQueries({ queryKey: configKeys.blacklist(appPubkey) })
+		subscription.on('eose', () => {
+			receivedEose = true
 		})
 
 		// Clean up subscription when unmounting

--- a/src/queries/featured.tsx
+++ b/src/queries/featured.tsx
@@ -1,7 +1,6 @@
-import { ndkActions } from '@/lib/stores/ndk'
+import { fetchLatestAppEvent, getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
 import { FEATURED_ITEMS_CONFIG } from '@/lib/schemas/featured'
 import type { FeaturedProducts, FeaturedCollections, FeaturedUsers } from '@/lib/schemas/featured'
-import { naddrFromAddress } from '@/lib/nostr/naddr'
 import { configKeys } from '@/queries/queryKeyFactory'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -15,11 +14,11 @@ import { filterBlacklistedProductCoords, filterBlacklistedCollectionCoords, filt
  * @returns Featured products data or null
  */
 export const fetchFeaturedProducts = async (appPubkey: string): Promise<FeaturedProducts | null> => {
-	const ndk = ndkActions.getNDK()
-	if (!ndk) throw new Error('NDK not initialized')
-
-	const naddr = naddrFromAddress(FEATURED_ITEMS_CONFIG.PRODUCTS.kind, appPubkey, FEATURED_ITEMS_CONFIG.PRODUCTS.dTag)
-	const event = await ndk.fetchEvent(naddr)
+	const event = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.PRODUCTS.kind],
+		authors: [appPubkey],
+		'#d': [FEATURED_ITEMS_CONFIG.PRODUCTS.dTag],
+	})
 
 	if (!event) return null
 
@@ -39,11 +38,11 @@ export const fetchFeaturedProducts = async (appPubkey: string): Promise<Featured
  * @returns Featured collections data or null
  */
 export const fetchFeaturedCollections = async (appPubkey: string): Promise<FeaturedCollections | null> => {
-	const ndk = ndkActions.getNDK()
-	if (!ndk) throw new Error('NDK not initialized')
-
-	const naddr = naddrFromAddress(FEATURED_ITEMS_CONFIG.COLLECTIONS.kind, appPubkey, FEATURED_ITEMS_CONFIG.COLLECTIONS.dTag)
-	const event = await ndk.fetchEvent(naddr)
+	const event = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.COLLECTIONS.kind],
+		authors: [appPubkey],
+		'#d': [FEATURED_ITEMS_CONFIG.COLLECTIONS.dTag],
+	})
 
 	if (!event) return null
 
@@ -63,11 +62,11 @@ export const fetchFeaturedCollections = async (appPubkey: string): Promise<Featu
  * @returns Featured users data or null
  */
 export const fetchFeaturedUsers = async (appPubkey: string): Promise<FeaturedUsers | null> => {
-	const ndk = ndkActions.getNDK()
-	if (!ndk) throw new Error('NDK not initialized')
-
-	const naddr = naddrFromAddress(FEATURED_ITEMS_CONFIG.USERS.kind, appPubkey, FEATURED_ITEMS_CONFIG.USERS.dTag)
-	const event = await ndk.fetchEvent(naddr)
+	const event = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.USERS.kind],
+		authors: [appPubkey],
+		'#d': [FEATURED_ITEMS_CONFIG.USERS.dTag],
+	})
 
 	if (!event) return null
 
@@ -90,21 +89,33 @@ const useFeaturedSettingsSubscription = (appPubkey: string, queryKey: readonly u
 	useEffect(() => {
 		if (!appPubkey || !ndk) return
 
+		let latestEventTime = 0
+		let receivedEose = false
+
 		const subscription = ndk.subscribe(
 			{
 				kinds: [expectedKind],
 				authors: [appPubkey],
+				'#d': [expectedDTag],
 			},
 			{
 				closeOnEose: false,
 			},
+			getAppRelaySet(),
 		)
 
 		subscription.on('event', (event) => {
-			const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1]
-			if (dTag !== expectedDTag) return
+			const eventTime = event.created_at ?? 0
+			if (receivedEose && eventTime > latestEventTime) {
+				void queryClient.invalidateQueries({ queryKey })
+			}
+			if (eventTime > latestEventTime) {
+				latestEventTime = eventTime
+			}
+		})
 
-			void queryClient.invalidateQueries({ queryKey })
+		subscription.on('eose', () => {
+			receivedEose = true
 		})
 
 		return () => {

--- a/src/server/EventHandler.ts
+++ b/src/server/EventHandler.ts
@@ -93,6 +93,12 @@ export class EventHandler {
 			console.warn('⚠️ Load existing data failed, continuing anyway:', e)
 		}
 
+		try {
+			this.ndkService.startSubscriptions()
+		} catch (e) {
+			console.warn('⚠️ Starting NDK service subscriptions failed, continuing anyway:', e)
+		}
+
 		// Set up NDK for blacklist and vanity managers
 		if (config.relayUrl) {
 			this.ndk = new NDK({ explicitRelayUrls: [config.relayUrl] })

--- a/src/server/NDKService.ts
+++ b/src/server/NDKService.ts
@@ -1,4 +1,4 @@
-import NDK from '@nostr-dev-kit/ndk'
+import NDK, { type NDKSubscription } from '@nostr-dev-kit/ndk'
 import { naddrFromAddress } from '../lib/nostr/naddr'
 import type { AdminManager, EditorManager, BootstrapManager } from './types'
 
@@ -8,6 +8,10 @@ export class NDKService {
 	private adminManager: AdminManager
 	private editorManager: EditorManager
 	private bootstrapManager: BootstrapManager
+	private adminSubscription: NDKSubscription | null = null
+	private editorSubscription: NDKSubscription | null = null
+	private latestAdminEventTime = 0
+	private latestEditorEventTime = 0
 
 	constructor(appPubkey: string, adminManager: AdminManager, editorManager: EditorManager, bootstrapManager: BootstrapManager) {
 		this.appPubkey = appPubkey
@@ -71,6 +75,7 @@ export class NDKService {
 			if (latestAdminEvent) {
 				console.log('Found existing admin list, updating internal list')
 				this.adminManager.updateFromEvent(latestAdminEvent)
+				this.latestAdminEventTime = latestAdminEvent.created_at ?? 0
 			}
 		} catch (e) {
 			console.error('Failed to load existing admin list', e)
@@ -86,13 +91,46 @@ export class NDKService {
 			if (latestEditorEvent) {
 				console.log('Found existing editor list, updating internal list')
 				this.editorManager.updateFromEvent(latestEditorEvent)
+				this.latestEditorEventTime = latestEditorEvent.created_at ?? 0
 			}
 		} catch (e) {
 			console.error('Failed to load existing editor list', e)
 		}
 	}
 
+	/**
+	 * Open long-lived subscriptions on the app relay for admin and editor list updates.
+	 * Without this, the in-memory admin/editor caches only refresh when the bun proxy
+	 * itself processes a publish for these kinds — direct relay publishes (via nak or
+	 * other clients) wouldn't propagate, and the authorization gate stays stale.
+	 */
+	public startSubscriptions(): void {
+		if (!this.ndk) return
+
+		this.adminSubscription = this.ndk.subscribe({ kinds: [30000], authors: [this.appPubkey], '#d': ['admins'] }, { closeOnEose: false })
+		this.adminSubscription.on('event', (event) => {
+			const ts = event.created_at ?? 0
+			if (ts <= this.latestAdminEventTime) return
+			this.latestAdminEventTime = ts
+			console.log(`Live admin list update received (created_at=${ts})`)
+			this.adminManager.updateFromEvent(event)
+		})
+
+		this.editorSubscription = this.ndk.subscribe({ kinds: [30000], authors: [this.appPubkey], '#d': ['editors'] }, { closeOnEose: false })
+		this.editorSubscription.on('event', (event) => {
+			const ts = event.created_at ?? 0
+			if (ts <= this.latestEditorEventTime) return
+			this.latestEditorEventTime = ts
+			console.log(`Live editor list update received (created_at=${ts})`)
+			this.editorManager.updateFromEvent(event)
+		})
+	}
+
 	public shutdown(): void {
+		this.adminSubscription?.stop()
+		this.editorSubscription?.stop()
+		this.adminSubscription = null
+		this.editorSubscription = null
 		if (this.ndk) {
 			this.ndk = null
 		}


### PR DESCRIPTION
…riptions

Add standardized utilities for fetching events exclusively from the app's main relay:
- add `getAppRelaySet` to get a relay set pinned to the app's configured relay
- add `fetchLatestAppEvent` to fetch the latest matching app config event from that relay

Refactor all existing event fetching logic in app-settings, blacklist, and featured queries to use these new utilities, removing redundant boilerplate code.

Add long-lived NDK subscriptions in NDKService to keep admin and editor list caches fresh via real-time relay events, and start these subscriptions on server startup with error handling.

Update client-side subscriptions to use the app relay set and add EOSE/last event time tracking to prevent duplicate query invalidations.