### PR TITLE
feat(auctions):next navigation between tabs in auction form

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1639,9 +1639,17 @@ export function AuctionFormContent() {
 				return missingLabels(['title', 'description'])
 			case 'auction':
 				return missingLabels([
-					'startingBid', 'bidIncrement', 'reserve', 'startAt', 'endAt',
-					'duration', 'antiSnipeWindowMinutes', 'minBidCurveShape',
-					'minBidCurvePeakMultiplier', 'settlementGracePreset', 'trustedMints',
+					'startingBid',
+					'bidIncrement',
+					'reserve',
+					'startAt',
+					'endAt',
+					'duration',
+					'antiSnipeWindowMinutes',
+					'minBidCurveShape',
+					'minBidCurvePeakMultiplier',
+					'settlementGracePreset',
+					'trustedMints',
 				])
 			case 'images':
 				return missingLabels(['imageUrls'])
@@ -1764,17 +1772,35 @@ export function AuctionFormContent() {
 				)}
 				<div className="flex gap-2">
 					{currentTabIndex > 0 && (
-						<Button type="button" variant="ghost" className="flex-1 uppercase border border-input bg-white hover:bg-white" onClick={handleBack}>
+						<Button
+							type="button"
+							variant="ghost"
+							className="flex-1 uppercase border border-input bg-white hover:bg-white"
+							onClick={handleBack}
+						>
 							<ArrowLeft className="w-4 h-4" />
 							Back
 						</Button>
 					)}
 					{isLastTab ? (
-						<Button type="submit" variant="secondary" className="flex-1 uppercase" disabled={!canSubmit || publishMutation.isPending}>
+						<Button
+							key="publish"
+							type="submit"
+							variant="secondary"
+							className="flex-1 uppercase"
+							disabled={!canSubmit || publishMutation.isPending}
+						>
 							{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 						</Button>
 					) : (
-						<Button type="button" variant="secondary" className="flex-1 uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
+						<Button
+							key="next"
+							type="button"
+							variant="secondary"
+							className="flex-1 uppercase"
+							onClick={handleNext}
+							disabled={!tabValid[activeTab]}
+						>
 							Next
 						</Button>
 					)}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -36,7 +36,7 @@ import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { CalendarIcon, Plus, X } from 'lucide-react'
+import { ArrowLeft, CalendarIcon, Plus, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
@@ -1487,6 +1487,24 @@ function ShippingTab({
 
 const TAB_ORDER: AuctionTab[] = ['name', 'auction', 'category', 'spec', 'images', 'shipping']
 
+const VALIDATION_FIELD_LABELS: Record<AuctionPublishValidationField, string> = {
+	title: 'Title',
+	description: 'Description',
+	startingBid: 'Starting Bid',
+	bidIncrement: 'Bid Increment',
+	reserve: 'Reserve',
+	startAt: 'Start Time',
+	endAt: 'End Time',
+	duration: 'Duration',
+	antiSnipeWindowMinutes: 'Anti-snipe Window',
+	minBidCurveShape: 'Curve Shape',
+	minBidCurvePeakMultiplier: 'Peak Multiplier',
+	settlementGracePreset: 'Settlement Grace',
+	trustedMints: 'Trusted Mints',
+	imageUrls: 'Image',
+	shippingExtraCost: 'Shipping Extra Cost',
+}
+
 export function AuctionFormContent() {
 	const navigate = useNavigate()
 	const publishMutation = usePublishAuctionMutation()
@@ -1588,6 +1606,14 @@ export function AuctionFormContent() {
 		shipping: Object.keys(shippingExtraCostErrors).length === 0,
 	}
 
+	// Tab at index i is reachable only if every tab before it is valid.
+	const isTabReachable = (tabIndex: number): boolean => {
+		for (let i = 0; i < tabIndex; i++) {
+			if (!tabValid[TAB_ORDER[i]]) return false
+		}
+		return true
+	}
+
 	const handleNext = () => {
 		const nextIndex = currentTabIndex + 1
 		if (nextIndex < TAB_ORDER.length) setActiveTab(TAB_ORDER[nextIndex])
@@ -1597,6 +1623,34 @@ export function AuctionFormContent() {
 		const prevIndex = currentTabIndex - 1
 		if (prevIndex >= 0) setActiveTab(TAB_ORDER[prevIndex])
 	}
+
+	const missingLabels = (fields: AuctionPublishValidationField[]): string[] => {
+		const fieldsWithIssues = new Set(validationIssues.filter((i) => fields.includes(i.field)).map((i) => i.field))
+		return [...fieldsWithIssues].map((f) => `Missing ${VALIDATION_FIELD_LABELS[f]}`)
+	}
+
+	const currentTabErrors: string[] = (() => {
+		if (isLastTab) {
+			const fieldsWithIssues = [...new Set(validationIssues.map((i) => i.field))]
+			return fieldsWithIssues.map((f) => `Missing ${VALIDATION_FIELD_LABELS[f]}`)
+		}
+		switch (activeTab) {
+			case 'name':
+				return missingLabels(['title', 'description'])
+			case 'auction':
+				return missingLabels([
+					'startingBid', 'bidIncrement', 'reserve', 'startAt', 'endAt',
+					'duration', 'antiSnipeWindowMinutes', 'minBidCurveShape',
+					'minBidCurvePeakMultiplier', 'settlementGracePreset', 'trustedMints',
+				])
+			case 'images':
+				return missingLabels(['imageUrls'])
+			case 'shipping':
+				return missingLabels(['shippingExtraCost'])
+			default:
+				return []
+		}
+	})()
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
@@ -1627,19 +1681,23 @@ export function AuctionFormContent() {
 	]
 
 	return (
-		<form onSubmit={handleSubmit} className="flex flex-col h-full mt-4">
-			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
+		<form onSubmit={handleSubmit} className="flex flex-col h-full mt-4 overflow-hidden">
+			<div className="flex-1 flex flex-col min-h-0 overflow-hidden">
 				<Tabs
 					value={activeTab}
-					onValueChange={(value) => setActiveTab(value as AuctionTab)}
+					onValueChange={(value) => {
+						const idx = TAB_ORDER.indexOf(value as AuctionTab)
+						if (isTabReachable(idx)) setActiveTab(value as AuctionTab)
+					}}
 					className="w-full flex flex-col flex-1 min-h-0 overflow-hidden"
 				>
 					<TabsList className="w-full bg-transparent h-auto p-0 flex flex-wrap gap-[1px]">
-						{tabs.map((tab) => (
+						{tabs.map((tab, index) => (
 							<TabsTrigger
 								key={tab.value}
 								value={tab.value}
-								className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none"
+								disabled={!isTabReachable(index)}
+								className="flex-1 px-4 py-2 text-xs font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black rounded-none disabled:opacity-40 disabled:cursor-not-allowed"
 							>
 								{tab.label}
 								{tab.showAsterisk && <span className="ml-1 text-red-500">*</span>}
@@ -1693,21 +1751,34 @@ export function AuctionFormContent() {
 				</Tabs>
 			</div>
 
-			<div className="bg-white border-t pt-4 pb-2 mt-2 flex gap-2">
-				{currentTabIndex > 0 && (
-					<Button type="button" variant="outline" className="flex-1 uppercase" onClick={handleBack}>
-						Back
-					</Button>
+			<div className="shrink-0 bg-white border-t pt-4 pb-2 mt-2">
+				{currentTabErrors.length > 0 && (
+					<ul className="mb-3 max-h-28 overflow-y-auto space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2">
+						{currentTabErrors.map((err, i) => (
+							<li key={i} className="text-xs text-red-600 flex items-center gap-1">
+								<span>•</span>
+								{err}
+							</li>
+						))}
+					</ul>
 				)}
-				{isLastTab ? (
-					<Button type="submit" variant="secondary" className="flex-1 uppercase" disabled={!canSubmit || publishMutation.isPending}>
-						{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
-					</Button>
-				) : (
-					<Button type="button" variant="secondary" className="flex-1 uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
-						Next
-					</Button>
-				)}
+				<div className="flex gap-2">
+					{currentTabIndex > 0 && (
+						<Button type="button" variant="ghost" className="flex-1 uppercase border border-input bg-white hover:bg-white" onClick={handleBack}>
+							<ArrowLeft className="w-4 h-4" />
+							Back
+						</Button>
+					)}
+					{isLastTab ? (
+						<Button type="submit" variant="secondary" className="flex-1 uppercase" disabled={!canSubmit || publishMutation.isPending}>
+							{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
+						</Button>
+					) : (
+						<Button type="button" variant="secondary" className="flex-1 uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
+							Next
+						</Button>
+					)}
+				</div>
 			</div>
 		</form>
 	)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1689,18 +1689,12 @@ export function AuctionFormContent() {
 			</div>
 
 			<div className="bg-white border-t pt-4 pb-2 mt-2">
-				{canSubmit ? (
-					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={publishMutation.isPending}>
+				{isLastTab ? (
+					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
 						{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 					</Button>
 				) : (
-					<Button
-						type="button"
-						variant="secondary"
-						className="w-full uppercase"
-						onClick={handleNext}
-						disabled={isLastTab || !tabValid[activeTab]}
-					>
+					<Button type="button" variant="secondary" className="w-full uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
 						Next
 					</Button>
 				)}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1574,6 +1574,24 @@ export function AuctionFormContent() {
 
 	const canSubmit = validationIssues.length === 0
 
+	const TAB_ORDER: AuctionTab[] = ['name', 'auction', 'category', 'spec', 'images', 'shipping']
+	const currentTabIndex = TAB_ORDER.indexOf(activeTab)
+	const isLastTab = currentTabIndex === TAB_ORDER.length - 1
+
+	const tabValid: Record<AuctionTab, boolean> = {
+		name: hasValidName && hasValidDescription,
+		auction: hasValidBidding && hasValidMints,
+		category: true,
+		spec: true,
+		images: hasValidImages,
+		shipping: Object.keys(shippingExtraCostErrors).length === 0,
+	}
+
+	const handleNext = () => {
+		const nextIndex = currentTabIndex + 1
+		if (nextIndex < TAB_ORDER.length) setActiveTab(TAB_ORDER[nextIndex])
+	}
+
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		event.stopPropagation()
@@ -1670,9 +1688,15 @@ export function AuctionFormContent() {
 			</div>
 
 			<div className="bg-white border-t pt-4 pb-2 mt-2">
-				<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
-					{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
-				</Button>
+				{isLastTab ? (
+					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
+						{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
+					</Button>
+				) : (
+					<Button type="button" variant="secondary" className="w-full uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
+						Next
+					</Button>
+				)}
 			</div>
 		</form>
 	)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1485,6 +1485,8 @@ function ShippingTab({
 	)
 }
 
+const TAB_ORDER: AuctionTab[] = ['name', 'auction', 'category', 'spec', 'images', 'shipping']
+
 export function AuctionFormContent() {
 	const navigate = useNavigate()
 	const publishMutation = usePublishAuctionMutation()
@@ -1574,7 +1576,6 @@ export function AuctionFormContent() {
 
 	const canSubmit = validationIssues.length === 0
 
-	const TAB_ORDER: AuctionTab[] = ['name', 'auction', 'category', 'spec', 'images', 'shipping']
 	const currentTabIndex = TAB_ORDER.indexOf(activeTab)
 	const isLastTab = currentTabIndex === TAB_ORDER.length - 1
 
@@ -1688,12 +1689,18 @@ export function AuctionFormContent() {
 			</div>
 
 			<div className="bg-white border-t pt-4 pb-2 mt-2">
-				{isLastTab ? (
-					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
+				{canSubmit ? (
+					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={publishMutation.isPending}>
 						{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 					</Button>
 				) : (
-					<Button type="button" variant="secondary" className="w-full uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
+					<Button
+						type="button"
+						variant="secondary"
+						className="w-full uppercase"
+						onClick={handleNext}
+						disabled={isLastTab || !tabValid[activeTab]}
+					>
 						Next
 					</Button>
 				)}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1593,6 +1593,11 @@ export function AuctionFormContent() {
 		if (nextIndex < TAB_ORDER.length) setActiveTab(TAB_ORDER[nextIndex])
 	}
 
+	const handleBack = () => {
+		const prevIndex = currentTabIndex - 1
+		if (prevIndex >= 0) setActiveTab(TAB_ORDER[prevIndex])
+	}
+
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		event.stopPropagation()
@@ -1688,13 +1693,18 @@ export function AuctionFormContent() {
 				</Tabs>
 			</div>
 
-			<div className="bg-white border-t pt-4 pb-2 mt-2">
+			<div className="bg-white border-t pt-4 pb-2 mt-2 flex gap-2">
+				{currentTabIndex > 0 && (
+					<Button type="button" variant="outline" className="flex-1 uppercase" onClick={handleBack}>
+						Back
+					</Button>
+				)}
 				{isLastTab ? (
-					<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
+					<Button type="submit" variant="secondary" className="flex-1 uppercase" disabled={!canSubmit || publishMutation.isPending}>
 						{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 					</Button>
 				) : (
-					<Button type="button" variant="secondary" className="w-full uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
+					<Button type="button" variant="secondary" className="flex-1 uppercase" onClick={handleNext} disabled={!tabValid[activeTab]}>
 						Next
 					</Button>
 				)}


### PR DESCRIPTION
# Summary
- Adds a sequential "Next" button to the auction creation form that advances the user through tabs in order (name → auction → category → spec → images → shipping)

- "Next" is disabled until required fields on the current tab are valid, guiding the user to complete each step before proceeding
"Publish Auction" replaces "Next" as soon as the entire form is valid (canSubmit)

# Screenshoots

https://github.com/user-attachments/assets/23469c1e-6e31-4e7a-8eee-b55fff55e435


https://github.com/user-attachments/assets/31803460-3390-4304-a33b-f8bf01a3a47d

closes #884


