### PR TITLE
Fix: Disable Bid on own auction

### DIFF
--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -170,7 +170,7 @@ export function AuctionCard({
 					<AuctionCountdown auction={auction} bids={bids} className="w-full justify-between" compact />
 				</div>
 
-				<AuctionBidder auction={auction} bids={bids} compact />
+				<AuctionBidder auction={auction} currentUserPubkey={currentUser?.pubkey} bids={bids} compact />
 			</div>
 		</div>
 	)


### PR DESCRIPTION
Small fix, thanks to the last fix contained in #886 I knew where the problem came from. This fixes the bid button being available in the auctions' home page. The details page bid button behaviour was already fixed in #886.

Closes #875 