### PR TITLE
feat(auctions): auctions form draft

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -33,9 +33,10 @@ import {
 	type AuctionSpecEntry,
 } from '@/publish/auctions'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { clearAuctionFormDraft, getAuctionFormDraft, saveAuctionFormDraft } from '@/lib/utils/auctionFormStorage'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { ArrowLeft, CalendarIcon, Plus, X } from 'lucide-react'
+import { ArrowLeft, CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { InfoTooltip } from '@/components/shared/InfoTooltip'
 import { Slider } from '@/components/ui/slider'
@@ -1623,6 +1624,45 @@ export function AuctionFormContent() {
 	const [endMode, setEndMode] = useState<EndMode>('duration')
 	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
 
+	const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null)
+	const draftLoadedRef = useRef(false)
+	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const draftGenerationRef = useRef(0)
+
+	const hasDraft = draftSavedAt !== null
+
+	useEffect(() => {
+		if (!userPubkey || draftLoadedRef.current) return
+
+		draftLoadedRef.current = true
+		const draft = getAuctionFormDraft(userPubkey)
+		if (!draft) return
+		setDraftSavedAt(draft.savedAt)
+		setFormData(draft.formData)
+		setImages(draft.images)
+		setStartMode(draft.startMode)
+		setEndMode(draft.endMode)
+		setDurationSeconds(draft.durationSeconds)
+		setSubCategoryInput(draft.subCategoryInput)
+	}, [userPubkey])
+
+	useEffect(() => {
+		if (!userPubkey || !draftLoadedRef.current) return
+
+		const gen = draftGenerationRef.current
+		if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+
+		saveTimerRef.current = setTimeout(() => {
+			if (draftGenerationRef.current !== gen) return
+			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
+			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
+		}, 1500)
+
+		return () => {
+			if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+		}
+	}, [formData, images, startMode, endMode, durationSeconds, subCategoryInput, userPubkey])
+
 	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')
 		let effectiveEndAt = formData.endAt
@@ -1738,6 +1778,19 @@ export function AuctionFormContent() {
 		}
 	})()
 
