### PR TITLE
feat(e2e): NIP-60 dev bridge for wallet-funded E2E tests

### DIFF
--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -927,6 +927,18 @@ export const nip60Actions = {
 			// Load pending tokens from localStorage
 			nip60Actions.loadPendingTokens()
 			void nip60Actions.syncAuctionTransfers()
+
+			if (typeof window !== 'undefined' && isNip60WalletDevModeEnabled()) {
+				;(window as any).__nip60 = {
+					mintTestEcash: nip60Actions.mintTestEcash,
+					getStatus: () => ({
+						status: nip60Store.state.status,
+						balance: nip60Store.state.balance,
+						mints: nip60Store.state.mints,
+						mintBalances: nip60Store.state.mintBalances,
+					}),
+				}
+			}
 		} catch (err) {
 			console.error('[nip60] Failed to initialize wallet:', err)
 			nip60Store.setState((s) => ({
@@ -1878,7 +1890,7 @@ export const nip60Actions = {
 		}
 
 		const wallet = nip60Store.state.wallet
-		if (!wallet || nip60Store.state.status !== 'ready') {
+		if (!wallet || (nip60Store.state.status !== 'ready' && nip60Store.state.status !== 'no_wallet')) {
 			throw new Error('NIP-60 wallet not ready')
 		}
 
@@ -1918,6 +1930,10 @@ export const nip60Actions = {
 				}
 
 				await nip60Actions.refresh()
+
+				if (nip60Store.state.status !== 'ready') {
+					nip60Store.setState((s) => ({ ...s, status: 'ready' }))
+				}
 
 				return {
 					mintUrl: targetMint,


### PR DESCRIPTION
## NIP-60 E2E Test Infrastructure

**Branch:** `fix/nip60-e2e-dev-bridge`
**Target:** `auctions/p2pk-path-oracle-via-cvm-v1`

### Why this PR exists

PR #886 (bidding with any mint) includes wallet-funded E2E tests that need to mint test ecash and check wallet status from the browser context. These 3 nip60.ts changes are E2E test infrastructure — not part of the mint-selection feature.

Extracting them per reviewer feedback (maximotodev, Franchovy) to keep #886 focused.

### Changes (1 file, 17 lines)

1. **`window.__nip60` dev bridge** — Exposes `mintTestEcash` and `getStatus` via `window.__nip60`. Gated behind `isNip60WalletDevModeEnabled()`, **never runs in production**.

2. **`no_wallet` status guard** — Allows `mintTestEcash` to work on fresh wallets before full initialization. Without this, a newly created wallet with status `"no_wallet"` throws "NIP-60 wallet not ready" before the first mint can complete.

3. **Post-mint status override** — Forces `status: "ready"` after `refresh()` when the store hasn't caught up. Handles race condition where refresh completes but store status remains stale.

### Safety

- All 3 changes are gated behind dev mode flags or are status-handling edge cases
- No production behavior change — `isNip60WalletDevModeEnabled()` returns false in production
- The status guard (#2) and override (#3) only affect `mintTestEcash`, which is a test-only action