### PR TITLE
fix(auction): UI inconsistencies refresh

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1127,7 +1127,7 @@ function AuctionTabContent({
 					}}
 				/>
 				<Label htmlFor="use-reserve">Set Reserve Price</Label>
-				<InfoTooltip content="A reserve price sets a minimum bid amount that must be met for the auction to be successful. If the highest bid is below the reserve, the auction ends with no winner." />
+				<InfoTooltip content="Minimum bid required for the auction to have a winner. No winner if highest bid is lower than the reserve." />
 			</div>
 
 			{(!!formData.reserve || useReserve) && (

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -166,7 +166,9 @@ function NameTab({ formData, setFormData }: TabProps) {
 type StartMode = 'immediate' | 'scheduled'
 type EndMode = 'duration' | 'absolute'
 
-const DURATION_PRESETS: { label: string; seconds: number }[] = [
+type AuctionDurationPreset = { label: string; seconds: number }
+
+const DURATION_PRESETS: AuctionDurationPreset[] = [
 	{ label: '1m', seconds: 1 * 60 },
 	{ label: '2m', seconds: 2 * 60 },
 	{ label: '3m', seconds: 3 * 60 },
@@ -182,8 +184,16 @@ const DURATION_PRESETS: { label: string; seconds: number }[] = [
 	{ label: '4h', seconds: 4 * 3600 },
 	{ label: '5h', seconds: 5 * 3600 },
 	{ label: '6h', seconds: 6 * 3600 },
+	{ label: '7h', seconds: 7 * 3600 },
+	{ label: '8h', seconds: 8 * 3600 },
+	{ label: '9h', seconds: 9 * 3600 },
+	{ label: '10h', seconds: 10 * 3600 },
 	{ label: '12h', seconds: 12 * 3600 },
+	{ label: '14h', seconds: 14 * 3600 },
+	{ label: '16h', seconds: 16 * 3600 },
 	{ label: '18h', seconds: 18 * 3600 },
+	{ label: '20h', seconds: 20 * 3600 },
+	{ label: '22h', seconds: 22 * 3600 },
 	{ label: '1d', seconds: 86400 },
 	{ label: '2d', seconds: 2 * 86400 },
 	{ label: '3d', seconds: 3 * 86400 },
@@ -202,6 +212,17 @@ const DURATION_PRESETS: { label: string; seconds: number }[] = [
 	{ label: '20d', seconds: 20 * 86400 },
 	{ label: '25d', seconds: 25 * 86400 },
 	{ label: '30d', seconds: 30 * 86400 },
+]
+
+const DURATION_PRESET_DEFAULT_INDEX = 25 // Index for 1 Day
+
+const DURATION_PRESETS_SHORTCUT: AuctionDurationPreset[] = [
+	DURATION_PRESETS[9], // 1 Hour
+	DURATION_PRESETS[19], // 12 Hours
+	DURATION_PRESETS[25], // 1 Day
+	DURATION_PRESETS[31], // 7 Days
+	DURATION_PRESETS[38], // 14 Days
+	DURATION_PRESETS[42], // 30 Days
 ]
 
 function pad2(n: number): string {
@@ -849,7 +870,7 @@ function AuctionTabContent({
 	onUserRemovedMintsChange: (next: Set<string>) => void
 }) {
 	const [useReserve, setUseReserve] = useState(false)
-	const [inputSliderValue, setInputSliderValue] = useState<number>(16) // Default value: 1 day (24 hours)
+	const [inputSliderValue, setInputSliderValue] = useState<number>(DURATION_PRESET_DEFAULT_INDEX)
 
 	const selectedMints = formData.trustedMints
 	const unselectedMints = availableMints.filter((mint) => !selectedMints.includes(mint))
@@ -991,6 +1012,30 @@ function AuctionTabContent({
 
 				{endMode === 'duration' ? (
 					<div className="space-y-3">
+						<div className="flex flex-wrap gap-1.5">
+							{DURATION_PRESETS_SHORTCUT.map((preset) => {
+								const isActive = durationSeconds === preset.seconds
+								return (
+									<button
+										key={preset.label}
+										type="button"
+										onClick={() => {
+											const indexSlider = DURATION_PRESETS.findIndex((v) => v.seconds === preset.seconds)
+											setInputSliderValue(indexSlider + 1)
+											setDurationSeconds(preset.seconds)
+										}}
+										className={`rounded-full px-3 py-1 text-xs font-semibold border ${
+											isActive
+												? 'border-secondary bg-secondary text-white'
+												: 'border-zinc-300 bg-white text-zinc-700 hover:border-secondary'
+										}`}
+									>
+										{preset.label}
+									</button>
+								)
+							})}
+						</div>
+
 						<div>
 							<Slider
 								min={1}
@@ -999,9 +1044,9 @@ function AuctionTabContent({
 								onValueChange={(val) => {
 									const sliderValue = val?.at(0)
 									if (sliderValue) {
-										const value = DURATION_PRESETS[sliderValue - 1]
-
 										setInputSliderValue(sliderValue)
+
+										const value = DURATION_PRESETS[sliderValue - 1]
 										setDurationSeconds(value.seconds)
 									}
 								}}
@@ -1595,6 +1640,7 @@ export function AuctionFormContent() {
 	const hasValidBidding =
 		!validationMessages.startingBid &&
 		!validationMessages.bidIncrement &&
+		!validationMessages.reserve &&
 		!validationMessages.startAt &&
 		!validationMessages.endAt &&
 		!validationMessages.duration &&

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -38,6 +38,8 @@ import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { InfoTooltip } from '@/components/shared/InfoTooltip'
+import { Slider } from '@/components/ui/slider'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 
@@ -50,7 +52,7 @@ const INITIAL_FORM: AuctionFormData = {
 	description: '',
 	startingBid: '',
 	bidIncrement: '1',
-	reserve: '0',
+	reserve: undefined,
 	startAt: '',
 	endAt: '',
 	// Anti-snipe defaults: no window, no curve, 1h settlement grace.
@@ -165,24 +167,49 @@ type StartMode = 'immediate' | 'scheduled'
 type EndMode = 'duration' | 'absolute'
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [
+	{ label: '1m', seconds: 1 * 60 },
+	{ label: '2m', seconds: 2 * 60 },
+	{ label: '3m', seconds: 3 * 60 },
+	{ label: '4m', seconds: 4 * 60 },
+	{ label: '5m', seconds: 5 * 60 },
+	{ label: '10m', seconds: 10 * 60 },
+	{ label: '15m', seconds: 15 * 60 },
+	{ label: '30m', seconds: 30 * 60 },
+	{ label: '45m', seconds: 45 * 60 },
 	{ label: '1h', seconds: 3600 },
+	{ label: '2h', seconds: 2 * 3600 },
+	{ label: '3h', seconds: 3 * 3600 },
+	{ label: '4h', seconds: 4 * 3600 },
+	{ label: '5h', seconds: 5 * 3600 },
 	{ label: '6h', seconds: 6 * 3600 },
+	{ label: '12h', seconds: 12 * 3600 },
+	{ label: '18h', seconds: 18 * 3600 },
 	{ label: '1d', seconds: 86400 },
+	{ label: '2d', seconds: 2 * 86400 },
 	{ label: '3d', seconds: 3 * 86400 },
+	{ label: '4d', seconds: 4 * 86400 },
+	{ label: '5d', seconds: 5 * 86400 },
+	{ label: '6d', seconds: 6 * 86400 },
 	{ label: '7d', seconds: 7 * 86400 },
+	{ label: '8d', seconds: 8 * 86400 },
+	{ label: '9d', seconds: 9 * 86400 },
+	{ label: '10d', seconds: 10 * 86400 },
+	{ label: '11d', seconds: 11 * 86400 },
+	{ label: '12d', seconds: 12 * 86400 },
+	{ label: '13d', seconds: 13 * 86400 },
 	{ label: '14d', seconds: 14 * 86400 },
+	{ label: '15d', seconds: 15 * 86400 },
+	{ label: '20d', seconds: 20 * 86400 },
+	{ label: '25d', seconds: 25 * 86400 },
 	{ label: '30d', seconds: 30 * 86400 },
 ]
-
-const MIN_DURATION_HOURS = 1
-const MAX_DURATION_HOURS = 30 * 24
 
 function pad2(n: number): string {
 	return n.toString().padStart(2, '0')
 }
 
 function toDatetimeLocal(date: Date): string {
-	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}`
+	return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}T${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}`
 }
 
 function parseDatetimeLocalSeconds(value: string): number | null {
@@ -821,6 +848,9 @@ function AuctionTabContent({
 	userRemovedMints: Set<string>
 	onUserRemovedMintsChange: (next: Set<string>) => void
 }) {
+	const [useReserve, setUseReserve] = useState(false)
+	const [inputSliderValue, setInputSliderValue] = useState<number>(16) // Default value: 1 day (24 hours)
+
 	const selectedMints = formData.trustedMints
 	const unselectedMints = availableMints.filter((mint) => !selectedMints.includes(mint))
 	const canRemoveMint = selectedMints.length > 1
@@ -843,7 +873,7 @@ function AuctionTabContent({
 
 	const startingBidNum = parseInt(formData.startingBid, 10)
 	const bidIncrementNum = parseInt(formData.bidIncrement, 10)
-	const reserveNum = parseInt(formData.reserve, 10)
+	const reserveNum = parseInt(formData.reserve ?? '', 10)
 	const antiSnipeWindowSeconds = formData.antiSnipeWindowMinutes * 60
 	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 
@@ -895,8 +925,6 @@ function AuctionTabContent({
 			return { ...prev, endAt: toDatetimeLocal(initial) }
 		})
 	}
-
-	const durationHours = Math.max(MIN_DURATION_HOURS, Math.round(durationSeconds / 3600))
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -963,38 +991,24 @@ function AuctionTabContent({
 
 				{endMode === 'duration' ? (
 					<div className="space-y-3">
-						<div className="flex flex-wrap gap-1.5">
-							{DURATION_PRESETS.map((preset) => {
-								const isActive = durationSeconds === preset.seconds
-								return (
-									<button
-										key={preset.label}
-										type="button"
-										onClick={() => setDurationSeconds(preset.seconds)}
-										className={`rounded-full px-3 py-1 text-xs font-semibold border ${
-											isActive
-												? 'border-secondary bg-secondary text-white'
-												: 'border-zinc-300 bg-white text-zinc-700 hover:border-secondary'
-										}`}
-									>
-										{preset.label}
-									</button>
-								)
-							})}
-						</div>
-
 						<div>
-							<input
-								type="range"
-								min={MIN_DURATION_HOURS}
-								max={MAX_DURATION_HOURS}
-								step={1}
-								value={durationHours}
-								onChange={(e) => setDurationSeconds(parseInt(e.target.value, 10) * 3600)}
+							<Slider
+								min={1}
+								max={DURATION_PRESETS.length}
+								value={[inputSliderValue]}
+								onValueChange={(val) => {
+									const sliderValue = val?.at(0)
+									if (sliderValue) {
+										const value = DURATION_PRESETS[sliderValue - 1]
+
+										setInputSliderValue(sliderValue)
+										setDurationSeconds(value.seconds)
+									}
+								}}
 								className="w-full accent-secondary"
 							/>
 							<div className="flex items-center justify-between text-[10px] text-zinc-500">
-								<span>1h</span>
+								<span>1m</span>
 								<span>30d</span>
 							</div>
 						</div>
@@ -1024,7 +1038,7 @@ function AuctionTabContent({
 				)}
 			</div>
 
-			<div className="grid sm:grid-cols-2 gap-4">
+			<div className="grid sm:grid-cols-2 gap-4 items-start">
 				<div className="grid w-full gap-1.5">
 					<Label htmlFor="auction-starting-bid">
 						<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Starting Bid (sats)</span>
@@ -1053,17 +1067,37 @@ function AuctionTabContent({
 				</div>
 			</div>
 
-			<div className="grid w-full gap-1.5">
-				<Label htmlFor="auction-reserve">Reserve (sats)</Label>
-				<Input
-					id="auction-reserve"
-					type="number"
-					min="0"
-					value={formData.reserve}
-					onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
+			<div className="flex items-center space-x-2">
+				<Checkbox
+					id="use-reserve"
+					checked={!!formData.reserve || useReserve}
+					onCheckedChange={(checked) => {
+						if (checked === true) {
+							setUseReserve(true)
+							setFormData((prev) => ({ ...prev, reserve: formData.startingBid }))
+						} else {
+							setUseReserve(false)
+							setFormData((prev) => ({ ...prev, reserve: undefined }))
+						}
+					}}
 				/>
-				{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
+				<Label htmlFor="use-reserve">Set Reserve Price</Label>
+				<InfoTooltip content="A reserve price sets a minimum bid amount that must be met for the auction to be successful. If the highest bid is below the reserve, the auction ends with no winner." />
 			</div>
+
+			{(!!formData.reserve || useReserve) && (
+				<div className="grid w-full gap-1.5">
+					<Label htmlFor="auction-reserve">Reserve (sats)</Label>
+					<Input
+						id="auction-reserve"
+						type="number"
+						min="0"
+						value={formData.reserve}
+						onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
+					/>
+					{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
+				</div>
+			)}
 
 			<BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />
 
@@ -1561,7 +1595,6 @@ export function AuctionFormContent() {
 	const hasValidBidding =
 		!validationMessages.startingBid &&
 		!validationMessages.bidIncrement &&
-		!validationMessages.reserve &&
 		!validationMessages.startAt &&
 		!validationMessages.endAt &&
 		!validationMessages.duration &&

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -268,7 +268,7 @@ const normalizeAuctionPublishInput = (
 	}
 
 	const durationSeconds = parsedEndAt ? parsedEndAt - effectiveStartBoundary : 0
-	if (parsedEndAt && options.minDurationSeconds && durationSeconds < options.minDurationSeconds) {
+	if (parsedEndAt !== null && options.minDurationSeconds !== undefined && durationSeconds < options.minDurationSeconds) {
 		// Compute the human label from the configured minimum so the message
 		// reflects the actual rule the form is enforcing, not a hard-coded
 		// "1 minute". Prefer minute granularity above 60 s so we don't say

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,994 +57,1063 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-	id: '/setup',
-	path: '/setup',
-	getParentRoute: () => rootRouteImport,
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-	id: '/checkout',
-	path: '/checkout',
-	getParentRoute: () => rootRouteImport,
+  id: '/checkout',
+  path: '/checkout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-	id: '/_dashboard-layout',
-	getParentRoute: () => rootRouteImport,
+  id: '/_dashboard-layout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-	id: '/$vanityName',
-	path: '/$vanityName',
-	getParentRoute: () => rootRouteImport,
+  id: '/$vanityName',
+  path: '/$vanityName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-	id: '/products/',
-	path: '/products/',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/',
+  path: '/products/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-	id: '/posts/',
-	path: '/posts/',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/',
+  path: '/posts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-	id: '/nostr/',
-	path: '/nostr/',
-	getParentRoute: () => rootRouteImport,
+  id: '/nostr/',
+  path: '/nostr/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-	id: '/community/',
-	path: '/community/',
-	getParentRoute: () => rootRouteImport,
+  id: '/community/',
+  path: '/community/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-	id: '/auctions/',
-	path: '/auctions/',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/',
+  path: '/auctions/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-	id: '/search/products',
-	path: '/search/products',
-	getParentRoute: () => rootRouteImport,
+  id: '/search/products',
+  path: '/search/products',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-	id: '/profile/$profileId',
-	path: '/profile/$profileId',
-	getParentRoute: () => rootRouteImport,
+  id: '/profile/$profileId',
+  path: '/profile/$profileId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-	id: '/products/$productId',
-	path: '/products/$productId',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/$productId',
+  path: '/products/$productId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-	id: '/posts/$postId',
-	path: '/posts/$postId',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/$postId',
+  path: '/posts/$postId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-	id: '/collection/$collectionId',
-	path: '/collection/$collectionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/collection/$collectionId',
+  path: '/collection/$collectionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-	id: '/auctions/$auctionId',
-	path: '/auctions/$auctionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/$auctionId',
+  path: '/auctions/$auctionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
-	id: '/dashboard/',
-	path: '/dashboard/',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
-	id: '/dashboard/about',
-	path: '/dashboard/about',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
-	id: '/dashboard/sales/sales',
-	path: '/dashboard/sales/sales',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
-	id: '/dashboard/sales/messages',
-	path: '/dashboard/sales/messages',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-	id: '/dashboard/sales/circular-economy',
-	path: '/dashboard/sales/circular-economy',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-	id: '/dashboard/products/shipping-options',
-	path: '/dashboard/products/shipping-options',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
-	id: '/dashboard/products/products',
-	path: '/dashboard/products/products',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-	id: '/dashboard/products/migration-tool',
-	path: '/dashboard/products/migration-tool',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-	id: '/dashboard/products/collections',
-	path: '/dashboard/products/collections',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
-	id: '/dashboard/products/bids',
-	path: '/dashboard/products/bids',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-	id: '/dashboard/products/auctions',
-	path: '/dashboard/products/auctions',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-	id: '/dashboard/orders/$orderId',
-	path: '/dashboard/orders/$orderId',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-	id: '/dashboard/app-settings/team',
-	path: '/dashboard/app-settings/team',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-	id: '/dashboard/app-settings/featured-items',
-	path: '/dashboard/app-settings/featured-items',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-	id: '/dashboard/app-settings/blacklists',
-	path: '/dashboard/app-settings/blacklists',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-	id: '/dashboard/app-settings/app-miscelleneous',
-	path: '/dashboard/app-settings/app-miscelleneous',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-	id: '/dashboard/account/your-purchases',
-	path: '/dashboard/account/your-purchases',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-	id: '/dashboard/account/vanity-url',
-	path: '/dashboard/account/vanity-url',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-	id: '/dashboard/account/receiving-payments',
-	path: '/dashboard/account/receiving-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
-	id: '/dashboard/account/profile',
-	path: '/dashboard/account/profile',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-	id: '/dashboard/account/preferences',
-	path: '/dashboard/account/preferences',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-	id: '/dashboard/account/nostr-address',
-	path: '/dashboard/account/nostr-address',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
-	id: '/dashboard/account/network',
-	path: '/dashboard/account/network',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-	id: '/dashboard/account/making-payments',
-	path: '/dashboard/account/making-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-	id: '/$pubkey',
-	path: '/$pubkey',
-	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-	id: '/$productId',
-	path: '/$productId',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-} as any)
+const DashboardLayoutDashboardIndexRoute =
+  DashboardLayoutDashboardIndexRouteImport.update({
+    id: '/dashboard/',
+    path: '/dashboard/',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAboutRoute =
+  DashboardLayoutDashboardAboutRouteImport.update({
+    id: '/dashboard/about',
+    path: '/dashboard/about',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesSalesRoute =
+  DashboardLayoutDashboardSalesSalesRouteImport.update({
+    id: '/dashboard/sales/sales',
+    path: '/dashboard/sales/sales',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesRoute =
+  DashboardLayoutDashboardSalesMessagesRouteImport.update({
+    id: '/dashboard/sales/messages',
+    path: '/dashboard/sales/messages',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute =
+  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+    id: '/dashboard/sales/circular-economy',
+    path: '/dashboard/sales/circular-economy',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute =
+  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+    id: '/dashboard/products/shipping-options',
+    path: '/dashboard/products/shipping-options',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsRoute =
+  DashboardLayoutDashboardProductsProductsRouteImport.update({
+    id: '/dashboard/products/products',
+    path: '/dashboard/products/products',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute =
+  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+    id: '/dashboard/products/migration-tool',
+    path: '/dashboard/products/migration-tool',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsRoute =
+  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+    id: '/dashboard/products/collections',
+    path: '/dashboard/products/collections',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsBidsRoute =
+  DashboardLayoutDashboardProductsBidsRouteImport.update({
+    id: '/dashboard/products/bids',
+    path: '/dashboard/products/bids',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsRoute =
+  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+    id: '/dashboard/products/auctions',
+    path: '/dashboard/products/auctions',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute =
+  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+    id: '/dashboard/orders/$orderId',
+    path: '/dashboard/orders/$orderId',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute =
+  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+    id: '/dashboard/app-settings/team',
+    path: '/dashboard/app-settings/team',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+    id: '/dashboard/app-settings/featured-items',
+    path: '/dashboard/app-settings/featured-items',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
+  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+    id: '/dashboard/app-settings/blacklists',
+    path: '/dashboard/app-settings/blacklists',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+    id: '/dashboard/app-settings/app-miscelleneous',
+    path: '/dashboard/app-settings/app-miscelleneous',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute =
+  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+    id: '/dashboard/account/your-purchases',
+    path: '/dashboard/account/your-purchases',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute =
+  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+    id: '/dashboard/account/vanity-url',
+    path: '/dashboard/account/vanity-url',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
+  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+    id: '/dashboard/account/receiving-payments',
+    path: '/dashboard/account/receiving-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountProfileRoute =
+  DashboardLayoutDashboardAccountProfileRouteImport.update({
+    id: '/dashboard/account/profile',
+    path: '/dashboard/account/profile',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountPreferencesRoute =
+  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+    id: '/dashboard/account/preferences',
+    path: '/dashboard/account/preferences',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute =
+  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+    id: '/dashboard/account/nostr-address',
+    path: '/dashboard/account/nostr-address',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNetworkRoute =
+  DashboardLayoutDashboardAccountNetworkRouteImport.update({
+    id: '/dashboard/account/network',
+    path: '/dashboard/account/network',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute =
+  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+    id: '/dashboard/account/making-payments',
+    path: '/dashboard/account/making-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
+  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+    id: '/$pubkey',
+    path: '/$pubkey',
+    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsNewRoute =
+  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute =
+  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+    id: '/$productId',
+    path: '/$productId',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute =
+  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-		id: '/$collectionId',
-		path: '/$collectionId',
-		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-	} as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-	id: '/$auctionId',
-	path: '/$auctionId',
-	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-} as any)
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+    id: '/$collectionId',
+    path: '/$collectionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+    id: '/$auctionId',
+    path: '/$auctionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions': typeof AuctionsIndexRoute
-	'/community': typeof CommunityIndexRoute
-	'/nostr': typeof NostrIndexRoute
-	'/posts': typeof PostsIndexRoute
-	'/products': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions': typeof AuctionsIndexRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/dashboard/about'
-		| '/dashboard/'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions'
-		| '/community'
-		| '/nostr'
-		| '/posts'
-		| '/products'
-		| '/dashboard/about'
-		| '/dashboard'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	id:
-		| '__root__'
-		| '/'
-		| '/$vanityName'
-		| '/_dashboard-layout'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/_dashboard-layout/dashboard/about'
-		| '/_dashboard-layout/dashboard/'
-		| '/_dashboard-layout/dashboard/account/making-payments'
-		| '/_dashboard-layout/dashboard/account/network'
-		| '/_dashboard-layout/dashboard/account/nostr-address'
-		| '/_dashboard-layout/dashboard/account/preferences'
-		| '/_dashboard-layout/dashboard/account/profile'
-		| '/_dashboard-layout/dashboard/account/receiving-payments'
-		| '/_dashboard-layout/dashboard/account/vanity-url'
-		| '/_dashboard-layout/dashboard/account/your-purchases'
-		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-		| '/_dashboard-layout/dashboard/app-settings/blacklists'
-		| '/_dashboard-layout/dashboard/app-settings/featured-items'
-		| '/_dashboard-layout/dashboard/app-settings/team'
-		| '/_dashboard-layout/dashboard/orders/$orderId'
-		| '/_dashboard-layout/dashboard/products/auctions'
-		| '/_dashboard-layout/dashboard/products/bids'
-		| '/_dashboard-layout/dashboard/products/collections'
-		| '/_dashboard-layout/dashboard/products/migration-tool'
-		| '/_dashboard-layout/dashboard/products/products'
-		| '/_dashboard-layout/dashboard/products/shipping-options'
-		| '/_dashboard-layout/dashboard/sales/circular-economy'
-		| '/_dashboard-layout/dashboard/sales/messages'
-		| '/_dashboard-layout/dashboard/sales/sales'
-		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
-		| '/_dashboard-layout/dashboard/products/collections/new'
-		| '/_dashboard-layout/dashboard/products/products/$productId'
-		| '/_dashboard-layout/dashboard/products/products/new'
-		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/dashboard/about'
+    | '/dashboard/'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  id:
+    | '__root__'
+    | '/'
+    | '/$vanityName'
+    | '/_dashboard-layout'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/_dashboard-layout/dashboard/about'
+    | '/_dashboard-layout/dashboard/'
+    | '/_dashboard-layout/dashboard/account/making-payments'
+    | '/_dashboard-layout/dashboard/account/network'
+    | '/_dashboard-layout/dashboard/account/nostr-address'
+    | '/_dashboard-layout/dashboard/account/preferences'
+    | '/_dashboard-layout/dashboard/account/profile'
+    | '/_dashboard-layout/dashboard/account/receiving-payments'
+    | '/_dashboard-layout/dashboard/account/vanity-url'
+    | '/_dashboard-layout/dashboard/account/your-purchases'
+    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+    | '/_dashboard-layout/dashboard/app-settings/blacklists'
+    | '/_dashboard-layout/dashboard/app-settings/featured-items'
+    | '/_dashboard-layout/dashboard/app-settings/team'
+    | '/_dashboard-layout/dashboard/orders/$orderId'
+    | '/_dashboard-layout/dashboard/products/auctions'
+    | '/_dashboard-layout/dashboard/products/bids'
+    | '/_dashboard-layout/dashboard/products/collections'
+    | '/_dashboard-layout/dashboard/products/migration-tool'
+    | '/_dashboard-layout/dashboard/products/products'
+    | '/_dashboard-layout/dashboard/products/shipping-options'
+    | '/_dashboard-layout/dashboard/sales/circular-economy'
+    | '/_dashboard-layout/dashboard/sales/messages'
+    | '/_dashboard-layout/dashboard/sales/sales'
+    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
+    | '/_dashboard-layout/dashboard/products/collections/new'
+    | '/_dashboard-layout/dashboard/products/products/$productId'
+    | '/_dashboard-layout/dashboard/products/products/new'
+    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	VanityNameRoute: typeof VanityNameRoute
-	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-	CheckoutRoute: typeof CheckoutRoute
-	SetupRoute: typeof SetupRoute
-	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-	PostsPostIdRoute: typeof PostsPostIdRoute
-	ProductsProductIdRoute: typeof ProductsProductIdRoute
-	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-	SearchProductsRoute: typeof SearchProductsRoute
-	AuctionsIndexRoute: typeof AuctionsIndexRoute
-	CommunityIndexRoute: typeof CommunityIndexRoute
-	NostrIndexRoute: typeof NostrIndexRoute
-	PostsIndexRoute: typeof PostsIndexRoute
-	ProductsIndexRoute: typeof ProductsIndexRoute
+  IndexRoute: typeof IndexRoute
+  VanityNameRoute: typeof VanityNameRoute
+  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+  CheckoutRoute: typeof CheckoutRoute
+  SetupRoute: typeof SetupRoute
+  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+  PostsPostIdRoute: typeof PostsPostIdRoute
+  ProductsProductIdRoute: typeof ProductsProductIdRoute
+  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+  SearchProductsRoute: typeof SearchProductsRoute
+  AuctionsIndexRoute: typeof AuctionsIndexRoute
+  CommunityIndexRoute: typeof CommunityIndexRoute
+  NostrIndexRoute: typeof NostrIndexRoute
+  PostsIndexRoute: typeof PostsIndexRoute
+  ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/setup': {
-			id: '/setup'
-			path: '/setup'
-			fullPath: '/setup'
-			preLoaderRoute: typeof SetupRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/checkout': {
-			id: '/checkout'
-			path: '/checkout'
-			fullPath: '/checkout'
-			preLoaderRoute: typeof CheckoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout': {
-			id: '/_dashboard-layout'
-			path: ''
-			fullPath: '/'
-			preLoaderRoute: typeof DashboardLayoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/$vanityName': {
-			id: '/$vanityName'
-			path: '/$vanityName'
-			fullPath: '/$vanityName'
-			preLoaderRoute: typeof VanityNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/': {
-			id: '/'
-			path: '/'
-			fullPath: '/'
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/': {
-			id: '/products/'
-			path: '/products'
-			fullPath: '/products/'
-			preLoaderRoute: typeof ProductsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/': {
-			id: '/posts/'
-			path: '/posts'
-			fullPath: '/posts/'
-			preLoaderRoute: typeof PostsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/nostr/': {
-			id: '/nostr/'
-			path: '/nostr'
-			fullPath: '/nostr/'
-			preLoaderRoute: typeof NostrIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/community/': {
-			id: '/community/'
-			path: '/community'
-			fullPath: '/community/'
-			preLoaderRoute: typeof CommunityIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/': {
-			id: '/auctions/'
-			path: '/auctions'
-			fullPath: '/auctions/'
-			preLoaderRoute: typeof AuctionsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/search/products': {
-			id: '/search/products'
-			path: '/search/products'
-			fullPath: '/search/products'
-			preLoaderRoute: typeof SearchProductsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/profile/$profileId': {
-			id: '/profile/$profileId'
-			path: '/profile/$profileId'
-			fullPath: '/profile/$profileId'
-			preLoaderRoute: typeof ProfileProfileIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/$productId': {
-			id: '/products/$productId'
-			path: '/products/$productId'
-			fullPath: '/products/$productId'
-			preLoaderRoute: typeof ProductsProductIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/$postId': {
-			id: '/posts/$postId'
-			path: '/posts/$postId'
-			fullPath: '/posts/$postId'
-			preLoaderRoute: typeof PostsPostIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/collection/$collectionId': {
-			id: '/collection/$collectionId'
-			path: '/collection/$collectionId'
-			fullPath: '/collection/$collectionId'
-			preLoaderRoute: typeof CollectionCollectionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/$auctionId': {
-			id: '/auctions/$auctionId'
-			path: '/auctions/$auctionId'
-			fullPath: '/auctions/$auctionId'
-			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout/dashboard/': {
-			id: '/_dashboard-layout/dashboard/'
-			path: '/dashboard'
-			fullPath: '/dashboard/'
-			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/about': {
-			id: '/_dashboard-layout/dashboard/about'
-			path: '/dashboard/about'
-			fullPath: '/dashboard/about'
-			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/sales': {
-			id: '/_dashboard-layout/dashboard/sales/sales'
-			path: '/dashboard/sales/sales'
-			fullPath: '/dashboard/sales/sales'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages': {
-			id: '/_dashboard-layout/dashboard/sales/messages'
-			path: '/dashboard/sales/messages'
-			fullPath: '/dashboard/sales/messages'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/circular-economy': {
-			id: '/_dashboard-layout/dashboard/sales/circular-economy'
-			path: '/dashboard/sales/circular-economy'
-			fullPath: '/dashboard/sales/circular-economy'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/shipping-options': {
-			id: '/_dashboard-layout/dashboard/products/shipping-options'
-			path: '/dashboard/products/shipping-options'
-			fullPath: '/dashboard/products/shipping-options'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/products': {
-			id: '/_dashboard-layout/dashboard/products/products'
-			path: '/dashboard/products/products'
-			fullPath: '/dashboard/products/products'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/migration-tool': {
-			id: '/_dashboard-layout/dashboard/products/migration-tool'
-			path: '/dashboard/products/migration-tool'
-			fullPath: '/dashboard/products/migration-tool'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections': {
-			id: '/_dashboard-layout/dashboard/products/collections'
-			path: '/dashboard/products/collections'
-			fullPath: '/dashboard/products/collections'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/bids': {
-			id: '/_dashboard-layout/dashboard/products/bids'
-			path: '/dashboard/products/bids'
-			fullPath: '/dashboard/products/bids'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions': {
-			id: '/_dashboard-layout/dashboard/products/auctions'
-			path: '/dashboard/products/auctions'
-			fullPath: '/dashboard/products/auctions'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/orders/$orderId': {
-			id: '/_dashboard-layout/dashboard/orders/$orderId'
-			path: '/dashboard/orders/$orderId'
-			fullPath: '/dashboard/orders/$orderId'
-			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/team': {
-			id: '/_dashboard-layout/dashboard/app-settings/team'
-			path: '/dashboard/app-settings/team'
-			fullPath: '/dashboard/app-settings/team'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/featured-items': {
-			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-			path: '/dashboard/app-settings/featured-items'
-			fullPath: '/dashboard/app-settings/featured-items'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/blacklists': {
-			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-			path: '/dashboard/app-settings/blacklists'
-			fullPath: '/dashboard/app-settings/blacklists'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-			path: '/dashboard/app-settings/app-miscelleneous'
-			fullPath: '/dashboard/app-settings/app-miscelleneous'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/your-purchases': {
-			id: '/_dashboard-layout/dashboard/account/your-purchases'
-			path: '/dashboard/account/your-purchases'
-			fullPath: '/dashboard/account/your-purchases'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/vanity-url': {
-			id: '/_dashboard-layout/dashboard/account/vanity-url'
-			path: '/dashboard/account/vanity-url'
-			fullPath: '/dashboard/account/vanity-url'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/receiving-payments': {
-			id: '/_dashboard-layout/dashboard/account/receiving-payments'
-			path: '/dashboard/account/receiving-payments'
-			fullPath: '/dashboard/account/receiving-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/profile': {
-			id: '/_dashboard-layout/dashboard/account/profile'
-			path: '/dashboard/account/profile'
-			fullPath: '/dashboard/account/profile'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/preferences': {
-			id: '/_dashboard-layout/dashboard/account/preferences'
-			path: '/dashboard/account/preferences'
-			fullPath: '/dashboard/account/preferences'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/nostr-address': {
-			id: '/_dashboard-layout/dashboard/account/nostr-address'
-			path: '/dashboard/account/nostr-address'
-			fullPath: '/dashboard/account/nostr-address'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/network': {
-			id: '/_dashboard-layout/dashboard/account/network'
-			path: '/dashboard/account/network'
-			fullPath: '/dashboard/account/network'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/making-payments': {
-			id: '/_dashboard-layout/dashboard/account/making-payments'
-			path: '/dashboard/account/making-payments'
-			fullPath: '/dashboard/account/making-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-			path: '/$pubkey'
-			fullPath: '/dashboard/sales/messages/$pubkey'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/new': {
-			id: '/_dashboard-layout/dashboard/products/products/new'
-			path: '/new'
-			fullPath: '/dashboard/products/products/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/$productId': {
-			id: '/_dashboard-layout/dashboard/products/products/$productId'
-			path: '/$productId'
-			fullPath: '/dashboard/products/products/$productId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/new': {
-			id: '/_dashboard-layout/dashboard/products/collections/new'
-			path: '/new'
-			fullPath: '/dashboard/products/collections/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
-			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-			path: '/$collectionId'
-			fullPath: '/dashboard/products/collections/$collectionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-			path: '/$auctionId'
-			fullPath: '/dashboard/products/auctions/$auctionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-		}
-	}
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/checkout': {
+      id: '/checkout'
+      path: '/checkout'
+      fullPath: '/checkout'
+      preLoaderRoute: typeof CheckoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout': {
+      id: '/_dashboard-layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DashboardLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$vanityName': {
+      id: '/$vanityName'
+      path: '/$vanityName'
+      fullPath: '/$vanityName'
+      preLoaderRoute: typeof VanityNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/': {
+      id: '/products/'
+      path: '/products'
+      fullPath: '/products/'
+      preLoaderRoute: typeof ProductsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/posts'
+      fullPath: '/posts/'
+      preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nostr/': {
+      id: '/nostr/'
+      path: '/nostr'
+      fullPath: '/nostr/'
+      preLoaderRoute: typeof NostrIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/community/': {
+      id: '/community/'
+      path: '/community'
+      fullPath: '/community/'
+      preLoaderRoute: typeof CommunityIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/': {
+      id: '/auctions/'
+      path: '/auctions'
+      fullPath: '/auctions/'
+      preLoaderRoute: typeof AuctionsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search/products': {
+      id: '/search/products'
+      path: '/search/products'
+      fullPath: '/search/products'
+      preLoaderRoute: typeof SearchProductsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile/$profileId': {
+      id: '/profile/$profileId'
+      path: '/profile/$profileId'
+      fullPath: '/profile/$profileId'
+      preLoaderRoute: typeof ProfileProfileIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/$productId': {
+      id: '/products/$productId'
+      path: '/products/$productId'
+      fullPath: '/products/$productId'
+      preLoaderRoute: typeof ProductsProductIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/posts/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collection/$collectionId': {
+      id: '/collection/$collectionId'
+      path: '/collection/$collectionId'
+      fullPath: '/collection/$collectionId'
+      preLoaderRoute: typeof CollectionCollectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/$auctionId': {
+      id: '/auctions/$auctionId'
+      path: '/auctions/$auctionId'
+      fullPath: '/auctions/$auctionId'
+      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout/dashboard/': {
+      id: '/_dashboard-layout/dashboard/'
+      path: '/dashboard'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/about': {
+      id: '/_dashboard-layout/dashboard/about'
+      path: '/dashboard/about'
+      fullPath: '/dashboard/about'
+      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/sales': {
+      id: '/_dashboard-layout/dashboard/sales/sales'
+      path: '/dashboard/sales/sales'
+      fullPath: '/dashboard/sales/sales'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages': {
+      id: '/_dashboard-layout/dashboard/sales/messages'
+      path: '/dashboard/sales/messages'
+      fullPath: '/dashboard/sales/messages'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/circular-economy': {
+      id: '/_dashboard-layout/dashboard/sales/circular-economy'
+      path: '/dashboard/sales/circular-economy'
+      fullPath: '/dashboard/sales/circular-economy'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/shipping-options': {
+      id: '/_dashboard-layout/dashboard/products/shipping-options'
+      path: '/dashboard/products/shipping-options'
+      fullPath: '/dashboard/products/shipping-options'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/products': {
+      id: '/_dashboard-layout/dashboard/products/products'
+      path: '/dashboard/products/products'
+      fullPath: '/dashboard/products/products'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/migration-tool': {
+      id: '/_dashboard-layout/dashboard/products/migration-tool'
+      path: '/dashboard/products/migration-tool'
+      fullPath: '/dashboard/products/migration-tool'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections': {
+      id: '/_dashboard-layout/dashboard/products/collections'
+      path: '/dashboard/products/collections'
+      fullPath: '/dashboard/products/collections'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/bids': {
+      id: '/_dashboard-layout/dashboard/products/bids'
+      path: '/dashboard/products/bids'
+      fullPath: '/dashboard/products/bids'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions': {
+      id: '/_dashboard-layout/dashboard/products/auctions'
+      path: '/dashboard/products/auctions'
+      fullPath: '/dashboard/products/auctions'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/orders/$orderId': {
+      id: '/_dashboard-layout/dashboard/orders/$orderId'
+      path: '/dashboard/orders/$orderId'
+      fullPath: '/dashboard/orders/$orderId'
+      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/team': {
+      id: '/_dashboard-layout/dashboard/app-settings/team'
+      path: '/dashboard/app-settings/team'
+      fullPath: '/dashboard/app-settings/team'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/featured-items': {
+      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+      path: '/dashboard/app-settings/featured-items'
+      fullPath: '/dashboard/app-settings/featured-items'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/blacklists': {
+      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+      path: '/dashboard/app-settings/blacklists'
+      fullPath: '/dashboard/app-settings/blacklists'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+      path: '/dashboard/app-settings/app-miscelleneous'
+      fullPath: '/dashboard/app-settings/app-miscelleneous'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/your-purchases': {
+      id: '/_dashboard-layout/dashboard/account/your-purchases'
+      path: '/dashboard/account/your-purchases'
+      fullPath: '/dashboard/account/your-purchases'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/vanity-url': {
+      id: '/_dashboard-layout/dashboard/account/vanity-url'
+      path: '/dashboard/account/vanity-url'
+      fullPath: '/dashboard/account/vanity-url'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/receiving-payments': {
+      id: '/_dashboard-layout/dashboard/account/receiving-payments'
+      path: '/dashboard/account/receiving-payments'
+      fullPath: '/dashboard/account/receiving-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/profile': {
+      id: '/_dashboard-layout/dashboard/account/profile'
+      path: '/dashboard/account/profile'
+      fullPath: '/dashboard/account/profile'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/preferences': {
+      id: '/_dashboard-layout/dashboard/account/preferences'
+      path: '/dashboard/account/preferences'
+      fullPath: '/dashboard/account/preferences'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/nostr-address': {
+      id: '/_dashboard-layout/dashboard/account/nostr-address'
+      path: '/dashboard/account/nostr-address'
+      fullPath: '/dashboard/account/nostr-address'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/network': {
+      id: '/_dashboard-layout/dashboard/account/network'
+      path: '/dashboard/account/network'
+      fullPath: '/dashboard/account/network'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/making-payments': {
+      id: '/_dashboard-layout/dashboard/account/making-payments'
+      path: '/dashboard/account/making-payments'
+      fullPath: '/dashboard/account/making-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+      path: '/$pubkey'
+      fullPath: '/dashboard/sales/messages/$pubkey'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/new': {
+      id: '/_dashboard-layout/dashboard/products/products/new'
+      path: '/new'
+      fullPath: '/dashboard/products/products/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/$productId': {
+      id: '/_dashboard-layout/dashboard/products/products/$productId'
+      path: '/$productId'
+      fullPath: '/dashboard/products/products/$productId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/new': {
+      id: '/_dashboard-layout/dashboard/products/collections/new'
+      path: '/new'
+      fullPath: '/dashboard/products/collections/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
+      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+      path: '/$collectionId'
+      fullPath: '/dashboard/products/collections/$collectionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+      path: '/$auctionId'
+      fullPath: '/dashboard/products/auctions/$auctionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+    }
+  }
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-}
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
+      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+  }
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsAuctionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
+  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsAuctionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
-}
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
+      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+    DashboardLayoutDashboardProductsCollectionsNewRoute:
+      DashboardLayoutDashboardProductsCollectionsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsCollectionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
+  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsCollectionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
-	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
-}
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsProductsProductIdRoute:
+      DashboardLayoutDashboardProductsProductsProductIdRoute,
+    DashboardLayoutDashboardProductsProductsNewRoute:
+      DashboardLayoutDashboardProductsProductsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsProductsRouteChildren,
-)
+const DashboardLayoutDashboardProductsProductsRouteWithChildren =
+  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsProductsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-}
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
+  {
+    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
+      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+  }
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-	DashboardLayoutDashboardSalesMessagesRouteChildren,
-)
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
+  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+    DashboardLayoutDashboardSalesMessagesRouteChildren,
+  )
 
 interface DashboardLayoutRouteChildren {
-	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
-	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
-	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
-	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
-	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
-	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
-	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
-	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
-	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
-	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
-	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
-	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
-	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
+  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+  DashboardLayoutDashboardAccountMakingPaymentsRoute:
+    DashboardLayoutDashboardAccountMakingPaymentsRoute,
+  DashboardLayoutDashboardAccountNetworkRoute:
+    DashboardLayoutDashboardAccountNetworkRoute,
+  DashboardLayoutDashboardAccountNostrAddressRoute:
+    DashboardLayoutDashboardAccountNostrAddressRoute,
+  DashboardLayoutDashboardAccountPreferencesRoute:
+    DashboardLayoutDashboardAccountPreferencesRoute,
+  DashboardLayoutDashboardAccountProfileRoute:
+    DashboardLayoutDashboardAccountProfileRoute,
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
+    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+  DashboardLayoutDashboardAccountVanityUrlRoute:
+    DashboardLayoutDashboardAccountVanityUrlRoute,
+  DashboardLayoutDashboardAccountYourPurchasesRoute:
+    DashboardLayoutDashboardAccountYourPurchasesRoute,
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
+    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
+    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
+    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+  DashboardLayoutDashboardAppSettingsTeamRoute:
+    DashboardLayoutDashboardAppSettingsTeamRoute,
+  DashboardLayoutDashboardOrdersOrderIdRoute:
+    DashboardLayoutDashboardOrdersOrderIdRoute,
+  DashboardLayoutDashboardProductsAuctionsRoute:
+    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+  DashboardLayoutDashboardProductsBidsRoute:
+    DashboardLayoutDashboardProductsBidsRoute,
+  DashboardLayoutDashboardProductsCollectionsRoute:
+    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+  DashboardLayoutDashboardProductsMigrationToolRoute:
+    DashboardLayoutDashboardProductsMigrationToolRoute,
+  DashboardLayoutDashboardProductsProductsRoute:
+    DashboardLayoutDashboardProductsProductsRouteWithChildren,
+  DashboardLayoutDashboardProductsShippingOptionsRoute:
+    DashboardLayoutDashboardProductsShippingOptionsRoute,
+  DashboardLayoutDashboardSalesCircularEconomyRoute:
+    DashboardLayoutDashboardSalesCircularEconomyRoute,
+  DashboardLayoutDashboardSalesMessagesRoute:
+    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+  DashboardLayoutDashboardSalesSalesRoute:
+    DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
+  DashboardLayoutRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	VanityNameRoute: VanityNameRoute,
-	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-	CheckoutRoute: CheckoutRoute,
-	SetupRoute: SetupRoute,
-	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-	PostsPostIdRoute: PostsPostIdRoute,
-	ProductsProductIdRoute: ProductsProductIdRoute,
-	ProfileProfileIdRoute: ProfileProfileIdRoute,
-	SearchProductsRoute: SearchProductsRoute,
-	AuctionsIndexRoute: AuctionsIndexRoute,
-	CommunityIndexRoute: CommunityIndexRoute,
-	NostrIndexRoute: NostrIndexRoute,
-	PostsIndexRoute: PostsIndexRoute,
-	ProductsIndexRoute: ProductsIndexRoute,
+  IndexRoute: IndexRoute,
+  VanityNameRoute: VanityNameRoute,
+  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+  CheckoutRoute: CheckoutRoute,
+  SetupRoute: SetupRoute,
+  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+  PostsPostIdRoute: PostsPostIdRoute,
+  ProductsProductIdRoute: ProductsProductIdRoute,
+  ProfileProfileIdRoute: ProfileProfileIdRoute,
+  SearchProductsRoute: SearchProductsRoute,
+  AuctionsIndexRoute: AuctionsIndexRoute,
+  CommunityIndexRoute: CommunityIndexRoute,
+  NostrIndexRoute: NostrIndexRoute,
+  PostsIndexRoute: PostsIndexRoute,
+  ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,1063 +57,994 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-  id: '/setup',
-  path: '/setup',
-  getParentRoute: () => rootRouteImport,
+	id: '/setup',
+	path: '/setup',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-  id: '/checkout',
-  path: '/checkout',
-  getParentRoute: () => rootRouteImport,
+	id: '/checkout',
+	path: '/checkout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-  id: '/_dashboard-layout',
-  getParentRoute: () => rootRouteImport,
+	id: '/_dashboard-layout',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-  id: '/$vanityName',
-  path: '/$vanityName',
-  getParentRoute: () => rootRouteImport,
+	id: '/$vanityName',
+	path: '/$vanityName',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => rootRouteImport,
+	id: '/',
+	path: '/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-  id: '/products/',
-  path: '/products/',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/',
+	path: '/products/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-  id: '/posts/',
-  path: '/posts/',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/',
+	path: '/posts/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-  id: '/nostr/',
-  path: '/nostr/',
-  getParentRoute: () => rootRouteImport,
+	id: '/nostr/',
+	path: '/nostr/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-  id: '/community/',
-  path: '/community/',
-  getParentRoute: () => rootRouteImport,
+	id: '/community/',
+	path: '/community/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-  id: '/auctions/',
-  path: '/auctions/',
-  getParentRoute: () => rootRouteImport,
+	id: '/auctions/',
+	path: '/auctions/',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-  id: '/search/products',
-  path: '/search/products',
-  getParentRoute: () => rootRouteImport,
+	id: '/search/products',
+	path: '/search/products',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-  id: '/profile/$profileId',
-  path: '/profile/$profileId',
-  getParentRoute: () => rootRouteImport,
+	id: '/profile/$profileId',
+	path: '/profile/$profileId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-  id: '/products/$productId',
-  path: '/products/$productId',
-  getParentRoute: () => rootRouteImport,
+	id: '/products/$productId',
+	path: '/products/$productId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-  id: '/posts/$postId',
-  path: '/posts/$postId',
-  getParentRoute: () => rootRouteImport,
+	id: '/posts/$postId',
+	path: '/posts/$postId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-  id: '/collection/$collectionId',
-  path: '/collection/$collectionId',
-  getParentRoute: () => rootRouteImport,
+	id: '/collection/$collectionId',
+	path: '/collection/$collectionId',
+	getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-  id: '/auctions/$auctionId',
-  path: '/auctions/$auctionId',
-  getParentRoute: () => rootRouteImport,
+	id: '/auctions/$auctionId',
+	path: '/auctions/$auctionId',
+	getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute =
-  DashboardLayoutDashboardIndexRouteImport.update({
-    id: '/dashboard/',
-    path: '/dashboard/',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAboutRoute =
-  DashboardLayoutDashboardAboutRouteImport.update({
-    id: '/dashboard/about',
-    path: '/dashboard/about',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesSalesRoute =
-  DashboardLayoutDashboardSalesSalesRouteImport.update({
-    id: '/dashboard/sales/sales',
-    path: '/dashboard/sales/sales',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesRoute =
-  DashboardLayoutDashboardSalesMessagesRouteImport.update({
-    id: '/dashboard/sales/messages',
-    path: '/dashboard/sales/messages',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute =
-  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-    id: '/dashboard/sales/circular-economy',
-    path: '/dashboard/sales/circular-economy',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute =
-  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-    id: '/dashboard/products/shipping-options',
-    path: '/dashboard/products/shipping-options',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsRoute =
-  DashboardLayoutDashboardProductsProductsRouteImport.update({
-    id: '/dashboard/products/products',
-    path: '/dashboard/products/products',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute =
-  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-    id: '/dashboard/products/migration-tool',
-    path: '/dashboard/products/migration-tool',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsRoute =
-  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-    id: '/dashboard/products/collections',
-    path: '/dashboard/products/collections',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsBidsRoute =
-  DashboardLayoutDashboardProductsBidsRouteImport.update({
-    id: '/dashboard/products/bids',
-    path: '/dashboard/products/bids',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardProductsAuctionsRoute =
-  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-    id: '/dashboard/products/auctions',
-    path: '/dashboard/products/auctions',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute =
-  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-    id: '/dashboard/orders/$orderId',
-    path: '/dashboard/orders/$orderId',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute =
-  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-    id: '/dashboard/app-settings/team',
-    path: '/dashboard/app-settings/team',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-    id: '/dashboard/app-settings/featured-items',
-    path: '/dashboard/app-settings/featured-items',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
-  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-    id: '/dashboard/app-settings/blacklists',
-    path: '/dashboard/app-settings/blacklists',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-    id: '/dashboard/app-settings/app-miscelleneous',
-    path: '/dashboard/app-settings/app-miscelleneous',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute =
-  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-    id: '/dashboard/account/your-purchases',
-    path: '/dashboard/account/your-purchases',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute =
-  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-    id: '/dashboard/account/vanity-url',
-    path: '/dashboard/account/vanity-url',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
-  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-    id: '/dashboard/account/receiving-payments',
-    path: '/dashboard/account/receiving-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountProfileRoute =
-  DashboardLayoutDashboardAccountProfileRouteImport.update({
-    id: '/dashboard/account/profile',
-    path: '/dashboard/account/profile',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountPreferencesRoute =
-  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-    id: '/dashboard/account/preferences',
-    path: '/dashboard/account/preferences',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute =
-  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-    id: '/dashboard/account/nostr-address',
-    path: '/dashboard/account/nostr-address',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountNetworkRoute =
-  DashboardLayoutDashboardAccountNetworkRouteImport.update({
-    id: '/dashboard/account/network',
-    path: '/dashboard/account/network',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute =
-  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-    id: '/dashboard/account/making-payments',
-    path: '/dashboard/account/making-payments',
-    getParentRoute: () => DashboardLayoutRoute,
-  } as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
-  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-    id: '/$pubkey',
-    path: '/$pubkey',
-    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsNewRoute =
-  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute =
-  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-    id: '/$productId',
-    path: '/$productId',
-    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute =
-  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-    id: '/new',
-    path: '/new',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
+const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
+	id: '/dashboard/',
+	path: '/dashboard/',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
+	id: '/dashboard/about',
+	path: '/dashboard/about',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
+	id: '/dashboard/sales/sales',
+	path: '/dashboard/sales/sales',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
+	id: '/dashboard/sales/messages',
+	path: '/dashboard/sales/messages',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+	id: '/dashboard/sales/circular-economy',
+	path: '/dashboard/sales/circular-economy',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+	id: '/dashboard/products/shipping-options',
+	path: '/dashboard/products/shipping-options',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
+	id: '/dashboard/products/products',
+	path: '/dashboard/products/products',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+	id: '/dashboard/products/migration-tool',
+	path: '/dashboard/products/migration-tool',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+	id: '/dashboard/products/collections',
+	path: '/dashboard/products/collections',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
+	id: '/dashboard/products/bids',
+	path: '/dashboard/products/bids',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+	id: '/dashboard/products/auctions',
+	path: '/dashboard/products/auctions',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+	id: '/dashboard/orders/$orderId',
+	path: '/dashboard/orders/$orderId',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+	id: '/dashboard/app-settings/team',
+	path: '/dashboard/app-settings/team',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+	id: '/dashboard/app-settings/featured-items',
+	path: '/dashboard/app-settings/featured-items',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+	id: '/dashboard/app-settings/blacklists',
+	path: '/dashboard/app-settings/blacklists',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+	id: '/dashboard/app-settings/app-miscelleneous',
+	path: '/dashboard/app-settings/app-miscelleneous',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+	id: '/dashboard/account/your-purchases',
+	path: '/dashboard/account/your-purchases',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+	id: '/dashboard/account/vanity-url',
+	path: '/dashboard/account/vanity-url',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+	id: '/dashboard/account/receiving-payments',
+	path: '/dashboard/account/receiving-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
+	id: '/dashboard/account/profile',
+	path: '/dashboard/account/profile',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+	id: '/dashboard/account/preferences',
+	path: '/dashboard/account/preferences',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+	id: '/dashboard/account/nostr-address',
+	path: '/dashboard/account/nostr-address',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
+	id: '/dashboard/account/network',
+	path: '/dashboard/account/network',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+	id: '/dashboard/account/making-payments',
+	path: '/dashboard/account/making-payments',
+	getParentRoute: () => DashboardLayoutRoute,
+} as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+	id: '/$pubkey',
+	path: '/$pubkey',
+	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+	id: '/$productId',
+	path: '/$productId',
+	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+} as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+	id: '/new',
+	path: '/new',
+	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+} as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-    id: '/$collectionId',
-    path: '/$collectionId',
-    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-  } as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
-  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-    id: '/$auctionId',
-    path: '/$auctionId',
-    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-  } as any)
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+		id: '/$collectionId',
+		path: '/$collectionId',
+		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+	} as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+	id: '/$auctionId',
+	path: '/$auctionId',
+	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions/': typeof AuctionsIndexRoute
-  '/community/': typeof CommunityIndexRoute
-  '/nostr/': typeof NostrIndexRoute
-  '/posts/': typeof PostsIndexRoute
-  '/products/': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions/': typeof AuctionsIndexRoute
+	'/community/': typeof CommunityIndexRoute
+	'/nostr/': typeof NostrIndexRoute
+	'/posts/': typeof PostsIndexRoute
+	'/products/': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions': typeof AuctionsIndexRoute
-  '/community': typeof CommunityIndexRoute
-  '/nostr': typeof NostrIndexRoute
-  '/posts': typeof PostsIndexRoute
-  '/products': typeof ProductsIndexRoute
-  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
-  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions': typeof AuctionsIndexRoute
+	'/community': typeof CommunityIndexRoute
+	'/nostr': typeof NostrIndexRoute
+	'/posts': typeof PostsIndexRoute
+	'/products': typeof ProductsIndexRoute
+	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
+	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/$vanityName': typeof VanityNameRoute
-  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-  '/checkout': typeof CheckoutRoute
-  '/setup': typeof SetupRoute
-  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-  '/collection/$collectionId': typeof CollectionCollectionIdRoute
-  '/posts/$postId': typeof PostsPostIdRoute
-  '/products/$productId': typeof ProductsProductIdRoute
-  '/profile/$profileId': typeof ProfileProfileIdRoute
-  '/search/products': typeof SearchProductsRoute
-  '/auctions/': typeof AuctionsIndexRoute
-  '/community/': typeof CommunityIndexRoute
-  '/nostr/': typeof NostrIndexRoute
-  '/posts/': typeof PostsIndexRoute
-  '/products/': typeof ProductsIndexRoute
-  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	__root__: typeof rootRouteImport
+	'/': typeof IndexRoute
+	'/$vanityName': typeof VanityNameRoute
+	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+	'/checkout': typeof CheckoutRoute
+	'/setup': typeof SetupRoute
+	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+	'/collection/$collectionId': typeof CollectionCollectionIdRoute
+	'/posts/$postId': typeof PostsPostIdRoute
+	'/products/$productId': typeof ProductsProductIdRoute
+	'/profile/$profileId': typeof ProfileProfileIdRoute
+	'/search/products': typeof SearchProductsRoute
+	'/auctions/': typeof AuctionsIndexRoute
+	'/community/': typeof CommunityIndexRoute
+	'/nostr/': typeof NostrIndexRoute
+	'/posts/': typeof PostsIndexRoute
+	'/products/': typeof ProductsIndexRoute
+	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions/'
-    | '/community/'
-    | '/nostr/'
-    | '/posts/'
-    | '/products/'
-    | '/dashboard/about'
-    | '/dashboard/'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/auctions'
-    | '/dashboard/products/bids'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/auctions/$auctionId'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/$vanityName'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions'
-    | '/community'
-    | '/nostr'
-    | '/posts'
-    | '/products'
-    | '/dashboard/about'
-    | '/dashboard'
-    | '/dashboard/account/making-payments'
-    | '/dashboard/account/network'
-    | '/dashboard/account/nostr-address'
-    | '/dashboard/account/preferences'
-    | '/dashboard/account/profile'
-    | '/dashboard/account/receiving-payments'
-    | '/dashboard/account/vanity-url'
-    | '/dashboard/account/your-purchases'
-    | '/dashboard/app-settings/app-miscelleneous'
-    | '/dashboard/app-settings/blacklists'
-    | '/dashboard/app-settings/featured-items'
-    | '/dashboard/app-settings/team'
-    | '/dashboard/orders/$orderId'
-    | '/dashboard/products/auctions'
-    | '/dashboard/products/bids'
-    | '/dashboard/products/collections'
-    | '/dashboard/products/migration-tool'
-    | '/dashboard/products/products'
-    | '/dashboard/products/shipping-options'
-    | '/dashboard/sales/circular-economy'
-    | '/dashboard/sales/messages'
-    | '/dashboard/sales/sales'
-    | '/dashboard/products/auctions/$auctionId'
-    | '/dashboard/products/collections/$collectionId'
-    | '/dashboard/products/collections/new'
-    | '/dashboard/products/products/$productId'
-    | '/dashboard/products/products/new'
-    | '/dashboard/sales/messages/$pubkey'
-  id:
-    | '__root__'
-    | '/'
-    | '/$vanityName'
-    | '/_dashboard-layout'
-    | '/checkout'
-    | '/setup'
-    | '/auctions/$auctionId'
-    | '/collection/$collectionId'
-    | '/posts/$postId'
-    | '/products/$productId'
-    | '/profile/$profileId'
-    | '/search/products'
-    | '/auctions/'
-    | '/community/'
-    | '/nostr/'
-    | '/posts/'
-    | '/products/'
-    | '/_dashboard-layout/dashboard/about'
-    | '/_dashboard-layout/dashboard/'
-    | '/_dashboard-layout/dashboard/account/making-payments'
-    | '/_dashboard-layout/dashboard/account/network'
-    | '/_dashboard-layout/dashboard/account/nostr-address'
-    | '/_dashboard-layout/dashboard/account/preferences'
-    | '/_dashboard-layout/dashboard/account/profile'
-    | '/_dashboard-layout/dashboard/account/receiving-payments'
-    | '/_dashboard-layout/dashboard/account/vanity-url'
-    | '/_dashboard-layout/dashboard/account/your-purchases'
-    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-    | '/_dashboard-layout/dashboard/app-settings/blacklists'
-    | '/_dashboard-layout/dashboard/app-settings/featured-items'
-    | '/_dashboard-layout/dashboard/app-settings/team'
-    | '/_dashboard-layout/dashboard/orders/$orderId'
-    | '/_dashboard-layout/dashboard/products/auctions'
-    | '/_dashboard-layout/dashboard/products/bids'
-    | '/_dashboard-layout/dashboard/products/collections'
-    | '/_dashboard-layout/dashboard/products/migration-tool'
-    | '/_dashboard-layout/dashboard/products/products'
-    | '/_dashboard-layout/dashboard/products/shipping-options'
-    | '/_dashboard-layout/dashboard/sales/circular-economy'
-    | '/_dashboard-layout/dashboard/sales/messages'
-    | '/_dashboard-layout/dashboard/sales/sales'
-    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
-    | '/_dashboard-layout/dashboard/products/collections/new'
-    | '/_dashboard-layout/dashboard/products/products/$productId'
-    | '/_dashboard-layout/dashboard/products/products/new'
-    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-  fileRoutesById: FileRoutesById
+	fileRoutesByFullPath: FileRoutesByFullPath
+	fullPaths:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions/'
+		| '/community/'
+		| '/nostr/'
+		| '/posts/'
+		| '/products/'
+		| '/dashboard/about'
+		| '/dashboard/'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/auctions'
+		| '/dashboard/products/bids'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/auctions/$auctionId'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	fileRoutesByTo: FileRoutesByTo
+	to:
+		| '/'
+		| '/$vanityName'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions'
+		| '/community'
+		| '/nostr'
+		| '/posts'
+		| '/products'
+		| '/dashboard/about'
+		| '/dashboard'
+		| '/dashboard/account/making-payments'
+		| '/dashboard/account/network'
+		| '/dashboard/account/nostr-address'
+		| '/dashboard/account/preferences'
+		| '/dashboard/account/profile'
+		| '/dashboard/account/receiving-payments'
+		| '/dashboard/account/vanity-url'
+		| '/dashboard/account/your-purchases'
+		| '/dashboard/app-settings/app-miscelleneous'
+		| '/dashboard/app-settings/blacklists'
+		| '/dashboard/app-settings/featured-items'
+		| '/dashboard/app-settings/team'
+		| '/dashboard/orders/$orderId'
+		| '/dashboard/products/auctions'
+		| '/dashboard/products/bids'
+		| '/dashboard/products/collections'
+		| '/dashboard/products/migration-tool'
+		| '/dashboard/products/products'
+		| '/dashboard/products/shipping-options'
+		| '/dashboard/sales/circular-economy'
+		| '/dashboard/sales/messages'
+		| '/dashboard/sales/sales'
+		| '/dashboard/products/auctions/$auctionId'
+		| '/dashboard/products/collections/$collectionId'
+		| '/dashboard/products/collections/new'
+		| '/dashboard/products/products/$productId'
+		| '/dashboard/products/products/new'
+		| '/dashboard/sales/messages/$pubkey'
+	id:
+		| '__root__'
+		| '/'
+		| '/$vanityName'
+		| '/_dashboard-layout'
+		| '/checkout'
+		| '/setup'
+		| '/auctions/$auctionId'
+		| '/collection/$collectionId'
+		| '/posts/$postId'
+		| '/products/$productId'
+		| '/profile/$profileId'
+		| '/search/products'
+		| '/auctions/'
+		| '/community/'
+		| '/nostr/'
+		| '/posts/'
+		| '/products/'
+		| '/_dashboard-layout/dashboard/about'
+		| '/_dashboard-layout/dashboard/'
+		| '/_dashboard-layout/dashboard/account/making-payments'
+		| '/_dashboard-layout/dashboard/account/network'
+		| '/_dashboard-layout/dashboard/account/nostr-address'
+		| '/_dashboard-layout/dashboard/account/preferences'
+		| '/_dashboard-layout/dashboard/account/profile'
+		| '/_dashboard-layout/dashboard/account/receiving-payments'
+		| '/_dashboard-layout/dashboard/account/vanity-url'
+		| '/_dashboard-layout/dashboard/account/your-purchases'
+		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+		| '/_dashboard-layout/dashboard/app-settings/blacklists'
+		| '/_dashboard-layout/dashboard/app-settings/featured-items'
+		| '/_dashboard-layout/dashboard/app-settings/team'
+		| '/_dashboard-layout/dashboard/orders/$orderId'
+		| '/_dashboard-layout/dashboard/products/auctions'
+		| '/_dashboard-layout/dashboard/products/bids'
+		| '/_dashboard-layout/dashboard/products/collections'
+		| '/_dashboard-layout/dashboard/products/migration-tool'
+		| '/_dashboard-layout/dashboard/products/products'
+		| '/_dashboard-layout/dashboard/products/shipping-options'
+		| '/_dashboard-layout/dashboard/sales/circular-economy'
+		| '/_dashboard-layout/dashboard/sales/messages'
+		| '/_dashboard-layout/dashboard/sales/sales'
+		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
+		| '/_dashboard-layout/dashboard/products/collections/new'
+		| '/_dashboard-layout/dashboard/products/products/$productId'
+		| '/_dashboard-layout/dashboard/products/products/new'
+		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+	fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  VanityNameRoute: typeof VanityNameRoute
-  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-  CheckoutRoute: typeof CheckoutRoute
-  SetupRoute: typeof SetupRoute
-  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-  PostsPostIdRoute: typeof PostsPostIdRoute
-  ProductsProductIdRoute: typeof ProductsProductIdRoute
-  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-  SearchProductsRoute: typeof SearchProductsRoute
-  AuctionsIndexRoute: typeof AuctionsIndexRoute
-  CommunityIndexRoute: typeof CommunityIndexRoute
-  NostrIndexRoute: typeof NostrIndexRoute
-  PostsIndexRoute: typeof PostsIndexRoute
-  ProductsIndexRoute: typeof ProductsIndexRoute
+	IndexRoute: typeof IndexRoute
+	VanityNameRoute: typeof VanityNameRoute
+	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+	CheckoutRoute: typeof CheckoutRoute
+	SetupRoute: typeof SetupRoute
+	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+	PostsPostIdRoute: typeof PostsPostIdRoute
+	ProductsProductIdRoute: typeof ProductsProductIdRoute
+	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+	SearchProductsRoute: typeof SearchProductsRoute
+	AuctionsIndexRoute: typeof AuctionsIndexRoute
+	CommunityIndexRoute: typeof CommunityIndexRoute
+	NostrIndexRoute: typeof NostrIndexRoute
+	PostsIndexRoute: typeof PostsIndexRoute
+	ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/setup': {
-      id: '/setup'
-      path: '/setup'
-      fullPath: '/setup'
-      preLoaderRoute: typeof SetupRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/checkout': {
-      id: '/checkout'
-      path: '/checkout'
-      fullPath: '/checkout'
-      preLoaderRoute: typeof CheckoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout': {
-      id: '/_dashboard-layout'
-      path: ''
-      fullPath: '/'
-      preLoaderRoute: typeof DashboardLayoutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/$vanityName': {
-      id: '/$vanityName'
-      path: '/$vanityName'
-      fullPath: '/$vanityName'
-      preLoaderRoute: typeof VanityNameRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/': {
-      id: '/products/'
-      path: '/products'
-      fullPath: '/products/'
-      preLoaderRoute: typeof ProductsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/': {
-      id: '/posts/'
-      path: '/posts'
-      fullPath: '/posts/'
-      preLoaderRoute: typeof PostsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/nostr/': {
-      id: '/nostr/'
-      path: '/nostr'
-      fullPath: '/nostr/'
-      preLoaderRoute: typeof NostrIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/community/': {
-      id: '/community/'
-      path: '/community'
-      fullPath: '/community/'
-      preLoaderRoute: typeof CommunityIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auctions/': {
-      id: '/auctions/'
-      path: '/auctions'
-      fullPath: '/auctions/'
-      preLoaderRoute: typeof AuctionsIndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/search/products': {
-      id: '/search/products'
-      path: '/search/products'
-      fullPath: '/search/products'
-      preLoaderRoute: typeof SearchProductsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/profile/$profileId': {
-      id: '/profile/$profileId'
-      path: '/profile/$profileId'
-      fullPath: '/profile/$profileId'
-      preLoaderRoute: typeof ProfileProfileIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/products/$productId': {
-      id: '/products/$productId'
-      path: '/products/$productId'
-      fullPath: '/products/$productId'
-      preLoaderRoute: typeof ProductsProductIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/posts/$postId': {
-      id: '/posts/$postId'
-      path: '/posts/$postId'
-      fullPath: '/posts/$postId'
-      preLoaderRoute: typeof PostsPostIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/collection/$collectionId': {
-      id: '/collection/$collectionId'
-      path: '/collection/$collectionId'
-      fullPath: '/collection/$collectionId'
-      preLoaderRoute: typeof CollectionCollectionIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/auctions/$auctionId': {
-      id: '/auctions/$auctionId'
-      path: '/auctions/$auctionId'
-      fullPath: '/auctions/$auctionId'
-      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/_dashboard-layout/dashboard/': {
-      id: '/_dashboard-layout/dashboard/'
-      path: '/dashboard'
-      fullPath: '/dashboard/'
-      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/about': {
-      id: '/_dashboard-layout/dashboard/about'
-      path: '/dashboard/about'
-      fullPath: '/dashboard/about'
-      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/sales': {
-      id: '/_dashboard-layout/dashboard/sales/sales'
-      path: '/dashboard/sales/sales'
-      fullPath: '/dashboard/sales/sales'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages': {
-      id: '/_dashboard-layout/dashboard/sales/messages'
-      path: '/dashboard/sales/messages'
-      fullPath: '/dashboard/sales/messages'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/circular-economy': {
-      id: '/_dashboard-layout/dashboard/sales/circular-economy'
-      path: '/dashboard/sales/circular-economy'
-      fullPath: '/dashboard/sales/circular-economy'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/shipping-options': {
-      id: '/_dashboard-layout/dashboard/products/shipping-options'
-      path: '/dashboard/products/shipping-options'
-      fullPath: '/dashboard/products/shipping-options'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/products': {
-      id: '/_dashboard-layout/dashboard/products/products'
-      path: '/dashboard/products/products'
-      fullPath: '/dashboard/products/products'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/migration-tool': {
-      id: '/_dashboard-layout/dashboard/products/migration-tool'
-      path: '/dashboard/products/migration-tool'
-      fullPath: '/dashboard/products/migration-tool'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections': {
-      id: '/_dashboard-layout/dashboard/products/collections'
-      path: '/dashboard/products/collections'
-      fullPath: '/dashboard/products/collections'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/bids': {
-      id: '/_dashboard-layout/dashboard/products/bids'
-      path: '/dashboard/products/bids'
-      fullPath: '/dashboard/products/bids'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/products/auctions': {
-      id: '/_dashboard-layout/dashboard/products/auctions'
-      path: '/dashboard/products/auctions'
-      fullPath: '/dashboard/products/auctions'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/orders/$orderId': {
-      id: '/_dashboard-layout/dashboard/orders/$orderId'
-      path: '/dashboard/orders/$orderId'
-      fullPath: '/dashboard/orders/$orderId'
-      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/team': {
-      id: '/_dashboard-layout/dashboard/app-settings/team'
-      path: '/dashboard/app-settings/team'
-      fullPath: '/dashboard/app-settings/team'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/featured-items': {
-      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-      path: '/dashboard/app-settings/featured-items'
-      fullPath: '/dashboard/app-settings/featured-items'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/blacklists': {
-      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-      path: '/dashboard/app-settings/blacklists'
-      fullPath: '/dashboard/app-settings/blacklists'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-      path: '/dashboard/app-settings/app-miscelleneous'
-      fullPath: '/dashboard/app-settings/app-miscelleneous'
-      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/your-purchases': {
-      id: '/_dashboard-layout/dashboard/account/your-purchases'
-      path: '/dashboard/account/your-purchases'
-      fullPath: '/dashboard/account/your-purchases'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/vanity-url': {
-      id: '/_dashboard-layout/dashboard/account/vanity-url'
-      path: '/dashboard/account/vanity-url'
-      fullPath: '/dashboard/account/vanity-url'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/receiving-payments': {
-      id: '/_dashboard-layout/dashboard/account/receiving-payments'
-      path: '/dashboard/account/receiving-payments'
-      fullPath: '/dashboard/account/receiving-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/profile': {
-      id: '/_dashboard-layout/dashboard/account/profile'
-      path: '/dashboard/account/profile'
-      fullPath: '/dashboard/account/profile'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/preferences': {
-      id: '/_dashboard-layout/dashboard/account/preferences'
-      path: '/dashboard/account/preferences'
-      fullPath: '/dashboard/account/preferences'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/nostr-address': {
-      id: '/_dashboard-layout/dashboard/account/nostr-address'
-      path: '/dashboard/account/nostr-address'
-      fullPath: '/dashboard/account/nostr-address'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/network': {
-      id: '/_dashboard-layout/dashboard/account/network'
-      path: '/dashboard/account/network'
-      fullPath: '/dashboard/account/network'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/account/making-payments': {
-      id: '/_dashboard-layout/dashboard/account/making-payments'
-      path: '/dashboard/account/making-payments'
-      fullPath: '/dashboard/account/making-payments'
-      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-      parentRoute: typeof DashboardLayoutRoute
-    }
-    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-      path: '/$pubkey'
-      fullPath: '/dashboard/sales/messages/$pubkey'
-      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/new': {
-      id: '/_dashboard-layout/dashboard/products/products/new'
-      path: '/new'
-      fullPath: '/dashboard/products/products/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/products/$productId': {
-      id: '/_dashboard-layout/dashboard/products/products/$productId'
-      path: '/$productId'
-      fullPath: '/dashboard/products/products/$productId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/new': {
-      id: '/_dashboard-layout/dashboard/products/collections/new'
-      path: '/new'
-      fullPath: '/dashboard/products/collections/new'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
-      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-      path: '/$collectionId'
-      fullPath: '/dashboard/products/collections/$collectionId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-    }
-    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-      path: '/$auctionId'
-      fullPath: '/dashboard/products/auctions/$auctionId'
-      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-    }
-  }
+	interface FileRoutesByPath {
+		'/setup': {
+			id: '/setup'
+			path: '/setup'
+			fullPath: '/setup'
+			preLoaderRoute: typeof SetupRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/checkout': {
+			id: '/checkout'
+			path: '/checkout'
+			fullPath: '/checkout'
+			preLoaderRoute: typeof CheckoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout': {
+			id: '/_dashboard-layout'
+			path: ''
+			fullPath: '/'
+			preLoaderRoute: typeof DashboardLayoutRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/$vanityName': {
+			id: '/$vanityName'
+			path: '/$vanityName'
+			fullPath: '/$vanityName'
+			preLoaderRoute: typeof VanityNameRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/': {
+			id: '/'
+			path: '/'
+			fullPath: '/'
+			preLoaderRoute: typeof IndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/': {
+			id: '/products/'
+			path: '/products'
+			fullPath: '/products/'
+			preLoaderRoute: typeof ProductsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/': {
+			id: '/posts/'
+			path: '/posts'
+			fullPath: '/posts/'
+			preLoaderRoute: typeof PostsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/nostr/': {
+			id: '/nostr/'
+			path: '/nostr'
+			fullPath: '/nostr/'
+			preLoaderRoute: typeof NostrIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/community/': {
+			id: '/community/'
+			path: '/community'
+			fullPath: '/community/'
+			preLoaderRoute: typeof CommunityIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/auctions/': {
+			id: '/auctions/'
+			path: '/auctions'
+			fullPath: '/auctions/'
+			preLoaderRoute: typeof AuctionsIndexRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/search/products': {
+			id: '/search/products'
+			path: '/search/products'
+			fullPath: '/search/products'
+			preLoaderRoute: typeof SearchProductsRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/profile/$profileId': {
+			id: '/profile/$profileId'
+			path: '/profile/$profileId'
+			fullPath: '/profile/$profileId'
+			preLoaderRoute: typeof ProfileProfileIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/products/$productId': {
+			id: '/products/$productId'
+			path: '/products/$productId'
+			fullPath: '/products/$productId'
+			preLoaderRoute: typeof ProductsProductIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/posts/$postId': {
+			id: '/posts/$postId'
+			path: '/posts/$postId'
+			fullPath: '/posts/$postId'
+			preLoaderRoute: typeof PostsPostIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/collection/$collectionId': {
+			id: '/collection/$collectionId'
+			path: '/collection/$collectionId'
+			fullPath: '/collection/$collectionId'
+			preLoaderRoute: typeof CollectionCollectionIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/auctions/$auctionId': {
+			id: '/auctions/$auctionId'
+			path: '/auctions/$auctionId'
+			fullPath: '/auctions/$auctionId'
+			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+			parentRoute: typeof rootRouteImport
+		}
+		'/_dashboard-layout/dashboard/': {
+			id: '/_dashboard-layout/dashboard/'
+			path: '/dashboard'
+			fullPath: '/dashboard/'
+			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/about': {
+			id: '/_dashboard-layout/dashboard/about'
+			path: '/dashboard/about'
+			fullPath: '/dashboard/about'
+			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/sales': {
+			id: '/_dashboard-layout/dashboard/sales/sales'
+			path: '/dashboard/sales/sales'
+			fullPath: '/dashboard/sales/sales'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages': {
+			id: '/_dashboard-layout/dashboard/sales/messages'
+			path: '/dashboard/sales/messages'
+			fullPath: '/dashboard/sales/messages'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/circular-economy': {
+			id: '/_dashboard-layout/dashboard/sales/circular-economy'
+			path: '/dashboard/sales/circular-economy'
+			fullPath: '/dashboard/sales/circular-economy'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/shipping-options': {
+			id: '/_dashboard-layout/dashboard/products/shipping-options'
+			path: '/dashboard/products/shipping-options'
+			fullPath: '/dashboard/products/shipping-options'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/products': {
+			id: '/_dashboard-layout/dashboard/products/products'
+			path: '/dashboard/products/products'
+			fullPath: '/dashboard/products/products'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/migration-tool': {
+			id: '/_dashboard-layout/dashboard/products/migration-tool'
+			path: '/dashboard/products/migration-tool'
+			fullPath: '/dashboard/products/migration-tool'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections': {
+			id: '/_dashboard-layout/dashboard/products/collections'
+			path: '/dashboard/products/collections'
+			fullPath: '/dashboard/products/collections'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/bids': {
+			id: '/_dashboard-layout/dashboard/products/bids'
+			path: '/dashboard/products/bids'
+			fullPath: '/dashboard/products/bids'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/products/auctions': {
+			id: '/_dashboard-layout/dashboard/products/auctions'
+			path: '/dashboard/products/auctions'
+			fullPath: '/dashboard/products/auctions'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/orders/$orderId': {
+			id: '/_dashboard-layout/dashboard/orders/$orderId'
+			path: '/dashboard/orders/$orderId'
+			fullPath: '/dashboard/orders/$orderId'
+			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/team': {
+			id: '/_dashboard-layout/dashboard/app-settings/team'
+			path: '/dashboard/app-settings/team'
+			fullPath: '/dashboard/app-settings/team'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/featured-items': {
+			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+			path: '/dashboard/app-settings/featured-items'
+			fullPath: '/dashboard/app-settings/featured-items'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/blacklists': {
+			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+			path: '/dashboard/app-settings/blacklists'
+			fullPath: '/dashboard/app-settings/blacklists'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+			path: '/dashboard/app-settings/app-miscelleneous'
+			fullPath: '/dashboard/app-settings/app-miscelleneous'
+			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/your-purchases': {
+			id: '/_dashboard-layout/dashboard/account/your-purchases'
+			path: '/dashboard/account/your-purchases'
+			fullPath: '/dashboard/account/your-purchases'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/vanity-url': {
+			id: '/_dashboard-layout/dashboard/account/vanity-url'
+			path: '/dashboard/account/vanity-url'
+			fullPath: '/dashboard/account/vanity-url'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/receiving-payments': {
+			id: '/_dashboard-layout/dashboard/account/receiving-payments'
+			path: '/dashboard/account/receiving-payments'
+			fullPath: '/dashboard/account/receiving-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/profile': {
+			id: '/_dashboard-layout/dashboard/account/profile'
+			path: '/dashboard/account/profile'
+			fullPath: '/dashboard/account/profile'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/preferences': {
+			id: '/_dashboard-layout/dashboard/account/preferences'
+			path: '/dashboard/account/preferences'
+			fullPath: '/dashboard/account/preferences'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/nostr-address': {
+			id: '/_dashboard-layout/dashboard/account/nostr-address'
+			path: '/dashboard/account/nostr-address'
+			fullPath: '/dashboard/account/nostr-address'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/network': {
+			id: '/_dashboard-layout/dashboard/account/network'
+			path: '/dashboard/account/network'
+			fullPath: '/dashboard/account/network'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/account/making-payments': {
+			id: '/_dashboard-layout/dashboard/account/making-payments'
+			path: '/dashboard/account/making-payments'
+			fullPath: '/dashboard/account/making-payments'
+			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+			parentRoute: typeof DashboardLayoutRoute
+		}
+		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+			path: '/$pubkey'
+			fullPath: '/dashboard/sales/messages/$pubkey'
+			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/new': {
+			id: '/_dashboard-layout/dashboard/products/products/new'
+			path: '/new'
+			fullPath: '/dashboard/products/products/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/products/$productId': {
+			id: '/_dashboard-layout/dashboard/products/products/$productId'
+			path: '/$productId'
+			fullPath: '/dashboard/products/products/$productId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/new': {
+			id: '/_dashboard-layout/dashboard/products/collections/new'
+			path: '/new'
+			fullPath: '/dashboard/products/collections/new'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
+			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+			path: '/$collectionId'
+			fullPath: '/dashboard/products/collections/$collectionId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+		}
+		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+			path: '/$auctionId'
+			fullPath: '/dashboard/products/auctions/$auctionId'
+			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+		}
+	}
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
-      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-  }
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
+	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+}
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
-  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsAuctionsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsAuctionsRouteChildren,
+)
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
-      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-    DashboardLayoutDashboardProductsCollectionsNewRoute:
-      DashboardLayoutDashboardProductsCollectionsNewRoute,
-  }
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
+	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
-  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsCollectionsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsCollectionsRouteChildren,
+)
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
-  {
-    DashboardLayoutDashboardProductsProductsProductIdRoute:
-      DashboardLayoutDashboardProductsProductsProductIdRoute,
-    DashboardLayoutDashboardProductsProductsNewRoute:
-      DashboardLayoutDashboardProductsProductsNewRoute,
-  }
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
+	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
+	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
+}
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren =
-  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-    DashboardLayoutDashboardProductsProductsRouteChildren,
-  )
+const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+	DashboardLayoutDashboardProductsProductsRouteChildren,
+)
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
-  {
-    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
-      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-  }
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
+	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+}
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
-  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-    DashboardLayoutDashboardSalesMessagesRouteChildren,
-  )
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+	DashboardLayoutDashboardSalesMessagesRouteChildren,
+)
 
 interface DashboardLayoutRouteChildren {
-  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-  DashboardLayoutDashboardAccountMakingPaymentsRoute:
-    DashboardLayoutDashboardAccountMakingPaymentsRoute,
-  DashboardLayoutDashboardAccountNetworkRoute:
-    DashboardLayoutDashboardAccountNetworkRoute,
-  DashboardLayoutDashboardAccountNostrAddressRoute:
-    DashboardLayoutDashboardAccountNostrAddressRoute,
-  DashboardLayoutDashboardAccountPreferencesRoute:
-    DashboardLayoutDashboardAccountPreferencesRoute,
-  DashboardLayoutDashboardAccountProfileRoute:
-    DashboardLayoutDashboardAccountProfileRoute,
-  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
-    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-  DashboardLayoutDashboardAccountVanityUrlRoute:
-    DashboardLayoutDashboardAccountVanityUrlRoute,
-  DashboardLayoutDashboardAccountYourPurchasesRoute:
-    DashboardLayoutDashboardAccountYourPurchasesRoute,
-  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
-    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
-    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
-    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-  DashboardLayoutDashboardAppSettingsTeamRoute:
-    DashboardLayoutDashboardAppSettingsTeamRoute,
-  DashboardLayoutDashboardOrdersOrderIdRoute:
-    DashboardLayoutDashboardOrdersOrderIdRoute,
-  DashboardLayoutDashboardProductsAuctionsRoute:
-    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-  DashboardLayoutDashboardProductsBidsRoute:
-    DashboardLayoutDashboardProductsBidsRoute,
-  DashboardLayoutDashboardProductsCollectionsRoute:
-    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-  DashboardLayoutDashboardProductsMigrationToolRoute:
-    DashboardLayoutDashboardProductsMigrationToolRoute,
-  DashboardLayoutDashboardProductsProductsRoute:
-    DashboardLayoutDashboardProductsProductsRouteWithChildren,
-  DashboardLayoutDashboardProductsShippingOptionsRoute:
-    DashboardLayoutDashboardProductsShippingOptionsRoute,
-  DashboardLayoutDashboardSalesCircularEconomyRoute:
-    DashboardLayoutDashboardSalesCircularEconomyRoute,
-  DashboardLayoutDashboardSalesMessagesRoute:
-    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-  DashboardLayoutDashboardSalesSalesRoute:
-    DashboardLayoutDashboardSalesSalesRoute,
+	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
+	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
+	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
+	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
+	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
+	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
+	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
+	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
+	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
+	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
+	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
+	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
+	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
+	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
+	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
-  DashboardLayoutRouteChildren,
-)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-  IndexRoute: IndexRoute,
-  VanityNameRoute: VanityNameRoute,
-  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-  CheckoutRoute: CheckoutRoute,
-  SetupRoute: SetupRoute,
-  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-  PostsPostIdRoute: PostsPostIdRoute,
-  ProductsProductIdRoute: ProductsProductIdRoute,
-  ProfileProfileIdRoute: ProfileProfileIdRoute,
-  SearchProductsRoute: SearchProductsRoute,
-  AuctionsIndexRoute: AuctionsIndexRoute,
-  CommunityIndexRoute: CommunityIndexRoute,
-  NostrIndexRoute: NostrIndexRoute,
-  PostsIndexRoute: PostsIndexRoute,
-  ProductsIndexRoute: ProductsIndexRoute,
+	IndexRoute: IndexRoute,
+	VanityNameRoute: VanityNameRoute,
+	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+	CheckoutRoute: CheckoutRoute,
+	SetupRoute: SetupRoute,
+	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+	PostsPostIdRoute: PostsPostIdRoute,
+	ProductsProductIdRoute: ProductsProductIdRoute,
+	ProfileProfileIdRoute: ProfileProfileIdRoute,
+	SearchProductsRoute: SearchProductsRoute,
+	AuctionsIndexRoute: AuctionsIndexRoute,
+	CommunityIndexRoute: CommunityIndexRoute,
+	NostrIndexRoute: NostrIndexRoute,
+	PostsIndexRoute: PostsIndexRoute,
+	ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport
-  ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()


### PR DESCRIPTION
## Summary

Restores Maxime's auction form UI improvements that were accidentally overwritten when PR #890 (trusted mint state ownership) was squash-merged.

The PR branch (6966c39d) was based on a version of AuctionFormContent.tsx that predates commits 1ef251d7..24edc0e6, so the squash merge into auctions/p2pk-path-oracle-via-cvm-v1 effectively reverted the timing/reserve UX back to an older state.

### What's restored

- **Granular duration presets** — 26+ options (1m, 2m, 3m, 5m, 10m, 15m, 30m, 45m, 1h-30d) instead of 7
- **Slider component** — Slider from @/components/ui/slider snapping to preset values, replacing the raw input type=range
- **Checkbox-based reserve** — Checkbox toggle with InfoTooltip explanation, conditionally revealing the reserve input field
- **reserve: undefined** in INITIAL_FORM — unchecked = no reserve (validator defaults to 0 at publish time)
- **Seconds in datetime** — toDatetimeLocal includes HH:mm:ss

### What's preserved from PR #890

All trusted mint state ownership features remain intact:
- syncMintSelection import + logic
- userRemovedMints ref + useEffect
- Mint add/remove tracking with onUserRemovedMintsChange
- Navigate to /auctions after publish

### Additional fix

One line in auctionPublishValidation.ts — stricter null check for parsedEndAt and minDurationSeconds (uses !== null / !== undefined instead of truthy check).

## Files changed

- src/components/sheet-contents/auctions/AuctionFormContent.tsx — UI revert (timing + reserve)
- src/lib/auctionPublishValidation.ts — Stricter null check (1 line)
- src/routeTree.gen.ts — Auto-generated