### PR TITLE
fix: use exclusive app relays to avoid stale settings copies

### DIFF
--- a/src/publish/featured.tsx
+++ b/src/publish/featured.tsx
@@ -1,5 +1,5 @@
 import { submitAppSettings } from '@/lib/appSettings'
-import { ndkActions } from '@/lib/stores/ndk'
+import { fetchLatestAppEvent, ndkActions } from '@/lib/stores/ndk'
 import { configKeys } from '@/queries/queryKeyFactory'
 import { FEATURED_ITEMS_CONFIG, validateCoordinates, validatePubkey } from '@/lib/schemas/featured'
 import NDK, { NDKEvent, NDKKind, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
@@ -157,16 +157,12 @@ export const addToFeaturedProducts = async (productCoords: string, signer: NDKSi
 	// Use app pubkey if provided, otherwise fallback to current user's pubkey
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured products directly from NDK
-	const filter = {
-		kinds: [FEATURED_ITEMS_CONFIG.PRODUCTS.kind as NDKKind],
+	// Fetch latest featured products from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.PRODUCTS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.PRODUCTS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentProducts = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'a').map((tag: string[]) => tag[1]) || []
 
 	// Check if product is already featured
@@ -198,16 +194,12 @@ export const removeFromFeaturedProducts = async (
 	// Use app pubkey if provided, otherwise fallback to current user's pubkey
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured products directly from NDK
-	const filter = {
-		kinds: [FEATURED_ITEMS_CONFIG.PRODUCTS.kind as NDKKind],
+	// Fetch latest featured products from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.PRODUCTS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.PRODUCTS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentProducts = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'a').map((tag: string[]) => tag[1]) || []
 
 	// Check if product is actually featured
@@ -244,16 +236,12 @@ export const addToFeaturedCollections = async (
 
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured collections directly from NDK
-	const filter = {
-		kinds: [FEATURED_ITEMS_CONFIG.COLLECTIONS.kind as NDKKind],
+	// Fetch latest featured collections from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.COLLECTIONS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.COLLECTIONS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentCollections = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'a').map((tag: string[]) => tag[1]) || []
 
 	if (currentCollections.includes(collectionCoords)) {
@@ -277,16 +265,12 @@ export const removeFromFeaturedCollections = async (
 
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured collections directly from NDK
-	const filter = {
+	// Fetch latest featured collections from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
 		kinds: [FEATURED_ITEMS_CONFIG.COLLECTIONS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.COLLECTIONS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentCollections = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'a').map((tag: string[]) => tag[1]) || []
 
 	if (!currentCollections.includes(collectionCoords)) {
@@ -312,16 +296,12 @@ export const addToFeaturedUsers = async (userPubkey: string, signer: NDKSigner, 
 
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured users directly from NDK
-	const filter = {
-		kinds: [FEATURED_ITEMS_CONFIG.USERS.kind as NDKKind],
+	// Fetch latest featured users from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
+		kinds: [FEATURED_ITEMS_CONFIG.USERS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.USERS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentUsers = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'p').map((tag: string[]) => tag[1]) || []
 
 	if (currentUsers.includes(userPubkey)) {
@@ -340,16 +320,12 @@ export const removeFromFeaturedUsers = async (userPubkey: string, signer: NDKSig
 
 	const targetAppPubkey = appPubkey || currentUser.pubkey
 
-	// Fetch current featured users directly from NDK
-	const filter = {
+	// Fetch latest featured users from the app relay only (avoid stale copies on other relays)
+	const currentEvent = await fetchLatestAppEvent({
 		kinds: [FEATURED_ITEMS_CONFIG.USERS.kind],
 		authors: [targetAppPubkey],
 		'#d': [FEATURED_ITEMS_CONFIG.USERS.dTag],
-		limit: 1,
-	}
-
-	const events = await ndk.fetchEvents(filter)
-	const currentEvent = Array.from(events)[0]
+	})
 	const currentUsers = currentEvent?.tags.filter((tag: string[]) => tag[0] === 'p').map((tag: string[]) => tag[1]) || []
 
 	if (!currentUsers.includes(userPubkey)) {

--- a/src/queries/app-settings.tsx
+++ b/src/queries/app-settings.tsx
@@ -77,13 +77,11 @@ export const useAdminSettings = (appPubkey?: string) => {
 		let latestEventTime = 0
 		let receivedEose = false
 
-		const subscription = ndk.subscribe(
-			adminListFilter,
-			{
-				closeOnEose: false, // Keep subscription open
-			},
-			getAppRelaySet(),
-		)
+		const subscription = ndk.subscribe(adminListFilter, {
+			closeOnEose: false, // Keep subscription open
+			relaySet: getAppRelaySet(),
+			exclusiveRelay: true, // Reject stale copies from other relays in the pool
+		})
 
 		// Event handler for admin list updates - only react to newer events after EOSE
 		subscription.on('event', (newEvent) => {
@@ -228,13 +226,11 @@ export const useEditorSettings = (appPubkey?: string) => {
 		let latestEventTime = 0
 		let receivedEose = false
 
-		const subscription = ndk.subscribe(
-			editorListFilter,
-			{
-				closeOnEose: false, // Keep subscription open
-			},
-			getAppRelaySet(),
-		)
+		const subscription = ndk.subscribe(editorListFilter, {
+			closeOnEose: false, // Keep subscription open
+			relaySet: getAppRelaySet(),
+			exclusiveRelay: true, // Reject stale copies from other relays in the pool
+		})
 
 		// Event handler for editor list updates - only react to newer events after EOSE
 		subscription.on('event', (newEvent) => {

--- a/src/queries/blacklist.tsx
+++ b/src/queries/blacklist.tsx
@@ -79,13 +79,11 @@ export const useBlacklistSettings = (appPubkey?: string) => {
 		let latestEventTime = 0
 		let receivedEose = false
 
-		const subscription = ndk.subscribe(
-			blacklistFilter,
-			{
-				closeOnEose: false, // Keep subscription open
-			},
-			getAppRelaySet(),
-		)
+		const subscription = ndk.subscribe(blacklistFilter, {
+			closeOnEose: false, // Keep subscription open
+			relaySet: getAppRelaySet(),
+			exclusiveRelay: true, // Reject stale copies from other relays in the pool
+		})
 
 		// Event handler for blacklist updates - only react to newer events after EOSE
 		subscription.on('event', (newEvent) => {

--- a/src/queries/featured.tsx
+++ b/src/queries/featured.tsx
@@ -100,8 +100,9 @@ const useFeaturedSettingsSubscription = (appPubkey: string, queryKey: readonly u
 			},
 			{
 				closeOnEose: false,
+				relaySet: getAppRelaySet(),
+				exclusiveRelay: true, // Reject stale copies from other relays in the pool
 			},
-			getAppRelaySet(),
 		)
 
 		subscription.on('event', (event) => {


### PR DESCRIPTION
Update all settings-related subscriptions to use correct relay set parameter order and add exclusiveRelay flag to reject stale copies from other relays. Refactor featured publish functions to use fetchLatestAppEvent helper for consistent, stale-free event fetching across all app settings workflows.