+	const handleClearDraft = () => {
+		draftGenerationRef.current++
+		draftLoadedRef.current = true
+		clearAuctionFormDraft(userPubkey)
+		setDraftSavedAt(null)
+		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
+		setImages([])
+		setStartMode('immediate')
+		setEndMode('duration')
+		setDurationSeconds(24 * 60 * 60)
+		setSubCategoryInput('')
+	}
+
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		event.stopPropagation()
@@ -1749,6 +1802,10 @@ export function AuctionFormContent() {
 			validateAuctionPublishInput(nextFormData, { nowSeconds, minDurationSeconds: AUCTION_MIN_DURATION_SECONDS })
 			const publishedEventId = await publishMutation.mutateAsync(nextFormData)
 			if (!publishedEventId) return
+
+			draftGenerationRef.current++
+			clearAuctionFormDraft(userPubkey)
+			setDraftSavedAt(null)
 
 			document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 			navigate({ to: '/auctions' })
@@ -1837,7 +1894,22 @@ export function AuctionFormContent() {
 				</Tabs>
 			</div>
 
-			<div className="shrink-0 bg-white border-t pt-4 pb-2 mt-2">
+			<div className="shrink-0 bg-white border-t pt-4 pb-2 mt-2 flex flex-col gap-2">
+				{hasDraft && (
+					<div className="flex items-center justify-between gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-1.5">
+						<p className="text-xs font-medium text-amber-700">Draft saved</p>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="flex items-center gap-1.5 text-xs text-amber-600 hover:text-red-600 px-2"
+							onClick={handleClearDraft}
+						>
+							<Trash2 className="w-3 h-3" />
+							Clear draft
+						</Button>
+					</div>
+				)}
 				{currentTabErrors.length > 0 && (
 					<ul className="mb-3 max-h-28 overflow-y-auto space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2">
 						{currentTabErrors.map((err, i) => (

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1584,6 +1584,24 @@ const VALIDATION_FIELD_LABELS: Record<AuctionPublishValidationField, string> = {
 	shippingExtraCost: 'Shipping Extra Cost',
 }
 
+function isMeaningfulDraft(formData: AuctionFormData, images: AuctionImage[], subCategoryInput: string): boolean {
+	return (
+		formData.title.trim().length > 0 ||
+		formData.summary.trim().length > 0 ||
+		formData.description.trim().length > 0 ||
+		formData.startingBid.trim().length > 0 ||
+		(formData.startAt ?? '').trim().length > 0 ||
+		formData.endAt.trim().length > 0 ||
+		formData.mainCategory.trim().length > 0 ||
+		formData.pathIssuerPubkey.trim().length > 0 ||
+		formData.isNSFW ||
+		formData.specs.length > 0 ||
+		formData.shippings.length > 0 ||
+		subCategoryInput.trim().length > 0 ||
+		images.length > 0
+	)
+}
+
 export function AuctionFormContent() {
 	const navigate = useNavigate()
 	const publishMutation = usePublishAuctionMutation()
@@ -1654,6 +1672,7 @@ export function AuctionFormContent() {
 
 		saveTimerRef.current = setTimeout(() => {
 			if (draftGenerationRef.current !== gen) return
+			if (!isMeaningfulDraft(formData, images, subCategoryInput)) return
 			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
 			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
 		}, 1500)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1584,22 +1584,8 @@ const VALIDATION_FIELD_LABELS: Record<AuctionPublishValidationField, string> = {
 	shippingExtraCost: 'Shipping Extra Cost',
 }
 
-function isMeaningfulDraft(formData: AuctionFormData, images: AuctionImage[], subCategoryInput: string): boolean {
-	return (
-		formData.title.trim().length > 0 ||
-		formData.summary.trim().length > 0 ||
-		formData.description.trim().length > 0 ||
-		formData.startingBid.trim().length > 0 ||
-		(formData.startAt ?? '').trim().length > 0 ||
-		formData.endAt.trim().length > 0 ||
-		formData.mainCategory.trim().length > 0 ||
-		formData.pathIssuerPubkey.trim().length > 0 ||
-		formData.isNSFW ||
-		formData.specs.length > 0 ||
-		formData.shippings.length > 0 ||
-		subCategoryInput.trim().length > 0 ||
-		images.length > 0
-	)
+function isMeaningfulDraft(formData: AuctionFormData): boolean {
+	return formData.title.trim().length > 0
 }
 
 export function AuctionFormContent() {
@@ -1672,7 +1658,7 @@ export function AuctionFormContent() {
 
 		saveTimerRef.current = setTimeout(() => {
 			if (draftGenerationRef.current !== gen) return
-			if (!isMeaningfulDraft(formData, images, subCategoryInput)) return
+			if (!isMeaningfulDraft(formData)) return
 			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
 			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
 		}, 1500)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1584,8 +1584,13 @@ const VALIDATION_FIELD_LABELS: Record<AuctionPublishValidationField, string> = {
 	shippingExtraCost: 'Shipping Extra Cost',
 }
 
-function isMeaningfulDraft(formData: AuctionFormData): boolean {
-	return formData.title.trim().length > 0
+function isMeaningfulDraft(formData: AuctionFormData, baselineMints: string[]): boolean {
+	if (formData.title.trim().length > 0) return true
+
+	const baseline = new Set(baselineMints)
+	const current = formData.trustedMints
+	if (baseline.size !== current.length) return true
+	return current.some((mint) => !baseline.has(mint))
 }
 
 export function AuctionFormContent() {
@@ -1658,7 +1663,7 @@ export function AuctionFormContent() {
 
 		saveTimerRef.current = setTimeout(() => {
 			if (draftGenerationRef.current !== gen) return
-			if (!isMeaningfulDraft(formData)) return
+			if (!isMeaningfulDraft(formData, availableMints)) return
 			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
 			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
 		}, 1500)
@@ -1666,7 +1671,7 @@ export function AuctionFormContent() {
 		return () => {
 			if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
 		}
-	}, [formData, images, startMode, endMode, durationSeconds, subCategoryInput, userPubkey])
+	}, [formData, images, startMode, endMode, durationSeconds, subCategoryInput, userPubkey, availableMints])
 
 	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+	clearAuctionFormDraft,
+	getAuctionFormDraft,
+	hasAuctionFormDraft,
+	saveAuctionFormDraft,
+	type AuctionFormDraft,
+} from '@/lib/utils/auctionFormStorage'
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const store: Record<string, string> = {}
+
+const localStorageMock = {
+	getItem: (key: string) => store[key] ?? null,
+	setItem: (key: string, value: string) => {
+		store[key] = value
+	},
+	removeItem: (key: string) => {
+		delete store[key]
+	},
+	clear: () => {
+		for (const k of Object.keys(store)) delete store[k]
+	},
+}
+
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true })
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PUBKEY_A = 'aaaa1111'
+const PUBKEY_B = 'bbbb2222'
+
+const baseDraft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'> = {
+	formData: {
+		title: 'Vintage Camera',
+		summary: 'Rare find',
+		description: 'A beautiful vintage camera in great condition.',
+		startingBid: '5000',
+		bidIncrement: '100',
+		reserve: '10000',
+		startAt: '',
+		endAt: '2099-01-01T12:00',
+		antiSnipeWindowMinutes: 15,
+		minBidCurveShape: 'linear',
+		minBidCurvePeakMultiplier: 5,
+		settlementGracePreset: '1h',
+		mainCategory: 'Photography',
+		categories: ['Collectibles', 'Film'],
+		imageUrls: ['https://example.com/camera.jpg'],
+		specs: [{ key: 'Brand', value: 'Leica' }],
+		shippings: [{ shippingRef: '30406:seller:standard', extraCost: '200' }],
+		trustedMints: ['https://mint.example.com'],
+		isNSFW: false,
+		pathIssuerPubkey: '',
+	},
+	images: [{ imageUrl: 'https://example.com/camera.jpg', imageOrder: 0 }],
+	startMode: 'immediate',
+	endMode: 'absolute',
+	durationSeconds: 86400,
+	subCategoryInput: 'Collectibles, Film',
+}
+
+beforeEach(() => localStorageMock.clear())
+afterEach(() => localStorageMock.clear())
+
+// ---------------------------------------------------------------------------
+// Save / load roundtrip
+// ---------------------------------------------------------------------------
+
+describe('save/load roundtrip', () => {
+	test('restores all formData fields exactly', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded).not.toBeNull()
+		expect(loaded!.formData.title).toBe('Vintage Camera')
+		expect(loaded!.formData.startingBid).toBe('5000')
+		expect(loaded!.formData.antiSnipeWindowMinutes).toBe(15)
+		expect(loaded!.formData.minBidCurveShape).toBe('linear')
+		expect(loaded!.formData.minBidCurvePeakMultiplier).toBe(5)
+		expect(loaded!.formData.settlementGracePreset).toBe('1h')
+		expect(loaded!.formData.specs).toEqual([{ key: 'Brand', value: 'Leica' }])
+		expect(loaded!.formData.shippings).toEqual([{ shippingRef: '30406:seller:standard', extraCost: '200' }])
+		expect(loaded!.formData.trustedMints).toEqual(['https://mint.example.com'])
+		expect(loaded!.formData.isNSFW).toBe(false)
+	})
+
+	test('restores top-level draft fields', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.startMode).toBe('immediate')
+		expect(loaded!.endMode).toBe('absolute')
+		expect(loaded!.durationSeconds).toBe(86400)
+		expect(loaded!.subCategoryInput).toBe('Collectibles, Film')
+		expect(loaded!.images).toEqual([{ imageUrl: 'https://example.com/camera.jpg', imageOrder: 0 }])
+	})
+
+	test('savedAt is a recent timestamp', () => {
+		const before = Date.now()
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const after = Date.now()
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.savedAt).toBeGreaterThanOrEqual(before)
+		expect(loaded!.savedAt).toBeLessThanOrEqual(after)
+	})
+
+	test('overwriting a draft replaces it entirely', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_A, { ...baseDraft, formData: { ...baseDraft.formData, title: 'Updated Title' } })
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.formData.title).toBe('Updated Title')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Malformed JSON handling
+// ---------------------------------------------------------------------------
+
+describe('malformed JSON handling', () => {
+	test('returns null for unparseable JSON', () => {
+		store[`auction_form_draft_${PUBKEY_A}`] = '{not valid json'
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null for JSON null', () => {
+		store[`auction_form_draft_${PUBKEY_A}`] = 'null'
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when pubkey field is missing', () => {
+		const { pubkey: _omit, ...withoutPubkey } = { ...baseDraft, pubkey: PUBKEY_A, savedAt: Date.now() }
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(withoutPubkey)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when savedAt is missing', () => {
+		const record = { ...baseDraft, pubkey: PUBKEY_A }
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(record)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('coerces unknown antiSnipeWindowMinutes to 0', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.antiSnipeWindowMinutes = 999
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.antiSnipeWindowMinutes).toBe(0)
+	})
+
+	test('coerces unknown minBidCurveShape to "none"', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.minBidCurveShape = 'zigzag'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.minBidCurveShape).toBe('none')
+	})
+
+	test('coerces unknown settlementGracePreset to "1h"', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.settlementGracePreset = 'forever'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.settlementGracePreset).toBe('1h')
+	})
+
+	test('drops non-string entries from trustedMints array', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.trustedMints = ['https://good.mint', 42, null, 'https://other.mint']
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.trustedMints).toEqual(['https://good.mint', 'https://other.mint'])
+	})
+
+	test('drops images with empty imageUrl', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.images = [
+			{ imageUrl: '', imageOrder: 0 },
+			{ imageUrl: 'https://example.com/ok.jpg', imageOrder: 1 },
+		]
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.images).toEqual([{ imageUrl: 'https://example.com/ok.jpg', imageOrder: 1 }])
+	})
+
+	test('stringified "true" for isNSFW is not treated as true', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.isNSFW = 'true'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.isNSFW).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Cross-user safety
+// ---------------------------------------------------------------------------
+
+describe('cross-user safety', () => {
+	test('drafts are isolated per pubkey', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_B, { ...baseDraft, formData: { ...baseDraft.formData, title: 'User B Draft' } })
+
+		expect(getAuctionFormDraft(PUBKEY_A)!.formData.title).toBe('Vintage Camera')
+		expect(getAuctionFormDraft(PUBKEY_B)!.formData.title).toBe('User B Draft')
+	})
+
+	test('clearing one user draft does not affect the other', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_B, baseDraft)
+
+		clearAuctionFormDraft(PUBKEY_A)
+
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+		expect(getAuctionFormDraft(PUBKEY_B)).not.toBeNull()
+	})
+
+	test('empty pubkey is rejected on save and returns null on load', () => {
+		saveAuctionFormDraft('', baseDraft)
+		expect(getAuctionFormDraft('')).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Clear draft behaviour
+// ---------------------------------------------------------------------------
+
+describe('clear draft behaviour', () => {
+	test('getAuctionFormDraft returns null after clear', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('hasAuctionFormDraft returns false after clear', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('clearing a non-existent draft is a no-op', () => {
+		expect(() => clearAuctionFormDraft(PUBKEY_A)).not.toThrow()
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Publish clears draft (simulated via the storage layer)
+// ---------------------------------------------------------------------------
+
+describe('publish clears draft', () => {
+	test('draft is absent after the publish flow removes it', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(true)
+
+		// simulate what handleSubmit does on success
+		clearAuctionFormDraft(PUBKEY_A)
+
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('saving a new draft after publish works correctly', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+
+		const newDraft = { ...baseDraft, formData: { ...baseDraft.formData, title: 'New Auction' } }
+		saveAuctionFormDraft(PUBKEY_A, newDraft)
+
+		expect(getAuctionFormDraft(PUBKEY_A)!.formData.title).toBe('New Auction')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Empty form not persisted (guard matches isMeaningfulDraft in the component)
+// ---------------------------------------------------------------------------
+
+describe('empty form not persisted', () => {
+	test('hasAuctionFormDraft returns false when nothing has been saved', () => {
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('getAuctionFormDraft returns null for a key that was never written', () => {
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('a draft saved then loaded with no meaningful fields still round-trips structurally', () => {
+		const emptyLike: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'> = {
+			...baseDraft,
+			formData: {
+				...baseDraft.formData,
+				title: '',
+				summary: '',
+				description: '',
+				startingBid: '',
+			},
+			images: [],
+			subCategoryInput: '',
+		}
+		// The storage layer itself does not block saving empty content —
+		// that guard lives in the component (isMeaningfulDraft). Verify that
+		// the storage layer faithfully round-trips whatever it receives.
+		saveAuctionFormDraft(PUBKEY_A, emptyLike)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.title).toBe('')
+		expect(loaded!.images).toEqual([])
+	})
+})

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -1,4 +1,15 @@
-import type { AuctionFormData } from '@/publish/auctions'
+import type {
+	AuctionAntiSnipeWindowMinutesPreset,
+	AuctionFormData,
+	AuctionMinBidCurvePeakPreset,
+	AuctionMinBidCurveShape,
+	AuctionSettlementGracePreset,
+} from '@/publish/auctions'
+import {
+	AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES,
+	AUCTION_MIN_BID_CURVE_PEAK_PRESETS,
+	AUCTION_SETTLEMENT_GRACE_PRESETS,
+} from '@/publish/auctions'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 type StartMode = 'immediate' | 'scheduled'
@@ -19,6 +30,110 @@ const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
 
 const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
+function str(v: unknown, fallback = ''): string {
+	return typeof v === 'string' ? v : fallback
+}
+
+function num(v: unknown, fallback: number): number {
+	return typeof v === 'number' && Number.isFinite(v) ? v : fallback
+}
+
+function strArray(v: unknown): string[] {
+	if (!Array.isArray(v)) return []
+	return v.filter((x): x is string => typeof x === 'string')
+}
+
+function validateDraft(raw: unknown): AuctionFormDraft | null {
+	if (!raw || typeof raw !== 'object') return null
+	const d = raw as Record<string, unknown>
+
+	const pubkey = str(d.pubkey)
+	if (!pubkey) return null
+
+	const savedAt = num(d.savedAt, 0)
+	if (!savedAt) return null
+
+	const fd = d.formData && typeof d.formData === 'object' ? (d.formData as Record<string, unknown>) : {}
+
+	const antiSnipeWindowMinutes = (AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES as readonly number[]).includes(
+		num(fd.antiSnipeWindowMinutes, 0),
+	)
+		? (num(fd.antiSnipeWindowMinutes, 0) as AuctionAntiSnipeWindowMinutesPreset)
+		: 0
+
+	const minBidCurveShapeOptions: AuctionMinBidCurveShape[] = ['none', 'linear', 'exponential']
+	const minBidCurveShape: AuctionMinBidCurveShape = minBidCurveShapeOptions.includes(fd.minBidCurveShape as AuctionMinBidCurveShape)
+		? (fd.minBidCurveShape as AuctionMinBidCurveShape)
+		: 'none'
+
+	const minBidCurvePeakMultiplier = (AUCTION_MIN_BID_CURVE_PEAK_PRESETS as readonly number[]).includes(num(fd.minBidCurvePeakMultiplier, 2))
+		? (num(fd.minBidCurvePeakMultiplier, 2) as AuctionMinBidCurvePeakPreset)
+		: 2
+
+	const settlementGraceOptions = Object.keys(AUCTION_SETTLEMENT_GRACE_PRESETS) as AuctionSettlementGracePreset[]
+	const settlementGracePreset: AuctionSettlementGracePreset = settlementGraceOptions.includes(
+		fd.settlementGracePreset as AuctionSettlementGracePreset,
+	)
+		? (fd.settlementGracePreset as AuctionSettlementGracePreset)
+		: '1h'
+
+	const rawSpecs = Array.isArray(fd.specs) ? fd.specs : []
+	const specs = rawSpecs
+		.filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+		.map((s) => ({ key: str(s.key), value: str(s.value) }))
+
+	const rawShippings = Array.isArray(fd.shippings) ? fd.shippings : []
+	const shippings = rawShippings
+		.filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+		.map((s) => ({ shippingRef: str(s.shippingRef), extraCost: str(s.extraCost) }))
+
+	const rawImages = Array.isArray(d.images) ? d.images : []
+	const images: AuctionImage[] = rawImages
+		.filter((i): i is Record<string, unknown> => !!i && typeof i === 'object')
+		.map((i) => ({ imageUrl: str(i.imageUrl), imageOrder: num(i.imageOrder, 0) }))
+		.filter((i) => i.imageUrl.length > 0)
+
+	const startModeRaw = str(d.startMode)
+	const startMode: StartMode = startModeRaw === 'scheduled' ? 'scheduled' : 'immediate'
+
+	const endModeRaw = str(d.endMode)
+	const endMode: EndMode = endModeRaw === 'absolute' ? 'absolute' : 'duration'
+
+	const formData: AuctionFormData = {
+		title: str(fd.title),
+		summary: str(fd.summary),
+		description: str(fd.description),
+		startingBid: str(fd.startingBid),
+		bidIncrement: str(fd.bidIncrement, '1'),
+		reserve: str(fd.reserve, '0'),
+		startAt: str(fd.startAt),
+		endAt: str(fd.endAt),
+		antiSnipeWindowMinutes,
+		minBidCurveShape,
+		minBidCurvePeakMultiplier,
+		settlementGracePreset,
+		mainCategory: str(fd.mainCategory),
+		categories: strArray(fd.categories),
+		imageUrls: strArray(fd.imageUrls),
+		specs,
+		shippings,
+		trustedMints: strArray(fd.trustedMints),
+		isNSFW: fd.isNSFW === true,
+		pathIssuerPubkey: str(fd.pathIssuerPubkey),
+	}
+
+	return {
+		pubkey,
+		formData,
+		images,
+		startMode,
+		endMode,
+		durationSeconds: num(d.durationSeconds, 86400),
+		subCategoryInput: str(d.subCategoryInput),
+		savedAt,
+	}
+}
+
 export const saveAuctionFormDraft = (pubkey: string, draft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'>): void => {
 	if (!isBrowser() || !pubkey) return
 	try {
@@ -34,7 +149,7 @@ export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => 
 	try {
 		const raw = localStorage.getItem(storageKey(pubkey))
 		if (!raw) return null
-		return JSON.parse(raw) as AuctionFormDraft
+		return validateDraft(JSON.parse(raw))
 	} catch (error) {
 		console.error('Failed to get auction form draft:', error)
 		return null

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -1,0 +1,53 @@
+import type { AuctionFormData } from '@/publish/auctions'
+
+type AuctionImage = { imageUrl: string; imageOrder: number }
+type StartMode = 'immediate' | 'scheduled'
+type EndMode = 'duration' | 'absolute'
+
+export type AuctionFormDraft = {
+	pubkey: string
+	formData: AuctionFormData
+	images: AuctionImage[]
+	startMode: StartMode
+	endMode: EndMode
+	durationSeconds: number
+	subCategoryInput: string
+	savedAt: number
+}
+
+const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+
+export const saveAuctionFormDraft = (pubkey: string, draft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'>): void => {
+	if (!isBrowser() || !pubkey) return
+	try {
+		const record: AuctionFormDraft = { ...draft, pubkey, savedAt: Date.now() }
+		localStorage.setItem(storageKey(pubkey), JSON.stringify(record))
+	} catch (error) {
+		console.error('Failed to save auction form draft:', error)
+	}
+}
+
+export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => {
+	if (!isBrowser() || !pubkey) return null
+	try {
+		const raw = localStorage.getItem(storageKey(pubkey))
+		if (!raw) return null
+		return JSON.parse(raw) as AuctionFormDraft
+	} catch (error) {
+		console.error('Failed to get auction form draft:', error)
+		return null
+	}
+}
+
+export const clearAuctionFormDraft = (pubkey: string): void => {
+	if (!isBrowser() || !pubkey) return
+	try {
+		localStorage.removeItem(storageKey(pubkey))
+	} catch (error) {
+		console.error('Failed to clear auction form draft:', error)
+	}
+}
+
+export const hasAuctionFormDraft = (pubkey: string): boolean => getAuctionFormDraft(pubkey) !== null


### PR DESCRIPTION
# Description

This PR adds support for saving auctions drafts to the local storage to prevent them from clearing when the user closes the sheet form or navigates to another url.

## Screenshots

https://github.com/user-attachments/assets/f6b37bdb-1ba8-4205-ae44-f6fccc9b0287

Closes #909


