### PR TITLE
fix(wallet): generate NIP-60 deposit invoices for testnut dev mint

### DIFF
--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -350,6 +350,17 @@ const createCashuWalletForMint = async (targetMint: string): Promise<{ cashuWall
 	}
 }
 
+const primeDevTestMintDepositWalletCache = async (wallet: NDKCashuWallet, targetMint: string): Promise<void> => {
+	const normalizedTargetMint = normalizeMintUrl(targetMint)
+
+	if (!isNip60WalletDevModeEnabled()) return
+	if (!NIP60_DEV_TEST_MINTS.includes(normalizedTargetMint)) return
+	if (wallet.cashuWallets.has(normalizedTargetMint)) return
+
+	const { cashuWallet } = await createCashuWalletForMint(normalizedTargetMint)
+	wallet.cashuWallets.set(normalizedTargetMint, cashuWallet)
+}
+
 const consolidateMintProofs = async (wallet: NDKCashuWallet, mint: string): Promise<void> => {
 	const allProofs = wallet.state.getProofs({ mint, includeDeleted: true, onlyAvailable: false })
 	if (allProofs.length === 0) return
@@ -1319,7 +1330,7 @@ export const nip60Actions = {
 			return null
 		}
 
-		const targetMint = mint ?? state.defaultMint
+		const targetMint = mint ? normalizeMintUrl(mint) : state.defaultMint ? normalizeMintUrl(state.defaultMint) : null
 		if (!targetMint) {
 			console.warn('[nip60] No mint specified and no default mint set')
 			nip60Store.setState((s) => ({
@@ -1341,6 +1352,8 @@ export const nip60Actions = {
 				depositStatus: 'pending',
 				error: null,
 			}))
+
+			await primeDevTestMintDepositWalletCache(wallet, targetMint)
 
 			const deposit = wallet.deposit(amount, targetMint)
 			const invoice = await deposit.start()


### PR DESCRIPTION
## Summary

Fixes #945.

This PR fixes manual NIP-60 Lightning deposit invoice generation for `https://testnut.cashu.space` in dev/test mode.

The issue happened before `depositInvoice` existed because the NDK deposit path loads a per-mint Cashu wallet before quote creation. This patch keeps the existing `nip60Actions.startDeposit(...)` lifecycle and primes the NDK per-mint Cashu wallet cache for known dev/test mints using the existing dev-only keyset fallback path already present in `nip60.ts`.

This is separate from #944 / #770. PR #944 owns the optional saved-NWC payment UI after a deposit invoice exists.

## What changed

- Added a private `primeDevTestMintDepositWalletCache(...)` helper in `src/lib/stores/nip60.ts`
- Normalized the selected/default mint before deposit start
- Primed the NDK Cashu wallet cache before `wallet.deposit(...).start()` for known dev/test mints only
- Kept the existing deposit lifecycle unchanged

## Scope

This PR does not:
- modify NWC behavior
- modify the deposit modal UI
- modify auction bidding
- modify auction settlement
- change NIP-60 event/storage semantics
- manually mark deposits successful
- manually mutate NIP-60 balances

## Manual testing

- No working saved NWC payment path required.
- Tested Deposit Lightning → amount `5` → `testnut.cashu.space`.
- QR code and Lightning invoice appeared.
- Deposit settled successfully.
- NIP-60 balance increased.

Follow-up note:
After a successful deposit, reopening the Deposit Lightning modal can still show the previous success state. This appears to be a modal deposit-status reset issue and is intentionally left out of this PR to keep #945 scoped to the mint/keyset invoice-generation fix. PR #944 already touches the deposit modal and is the better place to address that UX reset.

## Tests

- `bun run format`
- `bun run test:unit`
  - 143 passing
  - 0 failing
- `bun run build`
- `git diff --check`
