### PR TITLE
fix(orders): keep buyer delivery details out of public events

### DIFF
--- a/src/components/orders/OrderDetailComponent.tsx
+++ b/src/components/orders/OrderDetailComponent.tsx
@@ -27,6 +27,7 @@ import { toast } from 'sonner'
 import { DetailField } from '../ui/DetailField'
 import { Separator } from '../ui/separator'
 import { OrderActions } from './OrderActions'
+import { PrivateOrderDetailsCard } from './PrivateOrderDetailsCard'
 import { TimelineEventCard } from './TimelineEventCard'
 
 // Imported helpers and components
@@ -74,14 +75,14 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 	const sellerPubkey = getSellerPubkey(orderEvent)
 	const isBuyer = buyerPubkey === user?.pubkey
 	const isOrderSeller = sellerPubkey === user?.pubkey
-	const canViewBuyerContact = isBuyer || isOrderSeller
+	const canViewLegacyBuyerContact = isBuyer
 
 	const totalAmount = getTotalAmount(orderEvent)
 
 	// Extract shipping information
 	const shippingRef = getShippingRef(orderEvent)
-	const shippingAddress = orderEvent.tags.find((tag) => tag[0] === 'address')?.[1]
-	const deliveryContact = orderEvent.tags.find((tag) => tag[0] === 'email')?.[1]
+	const shippingAddress = isBuyer ? orderEvent.tags.find((tag) => tag[0] === 'address')?.[1] : undefined
+	const deliveryContact = isBuyer ? orderEvent.tags.find((tag) => tag[0] === 'email')?.[1] : undefined
 
 	// Get status styles for coloring the header
 	const { headerBgColor } = getStatusStyles(order)
@@ -192,6 +193,7 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 	const isPickupService = shippingOption ? getShippingService(shippingOption)?.[1] === 'pickup' : false
 	const isDigitalService = shippingOption ? getShippingService(shippingOption)?.[1] === 'digital' : false
 	const pickupAddress = shippingOption && isPickupService ? getShippingPickupAddressString(shippingOption) : null
+	const shouldShowPrivateDetailsUnavailable = isOrderSeller && Boolean(shippingOption) && !isPickupService && !order.privateOrderDetails
 
 	const products = productQueries.map((query) => query.data).filter(Boolean) as NDKEvent[]
 
@@ -293,7 +295,7 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 					</CardContent>
 				</Card>
 
-				{canViewBuyerContact && deliveryContact && (
+				{canViewLegacyBuyerContact && deliveryContact && (
 					<Card>
 						<CardHeader>
 							<CardTitle>Buyer Contact</CardTitle>
@@ -306,6 +308,8 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 						</CardContent>
 					</Card>
 				)}
+
+				<PrivateOrderDetailsCard order={order} currentUserPubkey={user?.pubkey} showUnavailable={shouldShowPrivateDetailsUnavailable} />
 
 				{/* Products */}
 				{products.length > 0 && (

--- a/src/components/orders/PrivateOrderDetailsCard.test.tsx
+++ b/src/components/orders/PrivateOrderDetailsCard.test.tsx
@@ -1,0 +1,112 @@
+import type { PrivateOrderDeliveryDetails } from '@/lib/orders/privateOrderMessage'
+import type { OrderWithRelatedEvents } from '@/queries/orders'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { describe, expect, test } from 'bun:test'
+import { canViewPrivateOrderDetails, getPrivateOrderDetailsRows } from './PrivateOrderDetailsCard'
+
+const SELLER_PUBKEY = 'a'.repeat(64)
+const BUYER_PUBKEY = 'b'.repeat(64)
+const OTHER_PUBKEY = 'c'.repeat(64)
+
+function orderWithSeller(sellerPubkey = SELLER_PUBKEY): OrderWithRelatedEvents {
+	return {
+		order: {
+			id: 'order-event',
+			pubkey: BUYER_PUBKEY,
+			tags: [
+				['p', sellerPubkey],
+				['order', 'order-123'],
+				['address', '123 Main Street'],
+				['email', 'public-leak@example.com'],
+				['phone', '+15550000000'],
+				['name', 'Public Name'],
+			],
+		} as NDKEvent,
+		paymentRequests: [],
+		statusUpdates: [],
+		shippingUpdates: [],
+		generalMessages: [],
+		paymentReceipts: [],
+	}
+}
+
+function privateDetails(overrides: Partial<PrivateOrderDeliveryDetails> = {}): PrivateOrderDeliveryDetails {
+	return {
+		orderId: 'order-123',
+		buyerPubkey: BUYER_PUBKEY,
+		sellerPubkey: SELLER_PUBKEY,
+		totalAmountSats: 1000,
+		items: [{ productRef: `30402:${SELLER_PUBKEY}:product`, quantity: 1 }],
+		delivery: {},
+		...overrides,
+	}
+}
+
+describe('PrivateOrderDetailsCard helpers', () => {
+	test('only allows the public order seller to view private details', () => {
+		const order = orderWithSeller()
+
+		expect(canViewPrivateOrderDetails(order, SELLER_PUBKEY)).toBe(true)
+		expect(canViewPrivateOrderDetails(order, BUYER_PUBKEY)).toBe(false)
+		expect(canViewPrivateOrderDetails(order, OTHER_PUBKEY)).toBe(false)
+		expect(canViewPrivateOrderDetails(order, undefined)).toBe(false)
+	})
+
+	test('uses correlated private details instead of public order PII tags', () => {
+		const rows = getPrivateOrderDetailsRows(
+			privateDetails({
+				delivery: {
+					email: 'buyer@example.com',
+				},
+			}),
+		)
+
+		const serializedRows = JSON.stringify(rows)
+		expect(serializedRows).toContain('buyer@example.com')
+		expect(serializedRows).not.toContain('123 Main Street')
+		expect(serializedRows).not.toContain('Public Name')
+		expect(serializedRows).not.toContain('+15550000000')
+		expect(serializedRows).not.toContain('public-leak@example.com')
+	})
+
+	test('digital delivery rows include email contact without phone, name, or address', () => {
+		const rows = getPrivateOrderDetailsRows(
+			privateDetails({
+				delivery: {
+					email: 'buyer@example.com',
+				},
+			}),
+		)
+
+		expect(rows).toEqual([{ label: 'Digital contact', value: 'buyer@example.com' }])
+	})
+
+	test('physical delivery rows include recipient, address, phone, and notes when present', () => {
+		const rows = getPrivateOrderDetailsRows(
+			privateDetails({
+				delivery: {
+					name: 'Satoshi Nakamoto',
+					email: 'buyer@example.com',
+					phone: '+15551234567',
+					address: {
+						firstLineOfAddress: '123 Main Street',
+						additionalInformation: 'Apt Secret Notes',
+						city: 'Los Angeles',
+						zipPostcode: '90210',
+						country: 'United States',
+					},
+				},
+				orderNotes: 'Apt Secret Notes',
+			}),
+		)
+
+		expect(rows).toContainEqual({ label: 'Digital contact', value: 'buyer@example.com' })
+		expect(rows).toContainEqual({ label: 'Recipient', value: 'Satoshi Nakamoto' })
+		expect(rows).toContainEqual({
+			label: 'Address',
+			value: '123 Main Street\nApt Secret Notes\nLos Angeles 90210\nUnited States',
+		})
+		expect(rows).toContainEqual({ label: 'Phone', value: '+15551234567' })
+		expect(rows).toContainEqual({ label: 'Order notes', value: 'Apt Secret Notes' })
+	})
+})

--- a/src/components/orders/PrivateOrderDetailsCard.tsx
+++ b/src/components/orders/PrivateOrderDetailsCard.tsx
@@ -1,0 +1,106 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import type { PrivateOrderDeliveryDetails } from '@/lib/orders/privateOrderMessage'
+import { cn } from '@/lib/utils'
+import type { OrderWithRelatedEvents } from '@/queries/orders'
+import { LockKeyhole } from 'lucide-react'
+import { getOrderId, getSellerPubkey } from './orderDetailHelpers'
+
+type PrivateOrderDetailsCardProps = {
+	order: OrderWithRelatedEvents
+	currentUserPubkey?: string
+	compact?: boolean
+	showUnavailable?: boolean
+	className?: string
+}
+
+type DetailRow = {
+	label: string
+	value: string
+}
+
+export function canViewPrivateOrderDetails(order: OrderWithRelatedEvents, currentUserPubkey?: string): boolean {
+	return Boolean(currentUserPubkey && getSellerPubkey(order.order) === currentUserPubkey)
+}
+
+export function getPrivateOrderDetailsRows(details: PrivateOrderDeliveryDetails): DetailRow[] {
+	const rows: DetailRow[] = []
+	const { delivery } = details
+
+	if (delivery.email) rows.push({ label: 'Digital contact', value: delivery.email })
+	if (delivery.name) rows.push({ label: 'Recipient', value: delivery.name })
+
+	const addressLines = getAddressLines(delivery.address)
+	if (addressLines.length > 0) {
+		rows.push({ label: 'Address', value: addressLines.join('\n') })
+	}
+
+	if (delivery.phone) rows.push({ label: 'Phone', value: delivery.phone })
+	if (details.orderNotes?.trim()) rows.push({ label: 'Order notes', value: details.orderNotes.trim() })
+
+	return rows
+}
+
+export function PrivateOrderDetailsCard({
+	order,
+	currentUserPubkey,
+	compact = false,
+	showUnavailable = false,
+	className,
+}: PrivateOrderDetailsCardProps) {
+	if (!canViewPrivateOrderDetails(order, currentUserPubkey)) return null
+
+	const details = order.privateOrderDetails
+	if (!details) {
+		if (!showUnavailable) return null
+		return (
+			<Card className={cn('border-amber-200 bg-amber-50', className)}>
+				<CardHeader className={cn(compact ? 'p-3 pb-2' : 'p-4 pb-2')}>
+					<div className="flex items-center gap-2">
+						<LockKeyhole className="h-4 w-4 text-amber-700" />
+						<CardTitle className={compact ? 'text-sm' : 'text-base'}>Private delivery details</CardTitle>
+					</div>
+				</CardHeader>
+				<CardContent className={cn('text-sm text-amber-900', compact ? 'p-3 pt-0' : 'p-4 pt-0')}>
+					Encrypted delivery details are unavailable. Connect the seller signer that received this order.
+				</CardContent>
+			</Card>
+		)
+	}
+
+	const rows = getPrivateOrderDetailsRows(details)
+	if (rows.length === 0) return null
+
+	const orderId = getOrderId(order.order)
+
+	return (
+		<Card className={cn('border-emerald-200 bg-emerald-50', className)}>
+			<CardHeader className={cn(compact ? 'p-3 pb-2' : 'p-4 pb-2')}>
+				<div className="flex items-center gap-2">
+					<LockKeyhole className="h-4 w-4 text-emerald-700" />
+					<div>
+						<CardTitle className={compact ? 'text-sm' : 'text-base'}>Private encrypted seller delivery details</CardTitle>
+						{compact && <p className="text-xs text-emerald-800">Order {orderId ? `${orderId.substring(0, 8)}...` : 'details'}</p>}
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className={cn(compact ? 'p-3 pt-0' : 'p-4 pt-0')}>
+				<dl className={cn('grid gap-3', compact ? 'text-sm' : 'sm:grid-cols-2')}>
+					{rows.map((row) => (
+						<div key={row.label} className={row.label === 'Address' || row.label === 'Order notes' ? 'sm:col-span-2' : undefined}>
+							<dt className="text-xs font-medium uppercase tracking-wide text-emerald-900">{row.label}</dt>
+							<dd className="mt-1 whitespace-pre-line break-words text-sm text-emerald-950">{row.value}</dd>
+						</div>
+					))}
+				</dl>
+			</CardContent>
+		</Card>
+	)
+}
+
+function getAddressLines(address: PrivateOrderDeliveryDetails['delivery']['address']): string[] {
+	if (!address) return []
+	const cityLine = [address.city, address.zipPostcode].filter(Boolean).join(' ')
+	return [address.firstLineOfAddress, address.additionalInformation, cityLine, address.country].filter((line): line is string =>
+		Boolean(line?.trim()),
+	)
+}

--- a/src/lib/nostr/nip59.test.ts
+++ b/src/lib/nostr/nip59.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'bun:test'
-import { finalizeEvent, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
+import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
-import { createNip59GiftWrap, NIP59_GIFT_WRAP_KIND, NIP59_SEAL_KIND, unwrapNip59GiftWrap, type UnsignedRumor } from './nip59'
+import {
+	createNip59GiftWrap,
+	NIP59_GIFT_WRAP_KIND,
+	NIP59_SEAL_KIND,
+	normalizeUnsignedRumorId,
+	unwrapNip59GiftWrap,
+	type UnsignedRumor,
+} from './nip59'
 
 const CREATED_AT = 1_700_000_000
 const PII_SENTINELS = [
@@ -36,6 +43,16 @@ function rumorFor(buyerPubkey: string): UnsignedRumor {
 		],
 		content: 'Satoshi Nakamoto buyer@example.com 123 Main Street Apt Secret Notes',
 	}
+}
+
+function canonicalRumorId(rumor: UnsignedRumor): string {
+	return getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
 }
 
 function encryptForRecipient(plaintext: string, senderPrivateKey: Uint8Array, recipientPubkey: string): string {
@@ -81,7 +98,11 @@ describe('NIP-59 helper', () => {
 		const wrapper = keyPair()
 		const rumor = rumorFor(buyer.pubkey)
 
-		const { seal, giftWrap } = createNip59GiftWrap({
+		const {
+			rumor: normalizedRumor,
+			seal,
+			giftWrap,
+		} = createNip59GiftWrap({
 			rumor,
 			senderPrivateKey: buyer.privateKey,
 			recipientPubkey: seller.pubkey,
@@ -90,6 +111,8 @@ describe('NIP-59 helper', () => {
 		})
 
 		expect('sig' in rumor).toBe(false)
+		expect(rumor.id).toBeUndefined()
+		expect(normalizedRumor.id).toBe(canonicalRumorId(rumor))
 		expect(seal.kind).toBe(NIP59_SEAL_KIND)
 		expect(seal.tags).toEqual([])
 		expect(seal.pubkey).toBe(buyer.pubkey)
@@ -110,8 +133,92 @@ describe('NIP-59 helper', () => {
 		})
 
 		expect(unwrapped.seal.id).toBe(seal.id)
-		expect(unwrapped.rumor).toEqual(rumor)
+		expect(unwrapped.rumor).toEqual(normalizedRumor)
 		expect(unwrapped.seal.pubkey).toBe(unwrapped.rumor.pubkey)
+	})
+
+	test('accepts a rumor with a correct id', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const rumor = rumorFor(buyer.pubkey)
+		const rumorWithId = { ...rumor, id: canonicalRumorId(rumor) }
+
+		const { rumor: normalizedRumor } = createNip59GiftWrap({
+			rumor: rumorWithId,
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(normalizedRumor).toEqual(rumorWithId)
+	})
+
+	test('normalizes a missing rumor id before encrypting the seal', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const rawRumor = rumorFor(buyer.pubkey)
+
+		const { rumor: normalizedRumor, giftWrap } = createNip59GiftWrap({
+			rumor: rawRumor,
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+		const unwrapped = unwrapNip59GiftWrap({
+			giftWrap,
+			recipientPrivateKey: seller.privateKey,
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
+
+		expect(rawRumor.id).toBeUndefined()
+		expect(normalizedRumor.id).toBe(canonicalRumorId(rawRumor))
+		expect(unwrapped.rumor).toEqual(normalizedRumor)
+		expect(unwrapped.rumor).not.toEqual(rawRumor)
+	})
+
+	test('rejects a rumor with an incorrect id', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const invalidRumor = { ...rumorFor(buyer.pubkey), id: '0'.repeat(64) }
+
+		expect(() =>
+			createNip59GiftWrap({
+				rumor: invalidRumor,
+				senderPrivateKey: buyer.privateKey,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('NIP-59 rumor id is invalid')
+	})
+
+	test('rejects decrypted rumor with an incorrect id', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const invalidRumor = { ...rumorFor(buyer.pubkey), id: '0'.repeat(64) }
+		const seal = sealForRumor(invalidRumor, buyer.privateKey, seller.pubkey)
+		const giftWrap = giftWrapForSeal(seal, wrapper.privateKey, seller.pubkey)
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('NIP-59 rumor id is invalid')
+	})
+
+	test('normalizes without mutating caller-owned rumor objects', () => {
+		const buyer = keyPair()
+		const rumor = rumorFor(buyer.pubkey)
+		const normalizedRumor = normalizeUnsignedRumorId(rumor)
+
+		expect(rumor.id).toBeUndefined()
+		expect(normalizedRumor.id).toBe(canonicalRumorId(rumor))
+		expect(normalizedRumor).not.toBe(rumor)
+		expect(normalizedRumor.tags).not.toBe(rumor.tags)
 	})
 
 	test('non-recipient cannot decrypt', () => {

--- a/src/lib/nostr/nip59.test.ts
+++ b/src/lib/nostr/nip59.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
+import type { Event } from 'nostr-tools'
+import { createNip59GiftWrap, NIP59_GIFT_WRAP_KIND, NIP59_SEAL_KIND, unwrapNip59GiftWrap, type UnsignedRumor } from './nip59'
+
+const CREATED_AT = 1_700_000_000
+const PII_SENTINELS = [
+	'buyer@example.com',
+	'123 Main Street',
+	'Satoshi Nakamoto',
+	'+15551234567',
+	'Los Angeles',
+	'90210',
+	'United States',
+	'Apt Secret Notes',
+]
+
+type KeyPair = {
+	privateKey: Uint8Array
+	pubkey: string
+}
+
+function keyPair(): KeyPair {
+	const privateKey = crypto.getRandomValues(new Uint8Array(32))
+	return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function rumorFor(buyerPubkey: string): UnsignedRumor {
+	return {
+		kind: 16,
+		pubkey: buyerPubkey,
+		created_at: CREATED_AT,
+		tags: [
+			['p', 'seller'],
+			['subject', 'order-info'],
+		],
+		content: 'Satoshi Nakamoto buyer@example.com 123 Main Street Apt Secret Notes',
+	}
+}
+
+function encryptForRecipient(plaintext: string, senderPrivateKey: Uint8Array, recipientPubkey: string): string {
+	const conversationKey = nip44.v2.utils.getConversationKey(senderPrivateKey, recipientPubkey)
+	return nip44.v2.encrypt(plaintext, conversationKey)
+}
+
+function giftWrapForSeal(seal: unknown, wrapperPrivateKey: Uint8Array, sellerPubkey: string): Event {
+	return finalizeEvent(
+		{
+			kind: NIP59_GIFT_WRAP_KIND,
+			content: encryptForRecipient(JSON.stringify(seal), wrapperPrivateKey, sellerPubkey),
+			created_at: CREATED_AT,
+			tags: [['p', sellerPubkey]],
+		},
+		wrapperPrivateKey,
+	)
+}
+
+function sealForRumor(rumor: unknown, buyerPrivateKey: Uint8Array, sellerPubkey: string, tags: string[][] = []): Event {
+	return finalizeEvent(
+		{
+			kind: NIP59_SEAL_KIND,
+			content: encryptForRecipient(JSON.stringify(rumor), buyerPrivateKey, sellerPubkey),
+			created_at: CREATED_AT,
+			tags,
+		},
+		buyerPrivateKey,
+	)
+}
+
+function expectNoPii(value: unknown): void {
+	const serialized = JSON.stringify(value)
+	for (const sentinel of PII_SENTINELS) {
+		expect(serialized).not.toContain(sentinel)
+	}
+}
+
+describe('NIP-59 helper', () => {
+	test('wraps an unsigned rumor as a signed kind 13 seal and signed kind 1059 gift wrap', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const rumor = rumorFor(buyer.pubkey)
+
+		const { seal, giftWrap } = createNip59GiftWrap({
+			rumor,
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			wrapperPrivateKey: wrapper.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect('sig' in rumor).toBe(false)
+		expect(seal.kind).toBe(NIP59_SEAL_KIND)
+		expect(seal.tags).toEqual([])
+		expect(seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(seal)).toBe(true)
+
+		expect(giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(giftWrap.pubkey).toBe(wrapper.pubkey)
+		expect(verifyEvent(giftWrap)).toBe(true)
+		expect(giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expectNoPii(giftWrap)
+		expect(JSON.stringify(giftWrap)).not.toContain('Satoshi Nakamoto')
+
+		const unwrapped = unwrapNip59GiftWrap({
+			giftWrap,
+			recipientPrivateKey: seller.privateKey,
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
+
+		expect(unwrapped.seal.id).toBe(seal.id)
+		expect(unwrapped.rumor).toEqual(rumor)
+		expect(unwrapped.seal.pubkey).toBe(unwrapped.rumor.pubkey)
+	})
+
+	test('non-recipient cannot decrypt', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const nonRecipient = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: nonRecipient.privateKey,
+				expectedRecipientPubkey: nonRecipient.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow()
+	})
+
+	test('rejects malformed seal', () => {
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const malformedGiftWrap = giftWrapForSeal({ kind: NIP59_SEAL_KIND }, wrapper.privateKey, seller.pubkey)
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap: malformedGiftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+			}),
+		).toThrow('Malformed NIP-59 seal')
+	})
+
+	test('rejects seal with non-empty tags', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const seal = sealForRumor(rumorFor(buyer.pubkey), buyer.privateKey, seller.pubkey, [['p', seller.pubkey]])
+		const giftWrap = giftWrapForSeal(seal, wrapper.privateKey, seller.pubkey)
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('NIP-59 seal tags must be empty')
+	})
+
+	test('rejects invalid seal signature', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const seal = sealForRumor(rumorFor(buyer.pubkey), buyer.privateKey, seller.pubkey)
+		const tamperedSeal = { ...seal, content: `${seal.content}x` }
+		const giftWrap = giftWrapForSeal(tamperedSeal, wrapper.privateKey, seller.pubkey)
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('Invalid NIP-59 seal signature')
+	})
+
+	test('rejects invalid gift wrap signature', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		const tamperedGiftWrap = { ...giftWrap, content: `${giftWrap.content}x` }
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap: tamperedGiftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('Invalid NIP-59 gift wrap signature')
+	})
+
+	test('rejects signed rumor', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signedRumor = { ...rumorFor(buyer.pubkey), sig: '0'.repeat(128) }
+
+		expect(() =>
+			createNip59GiftWrap({
+				rumor: signedRumor,
+				senderPrivateKey: buyer.privateKey,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('NIP-59 rumor must be unsigned')
+
+		const wrapper = keyPair()
+		const seal = sealForRumor(signedRumor, buyer.privateKey, seller.pubkey)
+		const giftWrap = giftWrapForSeal(seal, wrapper.privateKey, seller.pubkey)
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('NIP-59 rumor must be unsigned')
+	})
+
+	test('rejects mismatched seller pubkey', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: otherSeller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).toThrow('NIP-59 gift wrap recipient mismatch')
+	})
+
+	test('rejects mismatched buyer pubkey', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherBuyer = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(() =>
+			unwrapNip59GiftWrap({
+				giftWrap,
+				recipientPrivateKey: seller.privateKey,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: otherBuyer.pubkey,
+			}),
+		).toThrow('NIP-59 seal sender mismatch')
+	})
+})

--- a/src/lib/nostr/nip59.test.ts
+++ b/src/lib/nostr/nip59.test.ts
@@ -1,12 +1,16 @@
+import { NDKUser, type NDKEncryptionScheme, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
 import {
 	createNip59GiftWrap,
+	createNip59GiftWrapWithSigner,
 	NIP59_GIFT_WRAP_KIND,
 	NIP59_SEAL_KIND,
 	normalizeUnsignedRumorId,
+	signerSupportsNip44,
 	unwrapNip59GiftWrap,
+	unwrapNip59GiftWrapWithSigner,
 	type UnsignedRumor,
 } from './nip59'
 
@@ -27,9 +31,47 @@ type KeyPair = {
 	pubkey: string
 }
 
+type MockSignerOptions = {
+	supportsNip44?: boolean
+	canEncrypt?: boolean
+	canDecrypt?: boolean
+	encryptionEnabledThrows?: boolean
+}
+
 function keyPair(): KeyPair {
 	const privateKey = crypto.getRandomValues(new Uint8Array(32))
 	return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function signerFor(privateKey: Uint8Array, options: MockSignerOptions = {}): NDKSigner {
+	const pubkey = getPublicKey(privateKey)
+	const user = new NDKUser({ pubkey })
+	return {
+		get pubkey() {
+			return pubkey
+		},
+		blockUntilReady: async () => user,
+		user: async () => user,
+		get userSync() {
+			return user
+		},
+		encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
+			if (options.encryptionEnabledThrows) throw new Error('capability check failed')
+			if (options.supportsNip44 === false) return []
+			if (!scheme || scheme === 'nip44') return ['nip44']
+			return []
+		},
+		encrypt: async (recipient, value, scheme) => {
+			if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') throw new Error('NIP-44 unavailable')
+			return encryptForRecipient(value, privateKey, recipient.pubkey)
+		},
+		decrypt: async (sender, value, scheme) => {
+			if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') throw new Error('NIP-44 unavailable')
+			return decryptFromSender(value, privateKey, sender.pubkey)
+		},
+		sign: async (event) => finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig,
+		toPayload: () => JSON.stringify({ type: 'mock' }),
+	}
 }
 
 function rumorFor(buyerPubkey: string): UnsignedRumor {
@@ -58,6 +100,11 @@ function canonicalRumorId(rumor: UnsignedRumor): string {
 function encryptForRecipient(plaintext: string, senderPrivateKey: Uint8Array, recipientPubkey: string): string {
 	const conversationKey = nip44.v2.utils.getConversationKey(senderPrivateKey, recipientPubkey)
 	return nip44.v2.encrypt(plaintext, conversationKey)
+}
+
+function decryptFromSender(ciphertext: string, recipientPrivateKey: Uint8Array, senderPubkey: string): string {
+	const conversationKey = nip44.v2.utils.getConversationKey(recipientPrivateKey, senderPubkey)
+	return nip44.v2.decrypt(ciphertext, conversationKey)
 }
 
 function giftWrapForSeal(seal: unknown, wrapperPrivateKey: Uint8Array, sellerPubkey: string): Event {
@@ -135,6 +182,314 @@ describe('NIP-59 helper', () => {
 		expect(unwrapped.seal.id).toBe(seal.id)
 		expect(unwrapped.rumor).toEqual(normalizedRumor)
 		expect(unwrapped.seal.pubkey).toBe(unwrapped.rumor.pubkey)
+	})
+
+	test('signer-backed helper creates a valid kind 13 seal and kind 1059 gift wrap', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const rumor = rumorFor(buyer.pubkey)
+		const signer = signerFor(buyer.privateKey)
+
+		const {
+			rumor: normalizedRumor,
+			seal,
+			giftWrap,
+		} = await createNip59GiftWrapWithSigner({
+			rumor,
+			signer,
+			recipientPubkey: seller.pubkey,
+			wrapperPrivateKey: wrapper.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(normalizedRumor.id).toBe(canonicalRumorId(rumor))
+		expect(seal.kind).toBe(NIP59_SEAL_KIND)
+		expect(seal.tags).toEqual([])
+		expect(seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(seal)).toBe(true)
+		expect(giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(giftWrap.pubkey).toBe(wrapper.pubkey)
+		expect(giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expect(verifyEvent(giftWrap)).toBe(true)
+		expectNoPii(giftWrap)
+
+		const unwrapped = await unwrapNip59GiftWrapWithSigner({
+			giftWrap,
+			signer: signerFor(seller.privateKey),
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
+
+		expect(unwrapped.seal.id).toBe(seal.id)
+		expect(unwrapped.rumor).toEqual(normalizedRumor)
+	})
+
+	test('signer with encrypt support but no decrypt support can create a valid gift wrap', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signer = { ...signerFor(buyer.privateKey), decrypt: undefined } as unknown as NDKSigner
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(true)
+		await expect(signerSupportsNip44(signer, 'decrypt')).resolves.toBe(false)
+
+		const { giftWrap, seal } = await createNip59GiftWrapWithSigner({
+			rumor: rumorFor(buyer.pubkey),
+			signer,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(seal.kind).toBe(NIP59_SEAL_KIND)
+		expect(verifyEvent(seal)).toBe(true)
+		expect(giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expectNoPii(giftWrap)
+	})
+
+	test('signer with decrypt support but no encrypt support can unwrap a valid gift wrap', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const { giftWrap, rumor } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+		const signer = { ...signerFor(seller.privateKey), encrypt: undefined } as unknown as NDKSigner
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(false)
+		await expect(signerSupportsNip44(signer, 'decrypt')).resolves.toBe(true)
+
+		const unwrapped = await unwrapNip59GiftWrapWithSigner({
+			giftWrap,
+			signer,
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
+
+		expect(unwrapped.rumor).toEqual(rumor)
+		expect(unwrapped.seal.pubkey).toBe(buyer.pubkey)
+	})
+
+	test('signer-backed helper fails closed when NIP-44 encrypt is unavailable', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signer = signerFor(buyer.privateKey, { supportsNip44: false })
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(false)
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 encrypt')
+	})
+
+	test('signer-backed helper fails closed when NIP-44 encrypt throws', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signer = signerFor(buyer.privateKey, { canEncrypt: false })
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(true)
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('NIP-44 encryption failed for NIP-59 seal')
+	})
+
+	test('signer-backed helper fails closed when NIP-44 capability checks are unavailable', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signer: NDKSigner = { ...signerFor(buyer.privateKey), encryptionEnabled: undefined }
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(false)
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 encrypt')
+	})
+
+	test('operation-specific capability helper returns false when NIP-44 capability check throws', async () => {
+		const buyer = keyPair()
+		const signer = signerFor(buyer.privateKey, { encryptionEnabledThrows: true })
+
+		await expect(signerSupportsNip44(signer, 'encrypt')).resolves.toBe(false)
+		await expect(signerSupportsNip44(signer, 'decrypt')).resolves.toBe(false)
+	})
+
+	test('signer-backed unwrap fails closed when NIP-44 decrypt is unavailable', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+
+		await expect(
+			unwrapNip59GiftWrapWithSigner({
+				giftWrap,
+				signer: signerFor(seller.privateKey, { supportsNip44: false }),
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 decrypt')
+	})
+
+	test('signer-backed unwrap fails closed when NIP-44 decrypt throws', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+		const signer = signerFor(seller.privateKey, { canDecrypt: false })
+
+		await expect(signerSupportsNip44(signer, 'decrypt')).resolves.toBe(true)
+		await expect(
+			unwrapNip59GiftWrapWithSigner({
+				giftWrap,
+				signer,
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('NIP-44 decryption failed for NIP-59 gift wrap')
+	})
+
+	test('signer-backed helper requires signer pubkey to match rumor pubkey', async () => {
+		const buyer = keyPair()
+		const otherBuyer = keyPair()
+		const seller = keyPair()
+
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer: signerFor(otherBuyer.privateKey),
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('NIP-59 rumor pubkey must match the signer pubkey')
+	})
+
+	test('signer-backed creation fails closed when signing is unavailable or invalid', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const signerWithoutSign = { ...signerFor(buyer.privateKey), sign: undefined } as unknown as NDKSigner
+
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer: signerWithoutSign,
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Signer does not support signing NIP-59 seal')
+
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer: { ...signerFor(buyer.privateKey), sign: async () => Promise.reject(new Error('sign failed')) },
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Failed to sign NIP-59 seal')
+
+		await expect(
+			createNip59GiftWrapWithSigner({
+				rumor: rumorFor(buyer.pubkey),
+				signer: { ...signerFor(buyer.privateKey), sign: async () => '0'.repeat(128) },
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Invalid NIP-59 seal signature')
+	})
+
+	test('signer-backed unwrap does not call signer.sign', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const { giftWrap, rumor } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+		let signCalls = 0
+		const signer = {
+			...signerFor(seller.privateKey),
+			encrypt: undefined,
+			sign: async () => {
+				signCalls += 1
+				throw new Error('unwrap must not sign')
+			},
+		} as unknown as NDKSigner
+
+		const unwrapped = await unwrapNip59GiftWrapWithSigner({
+			giftWrap,
+			signer,
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
+
+		expect(unwrapped.rumor).toEqual(rumor)
+		expect(signCalls).toBe(0)
+	})
+
+	test('signer-backed unwrap verifies signatures and canonical rumor id', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const invalidRumor = { ...rumorFor(buyer.pubkey), id: '0'.repeat(64) }
+		const sealWithInvalidRumor = sealForRumor(invalidRumor, buyer.privateKey, seller.pubkey)
+		const giftWrapWithInvalidRumor = giftWrapForSeal(sealWithInvalidRumor, wrapper.privateKey, seller.pubkey)
+
+		await expect(
+			unwrapNip59GiftWrapWithSigner({
+				giftWrap: giftWrapWithInvalidRumor,
+				signer: signerFor(seller.privateKey),
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('NIP-59 rumor id is invalid')
+
+		const seal = sealForRumor(rumorFor(buyer.pubkey), buyer.privateKey, seller.pubkey)
+		const giftWrapWithInvalidSeal = giftWrapForSeal({ ...seal, content: `${seal.content}x` }, wrapper.privateKey, seller.pubkey)
+		await expect(
+			unwrapNip59GiftWrapWithSigner({
+				giftWrap: giftWrapWithInvalidSeal,
+				signer: signerFor(seller.privateKey),
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('Invalid NIP-59 seal signature')
+
+		const { giftWrap } = createNip59GiftWrap({
+			rumor: rumorFor(buyer.pubkey),
+			senderPrivateKey: buyer.privateKey,
+			recipientPubkey: seller.pubkey,
+			createdAt: CREATED_AT,
+		})
+		await expect(
+			unwrapNip59GiftWrapWithSigner({
+				giftWrap: { ...giftWrap, content: `${giftWrap.content}x` },
+				signer: signerFor(seller.privateKey),
+				expectedRecipientPubkey: seller.pubkey,
+				expectedSenderPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('Invalid NIP-59 gift wrap signature')
 	})
 
 	test('accepts a rumor with a correct id', () => {

--- a/src/lib/nostr/nip59.ts
+++ b/src/lib/nostr/nip59.ts
@@ -1,3 +1,4 @@
+import { NDKUser, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
 
@@ -23,9 +24,24 @@ export type CreateNip59GiftWrapParams = {
 	createdAt?: number
 }
 
+export type CreateNip59GiftWrapWithSignerParams = {
+	rumor: UnsignedRumor
+	signer: NDKSigner | null | undefined
+	recipientPubkey: string
+	wrapperPrivateKey?: Uint8Array
+	createdAt?: number
+}
+
 export type UnwrapNip59GiftWrapParams = {
 	giftWrap: Event
 	recipientPrivateKey: Uint8Array
+	expectedRecipientPubkey?: string
+	expectedSenderPubkey?: string
+}
+
+export type UnwrapNip59GiftWrapWithSignerParams = {
+	giftWrap: Event
+	signer: NDKSigner | null | undefined
 	expectedRecipientPubkey?: string
 	expectedSenderPubkey?: string
 }
@@ -40,6 +56,8 @@ export type UnwrappedNip59GiftWrap = {
 	seal: Event
 	rumor: UnsignedRumor
 }
+
+export type Nip44SignerOperation = 'encrypt' | 'decrypt'
 
 export function createNip59GiftWrap(params: CreateNip59GiftWrapParams): Nip59GiftWrap {
 	const { rumor, senderPrivateKey, recipientPubkey, createdAt = unixNow() } = params
@@ -60,6 +78,45 @@ export function createNip59GiftWrap(params: CreateNip59GiftWrapParams): Nip59Gif
 		},
 		senderPrivateKey,
 	)
+
+	const wrapperPrivateKey = params.wrapperPrivateKey ?? randomPrivateKey()
+	const giftWrap = finalizeEvent(
+		{
+			kind: NIP59_GIFT_WRAP_KIND,
+			content: encryptForRecipient(JSON.stringify(seal), wrapperPrivateKey, recipientPubkey),
+			created_at: createdAt,
+			tags: [['p', recipientPubkey]],
+		},
+		wrapperPrivateKey,
+	)
+
+	return { rumor: normalizedRumor, seal, giftWrap }
+}
+
+export async function createNip59GiftWrapWithSigner(params: CreateNip59GiftWrapWithSignerParams): Promise<Nip59GiftWrap> {
+	const { rumor, recipientPubkey, createdAt = unixNow() } = params
+	assertHexPubkey(recipientPubkey, 'recipient pubkey')
+	const signer = await assertSignerSupportsNip44(params.signer, 'encrypt')
+	const normalizedRumor = normalizeUnsignedRumorId(rumor)
+	const signerPubkey = await signerPubkeyFor(signer)
+
+	if (normalizedRumor.pubkey !== signerPubkey) {
+		throw new Error('NIP-59 rumor pubkey must match the signer pubkey')
+	}
+
+	const sealContent = await encryptForRecipientWithSigner(JSON.stringify(normalizedRumor), signer, recipientPubkey, 'NIP-59 seal')
+	const seal = await signEventWithSigner(
+		{
+			kind: NIP59_SEAL_KIND,
+			content: sealContent,
+			created_at: createdAt,
+			tags: [],
+			pubkey: signerPubkey,
+		},
+		signer,
+		'NIP-59 seal',
+	)
+	assertSeal(seal)
 
 	const wrapperPrivateKey = params.wrapperPrivateKey ?? randomPrivateKey()
 	const giftWrap = finalizeEvent(
@@ -104,6 +161,35 @@ export function unwrapNip59GiftWrap(params: UnwrapNip59GiftWrapParams): Unwrappe
 	return { seal, rumor }
 }
 
+export async function unwrapNip59GiftWrapWithSigner(params: UnwrapNip59GiftWrapWithSignerParams): Promise<UnwrappedNip59GiftWrap> {
+	const signer = await assertSignerSupportsNip44(params.signer, 'decrypt')
+	const signerPubkey = await signerPubkeyFor(signer)
+	const recipientPubkey = params.expectedRecipientPubkey ?? signerPubkey
+	assertHexPubkey(recipientPubkey, 'recipient pubkey')
+	if (signerPubkey !== recipientPubkey) throw new Error('NIP-59 recipient signer mismatch')
+	if (params.expectedSenderPubkey) assertHexPubkey(params.expectedSenderPubkey, 'sender pubkey')
+
+	assertGiftWrap(params.giftWrap, recipientPubkey)
+
+	const seal = parseEventJson(
+		await decryptFromSenderWithSigner(params.giftWrap.content, signer, params.giftWrap.pubkey, 'NIP-59 gift wrap'),
+		'NIP-59 seal',
+	)
+	assertSeal(seal)
+
+	if (params.expectedSenderPubkey && seal.pubkey !== params.expectedSenderPubkey) {
+		throw new Error('NIP-59 seal sender mismatch')
+	}
+
+	const rumor = parseUnsignedRumorJson(await decryptFromSenderWithSigner(seal.content, signer, seal.pubkey, 'NIP-59 seal'), 'NIP-59 rumor')
+
+	if (seal.pubkey !== rumor.pubkey) {
+		throw new Error('NIP-59 seal pubkey does not match rumor pubkey')
+	}
+
+	return { seal, rumor }
+}
+
 export function normalizeUnsignedRumorId(rumor: unknown): UnsignedRumor {
 	assertUnsignedRumor(rumor)
 	const canonicalId = getEventHash({
@@ -125,6 +211,20 @@ export function normalizeUnsignedRumorId(rumor: unknown): UnsignedRumor {
 		tags: rumor.tags.map((tag) => [...tag]),
 		content: rumor.content,
 		id: canonicalId,
+	}
+}
+
+export async function signerSupportsNip44(signer: NDKSigner | null | undefined, operation: Nip44SignerOperation): Promise<boolean> {
+	if (!signer) return false
+	if (typeof signer.encryptionEnabled !== 'function') return false
+	if (operation === 'encrypt' && typeof signer.encrypt !== 'function') return false
+	if (operation === 'decrypt' && typeof signer.decrypt !== 'function') return false
+
+	try {
+		const enabled = await signer.encryptionEnabled('nip44')
+		return enabled.includes('nip44')
+	} catch {
+		return false
 	}
 }
 
@@ -150,6 +250,74 @@ function decryptFromSender(ciphertext: string, recipientPrivateKey: Uint8Array, 
 	} catch {
 		throw new Error(`Malformed ${label}`)
 	}
+}
+
+async function assertSignerSupportsNip44(signer: NDKSigner | null | undefined, operation: Nip44SignerOperation): Promise<NDKSigner> {
+	if (!signer) {
+		throw new Error(`Signer does not support NIP-44 ${operation}`)
+	}
+	if (!(await signerSupportsNip44(signer, operation))) {
+		throw new Error(`Signer does not support NIP-44 ${operation}`)
+	}
+	return signer
+}
+
+async function signerPubkeyFor(signer: NDKSigner): Promise<string> {
+	const user = await signer.user()
+	const pubkey = user.pubkey
+	assertHexPubkey(pubkey, 'signer pubkey')
+	return pubkey
+}
+
+async function encryptForRecipientWithSigner(
+	plaintext: string,
+	signer: NDKSigner,
+	recipientPubkey: string,
+	label: string,
+): Promise<string> {
+	try {
+		return await signer.encrypt(new NDKUser({ pubkey: recipientPubkey }), plaintext, 'nip44')
+	} catch {
+		throw new Error(`NIP-44 encryption failed for ${label}`)
+	}
+}
+
+async function decryptFromSenderWithSigner(ciphertext: string, signer: NDKSigner, senderPubkey: string, label: string): Promise<string> {
+	try {
+		return await signer.decrypt(new NDKUser({ pubkey: senderPubkey }), ciphertext, 'nip44')
+	} catch {
+		throw new Error(`NIP-44 decryption failed for ${label}`)
+	}
+}
+
+type SignableEvent = {
+	kind: number
+	content: string
+	created_at: number
+	tags: string[][]
+	pubkey: string
+}
+
+async function signEventWithSigner(signableEvent: SignableEvent, signer: NDKSigner, label: string): Promise<Event> {
+	if (typeof signer.sign !== 'function') {
+		throw new Error(`Signer does not support signing ${label}`)
+	}
+
+	let sig: string
+	try {
+		sig = await signer.sign(signableEvent as Parameters<NDKSigner['sign']>[0])
+	} catch {
+		throw new Error(`Failed to sign ${label}`)
+	}
+
+	const event = {
+		...signableEvent,
+		id: getEventHash(signableEvent),
+		sig,
+	}
+	assertEvent(event, label)
+	if (!verifyEventSignature(event)) throw new Error(`Invalid ${label} signature`)
+	return event
 }
 
 function parseEventJson(json: string, label: string): Event {

--- a/src/lib/nostr/nip59.ts
+++ b/src/lib/nostr/nip59.ts
@@ -1,0 +1,215 @@
+import { finalizeEvent, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
+import type { Event } from 'nostr-tools'
+
+export const NIP59_SEAL_KIND = 13
+export const NIP59_GIFT_WRAP_KIND = 1059
+
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/i
+
+export type UnsignedRumor = {
+	kind: number
+	pubkey: string
+	created_at: number
+	tags: string[][]
+	content: string
+	id?: string
+}
+
+export type CreateNip59GiftWrapParams = {
+	rumor: UnsignedRumor
+	senderPrivateKey: Uint8Array
+	recipientPubkey: string
+	wrapperPrivateKey?: Uint8Array
+	createdAt?: number
+}
+
+export type UnwrapNip59GiftWrapParams = {
+	giftWrap: Event
+	recipientPrivateKey: Uint8Array
+	expectedRecipientPubkey?: string
+	expectedSenderPubkey?: string
+}
+
+export type Nip59GiftWrap = {
+	rumor: UnsignedRumor
+	seal: Event
+	giftWrap: Event
+}
+
+export type UnwrappedNip59GiftWrap = {
+	seal: Event
+	rumor: UnsignedRumor
+}
+
+export function createNip59GiftWrap(params: CreateNip59GiftWrapParams): Nip59GiftWrap {
+	const { rumor, senderPrivateKey, recipientPubkey, createdAt = unixNow() } = params
+	assertHexPubkey(recipientPubkey, 'recipient pubkey')
+	assertUnsignedRumor(rumor)
+
+	const senderPubkey = getPublicKey(senderPrivateKey)
+	if (rumor.pubkey !== senderPubkey) {
+		throw new Error('NIP-59 rumor pubkey must match the sender key')
+	}
+
+	const seal = finalizeEvent(
+		{
+			kind: NIP59_SEAL_KIND,
+			content: encryptForRecipient(JSON.stringify(rumor), senderPrivateKey, recipientPubkey),
+			created_at: createdAt,
+			tags: [],
+		},
+		senderPrivateKey,
+	)
+
+	const wrapperPrivateKey = params.wrapperPrivateKey ?? randomPrivateKey()
+	const giftWrap = finalizeEvent(
+		{
+			kind: NIP59_GIFT_WRAP_KIND,
+			content: encryptForRecipient(JSON.stringify(seal), wrapperPrivateKey, recipientPubkey),
+			created_at: createdAt,
+			tags: [['p', recipientPubkey]],
+		},
+		wrapperPrivateKey,
+	)
+
+	return { rumor, seal, giftWrap }
+}
+
+export function unwrapNip59GiftWrap(params: UnwrapNip59GiftWrapParams): UnwrappedNip59GiftWrap {
+	const recipientPubkey = params.expectedRecipientPubkey ?? getPublicKey(params.recipientPrivateKey)
+	assertHexPubkey(recipientPubkey, 'recipient pubkey')
+	if (params.expectedSenderPubkey) assertHexPubkey(params.expectedSenderPubkey, 'sender pubkey')
+
+	assertGiftWrap(params.giftWrap, recipientPubkey)
+
+	const seal = parseEventJson(
+		decryptFromSender(params.giftWrap.content, params.recipientPrivateKey, params.giftWrap.pubkey, 'NIP-59 gift wrap'),
+		'NIP-59 seal',
+	)
+	assertSeal(seal)
+
+	if (params.expectedSenderPubkey && seal.pubkey !== params.expectedSenderPubkey) {
+		throw new Error('NIP-59 seal sender mismatch')
+	}
+
+	const rumor = parseUnsignedRumorJson(
+		decryptFromSender(seal.content, params.recipientPrivateKey, seal.pubkey, 'NIP-59 seal'),
+		'NIP-59 rumor',
+	)
+
+	if (seal.pubkey !== rumor.pubkey) {
+		throw new Error('NIP-59 seal pubkey does not match rumor pubkey')
+	}
+
+	return { seal, rumor }
+}
+
+function unixNow(): number {
+	return Math.floor(Date.now() / 1000)
+}
+
+function randomPrivateKey(): Uint8Array {
+	const bytes = new Uint8Array(32)
+	crypto.getRandomValues(bytes)
+	return bytes
+}
+
+function encryptForRecipient(plaintext: string, senderPrivateKey: Uint8Array, recipientPubkey: string): string {
+	const conversationKey = nip44.v2.utils.getConversationKey(senderPrivateKey, recipientPubkey)
+	return nip44.v2.encrypt(plaintext, conversationKey)
+}
+
+function decryptFromSender(ciphertext: string, recipientPrivateKey: Uint8Array, senderPubkey: string, label: string): string {
+	try {
+		const conversationKey = nip44.v2.utils.getConversationKey(recipientPrivateKey, senderPubkey)
+		return nip44.v2.decrypt(ciphertext, conversationKey)
+	} catch {
+		throw new Error(`Malformed ${label}`)
+	}
+}
+
+function parseEventJson(json: string, label: string): Event {
+	const parsed = parseRecordJson(json, label)
+	assertEvent(parsed, label)
+	return parsed
+}
+
+function parseUnsignedRumorJson(json: string, label: string): UnsignedRumor {
+	const parsed = parseRecordJson(json, label)
+	assertUnsignedRumor(parsed)
+	return parsed
+}
+
+function parseRecordJson(json: string, label: string): Record<string, unknown> {
+	try {
+		const parsed: unknown = JSON.parse(json)
+		if (!isRecord(parsed)) throw new Error('not an object')
+		return parsed
+	} catch {
+		throw new Error(`Malformed ${label}`)
+	}
+}
+
+function assertGiftWrap(event: Event, expectedRecipientPubkey: string): void {
+	assertEvent(event, 'NIP-59 gift wrap')
+	if (event.kind !== NIP59_GIFT_WRAP_KIND) throw new Error('Invalid NIP-59 gift wrap kind')
+	if (!verifyEventSignature(event)) throw new Error('Invalid NIP-59 gift wrap signature')
+	const recipientTag = event.tags[0]
+	if (event.tags.length !== 1 || recipientTag?.[0] !== 'p' || recipientTag[1] !== expectedRecipientPubkey || recipientTag.length !== 2) {
+		throw new Error('NIP-59 gift wrap recipient mismatch')
+	}
+}
+
+function assertSeal(event: Event): void {
+	assertEvent(event, 'NIP-59 seal')
+	if (event.kind !== NIP59_SEAL_KIND) throw new Error('Invalid NIP-59 seal kind')
+	if (event.tags.length !== 0) throw new Error('NIP-59 seal tags must be empty')
+	if (!verifyEventSignature(event)) throw new Error('Invalid NIP-59 seal signature')
+}
+
+function verifyEventSignature(event: Event): boolean {
+	const plainEvent = {
+		id: event.id,
+		pubkey: event.pubkey,
+		created_at: event.created_at,
+		kind: event.kind,
+		tags: event.tags,
+		content: event.content,
+		sig: event.sig,
+	}
+	return verifyEvent(plainEvent)
+}
+
+function assertEvent(value: unknown, label: string): asserts value is Event {
+	if (!isRecord(value)) throw new Error(`Malformed ${label}`)
+	if (typeof value.kind !== 'number') throw new Error(`Malformed ${label}`)
+	if (typeof value.content !== 'string') throw new Error(`Malformed ${label}`)
+	if (typeof value.created_at !== 'number') throw new Error(`Malformed ${label}`)
+	if (typeof value.pubkey !== 'string' || !HEX_PUBKEY_RE.test(value.pubkey)) throw new Error(`Malformed ${label}`)
+	if (typeof value.id !== 'string') throw new Error(`Malformed ${label}`)
+	if (typeof value.sig !== 'string') throw new Error(`Malformed ${label}`)
+	if (!Array.isArray(value.tags) || !value.tags.every(isStringTag)) throw new Error(`Malformed ${label}`)
+}
+
+function assertUnsignedRumor(value: unknown): asserts value is UnsignedRumor {
+	if (!isRecord(value)) throw new Error('Malformed NIP-59 rumor')
+	if ('sig' in value) throw new Error('NIP-59 rumor must be unsigned')
+	if (typeof value.kind !== 'number') throw new Error('Malformed NIP-59 rumor')
+	if (typeof value.content !== 'string') throw new Error('Malformed NIP-59 rumor')
+	if (typeof value.created_at !== 'number') throw new Error('Malformed NIP-59 rumor')
+	if (typeof value.pubkey !== 'string' || !HEX_PUBKEY_RE.test(value.pubkey)) throw new Error('Malformed NIP-59 rumor')
+	if (!Array.isArray(value.tags) || !value.tags.every(isStringTag)) throw new Error('Malformed NIP-59 rumor')
+	if ('id' in value && typeof value.id !== 'string') throw new Error('Malformed NIP-59 rumor')
+}
+
+function assertHexPubkey(value: string, label: string): void {
+	if (!HEX_PUBKEY_RE.test(value)) throw new Error(`Invalid ${label}`)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isStringTag(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}

--- a/src/lib/nostr/nip59.ts
+++ b/src/lib/nostr/nip59.ts
@@ -1,4 +1,4 @@
-import { finalizeEvent, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
+import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
 
 export const NIP59_SEAL_KIND = 13
@@ -44,17 +44,17 @@ export type UnwrappedNip59GiftWrap = {
 export function createNip59GiftWrap(params: CreateNip59GiftWrapParams): Nip59GiftWrap {
 	const { rumor, senderPrivateKey, recipientPubkey, createdAt = unixNow() } = params
 	assertHexPubkey(recipientPubkey, 'recipient pubkey')
-	assertUnsignedRumor(rumor)
+	const normalizedRumor = normalizeUnsignedRumorId(rumor)
 
 	const senderPubkey = getPublicKey(senderPrivateKey)
-	if (rumor.pubkey !== senderPubkey) {
+	if (normalizedRumor.pubkey !== senderPubkey) {
 		throw new Error('NIP-59 rumor pubkey must match the sender key')
 	}
 
 	const seal = finalizeEvent(
 		{
 			kind: NIP59_SEAL_KIND,
-			content: encryptForRecipient(JSON.stringify(rumor), senderPrivateKey, recipientPubkey),
+			content: encryptForRecipient(JSON.stringify(normalizedRumor), senderPrivateKey, recipientPubkey),
 			created_at: createdAt,
 			tags: [],
 		},
@@ -72,7 +72,7 @@ export function createNip59GiftWrap(params: CreateNip59GiftWrapParams): Nip59Gif
 		wrapperPrivateKey,
 	)
 
-	return { rumor, seal, giftWrap }
+	return { rumor: normalizedRumor, seal, giftWrap }
 }
 
 export function unwrapNip59GiftWrap(params: UnwrapNip59GiftWrapParams): UnwrappedNip59GiftWrap {
@@ -102,6 +102,30 @@ export function unwrapNip59GiftWrap(params: UnwrapNip59GiftWrapParams): Unwrappe
 	}
 
 	return { seal, rumor }
+}
+
+export function normalizeUnsignedRumorId(rumor: unknown): UnsignedRumor {
+	assertUnsignedRumor(rumor)
+	const canonicalId = getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
+
+	if (rumor.id && rumor.id !== canonicalId) {
+		throw new Error('NIP-59 rumor id is invalid')
+	}
+
+	return {
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags.map((tag) => [...tag]),
+		content: rumor.content,
+		id: canonicalId,
+	}
 }
 
 function unixNow(): number {
@@ -136,8 +160,7 @@ function parseEventJson(json: string, label: string): Event {
 
 function parseUnsignedRumorJson(json: string, label: string): UnsignedRumor {
 	const parsed = parseRecordJson(json, label)
-	assertUnsignedRumor(parsed)
-	return parsed
+	return normalizeUnsignedRumorId(parsed)
 }
 
 function parseRecordJson(json: string, label: string): Record<string, unknown> {

--- a/src/lib/orders/privateOrderMessage.test.ts
+++ b/src/lib/orders/privateOrderMessage.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, test } from 'bun:test'
+import { getPublicKey, verifyEvent } from 'nostr-tools'
+import {
+	createEncryptedPrivateOrderMessage,
+	createPrivateOrderDetailsRumor,
+	decryptPrivateOrderMessage,
+	parsePrivateOrderDetailsRumor,
+	serializeBuyerAddress,
+	type PrivateOrderDeliveryDetails,
+} from './privateOrderMessage'
+
+const CREATED_AT = 1_700_000_000
+const PII_SENTINELS = [
+	'buyer@example.com',
+	'123 Main Street',
+	'Satoshi Nakamoto',
+	'+15551234567',
+	'Los Angeles',
+	'90210',
+	'United States',
+	'Apt Secret Notes',
+]
+
+type KeyPair = {
+	privateKey: Uint8Array
+	pubkey: string
+}
+
+function keyPair(): KeyPair {
+	const privateKey = crypto.getRandomValues(new Uint8Array(32))
+	return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function privateOrderDetails(
+	buyerPubkey: string,
+	sellerPubkey: string,
+	overrides: Partial<PrivateOrderDeliveryDetails> = {},
+): PrivateOrderDeliveryDetails {
+	return {
+		orderId: 'order-123',
+		buyerPubkey,
+		sellerPubkey,
+		totalAmountSats: 2100,
+		shippingRef: `30406:${sellerPubkey}:standard`,
+		items: [{ productRef: `30402:${sellerPubkey}:product-1`, quantity: 2 }],
+		delivery: {
+			name: 'Satoshi Nakamoto',
+			email: 'buyer@example.com',
+			phone: '+15551234567',
+			address: {
+				firstLineOfAddress: '123 Main Street',
+				additionalInformation: 'Apt Secret Notes',
+				city: 'Los Angeles',
+				zipPostcode: '90210',
+				country: 'United States',
+			},
+		},
+		orderNotes: 'Leave the package behind the planter',
+		...overrides,
+	}
+}
+
+function tagValue(tags: string[][], name: string): string | undefined {
+	return tags.find((tag) => tag[0] === name)?.[1]
+}
+
+function tagValues(tags: string[][], name: string): string[][] {
+	return tags.filter((tag) => tag[0] === name)
+}
+
+function expectNoPii(value: unknown): void {
+	const serialized = JSON.stringify(value)
+	for (const sentinel of PII_SENTINELS) {
+		expect(serialized).not.toContain(sentinel)
+	}
+}
+
+describe('private order message helper', () => {
+	test('creates valid Gamma-compatible unsigned kind 16/type=1 order details rumor', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+
+		const rumor = createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT })
+
+		expect(rumor.kind).toBe(16)
+		expect(rumor.pubkey).toBe(buyer.pubkey)
+		expect(rumor.created_at).toBe(CREATED_AT)
+		expect('sig' in rumor).toBe(false)
+		expect(rumor.tags).toContainEqual(['p', seller.pubkey])
+		expect(rumor.tags).toContainEqual(['subject', 'order-info'])
+		expect(rumor.tags).toContainEqual(['type', '1'])
+		expect(rumor.tags).toContainEqual(['order', 'order-123'])
+		expect(rumor.tags).toContainEqual(['amount', '2100'])
+		expect(rumor.tags).toContainEqual(['item', `30402:${seller.pubkey}:product-1`, '2'])
+		expect(rumor.tags).toContainEqual(['shipping', `30406:${seller.pubkey}:standard`])
+		expect(rumor.tags).toContainEqual(['name', 'Satoshi Nakamoto'])
+		expect(rumor.tags).toContainEqual(['address', '123 Main Street\nApt Secret Notes\nLos Angeles\n90210\nUnited States'])
+		expect(rumor.tags).toContainEqual(['email', 'buyer@example.com'])
+		expect(rumor.tags).toContainEqual(['phone', '+15551234567'])
+		expect(rumor.content).toBe('Leave the package behind the planter')
+	})
+
+	test('wraps private order details without exposing buyer PII in kind 1059', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+
+		const { rumor, seal, giftWrap } = createEncryptedPrivateOrderMessage({
+			details,
+			buyerPrivateKey: buyer.privateKey,
+			wrapperPrivateKey: wrapper.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(rumor.kind).toBe(16)
+		expect('sig' in rumor).toBe(false)
+		expect(seal.kind).toBe(13)
+		expect(seal.tags).toEqual([])
+		expect(seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(seal)).toBe(true)
+		expect(giftWrap.kind).toBe(1059)
+		expect(giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expect(verifyEvent(giftWrap)).toBe(true)
+		expectNoPii(giftWrap)
+		expect(JSON.stringify(giftWrap)).not.toContain('Satoshi Nakamoto')
+	})
+
+	test('seller decrypts gift wrap to seal to rumor to order details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const { giftWrap, rumor } = createEncryptedPrivateOrderMessage({
+			details,
+			buyerPrivateKey: buyer.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		const decrypted = decryptPrivateOrderMessage({
+			giftWrap,
+			sellerPrivateKey: seller.privateKey,
+			expectedSellerPubkey: seller.pubkey,
+			expectedBuyerPubkey: buyer.pubkey,
+		})
+
+		expect(decrypted.rumor).toEqual(rumor)
+		expect(decrypted.seal.pubkey).toBe(buyer.pubkey)
+		expect(decrypted.details).toEqual(details)
+	})
+
+	test('non-recipient cannot decrypt private order details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const nonRecipient = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const { giftWrap } = createEncryptedPrivateOrderMessage({
+			details,
+			buyerPrivateKey: buyer.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(() =>
+			decryptPrivateOrderMessage({
+				giftWrap,
+				sellerPrivateKey: nonRecipient.privateKey,
+				expectedSellerPubkey: nonRecipient.pubkey,
+				expectedBuyerPubkey: buyer.pubkey,
+			}),
+		).toThrow()
+	})
+
+	test('rejects signed rumor', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const rumor = { ...createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT }), sig: '0'.repeat(128) }
+
+		expect(() => parsePrivateOrderDetailsRumor(rumor)).toThrow('Private order rumor must be unsigned')
+	})
+
+	test('rejects mismatched seller pubkey', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const rumor = createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT })
+
+		expect(() => parsePrivateOrderDetailsRumor(rumor, { expectedSellerPubkey: otherSeller.pubkey })).toThrow(
+			'Private order seller pubkey mismatch',
+		)
+	})
+
+	test('rejects mismatched buyer pubkey', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherBuyer = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const { giftWrap } = createEncryptedPrivateOrderMessage({
+			details,
+			buyerPrivateKey: buyer.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(() =>
+			decryptPrivateOrderMessage({
+				giftWrap,
+				sellerPrivateKey: seller.privateKey,
+				expectedSellerPubkey: seller.pubkey,
+				expectedBuyerPubkey: otherBuyer.pubkey,
+			}),
+		).toThrow()
+	})
+
+	test('rejects invalid shippingRef', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+
+		expect(() =>
+			createPrivateOrderDetailsRumor({
+				details: privateOrderDetails(buyer.pubkey, seller.pubkey, {
+					shippingRef: `30406:${otherSeller.pubkey}:standard`,
+				}),
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('Private order shipping ref is invalid')
+	})
+
+	test('rejects invalid item refs and quantities', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+
+		expect(() =>
+			createPrivateOrderDetailsRumor({
+				details: privateOrderDetails(buyer.pubkey, seller.pubkey, {
+					items: [{ productRef: `30402:${otherSeller.pubkey}:product-1`, quantity: 1 }],
+				}),
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('Private order item ref is invalid')
+
+		expect(() =>
+			createPrivateOrderDetailsRumor({
+				details: privateOrderDetails(buyer.pubkey, seller.pubkey, {
+					items: [{ productRef: `30402:${seller.pubkey}:product-1`, quantity: 0 }],
+				}),
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('Private order item quantity is invalid')
+	})
+
+	test('multi-seller payloads are scoped per seller', () => {
+		const buyer = keyPair()
+		const sellerA = keyPair()
+		const sellerB = keyPair()
+		const sellerAProductRef = `30402:${sellerA.pubkey}:product-a`
+		const sellerBProductRef = `30402:${sellerB.pubkey}:product-b`
+
+		const sellerARumor = createPrivateOrderDetailsRumor({
+			details: privateOrderDetails(buyer.pubkey, sellerA.pubkey, {
+				orderId: 'order-a',
+				shippingRef: `30406:${sellerA.pubkey}:pickup`,
+				items: [{ productRef: sellerAProductRef, quantity: 1 }],
+			}),
+			createdAt: CREATED_AT,
+		})
+		const sellerBRumor = createPrivateOrderDetailsRumor({
+			details: privateOrderDetails(buyer.pubkey, sellerB.pubkey, {
+				orderId: 'order-b',
+				shippingRef: `30406:${sellerB.pubkey}:pickup`,
+				items: [{ productRef: sellerBProductRef, quantity: 3 }],
+			}),
+			createdAt: CREATED_AT,
+		})
+
+		expect(tagValues(sellerARumor.tags, 'item')).toEqual([['item', sellerAProductRef, '1']])
+		expect(tagValues(sellerBRumor.tags, 'item')).toEqual([['item', sellerBProductRef, '3']])
+		expect(JSON.stringify(sellerARumor)).not.toContain(sellerBProductRef)
+		expect(JSON.stringify(sellerBRumor)).not.toContain(sellerAProductRef)
+		expect(() =>
+			createPrivateOrderDetailsRumor({
+				details: privateOrderDetails(buyer.pubkey, sellerA.pubkey, {
+					items: [{ productRef: sellerBProductRef, quantity: 1 }],
+				}),
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('Private order item ref is invalid')
+	})
+
+	test('serializes typed address deterministically at the private message boundary', () => {
+		const addressString = serializeBuyerAddress({
+			firstLineOfAddress: '123 Main Street',
+			additionalInformation: 'Apt Secret Notes',
+			city: 'Los Angeles',
+			zipPostcode: '90210',
+			country: 'United States',
+		})
+
+		expect(addressString).toBe('123 Main Street\nApt Secret Notes\nLos Angeles\n90210\nUnited States')
+	})
+
+	test('private order details can omit optional buyer fields', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey, {
+			delivery: {},
+			orderNotes: '',
+			shippingRef: undefined,
+		})
+
+		const rumor = createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT })
+
+		expect(tagValue(rumor.tags, 'name')).toBeUndefined()
+		expect(tagValue(rumor.tags, 'address')).toBeUndefined()
+		expect(tagValue(rumor.tags, 'email')).toBeUndefined()
+		expect(tagValue(rumor.tags, 'phone')).toBeUndefined()
+		expect(tagValue(rumor.tags, 'shipping')).toBeUndefined()
+	})
+})

--- a/src/lib/orders/privateOrderMessage.test.ts
+++ b/src/lib/orders/privateOrderMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { getPublicKey, verifyEvent } from 'nostr-tools'
+import { getEventHash, getPublicKey, verifyEvent } from 'nostr-tools'
 import {
 	createEncryptedPrivateOrderMessage,
 	createPrivateOrderDetailsRumor,
@@ -75,6 +75,16 @@ function expectNoPii(value: unknown): void {
 	}
 }
 
+function canonicalRumorId(rumor: { pubkey: string; created_at: number; kind: number; tags: string[][]; content: string }): string {
+	return getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
+}
+
 describe('private order message helper', () => {
 	test('creates valid Gamma-compatible unsigned kind 16/type=1 order details rumor', () => {
 		const buyer = keyPair()
@@ -87,6 +97,7 @@ describe('private order message helper', () => {
 		expect(rumor.pubkey).toBe(buyer.pubkey)
 		expect(rumor.created_at).toBe(CREATED_AT)
 		expect('sig' in rumor).toBe(false)
+		expect(rumor.id).toBe(canonicalRumorId(rumor))
 		expect(rumor.tags).toContainEqual(['p', seller.pubkey])
 		expect(rumor.tags).toContainEqual(['subject', 'order-info'])
 		expect(rumor.tags).toContainEqual(['type', '1'])
@@ -177,6 +188,15 @@ describe('private order message helper', () => {
 		const rumor = { ...createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT }), sig: '0'.repeat(128) }
 
 		expect(() => parsePrivateOrderDetailsRumor(rumor)).toThrow('Private order rumor must be unsigned')
+	})
+
+	test('private order parser rejects a rumor with an incorrect id', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const rumor = { ...createPrivateOrderDetailsRumor({ details, createdAt: CREATED_AT }), id: '0'.repeat(64) }
+
+		expect(() => parsePrivateOrderDetailsRumor(rumor)).toThrow('NIP-59 rumor id is invalid')
 	})
 
 	test('rejects mismatched seller pubkey', () => {

--- a/src/lib/orders/privateOrderMessage.test.ts
+++ b/src/lib/orders/privateOrderMessage.test.ts
@@ -1,9 +1,12 @@
+import { NDKUser, type NDKEncryptionScheme, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { describe, expect, test } from 'bun:test'
-import { getEventHash, getPublicKey, verifyEvent } from 'nostr-tools'
+import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
 import {
 	createEncryptedPrivateOrderMessage,
+	createEncryptedPrivateOrderMessageWithSigner,
 	createPrivateOrderDetailsRumor,
 	decryptPrivateOrderMessage,
+	decryptPrivateOrderMessageWithSigner,
 	parsePrivateOrderDetailsRumor,
 	serializeBuyerAddress,
 	type PrivateOrderDeliveryDetails,
@@ -26,9 +29,47 @@ type KeyPair = {
 	pubkey: string
 }
 
+type MockSignerOptions = {
+	supportsNip44?: boolean
+	canEncrypt?: boolean
+	canDecrypt?: boolean
+}
+
 function keyPair(): KeyPair {
 	const privateKey = crypto.getRandomValues(new Uint8Array(32))
 	return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function signerFor(privateKey: Uint8Array, options: MockSignerOptions = {}): NDKSigner {
+	const pubkey = getPublicKey(privateKey)
+	const user = new NDKUser({ pubkey })
+	return {
+		get pubkey() {
+			return pubkey
+		},
+		blockUntilReady: async () => user,
+		user: async () => user,
+		get userSync() {
+			return user
+		},
+		encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
+			if (options.supportsNip44 === false) return []
+			if (!scheme || scheme === 'nip44') return ['nip44']
+			return []
+		},
+		encrypt: async (recipient, value, scheme) => {
+			if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') throw new Error('NIP-44 unavailable')
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(value, conversationKey)
+		},
+		decrypt: async (sender, value, scheme) => {
+			if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') throw new Error('NIP-44 unavailable')
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(value, conversationKey)
+		},
+		sign: async (event) => finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig,
+		toPayload: () => JSON.stringify({ type: 'mock' }),
+	}
 }
 
 function privateOrderDetails(
@@ -138,6 +179,32 @@ describe('private order message helper', () => {
 		expect(JSON.stringify(giftWrap)).not.toContain('Satoshi Nakamoto')
 	})
 
+	test('signer-backed helper wraps private order details without exposing buyer PII in kind 1059', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+
+		const { rumor, seal, giftWrap } = await createEncryptedPrivateOrderMessageWithSigner({
+			details,
+			signer: signerFor(buyer.privateKey),
+			wrapperPrivateKey: wrapper.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		expect(rumor.kind).toBe(16)
+		expect('sig' in rumor).toBe(false)
+		expect(seal.kind).toBe(13)
+		expect(seal.tags).toEqual([])
+		expect(seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(seal)).toBe(true)
+		expect(giftWrap.kind).toBe(1059)
+		expect(giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expect(verifyEvent(giftWrap)).toBe(true)
+		expectNoPii(giftWrap)
+		expect(JSON.stringify(giftWrap)).not.toContain('Satoshi Nakamoto')
+	})
+
 	test('seller decrypts gift wrap to seal to rumor to order details', () => {
 		const buyer = keyPair()
 		const seller = keyPair()
@@ -158,6 +225,57 @@ describe('private order message helper', () => {
 		expect(decrypted.rumor).toEqual(rumor)
 		expect(decrypted.seal.pubkey).toBe(buyer.pubkey)
 		expect(decrypted.details).toEqual(details)
+	})
+
+	test('seller signer decrypts gift wrap to seal to rumor to order details', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const { giftWrap, rumor } = await createEncryptedPrivateOrderMessageWithSigner({
+			details,
+			signer: signerFor(buyer.privateKey),
+			createdAt: CREATED_AT,
+		})
+
+		const decrypted = await decryptPrivateOrderMessageWithSigner({
+			giftWrap,
+			signer: signerFor(seller.privateKey),
+			expectedSellerPubkey: seller.pubkey,
+			expectedBuyerPubkey: buyer.pubkey,
+		})
+
+		expect(decrypted.rumor).toEqual(rumor)
+		expect(decrypted.seal.pubkey).toBe(buyer.pubkey)
+		expect(decrypted.details).toEqual(details)
+	})
+
+	test('signer-backed private order helpers fail closed without NIP-44 capability', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+
+		await expect(
+			createEncryptedPrivateOrderMessageWithSigner({
+				details,
+				signer: signerFor(buyer.privateKey, { supportsNip44: false }),
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 encrypt')
+
+		const { giftWrap } = createEncryptedPrivateOrderMessage({
+			details,
+			buyerPrivateKey: buyer.privateKey,
+			createdAt: CREATED_AT,
+		})
+
+		await expect(
+			decryptPrivateOrderMessageWithSigner({
+				giftWrap,
+				signer: signerFor(seller.privateKey, { supportsNip44: false }),
+				expectedSellerPubkey: seller.pubkey,
+				expectedBuyerPubkey: buyer.pubkey,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 decrypt')
 	})
 
 	test('non-recipient cannot decrypt private order details', () => {

--- a/src/lib/orders/privateOrderMessage.ts
+++ b/src/lib/orders/privateOrderMessage.ts
@@ -1,6 +1,14 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
 import { getPublicKey } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
-import { createNip59GiftWrap, normalizeUnsignedRumorId, unwrapNip59GiftWrap, type UnsignedRumor } from '../nostr/nip59'
+import {
+	createNip59GiftWrap,
+	createNip59GiftWrapWithSigner,
+	normalizeUnsignedRumorId,
+	unwrapNip59GiftWrap,
+	unwrapNip59GiftWrapWithSigner,
+	type UnsignedRumor,
+} from '../nostr/nip59'
 
 const GAMMA_ORDER_KIND = 16
 const GAMMA_ORDER_CREATION_TYPE = '1'
@@ -43,9 +51,21 @@ export type CreateEncryptedPrivateOrderMessageParams = CreatePrivateOrderDetails
 	wrapperPrivateKey?: Uint8Array
 }
 
+export type CreateEncryptedPrivateOrderMessageWithSignerParams = CreatePrivateOrderDetailsRumorParams & {
+	signer: NDKSigner | null | undefined
+	wrapperPrivateKey?: Uint8Array
+}
+
 export type DecryptPrivateOrderMessageParams = {
 	giftWrap: Event
 	sellerPrivateKey: Uint8Array
+	expectedSellerPubkey?: string
+	expectedBuyerPubkey?: string
+}
+
+export type DecryptPrivateOrderMessageWithSignerParams = {
+	giftWrap: Event
+	signer: NDKSigner | null | undefined
 	expectedSellerPubkey?: string
 	expectedBuyerPubkey?: string
 }
@@ -118,6 +138,24 @@ export function createEncryptedPrivateOrderMessage(
 	}
 }
 
+export async function createEncryptedPrivateOrderMessageWithSigner(
+	params: CreateEncryptedPrivateOrderMessageWithSignerParams,
+): Promise<DecryptedPrivateOrderMessage & { giftWrap: Event }> {
+	const rumor = createPrivateOrderDetailsRumor({ details: params.details, createdAt: params.createdAt })
+	const wrapped = await createNip59GiftWrapWithSigner({
+		rumor,
+		signer: params.signer,
+		recipientPubkey: params.details.sellerPubkey,
+		wrapperPrivateKey: params.wrapperPrivateKey,
+		createdAt: params.createdAt,
+	})
+
+	return {
+		...wrapped,
+		details: params.details,
+	}
+}
+
 export function decryptPrivateOrderMessage(params: DecryptPrivateOrderMessageParams): DecryptedPrivateOrderMessage {
 	const sellerPubkey = params.expectedSellerPubkey ?? getPublicKey(params.sellerPrivateKey)
 	const unwrapped = unwrapNip59GiftWrap({
@@ -129,6 +167,24 @@ export function decryptPrivateOrderMessage(params: DecryptPrivateOrderMessagePar
 
 	const details = parsePrivateOrderDetailsRumor(unwrapped.rumor, {
 		expectedSellerPubkey: sellerPubkey,
+		expectedBuyerPubkey: params.expectedBuyerPubkey,
+	})
+
+	return { ...unwrapped, details }
+}
+
+export async function decryptPrivateOrderMessageWithSigner(
+	params: DecryptPrivateOrderMessageWithSignerParams,
+): Promise<DecryptedPrivateOrderMessage> {
+	const unwrapped = await unwrapNip59GiftWrapWithSigner({
+		giftWrap: params.giftWrap,
+		signer: params.signer,
+		expectedRecipientPubkey: params.expectedSellerPubkey,
+		expectedSenderPubkey: params.expectedBuyerPubkey,
+	})
+
+	const details = parsePrivateOrderDetailsRumor(unwrapped.rumor, {
+		expectedSellerPubkey: params.expectedSellerPubkey,
 		expectedBuyerPubkey: params.expectedBuyerPubkey,
 	})
 

--- a/src/lib/orders/privateOrderMessage.ts
+++ b/src/lib/orders/privateOrderMessage.ts
@@ -1,0 +1,270 @@
+import { getPublicKey } from 'nostr-tools'
+import type { Event } from 'nostr-tools'
+import { createNip59GiftWrap, unwrapNip59GiftWrap, type UnsignedRumor } from '../nostr/nip59'
+
+const GAMMA_ORDER_KIND = 16
+const GAMMA_ORDER_CREATION_TYPE = '1'
+const GAMMA_ORDER_SUBJECT = 'order-info'
+const PRODUCT_REF_KIND = '30402'
+const SHIPPING_REF_KIND = '30406'
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/i
+
+export type PrivateOrderAddress = {
+	firstLineOfAddress?: string
+	additionalInformation?: string
+	city?: string
+	zipPostcode?: string
+	country?: string
+}
+
+export type PrivateOrderDeliveryDetails = {
+	orderId: string
+	buyerPubkey: string
+	sellerPubkey: string
+	totalAmountSats: number
+	shippingRef?: string
+	items: Array<{ productRef: string; quantity: number }>
+	delivery: {
+		name?: string
+		email?: string
+		phone?: string
+		address?: PrivateOrderAddress
+	}
+	orderNotes?: string
+}
+
+export type CreatePrivateOrderDetailsRumorParams = {
+	details: PrivateOrderDeliveryDetails
+	createdAt?: number
+}
+
+export type CreateEncryptedPrivateOrderMessageParams = CreatePrivateOrderDetailsRumorParams & {
+	buyerPrivateKey: Uint8Array
+	wrapperPrivateKey?: Uint8Array
+}
+
+export type DecryptPrivateOrderMessageParams = {
+	giftWrap: Event
+	sellerPrivateKey: Uint8Array
+	expectedSellerPubkey?: string
+	expectedBuyerPubkey?: string
+}
+
+export type DecryptedPrivateOrderMessage = {
+	seal: Event
+	rumor: UnsignedRumor
+	details: PrivateOrderDeliveryDetails
+}
+
+export function createPrivateOrderDetailsRumor(params: CreatePrivateOrderDetailsRumorParams): UnsignedRumor {
+	const { details, createdAt = unixNow() } = params
+	validatePrivateOrderDetails(details)
+
+	const tags: string[][] = [
+		['p', details.sellerPubkey],
+		['subject', GAMMA_ORDER_SUBJECT],
+		['type', GAMMA_ORDER_CREATION_TYPE],
+		['order', details.orderId],
+		['amount', String(details.totalAmountSats)],
+	]
+
+	for (const item of details.items) {
+		tags.push(['item', item.productRef, String(item.quantity)])
+	}
+
+	if (details.shippingRef) tags.push(['shipping', details.shippingRef])
+
+	const buyerName = normalizeOptionalText(details.delivery.name)
+	if (buyerName) tags.push(['name', buyerName])
+
+	const addressString = serializeBuyerAddress(details.delivery.address)
+	if (addressString) tags.push(['address', addressString])
+
+	const buyerEmail = normalizeOptionalText(details.delivery.email)
+	if (buyerEmail) tags.push(['email', buyerEmail])
+
+	const buyerPhone = normalizeOptionalText(details.delivery.phone)
+	if (buyerPhone) tags.push(['phone', buyerPhone])
+
+	return {
+		kind: GAMMA_ORDER_KIND,
+		pubkey: details.buyerPubkey,
+		created_at: createdAt,
+		tags,
+		content: details.orderNotes ?? '',
+	}
+}
+
+export function createEncryptedPrivateOrderMessage(
+	params: CreateEncryptedPrivateOrderMessageParams,
+): DecryptedPrivateOrderMessage & { giftWrap: Event } {
+	const buyerPubkey = getPublicKey(params.buyerPrivateKey)
+	if (buyerPubkey !== params.details.buyerPubkey) {
+		throw new Error('Private order buyer key does not match buyer pubkey')
+	}
+
+	const rumor = createPrivateOrderDetailsRumor({ details: params.details, createdAt: params.createdAt })
+	const wrapped = createNip59GiftWrap({
+		rumor,
+		senderPrivateKey: params.buyerPrivateKey,
+		recipientPubkey: params.details.sellerPubkey,
+		wrapperPrivateKey: params.wrapperPrivateKey,
+		createdAt: params.createdAt,
+	})
+
+	return {
+		...wrapped,
+		details: params.details,
+	}
+}
+
+export function decryptPrivateOrderMessage(params: DecryptPrivateOrderMessageParams): DecryptedPrivateOrderMessage {
+	const sellerPubkey = params.expectedSellerPubkey ?? getPublicKey(params.sellerPrivateKey)
+	const unwrapped = unwrapNip59GiftWrap({
+		giftWrap: params.giftWrap,
+		recipientPrivateKey: params.sellerPrivateKey,
+		expectedRecipientPubkey: sellerPubkey,
+		expectedSenderPubkey: params.expectedBuyerPubkey,
+	})
+
+	const details = parsePrivateOrderDetailsRumor(unwrapped.rumor, {
+		expectedSellerPubkey: sellerPubkey,
+		expectedBuyerPubkey: params.expectedBuyerPubkey,
+	})
+
+	return { ...unwrapped, details }
+}
+
+export function parsePrivateOrderDetailsRumor(
+	rumor: UnsignedRumor,
+	expected?: { expectedSellerPubkey?: string; expectedBuyerPubkey?: string },
+): PrivateOrderDeliveryDetails {
+	assertUnsignedPrivateOrderRumor(rumor)
+	const buyerPubkey = rumor.pubkey
+	if (expected?.expectedBuyerPubkey && buyerPubkey !== expected.expectedBuyerPubkey) {
+		throw new Error('Private order buyer pubkey mismatch')
+	}
+
+	const sellerPubkey = getSingleTagValue(rumor.tags, 'p')
+	if (!sellerPubkey || !isHexPubkey(sellerPubkey)) throw new Error('Private order seller pubkey is invalid')
+	if (expected?.expectedSellerPubkey && sellerPubkey !== expected.expectedSellerPubkey) {
+		throw new Error('Private order seller pubkey mismatch')
+	}
+
+	if (getSingleTagValue(rumor.tags, 'subject') !== GAMMA_ORDER_SUBJECT) throw new Error('Private order subject is invalid')
+	if (getSingleTagValue(rumor.tags, 'type') !== GAMMA_ORDER_CREATION_TYPE) throw new Error('Private order type is invalid')
+
+	const orderId = getSingleTagValue(rumor.tags, 'order')
+	if (!orderId) throw new Error('Private order id is required')
+
+	const amount = getSingleTagValue(rumor.tags, 'amount')
+	if (!amount || !/^\d+$/.test(amount)) throw new Error('Private order amount is invalid')
+	const totalAmountSats = Number(amount)
+	if (!Number.isSafeInteger(totalAmountSats) || totalAmountSats <= 0) throw new Error('Private order amount is invalid')
+
+	const itemTags = rumor.tags.filter((tag) => tag[0] === 'item')
+	if (itemTags.length === 0) throw new Error('Private order item is required')
+	const items = itemTags.map((tag) => {
+		const productRef = tag[1]
+		const quantityText = tag[2]
+		if (!productRef || !isAddressableRef(productRef, PRODUCT_REF_KIND, sellerPubkey)) throw new Error('Private order item ref is invalid')
+		if (!quantityText || !/^\d+$/.test(quantityText)) throw new Error('Private order item quantity is invalid')
+		const quantity = Number(quantityText)
+		if (!Number.isSafeInteger(quantity) || quantity <= 0) throw new Error('Private order item quantity is invalid')
+		return { productRef, quantity }
+	})
+
+	const shippingRef = getSingleTagValue(rumor.tags, 'shipping')
+	if (shippingRef && !isAddressableRef(shippingRef, SHIPPING_REF_KIND, sellerPubkey)) {
+		throw new Error('Private order shipping ref is invalid')
+	}
+
+	const delivery = {
+		name: getSingleTagValue(rumor.tags, 'name'),
+		address: parseBuyerAddress(getSingleTagValue(rumor.tags, 'address')),
+		email: getSingleTagValue(rumor.tags, 'email'),
+		phone: getSingleTagValue(rumor.tags, 'phone'),
+	}
+
+	return {
+		orderId,
+		buyerPubkey,
+		sellerPubkey,
+		totalAmountSats,
+		shippingRef,
+		items,
+		delivery,
+		orderNotes: rumor.content,
+	}
+}
+
+export function serializeBuyerAddress(address: PrivateOrderAddress | undefined): string | undefined {
+	if (!address) return undefined
+	const fields = [address.firstLineOfAddress, address.additionalInformation, address.city, address.zipPostcode, address.country].map(
+		(value) => normalizeOptionalText(value) ?? '',
+	)
+
+	if (fields.every((value) => value === '')) return undefined
+	return fields.join('\n')
+}
+
+function parseBuyerAddress(addressString: string | undefined): PrivateOrderAddress | undefined {
+	if (!addressString) return undefined
+	const [firstLineOfAddress, additionalInformation, city, zipPostcode, country] = addressString.split('\n')
+	return {
+		firstLineOfAddress,
+		additionalInformation,
+		city,
+		zipPostcode,
+		country,
+	}
+}
+
+function validatePrivateOrderDetails(details: PrivateOrderDeliveryDetails): void {
+	if (!details.orderId.trim()) throw new Error('Private order id is required')
+	if (!isHexPubkey(details.buyerPubkey)) throw new Error('Private order buyer pubkey is invalid')
+	if (!isHexPubkey(details.sellerPubkey)) throw new Error('Private order seller pubkey is invalid')
+	if (!Number.isSafeInteger(details.totalAmountSats) || details.totalAmountSats <= 0) throw new Error('Private order amount is invalid')
+	if (details.items.length === 0) throw new Error('Private order item is required')
+
+	for (const item of details.items) {
+		if (!isAddressableRef(item.productRef, PRODUCT_REF_KIND, details.sellerPubkey)) throw new Error('Private order item ref is invalid')
+		if (!Number.isSafeInteger(item.quantity) || item.quantity <= 0) throw new Error('Private order item quantity is invalid')
+	}
+
+	if (details.shippingRef && !isAddressableRef(details.shippingRef, SHIPPING_REF_KIND, details.sellerPubkey)) {
+		throw new Error('Private order shipping ref is invalid')
+	}
+}
+
+function assertUnsignedPrivateOrderRumor(rumor: UnsignedRumor): void {
+	if ('sig' in rumor) throw new Error('Private order rumor must be unsigned')
+	if (rumor.kind !== GAMMA_ORDER_KIND) throw new Error('Private order kind is invalid')
+	if (!isHexPubkey(rumor.pubkey)) throw new Error('Private order buyer pubkey is invalid')
+}
+
+function getSingleTagValue(tags: string[][], tagName: string): string | undefined {
+	const matches = tags.filter((tag) => tag[0] === tagName)
+	if (matches.length > 1) throw new Error(`Private order ${tagName} tag is duplicated`)
+	return matches[0]?.[1]
+}
+
+function isAddressableRef(value: string, expectedKind: string, expectedPubkey: string): boolean {
+	if (value.includes('\n') || value.includes('\r')) return false
+	const [kind, pubkey, ...dTagParts] = value.split(':')
+	const dTag = dTagParts.join(':')
+	return kind === expectedKind && pubkey === expectedPubkey && dTag.length > 0
+}
+
+function isHexPubkey(value: string): boolean {
+	return HEX_PUBKEY_RE.test(value)
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+	const trimmed = value?.trim()
+	return trimmed ? trimmed : undefined
+}
+
+function unixNow(): number {
+	return Math.floor(Date.now() / 1000)
+}

--- a/src/lib/orders/privateOrderMessage.ts
+++ b/src/lib/orders/privateOrderMessage.ts
@@ -1,6 +1,6 @@
 import { getPublicKey } from 'nostr-tools'
 import type { Event } from 'nostr-tools'
-import { createNip59GiftWrap, unwrapNip59GiftWrap, type UnsignedRumor } from '../nostr/nip59'
+import { createNip59GiftWrap, normalizeUnsignedRumorId, unwrapNip59GiftWrap, type UnsignedRumor } from '../nostr/nip59'
 
 const GAMMA_ORDER_KIND = 16
 const GAMMA_ORDER_CREATION_TYPE = '1'
@@ -86,13 +86,13 @@ export function createPrivateOrderDetailsRumor(params: CreatePrivateOrderDetails
 	const buyerPhone = normalizeOptionalText(details.delivery.phone)
 	if (buyerPhone) tags.push(['phone', buyerPhone])
 
-	return {
+	return normalizeUnsignedRumorId({
 		kind: GAMMA_ORDER_KIND,
 		pubkey: details.buyerPubkey,
 		created_at: createdAt,
 		tags,
 		content: details.orderNotes ?? '',
-	}
+	})
 }
 
 export function createEncryptedPrivateOrderMessage(
@@ -140,29 +140,31 @@ export function parsePrivateOrderDetailsRumor(
 	expected?: { expectedSellerPubkey?: string; expectedBuyerPubkey?: string },
 ): PrivateOrderDeliveryDetails {
 	assertUnsignedPrivateOrderRumor(rumor)
-	const buyerPubkey = rumor.pubkey
+	const normalizedRumor = normalizeUnsignedRumorId(rumor)
+	assertUnsignedPrivateOrderRumor(normalizedRumor)
+	const buyerPubkey = normalizedRumor.pubkey
 	if (expected?.expectedBuyerPubkey && buyerPubkey !== expected.expectedBuyerPubkey) {
 		throw new Error('Private order buyer pubkey mismatch')
 	}
 
-	const sellerPubkey = getSingleTagValue(rumor.tags, 'p')
+	const sellerPubkey = getSingleTagValue(normalizedRumor.tags, 'p')
 	if (!sellerPubkey || !isHexPubkey(sellerPubkey)) throw new Error('Private order seller pubkey is invalid')
 	if (expected?.expectedSellerPubkey && sellerPubkey !== expected.expectedSellerPubkey) {
 		throw new Error('Private order seller pubkey mismatch')
 	}
 
-	if (getSingleTagValue(rumor.tags, 'subject') !== GAMMA_ORDER_SUBJECT) throw new Error('Private order subject is invalid')
-	if (getSingleTagValue(rumor.tags, 'type') !== GAMMA_ORDER_CREATION_TYPE) throw new Error('Private order type is invalid')
+	if (getSingleTagValue(normalizedRumor.tags, 'subject') !== GAMMA_ORDER_SUBJECT) throw new Error('Private order subject is invalid')
+	if (getSingleTagValue(normalizedRumor.tags, 'type') !== GAMMA_ORDER_CREATION_TYPE) throw new Error('Private order type is invalid')
 
-	const orderId = getSingleTagValue(rumor.tags, 'order')
+	const orderId = getSingleTagValue(normalizedRumor.tags, 'order')
 	if (!orderId) throw new Error('Private order id is required')
 
-	const amount = getSingleTagValue(rumor.tags, 'amount')
+	const amount = getSingleTagValue(normalizedRumor.tags, 'amount')
 	if (!amount || !/^\d+$/.test(amount)) throw new Error('Private order amount is invalid')
 	const totalAmountSats = Number(amount)
 	if (!Number.isSafeInteger(totalAmountSats) || totalAmountSats <= 0) throw new Error('Private order amount is invalid')
 
-	const itemTags = rumor.tags.filter((tag) => tag[0] === 'item')
+	const itemTags = normalizedRumor.tags.filter((tag) => tag[0] === 'item')
 	if (itemTags.length === 0) throw new Error('Private order item is required')
 	const items = itemTags.map((tag) => {
 		const productRef = tag[1]
@@ -174,16 +176,16 @@ export function parsePrivateOrderDetailsRumor(
 		return { productRef, quantity }
 	})
 
-	const shippingRef = getSingleTagValue(rumor.tags, 'shipping')
+	const shippingRef = getSingleTagValue(normalizedRumor.tags, 'shipping')
 	if (shippingRef && !isAddressableRef(shippingRef, SHIPPING_REF_KIND, sellerPubkey)) {
 		throw new Error('Private order shipping ref is invalid')
 	}
 
 	const delivery = {
-		name: getSingleTagValue(rumor.tags, 'name'),
-		address: parseBuyerAddress(getSingleTagValue(rumor.tags, 'address')),
-		email: getSingleTagValue(rumor.tags, 'email'),
-		phone: getSingleTagValue(rumor.tags, 'phone'),
+		name: getSingleTagValue(normalizedRumor.tags, 'name'),
+		address: parseBuyerAddress(getSingleTagValue(normalizedRumor.tags, 'address')),
+		email: getSingleTagValue(normalizedRumor.tags, 'email'),
+		phone: getSingleTagValue(normalizedRumor.tags, 'phone'),
 	}
 
 	return {
@@ -194,7 +196,7 @@ export function parsePrivateOrderDetailsRumor(
 		shippingRef,
 		items,
 		delivery,
-		orderNotes: rumor.content,
+		orderNotes: normalizedRumor.content,
 	}
 }
 

--- a/src/publish/orders.test.ts
+++ b/src/publish/orders.test.ts
@@ -50,18 +50,29 @@ mock.module('@nostr-dev-kit/ndk', () => ({
 	},
 }))
 
-import { publishOrderWithDependencies } from '@/publish/orders'
+import { createOrder, createOrderCreationEvent, publishOrderWithDependencies } from '@/publish/orders'
 import type { CheckoutFormData } from '@/components/checkout/ShippingAddressForm'
+
+const PII_SENTINELS = [
+	'buyer@example.com',
+	'123 Main Street',
+	'Satoshi Nakamoto',
+	'+15551234567',
+	'Los Angeles',
+	'90210',
+	'United States',
+	'Apt Secret Notes',
+]
 
 const baseShippingData: CheckoutFormData = {
 	name: 'Satoshi Nakamoto',
-	email: '',
-	phone: '',
+	email: 'buyer@example.com',
+	phone: '+15551234567',
 	firstLineOfAddress: '123 Main Street',
 	zipPostcode: '90210',
 	city: 'Los Angeles',
 	country: 'United States',
-	additionalInformation: '',
+	additionalInformation: 'Apt Secret Notes',
 }
 
 function paramsFor(overrides: {
@@ -91,10 +102,62 @@ function orderEvents() {
 	return publishedEvents.filter((event) => event.kind === 16 && event.tags.some((tag) => tag[0] === 'type' && tag[1] === '1'))
 }
 
-describe('publishOrderWithDependencies delivery contact guard', () => {
+function expectPublicOrderEventsWithoutBuyerPii(publicOrderEvents: Array<{ tags: string[][]; content: string }>) {
+	const serializedPublicOrderEvents = JSON.stringify(publicOrderEvents)
+
+	for (const sentinel of PII_SENTINELS) {
+		expect(serializedPublicOrderEvents).not.toContain(sentinel)
+	}
+
+	for (const order of publicOrderEvents) {
+		expect(order.tags.some((tag) => tag[0] === 'address')).toBe(false)
+		expect(order.tags.some((tag) => tag[0] === 'email')).toBe(false)
+		expect(order.tags.some((tag) => tag[0] === 'phone')).toBe(false)
+		expect(order.content).not.toContain('buyer@example.com')
+		expect(order.content).not.toContain('123 Main Street')
+		expect(order.content).not.toContain('Apt Secret Notes')
+	}
+}
+
+describe('public order privacy guard', () => {
 	beforeEach(() => {
 		shippingServices = {}
 		publishedEvents.length = 0
+	})
+
+	test('sanitizes the spec order creation constructor', async () => {
+		const order = await createOrderCreationEvent({
+			merchantPubkey: 'seller',
+			buyerPubkey: 'buyer-pubkey',
+			orderItems: [{ productRef: '30402:seller:product', quantity: 1 }],
+			totalAmountSats: 1000,
+			shippingRef: '30406:seller:pickup',
+			shippingAddress: baseShippingData,
+			email: baseShippingData.email,
+			phone: baseShippingData.phone,
+			notes: baseShippingData.additionalInformation,
+		})
+
+		expectPublicOrderEventsWithoutBuyerPii([order])
+		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
+	})
+
+	test('sanitizes the legacy createOrder helper', async () => {
+		await createOrder({
+			productRef: '30402:seller:product',
+			sellerPubkey: 'seller',
+			quantity: 1,
+			price: 1000,
+			shippingRef: '30406:seller:pickup',
+			shippingAddress: baseShippingData.firstLineOfAddress,
+			email: baseShippingData.email,
+			phone: baseShippingData.phone,
+			notes: baseShippingData.additionalInformation,
+		})
+
+		const order = orderEvents()[0]
+		expectPublicOrderEventsWithoutBuyerPii([order])
+		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
 	})
 
 	test('rejects digital order without contact before publishing', async () => {
@@ -135,29 +198,65 @@ describe('publishOrderWithDependencies delivery contact guard', () => {
 		expect(publishedEvents).toHaveLength(0)
 	})
 
+	test('physical delivery requiring private details fails before publishing when encrypted delivery is unavailable', async () => {
+		shippingServices = {
+			'30406:seller:standard': 'standard',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						seller: [{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller:standard' }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('digital delivery requiring contact fails before publishing when encrypted delivery is unavailable', async () => {
+		shippingServices = {
+			'30406:seller:digital': 'digital',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					shippingData: { email: 'buyer@example.com' },
+					productsBySeller: {
+						seller: [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
 	test('preflights every seller group before publishing any order', async () => {
 		shippingServices = {
-			'30406:seller-a:standard': 'standard',
+			'30406:seller-a:pickup': 'pickup',
 			'30406:seller-b:digital': 'digital',
 		}
 
 		await expect(
 			publishOrderWithDependencies(
 				paramsFor({
-					shippingData: { email: '' },
 					sellers: ['seller-a', 'seller-b'],
 					productsBySeller: {
-						'seller-a': [{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller-a:standard' }],
+						'seller-a': [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller-a:pickup' }],
 						'seller-b': [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller-b:digital' }],
 					},
 				}),
 			),
-		).rejects.toThrow('Digital delivery contact is required')
+		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
 
 		expect(publishedEvents).toHaveLength(0)
 	})
 
-	test('does not emit fake fallback contact when no email is provided', async () => {
+	test('pickup order can publish a sanitized public order event', async () => {
 		shippingServices = {
 			'30406:seller:pickup': 'pickup',
 		}
@@ -172,31 +271,23 @@ describe('publishOrderWithDependencies delivery contact guard', () => {
 		)
 
 		const order = orderEvents()[0]
-		expect(order.tags.some((tag) => tag[0] === 'email')).toBe(false)
-		expect(order.tags.some((tag) => tag.includes('customer@example.com'))).toBe(false)
-		expect(order.tags.some((tag) => tag[0] === 'address')).toBe(false)
+		expectPublicOrderEventsWithoutBuyerPii([order])
+		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
 	})
 
-	test('emits buyer-provided digital delivery contact and preserves physical address behavior', async () => {
+	test('pickup order keeps optional buyer contact out of every public order event', async () => {
 		shippingServices = {
-			'30406:seller:digital': 'digital',
-			'30406:seller:standard': 'standard',
+			'30406:seller:pickup': 'pickup',
 		}
 
 		await publishOrderWithDependencies(
 			paramsFor({
-				shippingData: { email: 'buyer@example.com' },
 				productsBySeller: {
-					seller: [
-						{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' },
-						{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller:standard' },
-					],
+					seller: [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller:pickup' }],
 				},
 			}),
 		)
 
-		const order = orderEvents()[0]
-		expect(order.tags).toContainEqual(['email', 'buyer@example.com'])
-		expect(order.tags.some((tag) => tag[0] === 'address' && tag[1].includes('123 Main Street'))).toBe(true)
+		expectPublicOrderEventsWithoutBuyerPii(orderEvents())
 	})
 })

--- a/src/publish/orders.test.ts
+++ b/src/publish/orders.test.ts
@@ -1,7 +1,142 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { finalizeEvent, getEventHash, getPublicKey, nip44 } from 'nostr-tools'
+import type { Event, UnsignedEvent } from 'nostr-tools'
+
+type PublishedEvent = {
+	kind?: number
+	created_at?: number
+	content: string
+	tags: string[][]
+	id?: string
+	pubkey?: string
+	sig?: string
+	rawEvent?: () => Event
+}
+
+type TestKeyPair = {
+	privateKey: Uint8Array
+	pubkey: string
+}
+
+type TestSignerOptions = {
+	supportsNip44?: boolean
+	canEncrypt?: boolean
+	signThrows?: boolean
+	pubkeyOverride?: string
+}
 
 let shippingServices: Record<string, string | null | undefined> = {}
-const publishedEvents: Array<{ kind?: number; tags: string[][]; content: string }> = []
+let currentBuyer: TestKeyPair
+let currentSigner: TestSigner | undefined
+const publishedEvents: PublishedEvent[] = []
+const publishResults: unknown[] = []
+
+class TestNDKUser {
+	pubkey: string
+
+	constructor(params: { pubkey: string }) {
+		this.pubkey = params.pubkey
+	}
+}
+
+type TestSigner = {
+	user: () => Promise<TestNDKUser>
+	encryptionEnabled: (scheme?: 'nip04' | 'nip44') => Promise<Array<'nip04' | 'nip44'>>
+	encrypt: (recipient: TestNDKUser, plaintext: string, scheme?: 'nip04' | 'nip44') => Promise<string>
+	decrypt: (sender: TestNDKUser, ciphertext: string, scheme?: 'nip04' | 'nip44') => Promise<string>
+	sign: (event: UnsignedEvent & { pubkey: string }) => Promise<string>
+}
+
+function createKeyPair(): TestKeyPair {
+	const privateKey = crypto.getRandomValues(new Uint8Array(32))
+	return {
+		privateKey,
+		pubkey: getPublicKey(privateKey),
+	}
+}
+
+function createSigner(privateKey: Uint8Array, options: TestSignerOptions = {}): TestSigner {
+	const signerPubkey = options.pubkeyOverride ?? getPublicKey(privateKey)
+	const signerUser = new TestNDKUser({ pubkey: signerPubkey })
+
+	return {
+		user: async () => signerUser,
+		encryptionEnabled: async (scheme?: 'nip04' | 'nip44') => {
+			if (options.supportsNip44 === false) return []
+			return !scheme || scheme === 'nip44' ? ['nip44'] : []
+		},
+		encrypt: async (recipient: TestNDKUser, plaintext: string, scheme?: 'nip04' | 'nip44') => {
+			if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') {
+				throw new Error('NIP-44 encryption unavailable')
+			}
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(plaintext, conversationKey)
+		},
+		decrypt: async (sender: TestNDKUser, ciphertext: string, scheme?: 'nip04' | 'nip44') => {
+			if (options.supportsNip44 === false || scheme !== 'nip44') {
+				throw new Error('NIP-44 decryption unavailable')
+			}
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(ciphertext, conversationKey)
+		},
+		sign: async (event: UnsignedEvent & { pubkey: string }) => {
+			if (options.signThrows) throw new Error('sign failed')
+			return finalizeEvent(event, privateKey).sig
+		},
+	}
+}
+
+class TestNDKEvent {
+	kind?: number
+	created_at?: number
+	content = ''
+	tags: string[][] = []
+	id = ''
+	pubkey = ''
+	sig = ''
+
+	constructor(_ndk?: unknown, event?: Partial<Event>) {
+		if (!event) return
+		this.kind = event.kind
+		this.created_at = event.created_at
+		this.content = event.content ?? ''
+		this.tags = event.tags?.map((tag) => [...tag]) ?? []
+		this.id = event.id ?? ''
+		this.pubkey = event.pubkey ?? ''
+		this.sig = event.sig ?? ''
+	}
+
+	async sign(signer = currentSigner) {
+		if (!signer) throw new Error('No active signer')
+		const user = await signer.user()
+		this.pubkey = user.pubkey
+		this.created_at ??= Math.floor(Date.now() / 1000)
+		if (typeof this.kind !== 'number') throw new Error('Missing event kind')
+
+		const unsignedEvent = {
+			kind: this.kind,
+			created_at: this.created_at,
+			tags: this.tags,
+			content: this.content,
+			pubkey: this.pubkey,
+		}
+		this.id = getEventHash(unsignedEvent)
+		this.sig = await signer.sign(unsignedEvent)
+	}
+
+	rawEvent(): Event {
+		if (typeof this.kind !== 'number' || typeof this.created_at !== 'number') throw new Error('Incomplete test event')
+		return {
+			id: this.id,
+			pubkey: this.pubkey,
+			created_at: this.created_at,
+			kind: this.kind,
+			tags: this.tags.map((tag) => [...tag]),
+			content: this.content,
+			sig: this.sig,
+		}
+	}
+}
 
 mock.module('@/queries/shipping', () => ({
 	getShippingEvent: mock(async (shippingRef: string) => {
@@ -23,35 +158,32 @@ mock.module('@/queries/profiles', () => ({
 mock.module('@/lib/stores/ndk', () => ({
 	ndkActions: {
 		getNDK: () => ({
-			activeUser: {
-				pubkey: 'buyer-pubkey',
-			},
+			activeUser: currentBuyer
+				? {
+						pubkey: currentBuyer.pubkey,
+					}
+				: undefined,
 		}),
-		getSigner: () => ({}),
-		publishEvent: mock(async (event: { kind?: number; tags: string[][]; content: string }) => {
+		getSigner: () => currentSigner,
+		publishEvent: mock(async (event: PublishedEvent) => {
 			publishedEvents.push(event)
+			const nextResult = publishResults.shift()
+			if (nextResult instanceof Error) throw nextResult
+			if (nextResult !== undefined) return nextResult
+			return new Set(['wss://relay.example'])
 		}),
 	},
 }))
 
 mock.module('@nostr-dev-kit/ndk', () => ({
-	NDKEvent: class {
-		kind?: number
-		created_at?: number
-		content = ''
-		tags: string[][] = []
-		id = ''
-
-		constructor(_ndk?: unknown) {}
-
-		async sign() {
-			this.id = this.tags.find((tag) => tag[0] === 'order')?.[1] || `event-${publishedEvents.length + 1}`
-		}
-	},
+	NDKUser: TestNDKUser,
+	NDKEvent: TestNDKEvent,
 }))
 
-import { createOrder, createOrderCreationEvent, publishOrderWithDependencies } from '@/publish/orders'
 import type { CheckoutFormData } from '@/components/checkout/ShippingAddressForm'
+import { decryptPrivateOrderMessage } from '@/lib/orders/privateOrderMessage'
+import { createOrder, createOrderCreationEvent, publishOrderWithDependencies } from '@/publish/orders'
+import { privateDetailsMatchPublicOrder } from '@/queries/orders'
 
 const PII_SENTINELS = [
 	'buyer@example.com',
@@ -73,6 +205,14 @@ const baseShippingData: CheckoutFormData = {
 	city: 'Los Angeles',
 	country: 'United States',
 	additionalInformation: 'Apt Secret Notes',
+}
+
+function resetTestState() {
+	shippingServices = {}
+	publishedEvents.length = 0
+	publishResults.length = 0
+	currentBuyer = createKeyPair()
+	currentSigner = createSigner(currentBuyer.privateKey)
 }
 
 function paramsFor(overrides: {
@@ -98,40 +238,98 @@ function paramsFor(overrides: {
 	}
 }
 
-function orderEvents() {
+function publicOrderEvents() {
 	return publishedEvents.filter((event) => event.kind === 16 && event.tags.some((tag) => tag[0] === 'type' && tag[1] === '1'))
 }
 
-function expectPublicOrderEventsWithoutBuyerPii(publicOrderEvents: Array<{ tags: string[][]; content: string }>) {
-	const serializedPublicOrderEvents = JSON.stringify(publicOrderEvents)
+function privateGiftWrapEvents() {
+	return publishedEvents.filter((event) => event.kind === 1059)
+}
 
+function paymentRequestEvents() {
+	return publishedEvents.filter((event) => event.kind === 16 && event.tags.some((tag) => tag[0] === 'type' && tag[1] === '2'))
+}
+
+function expectNoBuyerPii(value: unknown) {
+	const serialized = JSON.stringify(value)
 	for (const sentinel of PII_SENTINELS) {
-		expect(serializedPublicOrderEvents).not.toContain(sentinel)
+		expect(serialized).not.toContain(sentinel)
 	}
+}
 
-	for (const order of publicOrderEvents) {
+function expectPublicOrderEventsWithoutBuyerPii(events: PublishedEvent[]) {
+	expectNoBuyerPii(events)
+
+	for (const order of events) {
 		expect(order.tags.some((tag) => tag[0] === 'address')).toBe(false)
 		expect(order.tags.some((tag) => tag[0] === 'email')).toBe(false)
 		expect(order.tags.some((tag) => tag[0] === 'phone')).toBe(false)
+		expect(order.tags.some((tag) => tag[0] === 'name')).toBe(false)
 		expect(order.content).not.toContain('buyer@example.com')
 		expect(order.content).not.toContain('123 Main Street')
 		expect(order.content).not.toContain('Apt Secret Notes')
 	}
 }
 
+function expectPublicOrderMarkerShape(order: PublishedEvent) {
+	expect(order.kind).toBe(16)
+	expect(order.tags.filter((tag) => tag[0] === 'type')).toEqual([['type', '1']])
+	expect(order.tags.filter((tag) => tag[0] === 'subject')).toEqual([['subject', 'order-info']])
+}
+
+function rawEventFromPublished(event: PublishedEvent): Event {
+	if (event.rawEvent) return event.rawEvent()
+	if (
+		typeof event.kind !== 'number' ||
+		typeof event.created_at !== 'number' ||
+		!event.id ||
+		!event.pubkey ||
+		typeof event.sig !== 'string'
+	) {
+		throw new Error('Published event is not raw-convertible')
+	}
+	return {
+		id: event.id,
+		pubkey: event.pubkey,
+		created_at: event.created_at,
+		kind: event.kind,
+		tags: event.tags.map((tag) => [...tag]),
+		content: event.content,
+		sig: event.sig,
+	}
+}
+
+function publicShippingRef(sellerPubkey: string, dTag: string) {
+	return `30406:${sellerPubkey}:${dTag}`
+}
+
+function publicProductRef(sellerPubkey: string, dTag: string) {
+	return `30402:${sellerPubkey}:${dTag}`
+}
+
+async function decryptGiftWrapForSeller(event: PublishedEvent, seller: TestKeyPair) {
+	return decryptPrivateOrderMessage({
+		giftWrap: rawEventFromPublished(event),
+		sellerPrivateKey: seller.privateKey,
+		expectedSellerPubkey: seller.pubkey,
+		expectedBuyerPubkey: currentBuyer.pubkey,
+	})
+}
+
 describe('public order privacy guard', () => {
 	beforeEach(() => {
-		shippingServices = {}
-		publishedEvents.length = 0
+		resetTestState()
 	})
 
 	test('sanitizes the spec order creation constructor', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'pickup')
 		const order = await createOrderCreationEvent({
-			merchantPubkey: 'seller',
-			buyerPubkey: 'buyer-pubkey',
-			orderItems: [{ productRef: '30402:seller:product', quantity: 1 }],
+			merchantPubkey: seller.pubkey,
+			buyerPubkey: currentBuyer.pubkey,
+			orderItems: [{ productRef: publicProductRef(seller.pubkey, 'product'), quantity: 1 }],
 			totalAmountSats: 1000,
-			shippingRef: '30406:seller:pickup',
+			shippingRef,
 			shippingAddress: baseShippingData,
 			email: baseShippingData.email,
 			phone: baseShippingData.phone,
@@ -139,30 +337,36 @@ describe('public order privacy guard', () => {
 		})
 
 		expectPublicOrderEventsWithoutBuyerPii([order])
-		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
+		expectPublicOrderMarkerShape(order)
+		expect(order.tags).toContainEqual(['shipping', shippingRef])
 	})
 
 	test('sanitizes the legacy createOrder helper', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'pickup')
 		await createOrder({
-			productRef: '30402:seller:product',
-			sellerPubkey: 'seller',
+			productRef: publicProductRef(seller.pubkey, 'product'),
+			sellerPubkey: seller.pubkey,
 			quantity: 1,
 			price: 1000,
-			shippingRef: '30406:seller:pickup',
+			shippingRef,
 			shippingAddress: baseShippingData.firstLineOfAddress,
 			email: baseShippingData.email,
 			phone: baseShippingData.phone,
 			notes: baseShippingData.additionalInformation,
 		})
 
-		const order = orderEvents()[0]
+		const order = publicOrderEvents()[0]
 		expectPublicOrderEventsWithoutBuyerPii([order])
-		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
+		expectPublicOrderMarkerShape(order)
+		expect(order.tags).toContainEqual(['shipping', shippingRef])
 	})
 
 	test('rejects digital order without contact before publishing', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'digital')
 		shippingServices = {
-			'30406:seller:digital': 'digital',
+			[shippingRef]: 'digital',
 		}
 
 		await expect(
@@ -170,7 +374,7 @@ describe('public order privacy guard', () => {
 				paramsFor({
 					shippingData: { email: '' },
 					productsBySeller: {
-						seller: [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' }],
+						[seller.pubkey]: [{ id: 'digital-product', amount: 1, shippingMethodId: shippingRef }],
 					},
 				}),
 			),
@@ -179,17 +383,39 @@ describe('public order privacy guard', () => {
 		expect(publishedEvents).toHaveLength(0)
 	})
 
-	test('rejects unresolved delivery requirements before publishing', async () => {
+	test('rejects physical order without address before publishing', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
 		shippingServices = {
-			'30406:seller:missing-service': null,
+			[shippingRef]: 'standard',
 		}
 
 		await expect(
 			publishOrderWithDependencies(
 				paramsFor({
-					shippingData: { email: 'buyer@example.com' },
+					shippingData: { firstLineOfAddress: '' },
 					productsBySeller: {
-						seller: [{ id: 'unknown-product', amount: 1, shippingMethodId: '30406:seller:missing-service' }],
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Shipping address is required')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('rejects unresolved delivery requirements before publishing', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'missing-service')
+		shippingServices = {
+			[shippingRef]: null,
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'unknown-product', amount: 1, shippingMethodId: shippingRef }],
 					},
 				}),
 			),
@@ -198,96 +424,357 @@ describe('public order privacy guard', () => {
 		expect(publishedEvents).toHaveLength(0)
 	})
 
-	test('physical delivery requiring private details fails before publishing when encrypted delivery is unavailable', async () => {
+	test('pickup order can publish a sanitized public order event without encrypted private details', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'pickup')
 		shippingServices = {
-			'30406:seller:standard': 'standard',
-		}
-
-		await expect(
-			publishOrderWithDependencies(
-				paramsFor({
-					productsBySeller: {
-						seller: [{ id: 'physical-product', amount: 1, shippingMethodId: '30406:seller:standard' }],
-					},
-				}),
-			),
-		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
-
-		expect(publishedEvents).toHaveLength(0)
-	})
-
-	test('digital delivery requiring contact fails before publishing when encrypted delivery is unavailable', async () => {
-		shippingServices = {
-			'30406:seller:digital': 'digital',
-		}
-
-		await expect(
-			publishOrderWithDependencies(
-				paramsFor({
-					shippingData: { email: 'buyer@example.com' },
-					productsBySeller: {
-						seller: [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller:digital' }],
-					},
-				}),
-			),
-		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
-
-		expect(publishedEvents).toHaveLength(0)
-	})
-
-	test('preflights every seller group before publishing any order', async () => {
-		shippingServices = {
-			'30406:seller-a:pickup': 'pickup',
-			'30406:seller-b:digital': 'digital',
-		}
-
-		await expect(
-			publishOrderWithDependencies(
-				paramsFor({
-					sellers: ['seller-a', 'seller-b'],
-					productsBySeller: {
-						'seller-a': [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller-a:pickup' }],
-						'seller-b': [{ id: 'digital-product', amount: 1, shippingMethodId: '30406:seller-b:digital' }],
-					},
-				}),
-			),
-		).rejects.toThrow('Encrypted seller delivery is required before creating this order')
-
-		expect(publishedEvents).toHaveLength(0)
-	})
-
-	test('pickup order can publish a sanitized public order event', async () => {
-		shippingServices = {
-			'30406:seller:pickup': 'pickup',
+			[shippingRef]: 'pickup',
 		}
 
 		await publishOrderWithDependencies(
 			paramsFor({
 				shippingData: { email: '' },
 				productsBySeller: {
-					seller: [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller:pickup' }],
+					[seller.pubkey]: [{ id: 'pickup-product', amount: 1, shippingMethodId: shippingRef }],
 				},
 			}),
 		)
 
-		const order = orderEvents()[0]
+		expect(privateGiftWrapEvents()).toHaveLength(0)
+		const order = publicOrderEvents()[0]
 		expectPublicOrderEventsWithoutBuyerPii([order])
-		expect(order.tags).toContainEqual(['shipping', '30406:seller:pickup'])
+		expectPublicOrderMarkerShape(order)
+		expect(order.tags).toContainEqual(['shipping', shippingRef])
 	})
 
 	test('pickup order keeps optional buyer contact out of every public order event', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'pickup')
 		shippingServices = {
-			'30406:seller:pickup': 'pickup',
+			[shippingRef]: 'pickup',
 		}
 
 		await publishOrderWithDependencies(
 			paramsFor({
 				productsBySeller: {
-					seller: [{ id: 'pickup-product', amount: 1, shippingMethodId: '30406:seller:pickup' }],
+					[seller.pubkey]: [{ id: 'pickup-product', amount: 1, shippingMethodId: shippingRef }],
 				},
 			}),
 		)
 
-		expectPublicOrderEventsWithoutBuyerPii(orderEvents())
+		expectPublicOrderEventsWithoutBuyerPii(publicOrderEvents())
+	})
+
+	test('physical delivery publishes encrypted private details before sanitized public order marker', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				productsBySeller: {
+					[seller.pubkey]: [{ id: 'physical-product', amount: 2, shippingMethodId: shippingRef }],
+				},
+				sellerData: {
+					[seller.pubkey]: { satsTotal: 5000, shippingSats: 1000, shares: { sellerAmount: 5000 } },
+				},
+			}),
+		)
+
+		const giftWrap = privateGiftWrapEvents()[0]
+		const order = publicOrderEvents()[0]
+		expect(publishedEvents.indexOf(giftWrap)).toBeLessThan(publishedEvents.indexOf(order))
+		expectNoBuyerPii(giftWrap)
+		expectPublicOrderEventsWithoutBuyerPii([order])
+		expectPublicOrderMarkerShape(order)
+
+		const decrypted = await decryptGiftWrapForSeller(giftWrap, seller)
+		expect(decrypted.details.delivery.name).toBe('Satoshi Nakamoto')
+		expect(decrypted.details.delivery.email).toBe('buyer@example.com')
+		expect(decrypted.details.delivery.phone).toBe('+15551234567')
+		expect(decrypted.details.delivery.address?.firstLineOfAddress).toBe('123 Main Street')
+		expect(decrypted.details.delivery.address?.additionalInformation).toBe('Apt Secret Notes')
+		expect(decrypted.details.items).toEqual([{ productRef: publicProductRef(seller.pubkey, 'physical-product'), quantity: 2 }])
+		expect(privateDetailsMatchPublicOrder(decrypted.details, order)).toBe(true)
+	})
+
+	test('digital delivery publishes encrypted contact details before sanitized public order marker', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'digital')
+		shippingServices = {
+			[shippingRef]: 'digital',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				productsBySeller: {
+					[seller.pubkey]: [{ id: 'digital-product', amount: 1, shippingMethodId: shippingRef }],
+				},
+			}),
+		)
+
+		const giftWrap = privateGiftWrapEvents()[0]
+		const order = publicOrderEvents()[0]
+		expect(publishedEvents.indexOf(giftWrap)).toBeLessThan(publishedEvents.indexOf(order))
+		expectNoBuyerPii(giftWrap)
+		expectPublicOrderEventsWithoutBuyerPii([order])
+
+		const decrypted = await decryptGiftWrapForSeller(giftWrap, seller)
+		expect(decrypted.details.delivery.email).toBe('buyer@example.com')
+		expect(decrypted.details.delivery.name).toBeUndefined()
+		expect(decrypted.details.delivery.phone).toBeUndefined()
+		expect(decrypted.details.delivery.address).toBeUndefined()
+		expect(privateDetailsMatchPublicOrder(decrypted.details, order)).toBe(true)
+	})
+
+	test('missing signer fails closed before any publish for required private delivery', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+		currentSigner = undefined
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be prepared')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('signer pubkey mismatch fails closed before any publish', async () => {
+		const seller = createKeyPair()
+		const otherBuyer = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+		currentSigner = createSigner(otherBuyer.privateKey)
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be prepared')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('signer without NIP-44 encrypt support fails closed before any publish', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+		currentSigner = createSigner(currentBuyer.privateKey, { supportsNip44: false })
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be prepared')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('private payload construction failure fails closed before any publish', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'bad\nproduct', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be prepared')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('encrypted gift wrap publish failure prevents public order and payment request publishes', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+		publishResults.push(new Set())
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be published')
+
+		expect(privateGiftWrapEvents()).toHaveLength(1)
+		expect(publicOrderEvents()).toHaveLength(0)
+		expect(paymentRequestEvents()).toHaveLength(0)
+	})
+
+	test('payment request creation is attempted only after the seller public marker publishes', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				productsBySeller: {
+					[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+				},
+			}),
+		)
+
+		const giftWrap = privateGiftWrapEvents()[0]
+		const order = publicOrderEvents()[0]
+		const paymentRequest = paymentRequestEvents()[0]
+		expect(publishedEvents.indexOf(giftWrap)).toBeLessThan(publishedEvents.indexOf(order))
+		expect(publishedEvents.indexOf(order)).toBeLessThan(publishedEvents.indexOf(paymentRequest))
+	})
+
+	test('public publish after private publish propagates and does not publish payment requests', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+		publishResults.push(new Set(['wss://relay.example']), new Error('public publish failed'))
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					productsBySeller: {
+						[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('public publish failed')
+
+		expect(privateGiftWrapEvents()).toHaveLength(1)
+		expect(publicOrderEvents()).toHaveLength(1)
+		expect(paymentRequestEvents()).toHaveLength(0)
+	})
+
+	test('multi-seller checkout publishes all private gift wraps before any public order marker', async () => {
+		const physicalSeller = createKeyPair()
+		const digitalSeller = createKeyPair()
+		const physicalShippingRef = publicShippingRef(physicalSeller.pubkey, 'standard')
+		const digitalShippingRef = publicShippingRef(digitalSeller.pubkey, 'digital')
+		shippingServices = {
+			[physicalShippingRef]: 'standard',
+			[digitalShippingRef]: 'digital',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				sellers: [physicalSeller.pubkey, digitalSeller.pubkey],
+				productsBySeller: {
+					[physicalSeller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: physicalShippingRef }],
+					[digitalSeller.pubkey]: [{ id: 'digital-product', amount: 3, shippingMethodId: digitalShippingRef }],
+				},
+			}),
+		)
+
+		const giftWraps = privateGiftWrapEvents()
+		const orders = publicOrderEvents()
+		expect(giftWraps).toHaveLength(2)
+		expect(orders).toHaveLength(2)
+
+		const firstPublicOrderIndex = Math.min(...orders.map((order) => publishedEvents.indexOf(order)))
+		for (const giftWrap of giftWraps) {
+			expect(publishedEvents.indexOf(giftWrap)).toBeLessThan(firstPublicOrderIndex)
+			expectNoBuyerPii(giftWrap)
+		}
+
+		const physicalDetails = await decryptGiftWrapForSeller(
+			giftWraps.find((event) => event.tags[0]?.[1] === physicalSeller.pubkey) as PublishedEvent,
+			physicalSeller,
+		)
+		const digitalDetails = await decryptGiftWrapForSeller(
+			giftWraps.find((event) => event.tags[0]?.[1] === digitalSeller.pubkey) as PublishedEvent,
+			digitalSeller,
+		)
+
+		expect(physicalDetails.details.items).toEqual([
+			{ productRef: publicProductRef(physicalSeller.pubkey, 'physical-product'), quantity: 1 },
+		])
+		expect(digitalDetails.details.items).toEqual([{ productRef: publicProductRef(digitalSeller.pubkey, 'digital-product'), quantity: 3 }])
+		expect(digitalDetails.details.delivery.email).toBe('buyer@example.com')
+		expect(digitalDetails.details.delivery.name).toBeUndefined()
+		expect(digitalDetails.details.delivery.address).toBeUndefined()
+		expect(digitalDetails.details.delivery.phone).toBeUndefined()
+		expect(JSON.stringify(physicalDetails.details.items)).not.toContain(digitalSeller.pubkey)
+		expect(JSON.stringify(digitalDetails.details.items)).not.toContain(physicalSeller.pubkey)
+		expectPublicOrderEventsWithoutBuyerPii(orders)
+	})
+
+	test('multi-seller private payload preparation failure publishes nothing', async () => {
+		const pickupSeller = createKeyPair()
+		const physicalSeller = createKeyPair()
+		const pickupShippingRef = publicShippingRef(pickupSeller.pubkey, 'pickup')
+		const physicalShippingRef = publicShippingRef(physicalSeller.pubkey, 'standard')
+		shippingServices = {
+			[pickupShippingRef]: 'pickup',
+			[physicalShippingRef]: 'standard',
+		}
+
+		await expect(
+			publishOrderWithDependencies(
+				paramsFor({
+					sellers: [pickupSeller.pubkey, physicalSeller.pubkey],
+					productsBySeller: {
+						[pickupSeller.pubkey]: [{ id: 'pickup-product', amount: 1, shippingMethodId: pickupShippingRef }],
+						[physicalSeller.pubkey]: [{ id: 'bad\nproduct', amount: 1, shippingMethodId: physicalShippingRef }],
+					},
+				}),
+			),
+		).rejects.toThrow('Encrypted seller delivery could not be prepared')
+
+		expect(publishedEvents).toHaveLength(0)
+	})
+
+	test('serialized public and gift-wrap events do not expose buyer PII sentinels', async () => {
+		const seller = createKeyPair()
+		const shippingRef = publicShippingRef(seller.pubkey, 'standard')
+		shippingServices = {
+			[shippingRef]: 'standard',
+		}
+
+		await publishOrderWithDependencies(
+			paramsFor({
+				productsBySeller: {
+					[seller.pubkey]: [{ id: 'physical-product', amount: 1, shippingMethodId: shippingRef }],
+				},
+			}),
+		)
+
+		expectNoBuyerPii(publicOrderEvents())
+		expectNoBuyerPii(privateGiftWrapEvents())
 	})
 })

--- a/src/publish/orders.tsx
+++ b/src/publish/orders.tsx
@@ -12,8 +12,10 @@ import {
 	resolveCheckoutDeliveryRequirements,
 	type CheckoutDeliveryRequirements,
 } from '@/lib/checkout/deliveryRequirements'
+import { createEncryptedPrivateOrderMessageWithSigner, type PrivateOrderDeliveryDetails } from '@/lib/orders/privateOrderMessage'
 import { fetchProfileByIdentifier } from '@/queries/profiles'
 import { getShippingEvent, getShippingService } from '@/queries/shipping'
+import type { Event } from 'nostr-tools'
 // import type { CartProduct, SellerData, V4VShare } from '@/lib/stores/cart'
 
 async function resolveDeliveryRequirementsForProducts(
@@ -63,13 +65,6 @@ function getPublicSellerShippingRef(shippingRef: string | null | undefined): str
 
 function requiresPrivateBuyerDeliveryDetails(requirements: CheckoutDeliveryRequirements): boolean {
 	return requirements.needsPhysicalAddress || requirements.needsDigitalDeliveryContact
-}
-
-function canPrepareSellerReadableEncryptedDeliveryPayload(): boolean {
-	// TODO(#904): replace fail-closed behavior with PM-specific encrypted seller
-	// delivery transport using NIP-59 wrapping and NIP-44 encryption once the
-	// seller-side read/decrypt/query path is implemented and tested.
-	return false
 }
 
 // Temporary type definitions - ideally these should be imported from a central types file
@@ -124,11 +119,11 @@ export const createOrder = async (params: OrderCreateParams): Promise<string> =>
 	// Create the order event according to Gamma Market Spec (NIP-17)
 	const event = new NDKEvent(ndk)
 	event.kind = ORDER_PROCESS_KIND // Kind 16 for order processing
-	event.content = `Order for ${params.quantity} item(s)`
+	event.content = 'Order created'
 	event.tags = [
 		// Required tags per spec
 		['p', params.sellerPubkey], // Merchant's pubkey
-		['subject', `Order for ${params.productRef.split(':').pop() || 'product'}`],
+		['subject', 'order-info'],
 		['type', ORDER_MESSAGE_TYPE.ORDER_CREATION], // Type 1 for order creation
 		['order', orderId],
 		['amount', total],
@@ -437,17 +432,20 @@ export interface PaymentReceiptData {
  * Following gamma_spec.md section 4.1
  */
 export async function createOrderCreationEvent(data: OrderCreationData): Promise<NDKEvent> {
+	return createOrderCreationEventWithOrderId(data, uuidv4())
+}
+
+async function createOrderCreationEventWithOrderId(data: OrderCreationData, orderId: string): Promise<NDKEvent> {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	const orderId = uuidv4()
 	const now = Math.floor(Date.now() / 1000)
 
 	// Build tags according to spec
 	const tags: NDKTag[] = [
 		// Required tags
 		['p', data.merchantPubkey],
-		['subject', `Order ${orderId.substring(0, 8)}`],
+		['subject', 'order-info'],
 		['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
 		['order', orderId],
 		['amount', data.totalAmountSats.toString()],
@@ -468,7 +466,7 @@ export async function createOrderCreationEvent(data: OrderCreationData): Promise
 	const event = new NDKEvent(ndk)
 	event.kind = ORDER_PROCESS_KIND
 	event.created_at = now
-	event.content = `Order for ${data.orderItems.length} item(s)`
+	event.content = 'Order created'
 	event.tags = tags
 
 	// Sign the event
@@ -706,6 +704,103 @@ type SellerOrderPreflight = {
 	shippingRef?: string
 }
 
+type PreparedSellerOrderData = SellerOrderPreflight & {
+	orderData: OrderCreationData
+	orderId: string
+	privateGiftWrapEvent?: NDKEvent
+}
+
+type PreparedSellerOrderPublishWork = PreparedSellerOrderData & {
+	orderEvent: NDKEvent
+}
+
+function trimOptional(value: string | undefined): string | undefined {
+	const trimmed = value?.trim()
+	return trimmed || undefined
+}
+
+function createPrivateOrderDeliveryDetails(params: {
+	sellerPubkey: string
+	buyerPubkey: string
+	orderId: string
+	sellerProducts: CartProduct[]
+	data: SellerData
+	shippingRef?: string
+	shippingData: CheckoutFormData
+	requirements: CheckoutDeliveryRequirements
+}): PrivateOrderDeliveryDetails {
+	const { sellerPubkey, buyerPubkey, orderId, sellerProducts, data, shippingRef, shippingData, requirements } = params
+	const delivery: PrivateOrderDeliveryDetails['delivery'] = {}
+
+	if (requirements.needsPhysicalAddress) {
+		delivery.name = trimOptional(shippingData.name)
+		delivery.address = {
+			firstLineOfAddress: trimOptional(shippingData.firstLineOfAddress),
+			additionalInformation: trimOptional(shippingData.additionalInformation),
+			city: trimOptional(shippingData.city),
+			zipPostcode: trimOptional(shippingData.zipPostcode),
+			country: trimOptional(shippingData.country),
+		}
+	}
+
+	const buyerEmail = trimOptional(shippingData.email)
+	if (buyerEmail && isValidDigitalDeliveryContact(buyerEmail)) {
+		delivery.email = buyerEmail
+	}
+
+	if (requirements.needsPhysicalAddress) {
+		delivery.phone = trimOptional(shippingData.phone)
+	}
+
+	return {
+		orderId,
+		buyerPubkey,
+		sellerPubkey,
+		totalAmountSats: data.satsTotal,
+		shippingRef,
+		items: sellerProducts.map((product) => ({
+			productRef: `30402:${sellerPubkey}:${product.id}`,
+			quantity: product.amount,
+		})),
+		delivery,
+		orderNotes: '',
+	}
+}
+
+function createNdkEventFromRawEvent(event: Event): NDKEvent {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	return new NDKEvent(ndk, {
+		id: event.id,
+		pubkey: event.pubkey,
+		created_at: event.created_at,
+		kind: event.kind,
+		tags: event.tags.map((tag) => [...tag]),
+		content: event.content,
+		sig: event.sig,
+	})
+}
+
+function publishResultHasRelayDetails(result: unknown): boolean {
+	return result instanceof Set || Array.isArray(result) || (typeof result === 'object' && result !== null && 'size' in result)
+}
+
+function publishResultHasRelaySuccess(result: unknown): boolean {
+	if (result instanceof Set) return result.size > 0
+	if (Array.isArray(result)) return result.length > 0
+	if (typeof result === 'object' && result !== null && 'size' in result && typeof (result as { size?: unknown }).size === 'number') {
+		return (result as { size: number }).size > 0
+	}
+	return true
+}
+
+async function publishRequiredPrivateGiftWrap(event: NDKEvent): Promise<void> {
+	const result = await ndkActions.publishEvent(event)
+	if (publishResultHasRelayDetails(result) && !publishResultHasRelaySuccess(result)) {
+		throw new Error('Encrypted seller delivery could not be published')
+	}
+}
+
 /**
  * Creates and publishes a spec-compliant order for each seller,
  * then creates and publishes all necessary payment requests (merchant + V4V).
@@ -750,10 +845,6 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 			throw new Error('Shipping address is required before creating the order')
 		}
 
-		if (requiresPrivateBuyerDeliveryDetails(requirements) && !canPrepareSellerReadableEncryptedDeliveryPayload()) {
-			throw new Error('Encrypted seller delivery is required before creating this order')
-		}
-
 		preflight.push({
 			sellerPubkey,
 			sellerProducts,
@@ -763,9 +854,17 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 		})
 	}
 
-	const newOrderIds: string[] = []
+	const signerRequired = preflight.some(({ requirements }) => requiresPrivateBuyerDeliveryDetails(requirements))
+	const signer = signerRequired ? ndkActions.getSigner() : undefined
+	if (signerRequired && !signer) {
+		throw new Error('Encrypted seller delivery could not be prepared')
+	}
 
-	for (const { sellerPubkey, sellerProducts, data, shippingRef } of preflight) {
+	const preparedOrderData: PreparedSellerOrderData[] = []
+
+	for (const preflightItem of preflight) {
+		const { sellerPubkey, sellerProducts, data, requirements, shippingRef } = preflightItem
+		const orderId = uuidv4()
 		const orderData: OrderCreationData = {
 			merchantPubkey: sellerPubkey,
 			buyerPubkey: buyerPubkey,
@@ -777,11 +876,62 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 			shippingRef: shippingRef || undefined,
 		}
 
-		// 1. Create the main order event
-		const { orderId, success } = await createAndPublishOrder(orderData)
-		if (!success || !orderId) {
-			console.warn(`Failed to create order for seller ${sellerPubkey}. Skipping...`)
-			continue
+		let privateGiftWrapEvent: NDKEvent | undefined
+		if (requiresPrivateBuyerDeliveryDetails(requirements)) {
+			try {
+				const privateDetails = createPrivateOrderDeliveryDetails({
+					sellerPubkey,
+					buyerPubkey,
+					orderId,
+					sellerProducts,
+					data,
+					shippingRef: shippingRef || undefined,
+					shippingData,
+					requirements,
+				})
+				const { giftWrap } = await createEncryptedPrivateOrderMessageWithSigner({
+					details: privateDetails,
+					signer,
+				})
+				privateGiftWrapEvent = createNdkEventFromRawEvent(giftWrap)
+			} catch {
+				throw new Error('Encrypted seller delivery could not be prepared')
+			}
+		}
+
+		preparedOrderData.push({
+			...preflightItem,
+			orderData,
+			orderId,
+			privateGiftWrapEvent,
+		})
+	}
+
+	const preparedOrders: PreparedSellerOrderPublishWork[] = []
+	for (const preparedOrder of preparedOrderData) {
+		const orderEvent = await createOrderCreationEventWithOrderId(preparedOrder.orderData, preparedOrder.orderId)
+		preparedOrders.push({
+			...preparedOrder,
+			orderEvent,
+		})
+	}
+
+	for (const preparedOrder of preparedOrders) {
+		if (!preparedOrder.privateGiftWrapEvent) continue
+		try {
+			await publishRequiredPrivateGiftWrap(preparedOrder.privateGiftWrapEvent)
+		} catch {
+			throw new Error('Encrypted seller delivery could not be published')
+		}
+	}
+
+	const newOrderIds: string[] = []
+
+	for (const { sellerPubkey, data, orderEvent, orderId } of preparedOrders) {
+		// 1. Publish the sanitized public order marker only after required private details are published.
+		const orderPublishResult = await ndkActions.publishEvent(orderEvent)
+		if (publishResultHasRelayDetails(orderPublishResult) && !publishResultHasRelaySuccess(orderPublishResult)) {
+			throw new Error('Order could not be published')
 		}
 		newOrderIds.push(orderId)
 		console.log(`✅ Spec-compliant order created for seller ${sellerPubkey.substring(0, 8)}...:`, orderId)

--- a/src/publish/orders.tsx
+++ b/src/publish/orders.tsx
@@ -50,6 +50,28 @@ function hasRequiredPhysicalAddress(shippingData: CheckoutFormData): boolean {
 	)
 }
 
+function getPublicSellerShippingRef(shippingRef: string | null | undefined): string | undefined {
+	const trimmed = shippingRef?.trim()
+	if (!trimmed || trimmed.includes('\n') || trimmed.includes('\r')) return undefined
+
+	const [kind, sellerPubkey, ...dTagParts] = trimmed.split(':')
+	const dTag = dTagParts.join(':')
+	if (kind !== '30406' || !sellerPubkey || !dTag) return undefined
+
+	return trimmed
+}
+
+function requiresPrivateBuyerDeliveryDetails(requirements: CheckoutDeliveryRequirements): boolean {
+	return requirements.needsPhysicalAddress || requirements.needsDigitalDeliveryContact
+}
+
+function canPrepareSellerReadableEncryptedDeliveryPayload(): boolean {
+	// TODO(#904): replace fail-closed behavior with PM-specific encrypted seller
+	// delivery transport using NIP-59 wrapping and NIP-44 encryption once the
+	// seller-side read/decrypt/query path is implemented and tested.
+	return false
+}
+
 // Temporary type definitions - ideally these should be imported from a central types file
 interface CartProduct {
 	id: string
@@ -102,7 +124,7 @@ export const createOrder = async (params: OrderCreateParams): Promise<string> =>
 	// Create the order event according to Gamma Market Spec (NIP-17)
 	const event = new NDKEvent(ndk)
 	event.kind = ORDER_PROCESS_KIND // Kind 16 for order processing
-	event.content = params.notes || ''
+	event.content = `Order for ${params.quantity} item(s)`
 	event.tags = [
 		// Required tags per spec
 		['p', params.sellerPubkey], // Merchant's pubkey
@@ -116,24 +138,9 @@ export const createOrder = async (params: OrderCreateParams): Promise<string> =>
 	]
 
 	// Add optional tags
-	if (params.shippingRef) {
-		event.tags.push(['shipping', params.shippingRef])
-	}
-
-	if (params.shippingAddress) {
-		event.tags.push(['address', params.shippingAddress])
-	}
-
-	if (params.email) {
-		event.tags.push(['email', params.email])
-	}
-
-	if (params.phone) {
-		event.tags.push(['phone', params.phone])
-	}
-
-	if (params.notes) {
-		event.tags.push(['notes', params.notes])
+	const shippingRef = getPublicSellerShippingRef(params.shippingRef)
+	if (shippingRef) {
+		event.tags.push(['shipping', shippingRef])
 	}
 
 	// Sign and publish the event
@@ -452,38 +459,16 @@ export async function createOrderCreationEvent(data: OrderCreationData): Promise
 	})
 
 	// Optional tags
-	if (data.shippingRef) {
-		tags.push(['shipping', data.shippingRef])
-	}
-
-	if (data.shippingAddress) {
-		// Create a newline-separated address for better parsing and readability
-		const addressParts = [
-			data.shippingAddress.name,
-			data.shippingAddress.firstLineOfAddress,
-			data.shippingAddress.additionalInformation, // Include additional info if present
-			data.shippingAddress.city,
-			data.shippingAddress.zipPostcode,
-			data.shippingAddress.country,
-		].filter(Boolean) // Remove empty values
-
-		const addressString = addressParts.join('\n')
-		tags.push(['address', addressString])
-	}
-
-	if (data.email) {
-		tags.push(['email', data.email])
-	}
-
-	if (data.phone) {
-		tags.push(['phone', data.phone])
+	const shippingRef = getPublicSellerShippingRef(data.shippingRef)
+	if (shippingRef) {
+		tags.push(['shipping', shippingRef])
 	}
 
 	// Create the event
 	const event = new NDKEvent(ndk)
 	event.kind = ORDER_PROCESS_KIND
 	event.created_at = now
-	event.content = data.notes || `Order for ${data.orderItems.length} items`
+	event.content = `Order for ${data.orderItems.length} item(s)`
 	event.tags = tags
 
 	// Sign the event
@@ -765,18 +750,22 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 			throw new Error('Shipping address is required before creating the order')
 		}
 
+		if (requiresPrivateBuyerDeliveryDetails(requirements) && !canPrepareSellerReadableEncryptedDeliveryPayload()) {
+			throw new Error('Encrypted seller delivery is required before creating this order')
+		}
+
 		preflight.push({
 			sellerPubkey,
 			sellerProducts,
 			data,
 			requirements,
-			shippingRef: sellerProducts.find((p) => p.shippingMethodId)?.shippingMethodId || undefined,
+			shippingRef: getPublicSellerShippingRef(sellerProducts.find((p) => p.shippingMethodId)?.shippingMethodId),
 		})
 	}
 
 	const newOrderIds: string[] = []
 
-	for (const { sellerPubkey, sellerProducts, data, requirements, shippingRef } of preflight) {
+	for (const { sellerPubkey, sellerProducts, data, shippingRef } of preflight) {
 		const orderData: OrderCreationData = {
 			merchantPubkey: sellerPubkey,
 			buyerPubkey: buyerPubkey,
@@ -786,11 +775,6 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 			})),
 			totalAmountSats: data.satsTotal,
 			shippingRef: shippingRef || undefined,
-			shippingAddress: requirements.needsPhysicalAddress ? shippingData : undefined,
-			// Current app order metadata uses the existing email tag for v1 digital delivery contact.
-			// This is not a NIP-99 listing change.
-			email: buyerEmail || undefined,
-			notes: `Order for ${sellerProducts.length} item(s) from seller.`,
 		}
 
 		// 1. Create the main order event

--- a/src/queries/__tests__/orders-private-details.test.ts
+++ b/src/queries/__tests__/orders-private-details.test.ts
@@ -1,0 +1,590 @@
+import { NDKEvent, NDKUser, type NDKEncryptionScheme, type NDKSigner } from '@nostr-dev-kit/ndk'
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, getPublicKey, nip44 } from 'nostr-tools'
+import type { Event } from 'nostr-tools'
+import { createEncryptedPrivateOrderMessage, type PrivateOrderDeliveryDetails } from '../../lib/orders/privateOrderMessage'
+import {
+	attachPrivateOrderDetailsToOrders,
+	decryptSellerPrivateOrderGiftWraps,
+	privateDetailsMatchPublicOrder,
+	type OrderWithRelatedEvents,
+	type SellerPrivateOrderDetailsCandidate,
+} from '../orders'
+
+const CREATED_AT = 1_700_000_000
+const PII_SENTINELS = [
+	'buyer@example.com',
+	'123 Main Street',
+	'Satoshi Nakamoto',
+	'+15551234567',
+	'Los Angeles',
+	'90210',
+	'United States',
+	'Apt Secret Notes',
+]
+
+type KeyPair = {
+	privateKey: Uint8Array
+	pubkey: string
+}
+
+type MockSignerOptions = {
+	supportsNip44?: boolean
+	canDecrypt?: boolean
+	onSign?: () => void
+}
+
+function keyPair(): KeyPair {
+	const privateKey = crypto.getRandomValues(new Uint8Array(32))
+	return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function signerFor(privateKey: Uint8Array, options: MockSignerOptions = {}): NDKSigner {
+	const pubkey = getPublicKey(privateKey)
+	const user = new NDKUser({ pubkey })
+	return {
+		get pubkey() {
+			return pubkey
+		},
+		blockUntilReady: async () => user,
+		user: async () => user,
+		get userSync() {
+			return user
+		},
+		encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
+			if (options.supportsNip44 === false) return []
+			if (!scheme || scheme === 'nip44') return ['nip44']
+			return []
+		},
+		encrypt: async (recipient, value, scheme) => {
+			if (scheme !== 'nip44') throw new Error('NIP-44 required')
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(value, conversationKey)
+		},
+		decrypt: async (sender, value, scheme) => {
+			if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') throw new Error('NIP-44 unavailable')
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(value, conversationKey)
+		},
+		sign: async (event) => {
+			options.onSign?.()
+			return finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig
+		},
+		toPayload: () => JSON.stringify({ type: 'mock' }),
+	}
+}
+
+function privateOrderDetails(
+	buyerPubkey: string,
+	sellerPubkey: string,
+	overrides: Partial<PrivateOrderDeliveryDetails> = {},
+): PrivateOrderDeliveryDetails {
+	return {
+		orderId: 'order-123',
+		buyerPubkey,
+		sellerPubkey,
+		totalAmountSats: 2100,
+		shippingRef: `30406:${sellerPubkey}:standard`,
+		items: [{ productRef: `30402:${sellerPubkey}:product-1`, quantity: 2 }],
+		delivery: {
+			name: 'Satoshi Nakamoto',
+			email: 'buyer@example.com',
+			phone: '+15551234567',
+			address: {
+				firstLineOfAddress: '123 Main Street',
+				additionalInformation: 'Apt Secret Notes',
+				city: 'Los Angeles',
+				zipPostcode: '90210',
+				country: 'United States',
+			},
+		},
+		orderNotes: 'Apt Secret Notes',
+		...overrides,
+	}
+}
+
+function publicOrderEvent(
+	details: PrivateOrderDeliveryDetails,
+	buyerPrivateKey: Uint8Array,
+	overrides?: { kind?: number; tags?: string[][] },
+): NDKEvent {
+	const tags: string[][] = [
+		['p', details.sellerPubkey],
+		['subject', 'order-info'],
+		['type', '1'],
+		['order', details.orderId],
+		['amount', String(details.totalAmountSats)],
+		...details.items.map((item) => ['item', item.productRef, String(item.quantity)]),
+	]
+	if (details.shippingRef) tags.push(['shipping', details.shippingRef])
+
+	return ndkEvent(
+		finalizeEvent(
+			{
+				kind: overrides?.kind ?? 16,
+				content: '',
+				created_at: CREATED_AT,
+				tags: overrides?.tags ?? tags,
+			},
+			buyerPrivateKey,
+		),
+	)
+}
+
+function orderWithRelatedEvents(order: NDKEvent): OrderWithRelatedEvents {
+	return {
+		order,
+		paymentRequests: [],
+		statusUpdates: [],
+		shippingUpdates: [],
+		generalMessages: [],
+		paymentReceipts: [],
+	}
+}
+
+function encryptedPrivateOrderGiftWrapEvent(
+	details: PrivateOrderDeliveryDetails,
+	buyerPrivateKey: Uint8Array,
+	createdAt = CREATED_AT + 1,
+): NDKEvent {
+	const { giftWrap } = createEncryptedPrivateOrderMessage({
+		details,
+		buyerPrivateKey,
+		createdAt,
+	})
+	return ndkEvent(giftWrap)
+}
+
+function ndkEvent(event: Event): NDKEvent {
+	return new NDKEvent(undefined, event)
+}
+
+function candidateEvent(id: string, createdAt: number): NDKEvent {
+	return new NDKEvent(undefined, {
+		id,
+		pubkey: '0'.repeat(64),
+		created_at: createdAt,
+		kind: 1059,
+		tags: [],
+		content: '',
+		sig: '0'.repeat(128),
+	})
+}
+
+function expectNoPii(value: unknown): void {
+	const serialized = JSON.stringify(value)
+	for (const sentinel of PII_SENTINELS) {
+		expect(serialized).not.toContain(sentinel)
+	}
+}
+
+describe('seller private order details query helpers', () => {
+	test('valid kind 1059 gift wrap decrypts and attaches private details to the matching public order', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent(details, buyer.privateKey)
+		const giftWrapEvent = encryptedPrivateOrderGiftWrapEvent(details, buyer.privateKey)
+
+		const candidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [giftWrapEvent],
+			sellerPubkey: seller.pubkey,
+			signer: signerFor(seller.privateKey),
+		})
+		const [enrichedOrder] = attachPrivateOrderDetailsToOrders([orderWithRelatedEvents(order)], candidates)
+
+		expect(candidates).toHaveLength(1)
+		expect(enrichedOrder.privateOrderDetails).toEqual(details)
+		expect(enrichedOrder.privateOrderDetailsEvent?.id).toBe(giftWrapEvent.id)
+	})
+
+	test('non-matching order id does not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent({ ...details, orderId: 'other-order' }, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(false)
+	})
+
+	test('matching private details attach only to expected public order marker shape', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const validOrder = publicOrderEvent(details, buyer.privateKey)
+		const wrongKindOrder = publicOrderEvent(details, buyer.privateKey, { kind: 14 })
+		const missingTypeOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', details.items[0].productRef, String(details.items[0].quantity)],
+				['shipping', details.shippingRef!],
+			],
+		})
+		const wrongTypeOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['type', '2'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', details.items[0].productRef, String(details.items[0].quantity)],
+				['shipping', details.shippingRef!],
+			],
+		})
+
+		expect(privateDetailsMatchPublicOrder(details, validOrder)).toBe(true)
+		expect(privateDetailsMatchPublicOrder(details, wrongKindOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, missingTypeOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, wrongTypeOrder)).toBe(false)
+	})
+
+	test('duplicate type, order, amount, or p tags do not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const baseTags: string[][] = [
+			['p', seller.pubkey],
+			['subject', 'order-info'],
+			['type', '1'],
+			['order', details.orderId],
+			['amount', String(details.totalAmountSats)],
+			['item', details.items[0].productRef, String(details.items[0].quantity)],
+			['shipping', details.shippingRef!],
+		]
+
+		for (const duplicateTag of [
+			['type', '1'],
+			['order', details.orderId],
+			['amount', String(details.totalAmountSats)],
+			['p', seller.pubkey],
+		]) {
+			const order = publicOrderEvent(details, buyer.privateKey, { tags: [...baseTags, duplicateTag] })
+			expect(privateDetailsMatchPublicOrder(details, order)).toBe(false)
+		}
+	})
+
+	test('missing or wrong subject tag does not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const tagsWithoutSubject: string[][] = [
+			['p', seller.pubkey],
+			['type', '1'],
+			['order', details.orderId],
+			['amount', String(details.totalAmountSats)],
+			['item', details.items[0].productRef, String(details.items[0].quantity)],
+			['shipping', details.shippingRef!],
+		]
+		const wrongSubjectOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [['subject', 'not-order-info'], ...tagsWithoutSubject],
+		})
+		const duplicateSubjectOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [['subject', 'order-info'], ['subject', 'order-info'], ...tagsWithoutSubject],
+		})
+
+		expect(privateDetailsMatchPublicOrder(details, publicOrderEvent(details, buyer.privateKey, { tags: tagsWithoutSubject }))).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, wrongSubjectOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, duplicateSubjectOrder)).toBe(false)
+	})
+
+	test('non-matching buyer pubkey does not attach private details', () => {
+		const buyer = keyPair()
+		const otherBuyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent({ ...details, buyerPubkey: otherBuyer.pubkey }, otherBuyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(false)
+	})
+
+	test('non-matching seller pubkey does not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', otherSeller.pubkey],
+				['subject', 'order-info'],
+				['type', '1'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', `30402:${otherSeller.pubkey}:product-1`, '2'],
+				['shipping', `30406:${otherSeller.pubkey}:standard`],
+			],
+		})
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(false)
+	})
+
+	test('non-matching amount does not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent({ ...details, totalAmountSats: details.totalAmountSats + 1 }, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(false)
+	})
+
+	test('non-matching item refs and quantities do not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+
+		const differentRefOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['type', '1'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', `30402:${seller.pubkey}:other-product`, '2'],
+				['shipping', details.shippingRef!],
+			],
+		})
+		const differentQuantityOrder = publicOrderEvent({ ...details, items: [{ ...details.items[0], quantity: 3 }] }, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, differentRefOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, differentQuantityOrder)).toBe(false)
+	})
+
+	test('item refs and quantities match independent of array order', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const productA = `30402:${seller.pubkey}:product-a`
+		const productB = `30402:${seller.pubkey}:product-b`
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey, {
+			items: [
+				{ productRef: productA, quantity: 2 },
+				{ productRef: productB, quantity: 1 },
+			],
+		})
+		const order = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['type', '1'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', productB, '1'],
+				['item', productA, '2'],
+				['shipping', details.shippingRef!],
+			],
+		})
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(true)
+	})
+
+	test('duplicate item refs and quantities are handled deterministically', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const productRef = `30402:${seller.pubkey}:product-1`
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey, {
+			items: [
+				{ productRef, quantity: 1 },
+				{ productRef, quantity: 2 },
+			],
+		})
+		const matchingOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['type', '1'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', productRef, '3'],
+				['shipping', details.shippingRef!],
+			],
+		})
+		const nonMatchingOrder = publicOrderEvent({ ...details, items: [{ productRef, quantity: 2 }] }, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, matchingOrder)).toBe(true)
+		expect(privateDetailsMatchPublicOrder(details, nonMatchingOrder)).toBe(false)
+	})
+
+	test('non-matching shipping ref and one-sided shipping ref presence do not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const differentShippingOrder = publicOrderEvent({ ...details, shippingRef: `30406:${seller.pubkey}:express` }, buyer.privateKey)
+		const noPublicShippingOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [
+				['p', seller.pubkey],
+				['subject', 'order-info'],
+				['type', '1'],
+				['order', details.orderId],
+				['amount', String(details.totalAmountSats)],
+				['item', details.items[0].productRef, String(details.items[0].quantity)],
+			],
+		})
+		const privateWithoutShipping = privateOrderDetails(buyer.pubkey, seller.pubkey, { shippingRef: undefined })
+		const publicWithShipping = publicOrderEvent(details, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, differentShippingOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, noPublicShippingOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(privateWithoutShipping, publicWithShipping)).toBe(false)
+	})
+
+	test('malformed public shipping metadata does not attach private details', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey, { shippingRef: undefined })
+		const baseTags: string[][] = [
+			['p', seller.pubkey],
+			['subject', 'order-info'],
+			['type', '1'],
+			['order', details.orderId],
+			['amount', String(details.totalAmountSats)],
+			['item', details.items[0].productRef, String(details.items[0].quantity)],
+		]
+
+		const missingValueOrder = publicOrderEvent(details, buyer.privateKey, { tags: [...baseTags, ['shipping']] })
+		const emptyValueOrder = publicOrderEvent(details, buyer.privateKey, { tags: [...baseTags, ['shipping', '']] })
+		const duplicateShippingOrder = publicOrderEvent(details, buyer.privateKey, {
+			tags: [...baseTags, ['shipping', `30406:${seller.pubkey}:standard`], ['shipping', `30406:${seller.pubkey}:express`]],
+		})
+
+		expect(privateDetailsMatchPublicOrder(details, missingValueOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, emptyValueOrder)).toBe(false)
+		expect(privateDetailsMatchPublicOrder(details, duplicateShippingOrder)).toBe(false)
+	})
+
+	test('orders without shipping on both sides still match', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey, { shippingRef: undefined })
+		const order = publicOrderEvent(details, buyer.privateKey)
+
+		expect(privateDetailsMatchPublicOrder(details, order)).toBe(true)
+	})
+
+	test('malformed kind 1059 gift wrap does not leak PII or attach details', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const wrapper = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent(details, buyer.privateKey)
+		const malformedGiftWrap = ndkEvent(
+			finalizeEvent(
+				{
+					kind: 1059,
+					content: 'not encrypted Satoshi Nakamoto buyer@example.com 123 Main Street',
+					created_at: CREATED_AT,
+					tags: [['p', seller.pubkey]],
+				},
+				wrapper.privateKey,
+			),
+		)
+
+		const candidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [malformedGiftWrap],
+			sellerPubkey: seller.pubkey,
+			signer: signerFor(seller.privateKey),
+		})
+		const [enrichedOrder] = attachPrivateOrderDetailsToOrders([orderWithRelatedEvents(order)], candidates)
+
+		expect(candidates).toEqual([])
+		expect(enrichedOrder.privateOrderDetails).toBeUndefined()
+		expectNoPii(enrichedOrder)
+	})
+
+	test('signer without NIP-44 decrypt support fails closed', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const giftWrapEvent = encryptedPrivateOrderGiftWrapEvent(details, buyer.privateKey)
+
+		const candidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [giftWrapEvent],
+			sellerPubkey: seller.pubkey,
+			signer: signerFor(seller.privateKey, { supportsNip44: false }),
+		})
+
+		expect(candidates).toEqual([])
+	})
+
+	test('active signer pubkey mismatch fails closed and returns public orders without private details', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const otherSeller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = orderWithRelatedEvents(publicOrderEvent(details, buyer.privateKey))
+		const giftWrapEvent = encryptedPrivateOrderGiftWrapEvent(details, buyer.privateKey)
+
+		const candidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [giftWrapEvent],
+			sellerPubkey: seller.pubkey,
+			signer: signerFor(otherSeller.privateKey),
+		})
+		const [enrichedOrder] = attachPrivateOrderDetailsToOrders([order], candidates)
+
+		expect(candidates).toEqual([])
+		expect(enrichedOrder.order.id).toBe(order.order.id)
+		expect(enrichedOrder.privateOrderDetails).toBeUndefined()
+	})
+
+	test('seller decrypt/read path does not call signer.sign', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const giftWrapEvent = encryptedPrivateOrderGiftWrapEvent(details, buyer.privateKey)
+		let signCalls = 0
+
+		const candidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [giftWrapEvent],
+			sellerPubkey: seller.pubkey,
+			signer: signerFor(seller.privateKey, { onSign: () => signCalls++ }),
+		})
+
+		expect(candidates).toHaveLength(1)
+		expect(signCalls).toBe(0)
+	})
+
+	test('public kind 16 order data contains no PII sentinels', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = publicOrderEvent(details, buyer.privateKey)
+
+		expectNoPii(order.rawEvent())
+	})
+
+	test('public orders are unchanged when no private gift wraps or no signer are available', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = orderWithRelatedEvents(publicOrderEvent(details, buyer.privateKey))
+
+		const noSignerCandidates = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents: [encryptedPrivateOrderGiftWrapEvent(details, buyer.privateKey)],
+			sellerPubkey: seller.pubkey,
+			signer: null,
+		})
+
+		expect(attachPrivateOrderDetailsToOrders([order], [])).toEqual([order])
+		expect(noSignerCandidates).toEqual([])
+		expect(attachPrivateOrderDetailsToOrders([order], noSignerCandidates)).toEqual([order])
+	})
+
+	test('newest matching private payload wins with deterministic event-id tie-breaker', () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const details = privateOrderDetails(buyer.pubkey, seller.pubkey)
+		const order = orderWithRelatedEvents(publicOrderEvent(details, buyer.privateKey))
+		const oldDetails = { ...details, delivery: { ...details.delivery, email: 'old@example.com' } }
+		const newDetails = { ...details, delivery: { ...details.delivery, email: 'new@example.com' } }
+		const tieWinnerDetails = { ...details, delivery: { ...details.delivery, email: 'tie-winner@example.com' } }
+		const candidates: SellerPrivateOrderDetailsCandidate[] = [
+			{ details: oldDetails, event: candidateEvent('b'.repeat(64), CREATED_AT + 1) },
+			{ details: newDetails, event: candidateEvent('a'.repeat(64), CREATED_AT + 2) },
+			{ details: tieWinnerDetails, event: candidateEvent('c'.repeat(64), CREATED_AT + 2) },
+		]
+
+		const [enrichedOrder] = attachPrivateOrderDetailsToOrders([order], candidates)
+
+		expect(enrichedOrder.privateOrderDetails?.delivery.email).toBe('tie-winner@example.com')
+	})
+})

--- a/src/queries/orders.tsx
+++ b/src/queries/orders.tsx
@@ -1,7 +1,10 @@
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, ORDER_STATUS, PAYMENT_RECEIPT_KIND } from '@/lib/schemas/order'
+import { NIP59_GIFT_WRAP_KIND, signerSupportsNip44 } from '@/lib/nostr/nip59'
+import { decryptPrivateOrderMessageWithSigner, type PrivateOrderDeliveryDetails } from '@/lib/orders/privateOrderMessage'
 import { ndkActions } from '@/lib/stores/ndk'
-import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
+import type { NDKEvent, NDKFilter, NDKSigner } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
+import type { Event } from 'nostr-tools'
 import { useEffect } from 'react'
 import { orderKeys } from './queryKeyFactory'
 
@@ -19,6 +22,150 @@ export type OrderWithRelatedEvents = {
 	latestPaymentRequest?: NDKEvent
 	latestPaymentReceipt?: NDKEvent
 	latestMessage?: NDKEvent
+	privateOrderDetails?: PrivateOrderDeliveryDetails
+	privateOrderDetailsEvent?: NDKEvent
+}
+
+type FetchOrdersBySellerOptions = {
+	includePrivateOrderDetails?: boolean
+	signer?: NDKSigner | null
+}
+
+type PublicOrderCorrelationFields = {
+	orderId: string
+	buyerPubkey: string
+	sellerPubkey: string
+	totalAmountSats: number
+	items: Map<string, number>
+	shippingRef?: string
+}
+
+export type SellerPrivateOrderDetailsCandidate = {
+	details: PrivateOrderDeliveryDetails
+	event: NDKEvent
+}
+
+const PRODUCT_REF_KIND = '30402'
+const SHIPPING_REF_KIND = '30406'
+const ORDER_CREATION_SUBJECT = 'order-info'
+const HEX_PUBKEY_RE = /^[0-9a-f]{64}$/i
+
+export const fetchSellerPrivateOrderGiftWraps = async (sellerPubkey: string): Promise<NDKEvent[]> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+
+	const giftWrapFilter: NDKFilter = {
+		kinds: [NIP59_GIFT_WRAP_KIND],
+		'#p': [sellerPubkey],
+		limit: 500,
+	}
+
+	return Array.from(await ndk.fetchEvents(giftWrapFilter))
+}
+
+export const decryptSellerPrivateOrderGiftWraps = async (params: {
+	giftWrapEvents: NDKEvent[]
+	sellerPubkey: string
+	signer?: NDKSigner | null
+}): Promise<SellerPrivateOrderDetailsCandidate[]> => {
+	const { giftWrapEvents, sellerPubkey, signer } = params
+	if (!isHexPubkey(sellerPubkey)) return []
+	if (!signer) return []
+
+	const signerPubkey = await getSignerPubkey(signer)
+	if (signerPubkey !== sellerPubkey) return []
+	if (!(await signerSupportsNip44(signer, 'decrypt'))) return []
+
+	const decryptedCandidates: SellerPrivateOrderDetailsCandidate[] = []
+	for (const giftWrapEvent of giftWrapEvents) {
+		try {
+			const giftWrap = ndkEventToRawEvent(giftWrapEvent)
+			const decrypted = await decryptPrivateOrderMessageWithSigner({
+				giftWrap,
+				signer,
+				expectedSellerPubkey: sellerPubkey,
+			})
+			decryptedCandidates.push({ details: decrypted.details, event: giftWrapEvent })
+		} catch {
+			// Private delivery details are best-effort seller enrichment. Keep public orders usable.
+		}
+	}
+
+	return decryptedCandidates
+}
+
+export const getPublicOrderCorrelationFields = (order: NDKEvent): PublicOrderCorrelationFields | null => {
+	if (order.kind !== ORDER_PROCESS_KIND) return null
+
+	const type = getRequiredSingleTagValue(order.tags, 'type')
+	if (type !== ORDER_MESSAGE_TYPE.ORDER_CREATION) return null
+
+	const subject = getRequiredSingleTagValue(order.tags, 'subject')
+	if (subject !== ORDER_CREATION_SUBJECT) return null
+
+	const sellerPubkey = getRequiredSingleTagValue(order.tags, 'p')
+	if (!sellerPubkey || !isHexPubkey(sellerPubkey)) return null
+	if (!isHexPubkey(order.pubkey)) return null
+
+	const orderId = getRequiredSingleTagValue(order.tags, 'order')
+	if (!orderId) return null
+
+	const amount = getRequiredSingleTagValue(order.tags, 'amount')
+	if (!amount || !/^\d+$/.test(amount)) return null
+	const totalAmountSats = Number(amount)
+	if (!Number.isSafeInteger(totalAmountSats) || totalAmountSats <= 0) return null
+
+	const items = canonicalizeItemTags(order.tags, sellerPubkey)
+	if (!items) return null
+
+	const shippingRef = getOptionalSingleTagValue(order.tags, 'shipping')
+	if (shippingRef === null) return null
+	if (shippingRef && !isAddressableRef(shippingRef, SHIPPING_REF_KIND, sellerPubkey)) return null
+
+	return {
+		orderId,
+		buyerPubkey: order.pubkey,
+		sellerPubkey,
+		totalAmountSats,
+		items,
+		shippingRef,
+	}
+}
+
+export const privateDetailsMatchPublicOrder = (details: PrivateOrderDeliveryDetails, order: NDKEvent): boolean => {
+	const publicFields = getPublicOrderCorrelationFields(order)
+	if (!publicFields) return false
+
+	if (details.orderId !== publicFields.orderId) return false
+	if (details.buyerPubkey !== publicFields.buyerPubkey) return false
+	if (details.sellerPubkey !== publicFields.sellerPubkey) return false
+	if (details.totalAmountSats !== publicFields.totalAmountSats) return false
+
+	const privateItems = canonicalizeItems(details.items)
+	if (!privateItems) return false
+	if (!itemMapsEqual(publicFields.items, privateItems)) return false
+
+	const privateShippingRef = details.shippingRef
+	if (publicFields.shippingRef !== privateShippingRef) return false
+
+	return true
+}
+
+export const attachPrivateOrderDetailsToOrders = (
+	orders: OrderWithRelatedEvents[],
+	decryptedDetails: SellerPrivateOrderDetailsCandidate[],
+): OrderWithRelatedEvents[] => {
+	const sortedDetails = [...decryptedDetails].sort(comparePrivateOrderDetailsCandidates)
+
+	return orders.map((orderWithEvents) => {
+		const match = sortedDetails.find((candidate) => privateDetailsMatchPublicOrder(candidate.details, orderWithEvents.order))
+		if (!match) return orderWithEvents
+		return {
+			...orderWithEvents,
+			privateOrderDetails: match.details,
+			privateOrderDetailsEvent: match.event,
+		}
+	})
 }
 
 /**
@@ -427,7 +574,10 @@ export const useOrdersByBuyer = (buyerPubkey: string) => {
 /**
  * Fetches orders where the specified user is the seller (recipient of order messages)
  */
-export const fetchOrdersBySeller = async (sellerPubkey: string): Promise<OrderWithRelatedEvents[]> => {
+export const fetchOrdersBySeller = async (
+	sellerPubkey: string,
+	options: FetchOrdersBySellerOptions = {},
+): Promise<OrderWithRelatedEvents[]> => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
@@ -551,7 +701,7 @@ export const fetchOrdersBySeller = async (sellerPubkey: string): Promise<OrderWi
 	}
 
 	// Create the combined order objects
-	return Array.from(orders).map((order) => {
+	const publicOrders = Array.from(orders).map((order) => {
 		const orderTag = order.tags.find((tag) => tag[0] === 'order')
 		if (!orderTag?.[1]) {
 			return {
@@ -594,6 +744,20 @@ export const fetchOrdersBySeller = async (sellerPubkey: string): Promise<OrderWi
 			latestMessage: related.generalMessages[0],
 		}
 	})
+
+	if (!options.includePrivateOrderDetails) return publicOrders
+
+	try {
+		const giftWrapEvents = await fetchSellerPrivateOrderGiftWraps(sellerPubkey)
+		const decryptedDetails = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents,
+			sellerPubkey,
+			signer: options.signer ?? ndkActions.getSigner(),
+		})
+		return attachPrivateOrderDetailsToOrders(publicOrders, decryptedDetails)
+	} catch {
+		return publicOrders
+	}
 }
 
 /**
@@ -882,6 +1046,119 @@ export const getOrderId = (order: NDKEvent): string | undefined => {
 export const getOrderAmount = (order: NDKEvent): string | undefined => {
 	const amountTag = order.tags.find((tag) => tag[0] === 'amount')
 	return amountTag?.[1]
+}
+
+function comparePrivateOrderDetailsCandidates(a: SellerPrivateOrderDetailsCandidate, b: SellerPrivateOrderDetailsCandidate): number {
+	const createdAtDiff = (b.event.created_at || 0) - (a.event.created_at || 0)
+	if (createdAtDiff !== 0) return createdAtDiff
+	return (b.event.id || '').localeCompare(a.event.id || '')
+}
+
+async function getSignerPubkey(signer: NDKSigner): Promise<string | null> {
+	try {
+		const user = await signer.user()
+		return user.pubkey
+	} catch {
+		return null
+	}
+}
+
+function ndkEventToRawEvent(event: NDKEvent): Event {
+	const rawEvent =
+		typeof event.rawEvent === 'function'
+			? event.rawEvent()
+			: {
+					id: event.id,
+					pubkey: event.pubkey,
+					created_at: event.created_at,
+					kind: event.kind,
+					tags: event.tags,
+					content: event.content,
+					sig: event.sig,
+				}
+
+	if (typeof rawEvent.kind !== 'number') throw new Error('Malformed private order gift wrap')
+	if (typeof rawEvent.content !== 'string') throw new Error('Malformed private order gift wrap')
+	if (typeof rawEvent.created_at !== 'number') throw new Error('Malformed private order gift wrap')
+	if (typeof rawEvent.pubkey !== 'string' || !isHexPubkey(rawEvent.pubkey)) throw new Error('Malformed private order gift wrap')
+	if (typeof rawEvent.id !== 'string') throw new Error('Malformed private order gift wrap')
+	if (typeof rawEvent.sig !== 'string') throw new Error('Malformed private order gift wrap')
+	if (
+		!Array.isArray(rawEvent.tags) ||
+		!rawEvent.tags.every((tag) => Array.isArray(tag) && tag.every((value) => typeof value === 'string'))
+	) {
+		throw new Error('Malformed private order gift wrap')
+	}
+
+	return rawEvent as Event
+}
+
+function getRequiredSingleTagValue(tags: string[][], tagName: string): string | undefined {
+	const matches = tags.filter((tag) => tag[0] === tagName)
+	if (matches.length !== 1) return undefined
+	return matches[0]?.[1]
+}
+
+function getOptionalSingleTagValue(tags: string[][], tagName: string): string | undefined | null {
+	const matches = tags.filter((tag) => tag[0] === tagName)
+	if (matches.length === 0) return undefined
+	if (matches.length > 1) return null
+	const value = matches[0]?.[1]
+	if (!value) return null
+	return value
+}
+
+function canonicalizeItemTags(tags: string[][], sellerPubkey: string): Map<string, number> | null {
+	const itemTags = tags.filter((tag) => tag[0] === 'item')
+	if (itemTags.length === 0) return null
+
+	const items = itemTags.map((tag) => {
+		const productRef = tag[1]
+		const quantityText = tag[2]
+		if (!productRef || !isAddressableRef(productRef, PRODUCT_REF_KIND, sellerPubkey)) return null
+		if (!quantityText || !/^\d+$/.test(quantityText)) return null
+		const quantity = Number(quantityText)
+		if (!Number.isSafeInteger(quantity) || quantity <= 0) return null
+		return { productRef, quantity }
+	})
+
+	if (items.some((item) => item === null)) return null
+	return canonicalizeItems(items as Array<{ productRef: string; quantity: number }>)
+}
+
+function canonicalizeItems(items: Array<{ productRef: string; quantity: number }>): Map<string, number> | null {
+	if (items.length === 0) return null
+	const canonicalItems = new Map<string, number>()
+
+	for (const item of items) {
+		if (!item.productRef) return null
+		if (!Number.isSafeInteger(item.quantity) || item.quantity <= 0) return null
+		const currentQuantity = canonicalItems.get(item.productRef) ?? 0
+		const nextQuantity = currentQuantity + item.quantity
+		if (!Number.isSafeInteger(nextQuantity)) return null
+		canonicalItems.set(item.productRef, nextQuantity)
+	}
+
+	return canonicalItems
+}
+
+function itemMapsEqual(a: Map<string, number>, b: Map<string, number>): boolean {
+	if (a.size !== b.size) return false
+	for (const [productRef, quantity] of a) {
+		if (b.get(productRef) !== quantity) return false
+	}
+	return true
+}
+
+function isAddressableRef(value: string, expectedKind: string, expectedPubkey: string): boolean {
+	if (value.includes('\n') || value.includes('\r')) return false
+	const [kind, pubkey, ...dTagParts] = value.split(':')
+	const dTag = dTagParts.join(':')
+	return kind === expectedKind && pubkey === expectedPubkey && dTag.length > 0
+}
+
+function isHexPubkey(value: string): boolean {
+	return HEX_PUBKEY_RE.test(value)
 }
 
 /**

--- a/src/queries/orders.tsx
+++ b/src/queries/orders.tsx
@@ -5,7 +5,7 @@ import { ndkActions } from '@/lib/stores/ndk'
 import type { NDKEvent, NDKFilter, NDKSigner } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { Event } from 'nostr-tools'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { orderKeys } from './queryKeyFactory'
 
 export type OrderWithRelatedEvents = {
@@ -29,6 +29,19 @@ export type OrderWithRelatedEvents = {
 type FetchOrdersBySellerOptions = {
 	includePrivateOrderDetails?: boolean
 	signer?: NDKSigner | null
+}
+
+type UseOrdersBySellerOptions = {
+	includePrivateOrderDetails?: boolean
+}
+
+type FetchOrderByIdOptions = {
+	includePrivateOrderDetails?: boolean
+	signer?: NDKSigner | null
+}
+
+type UseOrderByIdOptions = {
+	includePrivateOrderDetails?: boolean
 }
 
 type PublicOrderCorrelationFields = {
@@ -763,10 +776,20 @@ export const fetchOrdersBySeller = async (
 /**
  * Hook to fetch orders where the specified user is the seller
  */
-export const useOrdersBySeller = (sellerPubkey: string) => {
+export const useOrdersBySeller = (sellerPubkey: string, options: UseOrdersBySellerOptions = {}) => {
+	const includePrivateOrderDetails = options.includePrivateOrderDetails === true
 	return useQuery({
-		queryKey: orderKeys.bySeller(sellerPubkey),
-		queryFn: () => fetchOrdersBySeller(sellerPubkey),
+		queryKey: includePrivateOrderDetails ? orderKeys.bySellerWithPrivate(sellerPubkey) : orderKeys.bySeller(sellerPubkey),
+		queryFn: () =>
+			fetchOrdersBySeller(
+				sellerPubkey,
+				includePrivateOrderDetails
+					? {
+							includePrivateOrderDetails: true,
+							signer: ndkActions.getSigner(),
+						}
+					: undefined,
+			),
 		enabled: !!sellerPubkey,
 	})
 }
@@ -774,7 +797,7 @@ export const useOrdersBySeller = (sellerPubkey: string) => {
 /**
  * Fetches a specific order by its ID
  */
-export const fetchOrderById = async (orderId: string): Promise<OrderWithRelatedEvents | null> => {
+export const fetchOrderById = async (orderId: string, options: FetchOrderByIdOptions = {}): Promise<OrderWithRelatedEvents | null> => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
@@ -901,7 +924,7 @@ export const fetchOrderById = async (orderId: string): Promise<OrderWithRelatedE
 	generalMessages.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 	paymentReceipts.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 
-	return {
+	const publicOrder = {
 		order: orderEvent,
 		paymentRequests,
 		statusUpdates,
@@ -914,17 +937,45 @@ export const fetchOrderById = async (orderId: string): Promise<OrderWithRelatedE
 		latestPaymentReceipt: paymentReceipts[0],
 		latestMessage: generalMessages[0],
 	}
+
+	if (!options.includePrivateOrderDetails) return publicOrder
+
+	try {
+		const giftWrapEvents = await fetchSellerPrivateOrderGiftWraps(seller)
+		const decryptedDetails = await decryptSellerPrivateOrderGiftWraps({
+			giftWrapEvents,
+			sellerPubkey: seller,
+			signer: options.signer ?? ndkActions.getSigner(),
+		})
+		return attachPrivateOrderDetailsToOrders([publicOrder], decryptedDetails)[0] ?? publicOrder
+	} catch {
+		return publicOrder
+	}
 }
 
 /**
  * Hook to fetch a specific order by its ID
  */
-export const useOrderById = (orderId: string) => {
+export const useOrderById = (orderId: string, options: UseOrderByIdOptions = {}) => {
 	const queryClient = useQueryClient()
 	const ndk = ndkActions.getNDK()
+	const includePrivateOrderDetails = options.includePrivateOrderDetails === true
+	const queryKey = useMemo(
+		() => (includePrivateOrderDetails ? orderKeys.detailsWithPrivate(orderId) : orderKeys.details(orderId)),
+		[includePrivateOrderDetails, orderId],
+	)
 	const orderQuery = useQuery({
-		queryKey: orderKeys.details(orderId),
-		queryFn: () => fetchOrderById(orderId),
+		queryKey,
+		queryFn: () =>
+			fetchOrderById(
+				orderId,
+				includePrivateOrderDetails
+					? {
+							includePrivateOrderDetails: true,
+							signer: ndkActions.getSigner(),
+						}
+					: undefined,
+			),
 		enabled: !!orderId,
 		staleTime: Infinity,
 		refetchOnMount: true,
@@ -949,8 +1000,8 @@ export const useOrderById = (orderId: string) => {
 		})
 
 		const refreshOrderDetails = () => {
-			void queryClient.invalidateQueries({ queryKey: orderKeys.details(orderId) })
-			void queryClient.refetchQueries({ queryKey: orderKeys.details(orderId) })
+			void queryClient.invalidateQueries({ queryKey })
+			void queryClient.refetchQueries({ queryKey })
 		}
 
 		// Event handler for all events related to this order
@@ -969,7 +1020,7 @@ export const useOrderById = (orderId: string) => {
 		return () => {
 			subscription.stop()
 		}
-	}, [fetchedOrderEventId, logicalOrderId, ndk, orderId, queryClient])
+	}, [fetchedOrderEventId, logicalOrderId, ndk, orderId, queryClient, queryKey])
 
 	return orderQuery
 }

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -11,8 +11,10 @@ export const productKeys = {
 export const orderKeys = {
 	all: ['orders'] as const,
 	details: (id: string) => [...orderKeys.all, id] as const,
+	detailsWithPrivate: (id: string) => [...orderKeys.details(id), 'privateDetails'] as const,
 	byPubkey: (pubkey: string) => [...orderKeys.all, 'byPubkey', pubkey] as const,
 	bySeller: (pubkey: string) => [...orderKeys.all, 'bySeller', pubkey] as const,
+	bySellerWithPrivate: (pubkey: string) => [...orderKeys.bySeller(pubkey), 'privateDetails'] as const,
 	byBuyer: (pubkey: string) => [...orderKeys.all, 'byBuyer', pubkey] as const,
 } as const
 

--- a/src/routes/_dashboard-layout/dashboard/orders/$orderId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/orders/$orderId.tsx
@@ -13,7 +13,7 @@ function OrderDetailRouteComponent() {
 	const { orderId } = Route.useParams()
 	useDashboardTitle('Order Details')
 
-	const { data: order, isLoading, isFetching, error } = useOrderById(orderId)
+	const { data: order, isLoading, isFetching, error } = useOrderById(orderId, { includePrivateOrderDetails: true })
 	const isPending = isLoading || (!order && isFetching)
 
 	if (isPending) {

--- a/src/routes/_dashboard-layout/dashboard/sales/messages/$pubkey.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/messages/$pubkey.tsx
@@ -1,17 +1,22 @@
 import { ChatMessageBubble } from '@/components/messages/ChatMessageBubble'
 import { MessageInput } from '@/components/messages/MessageInput'
+import { PrivateOrderDetailsCard } from '@/components/orders/PrivateOrderDetailsCard'
 import { Button } from '@/components/ui/button'
 import { authStore } from '@/lib/stores/auth'
 import { notificationActions } from '@/lib/stores/notifications'
+import { isValidHexKey, isValidNpub } from '@/lib/utils'
 import { sendChatMessage, useConversationMessages } from '@/queries/messages'
+import { useOrdersBySeller } from '@/queries/orders'
 import { messageKeys } from '@/queries/queryKeyFactory'
+import { getSellerPubkey } from '@/components/orders/orderDetailHelpers'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { useProfileName } from '@/queries/profiles'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { Loader2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { decode } from 'nostr-tools/nip19'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/sales/messages/$pubkey')({
@@ -24,6 +29,7 @@ function ConversationDetailComponent() {
 	const queryClient = useQueryClient()
 	const messagesEndRef = useRef<HTMLDivElement | null>(null)
 	const [isSending, setIsSending] = useState(false)
+	const normalizedBuyerPubkey = useMemo(() => normalizePubkeyParam(otherUserPubkey), [otherUserPubkey])
 
 	// Get the user's profile name for the title
 	const { data: userName, isLoading: isLoadingName } = useProfileName(otherUserPubkey)
@@ -32,6 +38,21 @@ function ConversationDetailComponent() {
 	useDashboardTitle(displayTitle)
 
 	const { data: messages, isLoading, error, refetch } = useConversationMessages(otherUserPubkey)
+	const { data: sellerOrders } = useOrdersBySeller(currentUser?.pubkey || '', { includePrivateOrderDetails: true })
+
+	const matchingBuyerOrders = useMemo(() => {
+		if (!sellerOrders || !currentUser?.pubkey || !normalizedBuyerPubkey) return []
+		return sellerOrders
+			.filter((order) => {
+				return order.order.pubkey === normalizedBuyerPubkey && getSellerPubkey(order.order) === currentUser.pubkey
+			})
+			.sort((a, b) => (b.order.created_at || 0) - (a.order.created_at || 0))
+	}, [currentUser?.pubkey, normalizedBuyerPubkey, sellerOrders])
+
+	const privateDetailOrders = useMemo(
+		() => matchingBuyerOrders.filter((order) => order.privateOrderDetails).slice(0, 3),
+		[matchingBuyerOrders],
+	)
 
 	const scrollToBottom = () => {
 		setTimeout(() => messagesEndRef.current?.scrollIntoView({ behavior: 'auto' }), 0) // Use auto for instant scroll on load
@@ -100,6 +121,13 @@ function ConversationDetailComponent() {
 						<p>No messages yet. Start the conversation!</p>
 					</div>
 				)}
+				{privateDetailOrders.length > 0 && (
+					<div className="space-y-3">
+						{privateDetailOrders.map((order) => (
+							<PrivateOrderDetailsCard key={order.order.id} order={order} currentUserPubkey={currentUser?.pubkey} compact />
+						))}
+					</div>
+				)}
 				{!isLoading &&
 					!error &&
 					messages?.map((event) => <ChatMessageBubble key={event.id} event={event} isCurrentUser={event.pubkey === currentUser?.pubkey} />)}
@@ -114,4 +142,13 @@ function ConversationDetailComponent() {
 			)}
 		</div>
 	)
+}
+
+function normalizePubkeyParam(value: string): string | null {
+	if (isValidHexKey(value)) return value
+	if (!isValidNpub(value)) return null
+
+	const { type, data } = decode(value)
+	if (type !== 'npub' || typeof data !== 'string') return null
+	return data
 }

--- a/src/routes/_dashboard-layout/dashboard/sales/sales.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/sales.tsx
@@ -18,7 +18,7 @@ function SalesComponent() {
 	const currentUser = ndk?.activeUser
 	const [statusFilter, setStatusFilter] = useState<string>('any')
 	const [orderBy, setOrderBy] = useState<string>('newest')
-	const { data: sales, isLoading } = useOrdersBySeller(currentUser?.pubkey || '')
+	const { data: sales, isLoading } = useOrdersBySeller(currentUser?.pubkey || '', { includePrivateOrderDetails: true })
 
 	// Mark all orders as seen when the page is viewed
 	useEffect(() => {


### PR DESCRIPTION
Fixes #904.

## Summary

This PR prevents buyer delivery/contact PII from being serialized into public order events.

Public order creation events now retain only non-sensitive metadata needed by the current checkout/order workflow. Buyer name, address, email, phone, delivery notes, and raw checkout delivery data are not included in public order tags or content.

Because the repo does not currently have a tested seller-readable encrypted delivery transport for this checkout path, delivery flows that require private buyer details now fail closed before publishing a public order marker.

This does not claim a full NIP-17 order inbox migration.

## Behavior changed

- Removed buyer `address`, `email`, `phone`, and delivery notes from public order creation events.
- Sanitized both the spec order creation constructor and legacy `createOrder` helper.
- Physical delivery requiring buyer address now fails before publishing if encrypted seller delivery is unavailable.
- Digital delivery requiring buyer contact now fails before publishing if encrypted seller delivery is unavailable.
- Multi-seller checkout preflights privacy requirements before publishing any public order.

## Behavior preserved

- Public seller-defined shipping refs remain allowed when they do not contain buyer PII.
- Pickup/no-private-details checkout can still publish sanitized public order events.
- Payment request, invoice, NWC, zap, and receipt semantics are unchanged.

## Tests

- `bun test src/publish/orders.test.ts`
- `bun run test:unit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

## Manual test

- Started local relay at `ws://localhost:10547`.
- Ran app with `LOCAL_RELAY_ONLY=true`.
- Created a physical-shipping checkout using fake buyer PII.
- Checkout failed closed with: `Encrypted seller delivery is required before creating this order`.
- Queried local relay with `nak req -k 16 ws://localhost:10547`.
- Result: `0` kind-16 order events for the failed physical-delivery checkout.
- Grep found no buyer name/email/phone/address/delivery notes in relay output.

## Follow-up

Add PM-specific seller-readable encrypted delivery transport using NIP-59 wrapping and NIP-44 encryption, with seller-side read/decrypt/query support.