### PR TITLE
test(auctions): extract and test isMeaningfulDraft

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1679,8 +1679,8 @@ export function AuctionFormContent() {
 	]
 
 	return (
-		<form onSubmit={handleSubmit} className="flex flex-col h-full mt-4">
-			<div className="flex-1 flex flex-col min-h-0 overflow-hidden max-h-[calc(100vh-200px)]">
+		<form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 mt-4">
+			<div className="flex-1 flex flex-col min-h-0 overflow-hidden">
 				<Tabs
 					value={activeTab}
 					onValueChange={(value) => setActiveTab(value as AuctionTab)}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1486,22 +1486,8 @@ function ShippingTab({
 	)
 }
 
-function isMeaningfulDraft(formData: AuctionFormData, images: AuctionImage[], subCategoryInput: string): boolean {
-	return (
-		formData.title.trim().length > 0 ||
-		formData.summary.trim().length > 0 ||
-		formData.description.trim().length > 0 ||
-		formData.startingBid.trim().length > 0 ||
-		(formData.startAt ?? '').trim().length > 0 ||
-		formData.endAt.trim().length > 0 ||
-		formData.mainCategory.trim().length > 0 ||
-		formData.pathIssuerPubkey.trim().length > 0 ||
-		formData.isNSFW ||
-		formData.specs.length > 0 ||
-		formData.shippings.length > 0 ||
-		subCategoryInput.trim().length > 0 ||
-		images.length > 0
-	)
+function isMeaningfulDraft(formData: AuctionFormData): boolean {
+	return formData.title.trim().length > 0
 }
 
 export function AuctionFormContent() {
@@ -1574,7 +1560,7 @@ export function AuctionFormContent() {
 
 		saveTimerRef.current = setTimeout(() => {
 			if (draftGenerationRef.current !== gen) return
-			if (!isMeaningfulDraft(formData, images, subCategoryInput)) return
+			if (!isMeaningfulDraft(formData)) return
 			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
 			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
 		}, 1500)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1545,16 +1545,16 @@ export function AuctionFormContent() {
 	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
 
 	const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null)
-	const draftLoadedRef = useRef(false)
+	const draftLoadedRef = useRef('')
 	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 	const draftGenerationRef = useRef(0)
 
 	const hasDraft = draftSavedAt !== null
 
 	useEffect(() => {
-		if (!userPubkey || draftLoadedRef.current) return
+		if (!userPubkey || draftLoadedRef.current === userPubkey) return
 
-		draftLoadedRef.current = true
+		draftLoadedRef.current = userPubkey
 		const draft = getAuctionFormDraft(userPubkey)
 		if (!draft) return
 		setDraftSavedAt(draft.savedAt)
@@ -1567,7 +1567,7 @@ export function AuctionFormContent() {
 	}, [userPubkey])
 
 	useEffect(() => {
-		if (!userPubkey || !draftLoadedRef.current) return
+		if (!userPubkey || draftLoadedRef.current !== userPubkey) return
 
 		const gen = draftGenerationRef.current
 		if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
@@ -1635,7 +1635,7 @@ export function AuctionFormContent() {
 
 	const handleClearDraft = () => {
 		draftGenerationRef.current++
-		draftLoadedRef.current = true
+		draftLoadedRef.current = userPubkey
 		clearAuctionFormDraft(userPubkey)
 		setDraftSavedAt(null)
 		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1487,7 +1487,20 @@ function ShippingTab({
 }
 
 function isMeaningfulDraft(formData: AuctionFormData): boolean {
-	return formData.title.trim().length > 0
+	return (
+		formData.title.trim().length > 0 ||
+		formData.summary.trim().length > 0 ||
+		formData.description.trim().length > 0 ||
+		formData.startingBid.trim().length > 0 ||
+		(formData.startAt?.trim().length ?? 0) > 0 ||
+		formData.endAt.trim().length > 0 ||
+		formData.mainCategory.trim().length > 0 ||
+		formData.categories.length > 0 ||
+		formData.imageUrls.length > 0 ||
+		formData.specs.length > 0 ||
+		formData.shippings.length > 0 ||
+		formData.isNSFW
+	)
 }
 
 export function AuctionFormContent() {

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1486,6 +1486,24 @@ function ShippingTab({
 	)
 }
 
+function isMeaningfulDraft(formData: AuctionFormData, images: AuctionImage[], subCategoryInput: string): boolean {
+	return (
+		formData.title.trim().length > 0 ||
+		formData.summary.trim().length > 0 ||
+		formData.description.trim().length > 0 ||
+		formData.startingBid.trim().length > 0 ||
+		(formData.startAt ?? '').trim().length > 0 ||
+		formData.endAt.trim().length > 0 ||
+		formData.mainCategory.trim().length > 0 ||
+		formData.pathIssuerPubkey.trim().length > 0 ||
+		formData.isNSFW ||
+		formData.specs.length > 0 ||
+		formData.shippings.length > 0 ||
+		subCategoryInput.trim().length > 0 ||
+		images.length > 0
+	)
+}
+
 export function AuctionFormContent() {
 	const navigate = useNavigate()
 	const publishMutation = usePublishAuctionMutation()
@@ -1556,6 +1574,7 @@ export function AuctionFormContent() {
 
 		saveTimerRef.current = setTimeout(() => {
 			if (draftGenerationRef.current !== gen) return
+			if (!isMeaningfulDraft(formData, images, subCategoryInput)) return
 			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
 			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
 		}, 1500)

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -1556,7 +1556,16 @@ export function AuctionFormContent() {
 
 		draftLoadedRef.current = userPubkey
 		const draft = getAuctionFormDraft(userPubkey)
-		if (!draft) return
+		if (!draft) {
+			setDraftSavedAt(null)
+			setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
+			setImages([])
+			setStartMode(DEFAULT_AUCTION_START_MODE)
+			setEndMode(DEFAULT_AUCTION_END_MODE)
+			setDurationSeconds(24 * 60 * 60)
+			setSubCategoryInput('')
+			return
+		}
 		setDraftSavedAt(draft.savedAt)
 		setFormData(draft.formData)
 		setImages(draft.images)
@@ -1564,7 +1573,7 @@ export function AuctionFormContent() {
 		setEndMode(draft.endMode)
 		setDurationSeconds(draft.durationSeconds)
 		setSubCategoryInput(draft.subCategoryInput)
-	}, [userPubkey])
+	}, [userPubkey, availableMints])
 
 	useEffect(() => {
 		if (!userPubkey || draftLoadedRef.current !== userPubkey) return

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/publish/auctions'
 import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
-import { clearAuctionFormDraft, getAuctionFormDraft, saveAuctionFormDraft } from '@/lib/utils/auctionFormStorage'
+import { clearAuctionFormDraft, getAuctionFormDraft, isMeaningfulDraft, saveAuctionFormDraft } from '@/lib/utils/auctionFormStorage'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
@@ -1484,23 +1484,6 @@ function ShippingTab({
 				)}
 			</div>
 		</div>
-	)
-}
-
-function isMeaningfulDraft(formData: AuctionFormData): boolean {
-	return (
-		formData.title.trim().length > 0 ||
-		formData.summary.trim().length > 0 ||
-		formData.description.trim().length > 0 ||
-		formData.startingBid.trim().length > 0 ||
-		(formData.startAt?.trim().length ?? 0) > 0 ||
-		formData.endAt.trim().length > 0 ||
-		formData.mainCategory.trim().length > 0 ||
-		formData.categories.length > 0 ||
-		formData.imageUrls.length > 0 ||
-		formData.specs.length > 0 ||
-		formData.shippings.length > 0 ||
-		formData.isNSFW
 	)
 }
 

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -24,13 +24,17 @@ import {
 	AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES,
 	AUCTION_MIN_BID_CURVE_PEAK_PRESETS,
 	AUCTION_SETTLEMENT_GRACE_PRESETS,
+	DEFAULT_AUCTION_END_MODE,
+	DEFAULT_AUCTION_START_MODE,
 	usePublishAuctionMutation,
 	type AuctionAntiSnipeWindowMinutesPreset,
+	type AuctionEndMode,
 	type AuctionFormData,
 	type AuctionMinBidCurvePeakPreset,
 	type AuctionMinBidCurveShape,
 	type AuctionSettlementGracePreset,
 	type AuctionSpecEntry,
+	type AuctionStartMode,
 } from '@/publish/auctions'
 import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
@@ -161,9 +165,6 @@ function NameTab({ formData, setFormData }: TabProps) {
 		</div>
 	)
 }
-
-type StartMode = 'immediate' | 'scheduled'
-type EndMode = 'duration' | 'absolute'
 
 const DURATION_PRESETS: { label: string; seconds: number }[] = [
 	{ label: '1h', seconds: 3600 },
@@ -812,10 +813,10 @@ function AuctionTabContent({
 	onUserRemovedMintsChange,
 }: TabProps & {
 	availableMints: readonly string[]
-	startMode: StartMode
-	setStartMode: Dispatch<SetStateAction<StartMode>>
-	endMode: EndMode
-	setEndMode: Dispatch<SetStateAction<EndMode>>
+	startMode: AuctionStartMode
+	setStartMode: Dispatch<SetStateAction<AuctionStartMode>>
+	endMode: AuctionEndMode
+	setEndMode: Dispatch<SetStateAction<AuctionEndMode>>
 	durationSeconds: number
 	setDurationSeconds: Dispatch<SetStateAction<number>>
 	validationMessages: ValidationMessages
@@ -1539,8 +1540,8 @@ export function AuctionFormContent() {
 	const [images, setImages] = useState<AuctionImage[]>([])
 	const [activeTab, setActiveTab] = useState<AuctionTab>('name')
 	const [subCategoryInput, setSubCategoryInput] = useState('')
-	const [startMode, setStartMode] = useState<StartMode>('immediate')
-	const [endMode, setEndMode] = useState<EndMode>('duration')
+	const [startMode, setStartMode] = useState<AuctionStartMode>(DEFAULT_AUCTION_START_MODE)
+	const [endMode, setEndMode] = useState<AuctionEndMode>(DEFAULT_AUCTION_END_MODE)
 	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
 
 	const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null)
@@ -1639,8 +1640,8 @@ export function AuctionFormContent() {
 		setDraftSavedAt(null)
 		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
 		setImages([])
-		setStartMode('immediate')
-		setEndMode('duration')
+		setStartMode(DEFAULT_AUCTION_START_MODE)
+		setEndMode(DEFAULT_AUCTION_END_MODE)
 		setDurationSeconds(24 * 60 * 60)
 		setSubCategoryInput('')
 	}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -34,9 +34,10 @@ import {
 } from '@/publish/auctions'
 import { AuctionOracleSelector } from './AuctionOracleSelector'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
+import { clearAuctionFormDraft, getAuctionFormDraft, saveAuctionFormDraft } from '@/lib/utils/auctionFormStorage'
 import { useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { CalendarIcon, Plus, X } from 'lucide-react'
+import { CalendarIcon, Plus, Trash2, X } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
@@ -843,7 +844,7 @@ function AuctionTabContent({
 
 	const startingBidNum = parseInt(formData.startingBid, 10)
 	const bidIncrementNum = parseInt(formData.bidIncrement, 10)
-	const reserveNum = parseInt(formData.reserve, 10)
+	const reserveNum = parseInt(formData.reserve ?? '0', 10)
 	const antiSnipeWindowSeconds = formData.antiSnipeWindowMinutes * 60
 	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 
@@ -1525,6 +1526,45 @@ export function AuctionFormContent() {
 	const [endMode, setEndMode] = useState<EndMode>('duration')
 	const [durationSeconds, setDurationSeconds] = useState<number>(24 * 60 * 60)
 
+	const [draftSavedAt, setDraftSavedAt] = useState<number | null>(null)
+	const draftLoadedRef = useRef(false)
+	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const draftGenerationRef = useRef(0)
+
+	const hasDraft = draftSavedAt !== null
+
+	useEffect(() => {
+		if (!userPubkey || draftLoadedRef.current) return
+
+		draftLoadedRef.current = true
+		const draft = getAuctionFormDraft(userPubkey)
+		if (!draft) return
+		setDraftSavedAt(draft.savedAt)
+		setFormData(draft.formData)
+		setImages(draft.images)
+		setStartMode(draft.startMode)
+		setEndMode(draft.endMode)
+		setDurationSeconds(draft.durationSeconds)
+		setSubCategoryInput(draft.subCategoryInput)
+	}, [userPubkey])
+
+	useEffect(() => {
+		if (!userPubkey || !draftLoadedRef.current) return
+
+		const gen = draftGenerationRef.current
+		if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+
+		saveTimerRef.current = setTimeout(() => {
+			if (draftGenerationRef.current !== gen) return
+			saveAuctionFormDraft(userPubkey, { formData, images, startMode, endMode, durationSeconds, subCategoryInput })
+			if (draftGenerationRef.current === gen) setDraftSavedAt(Date.now())
+		}, 1500)
+
+		return () => {
+			if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
+		}
+	}, [formData, images, startMode, endMode, durationSeconds, subCategoryInput, userPubkey])
+
 	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')
 		let effectiveEndAt = formData.endAt
@@ -1574,6 +1614,19 @@ export function AuctionFormContent() {
 
 	const canSubmit = validationIssues.length === 0
 
+	const handleClearDraft = () => {
+		draftGenerationRef.current++
+		draftLoadedRef.current = true
+		clearAuctionFormDraft(userPubkey)
+		setDraftSavedAt(null)
+		setFormData({ ...INITIAL_FORM, trustedMints: [...availableMints] })
+		setImages([])
+		setStartMode('immediate')
+		setEndMode('duration')
+		setDurationSeconds(24 * 60 * 60)
+		setSubCategoryInput('')
+	}
+
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		event.stopPropagation()
@@ -1585,6 +1638,10 @@ export function AuctionFormContent() {
 			validateAuctionPublishInput(nextFormData, { nowSeconds, minDurationSeconds: AUCTION_MIN_DURATION_SECONDS })
 			const publishedEventId = await publishMutation.mutateAsync(nextFormData)
 			if (!publishedEventId) return
+
+			draftGenerationRef.current++
+			clearAuctionFormDraft(userPubkey)
+			setDraftSavedAt(null)
 
 			document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
 			navigate({ to: '/auctions' })
@@ -1669,7 +1726,22 @@ export function AuctionFormContent() {
 				</Tabs>
 			</div>
 
-			<div className="bg-white border-t pt-4 pb-2 mt-2">
+			<div className="bg-white border-t pt-4 pb-2 mt-2 flex flex-col gap-2">
+				{hasDraft && (
+					<div className="flex items-center justify-between gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-1.5">
+						<p className="text-xs font-medium text-amber-700">Draft saved</p>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							className="flex items-center gap-1.5 text-xs text-amber-600 hover:text-red-600 px-2"
+							onClick={handleClearDraft}
+						>
+							<Trash2 className="w-3 h-3" />
+							Clear draft
+						</Button>
+					</div>
+				)}
 				<Button type="submit" variant="secondary" className="w-full uppercase" disabled={!canSubmit || publishMutation.isPending}>
 					{publishMutation.isPending ? 'Publishing...' : 'Publish Auction'}
 				</Button>

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+	clearAuctionFormDraft,
+	getAuctionFormDraft,
+	hasAuctionFormDraft,
+	saveAuctionFormDraft,
+	type AuctionFormDraft,
+} from '@/lib/utils/auctionFormStorage'
+
+// ---------------------------------------------------------------------------
+// localStorage mock
+// ---------------------------------------------------------------------------
+
+const store: Record<string, string> = {}
+
+const localStorageMock = {
+	getItem: (key: string) => store[key] ?? null,
+	setItem: (key: string, value: string) => {
+		store[key] = value
+	},
+	removeItem: (key: string) => {
+		delete store[key]
+	},
+	clear: () => {
+		for (const k of Object.keys(store)) delete store[k]
+	},
+}
+
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true })
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PUBKEY_A = 'aaaa1111'
+const PUBKEY_B = 'bbbb2222'
+
+const baseDraft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'> = {
+	formData: {
+		title: 'Vintage Camera',
+		summary: 'Rare find',
+		description: 'A beautiful vintage camera in great condition.',
+		startingBid: '5000',
+		bidIncrement: '100',
+		reserve: '10000',
+		startAt: '',
+		endAt: '2099-01-01T12:00',
+		antiSnipeWindowMinutes: 15,
+		minBidCurveShape: 'linear',
+		minBidCurvePeakMultiplier: 5,
+		settlementGracePreset: '1h',
+		mainCategory: 'Photography',
+		categories: ['Collectibles', 'Film'],
+		imageUrls: ['https://example.com/camera.jpg'],
+		specs: [{ key: 'Brand', value: 'Leica' }],
+		shippings: [{ shippingRef: '30406:seller:standard', extraCost: '200' }],
+		trustedMints: ['https://mint.example.com'],
+		isNSFW: false,
+		pathIssuerPubkey: '',
+	},
+	images: [{ imageUrl: 'https://example.com/camera.jpg', imageOrder: 0 }],
+	startMode: 'immediate',
+	endMode: 'absolute',
+	durationSeconds: 86400,
+	subCategoryInput: 'Collectibles, Film',
+}
+
+beforeEach(() => localStorageMock.clear())
+afterEach(() => localStorageMock.clear())
+
+// ---------------------------------------------------------------------------
+// Save / load roundtrip
+// ---------------------------------------------------------------------------
+
+describe('save/load roundtrip', () => {
+	test('restores all formData fields exactly', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded).not.toBeNull()
+		expect(loaded!.formData.title).toBe('Vintage Camera')
+		expect(loaded!.formData.startingBid).toBe('5000')
+		expect(loaded!.formData.antiSnipeWindowMinutes).toBe(15)
+		expect(loaded!.formData.minBidCurveShape).toBe('linear')
+		expect(loaded!.formData.minBidCurvePeakMultiplier).toBe(5)
+		expect(loaded!.formData.settlementGracePreset).toBe('1h')
+		expect(loaded!.formData.specs).toEqual([{ key: 'Brand', value: 'Leica' }])
+		expect(loaded!.formData.shippings).toEqual([{ shippingRef: '30406:seller:standard', extraCost: '200' }])
+		expect(loaded!.formData.trustedMints).toEqual(['https://mint.example.com'])
+		expect(loaded!.formData.isNSFW).toBe(false)
+	})
+
+	test('restores top-level draft fields', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.startMode).toBe('immediate')
+		expect(loaded!.endMode).toBe('absolute')
+		expect(loaded!.durationSeconds).toBe(86400)
+		expect(loaded!.subCategoryInput).toBe('Collectibles, Film')
+		expect(loaded!.images).toEqual([{ imageUrl: 'https://example.com/camera.jpg', imageOrder: 0 }])
+	})
+
+	test('savedAt is a recent timestamp', () => {
+		const before = Date.now()
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const after = Date.now()
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.savedAt).toBeGreaterThanOrEqual(before)
+		expect(loaded!.savedAt).toBeLessThanOrEqual(after)
+	})
+
+	test('overwriting a draft replaces it entirely', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_A, { ...baseDraft, formData: { ...baseDraft.formData, title: 'Updated Title' } })
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+
+		expect(loaded!.formData.title).toBe('Updated Title')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Malformed JSON handling
+// ---------------------------------------------------------------------------
+
+describe('malformed JSON handling', () => {
+	test('returns null for unparseable JSON', () => {
+		store[`auction_form_draft_${PUBKEY_A}`] = '{not valid json'
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null for JSON null', () => {
+		store[`auction_form_draft_${PUBKEY_A}`] = 'null'
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when pubkey field is missing', () => {
+		const { pubkey: _omit, ...withoutPubkey } = { ...baseDraft, pubkey: PUBKEY_A, savedAt: Date.now() }
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(withoutPubkey)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('returns null when savedAt is missing', () => {
+		const record = { ...baseDraft, pubkey: PUBKEY_A }
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(record)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('coerces unknown antiSnipeWindowMinutes to 0', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.antiSnipeWindowMinutes = 999
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.antiSnipeWindowMinutes).toBe(0)
+	})
+
+	test('coerces unknown minBidCurveShape to "none"', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.minBidCurveShape = 'zigzag'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.minBidCurveShape).toBe('none')
+	})
+
+	test('coerces unknown settlementGracePreset to "1h"', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.settlementGracePreset = 'forever'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.settlementGracePreset).toBe('1h')
+	})
+
+	test('drops non-string entries from trustedMints array', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.trustedMints = ['https://good.mint', 42, null, 'https://other.mint']
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.trustedMints).toEqual(['https://good.mint', 'https://other.mint'])
+	})
+
+	test('drops images with empty imageUrl', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.images = [
+			{ imageUrl: '', imageOrder: 0 },
+			{ imageUrl: 'https://example.com/ok.jpg', imageOrder: 1 },
+		]
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.images).toEqual([{ imageUrl: 'https://example.com/ok.jpg', imageOrder: 1 }])
+	})
+
+	test('stringified "true" for isNSFW is not treated as true', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		const raw = JSON.parse(store[`auction_form_draft_${PUBKEY_A}`]!)
+		raw.formData.isNSFW = 'true'
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(raw)
+
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.isNSFW).toBe(false)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Cross-user safety
+// ---------------------------------------------------------------------------
+
+describe('cross-user safety', () => {
+	test('drafts are isolated per pubkey', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_B, { ...baseDraft, formData: { ...baseDraft.formData, title: 'User B Draft' } })
+
+		expect(getAuctionFormDraft(PUBKEY_A)!.formData.title).toBe('Vintage Camera')
+		expect(getAuctionFormDraft(PUBKEY_B)!.formData.title).toBe('User B Draft')
+	})
+
+	test('clearing one user draft does not affect the other', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		saveAuctionFormDraft(PUBKEY_B, baseDraft)
+
+		clearAuctionFormDraft(PUBKEY_A)
+
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+		expect(getAuctionFormDraft(PUBKEY_B)).not.toBeNull()
+	})
+
+	test('empty pubkey is rejected on save and returns null on load', () => {
+		saveAuctionFormDraft('', baseDraft)
+		expect(getAuctionFormDraft('')).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Clear draft behaviour
+// ---------------------------------------------------------------------------
+
+describe('clear draft behaviour', () => {
+	test('getAuctionFormDraft returns null after clear', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('hasAuctionFormDraft returns false after clear', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('clearing a non-existent draft is a no-op', () => {
+		expect(() => clearAuctionFormDraft(PUBKEY_A)).not.toThrow()
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Publish clears draft (simulated via the storage layer)
+// ---------------------------------------------------------------------------
+
+describe('publish clears draft', () => {
+	test('draft is absent after the publish flow removes it', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(true)
+
+		// simulate what handleSubmit does on success
+		clearAuctionFormDraft(PUBKEY_A)
+
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('saving a new draft after publish works correctly', () => {
+		saveAuctionFormDraft(PUBKEY_A, baseDraft)
+		clearAuctionFormDraft(PUBKEY_A)
+
+		const newDraft = { ...baseDraft, formData: { ...baseDraft.formData, title: 'New Auction' } }
+		saveAuctionFormDraft(PUBKEY_A, newDraft)
+
+		expect(getAuctionFormDraft(PUBKEY_A)!.formData.title).toBe('New Auction')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Empty form not persisted (guard matches isMeaningfulDraft in the component)
+// ---------------------------------------------------------------------------
+
+describe('empty form not persisted', () => {
+	test('hasAuctionFormDraft returns false when nothing has been saved', () => {
+		expect(hasAuctionFormDraft(PUBKEY_A)).toBe(false)
+	})
+
+	test('getAuctionFormDraft returns null for a key that was never written', () => {
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+
+	test('a draft saved then loaded with no meaningful fields still round-trips structurally', () => {
+		const emptyLike: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'> = {
+			...baseDraft,
+			formData: {
+				...baseDraft.formData,
+				title: '',
+				summary: '',
+				description: '',
+				startingBid: '',
+			},
+			images: [],
+			subCategoryInput: '',
+		}
+		// The storage layer itself does not block saving empty content —
+		// that guard lives in the component (isMeaningfulDraft). Verify that
+		// the storage layer faithfully round-trips whatever it receives.
+		saveAuctionFormDraft(PUBKEY_A, emptyLike)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.title).toBe('')
+		expect(loaded!.images).toEqual([])
+	})
+})

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -3,9 +3,11 @@ import {
 	clearAuctionFormDraft,
 	getAuctionFormDraft,
 	hasAuctionFormDraft,
+	isMeaningfulDraft,
 	saveAuctionFormDraft,
 	type AuctionFormDraft,
 } from '@/lib/utils/auctionFormStorage'
+import type { AuctionFormData } from '@/publish/auctions'
 
 // ---------------------------------------------------------------------------
 // localStorage mock
@@ -363,5 +365,103 @@ describe('empty form not persisted', () => {
 		const loaded = getAuctionFormDraft(PUBKEY_A)
 		expect(loaded!.formData.title).toBe('')
 		expect(loaded!.images).toEqual([])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// isMeaningfulDraft
+// ---------------------------------------------------------------------------
+
+const EMPTY_FORM: AuctionFormData = {
+	title: '',
+	summary: '',
+	description: '',
+	startingBid: '',
+	bidIncrement: '1',
+	reserve: '0',
+	startAt: '',
+	endAt: '',
+	antiSnipeWindowMinutes: 0,
+	minBidCurveShape: 'none',
+	minBidCurvePeakMultiplier: 2,
+	settlementGracePreset: '1h',
+	mainCategory: '',
+	categories: [],
+	imageUrls: [],
+	specs: [],
+	shippings: [],
+	trustedMints: [],
+	isNSFW: false,
+	pathIssuerPubkey: '',
+}
+
+describe('isMeaningfulDraft', () => {
+	test('returns false for completely empty form', () => {
+		expect(isMeaningfulDraft(EMPTY_FORM)).toBe(false)
+	})
+
+	test('returns false when all fields are whitespace-only', () => {
+		expect(
+			isMeaningfulDraft({
+				...EMPTY_FORM,
+				title: '   ',
+				summary: '\t',
+				description: '\n',
+				startingBid: ' ',
+				mainCategory: '  ',
+			}),
+		).toBe(false)
+	})
+
+	test('returns true when title is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, title: 'Vintage Camera' })).toBe(true)
+	})
+
+	test('returns true when summary is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, summary: 'Rare find' })).toBe(true)
+	})
+
+	test('returns true when description is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, description: 'Detailed description' })).toBe(true)
+	})
+
+	test('returns true when startingBid is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, startingBid: '5000' })).toBe(true)
+	})
+
+	test('returns true when startAt is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, startAt: '2099-01-01T12:00' })).toBe(true)
+	})
+
+	test('returns true when endAt is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, endAt: '2099-06-01T12:00' })).toBe(true)
+	})
+
+	test('returns true when mainCategory is set', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, mainCategory: 'Electronics' })).toBe(true)
+	})
+
+	test('returns true when categories has entries', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, categories: ['Photography'] })).toBe(true)
+	})
+
+	test('returns true when imageUrls has entries', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, imageUrls: ['https://example.com/img.jpg'] })).toBe(true)
+	})
+
+	test('returns true when specs has entries', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, specs: [{ key: 'Brand', value: 'Leica' }] })).toBe(true)
+	})
+
+	test('returns true when shippings has entries', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, shippings: [{ shippingRef: '30406:seller:standard', extraCost: '200' }] })).toBe(true)
+	})
+
+	test('returns true when isNSFW is toggled', () => {
+		expect(isMeaningfulDraft({ ...EMPTY_FORM, isNSFW: true })).toBe(true)
+	})
+
+	test('returns true when all fields are populated', () => {
+		expect(isMeaningfulDraft(baseDraft.formData)).toBe(true)
 	})
 })

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -239,6 +239,46 @@ describe('cross-user safety', () => {
 		saveAuctionFormDraft('', baseDraft)
 		expect(getAuctionFormDraft('')).toBeNull()
 	})
+
+	test('returns null when stored pubkey does not match the requested pubkey', () => {
+		// simulate a tampered or misplaced draft: PUBKEY_B's data written under PUBKEY_A's key
+		const tampered = { ...baseDraft, pubkey: PUBKEY_B, savedAt: Date.now() }
+		store[`auction_form_draft_${PUBKEY_A}`] = JSON.stringify(tampered)
+		expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Storage access hardening
+// ---------------------------------------------------------------------------
+
+const throwingWindow = Object.defineProperty({}, 'localStorage', {
+	get() {
+		throw new Error('Storage access denied')
+	},
+})
+
+describe('storage access hardening', () => {
+	test('save is a no-op when window.localStorage access throws', () => {
+		const original = (globalThis as Record<string, unknown>).window
+		;(globalThis as Record<string, unknown>).window = throwingWindow
+		try {
+			expect(() => saveAuctionFormDraft(PUBKEY_A, baseDraft)).not.toThrow()
+		} finally {
+			;(globalThis as Record<string, unknown>).window = original
+		}
+		expect(store[`auction_form_draft_${PUBKEY_A}`]).toBeUndefined()
+	})
+
+	test('get returns null when window.localStorage access throws', () => {
+		const original = (globalThis as Record<string, unknown>).window
+		;(globalThis as Record<string, unknown>).window = throwingWindow
+		try {
+			expect(getAuctionFormDraft(PUBKEY_A)).toBeNull()
+		} finally {
+			;(globalThis as Record<string, unknown>).window = original
+		}
+	})
 })
 
 // ---------------------------------------------------------------------------

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -45,12 +45,12 @@ function strArray(v: unknown): string[] {
 	return v.filter((x): x is string => typeof x === 'string')
 }
 
-function validateDraft(raw: unknown): AuctionFormDraft | null {
+function validateDraft(raw: unknown, expectedPubkey: string): AuctionFormDraft | null {
 	if (!raw || typeof raw !== 'object') return null
 	const d = raw as Record<string, unknown>
 
 	const pubkey = str(d.pubkey)
-	if (!pubkey) return null
+	if (!pubkey || pubkey !== expectedPubkey) return null
 
 	const savedAt = num(d.savedAt, 0)
 	if (!savedAt) return null
@@ -151,7 +151,7 @@ export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => 
 	try {
 		const raw = localStorage.getItem(storageKey(pubkey))
 		if (!raw) return null
-		return validateDraft(JSON.parse(raw))
+		return validateDraft(JSON.parse(raw), pubkey)
 	} catch (error) {
 		console.error('Failed to get auction form draft:', error)
 		return null

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -1,26 +1,28 @@
 import type {
 	AuctionAntiSnipeWindowMinutesPreset,
+	AuctionEndMode,
 	AuctionFormData,
 	AuctionMinBidCurvePeakPreset,
 	AuctionMinBidCurveShape,
 	AuctionSettlementGracePreset,
+	AuctionStartMode,
 } from '@/publish/auctions'
 import {
 	AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES,
 	AUCTION_MIN_BID_CURVE_PEAK_PRESETS,
 	AUCTION_SETTLEMENT_GRACE_PRESETS,
+	DEFAULT_AUCTION_END_MODE,
+	DEFAULT_AUCTION_START_MODE,
 } from '@/publish/auctions'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
-type StartMode = 'immediate' | 'scheduled'
-type EndMode = 'duration' | 'absolute'
 
 export type AuctionFormDraft = {
 	pubkey: string
 	formData: AuctionFormData
 	images: AuctionImage[]
-	startMode: StartMode
-	endMode: EndMode
+	startMode: AuctionStartMode
+	endMode: AuctionEndMode
 	durationSeconds: number
 	subCategoryInput: string
 	savedAt: number
@@ -94,10 +96,10 @@ function validateDraft(raw: unknown): AuctionFormDraft | null {
 		.filter((i) => i.imageUrl.length > 0)
 
 	const startModeRaw = str(d.startMode)
-	const startMode: StartMode = startModeRaw === 'scheduled' ? 'scheduled' : 'immediate'
+	const startMode: AuctionStartMode = startModeRaw === 'scheduled' ? 'scheduled' : DEFAULT_AUCTION_START_MODE
 
 	const endModeRaw = str(d.endMode)
-	const endMode: EndMode = endModeRaw === 'absolute' ? 'absolute' : 'duration'
+	const endMode: AuctionEndMode = endModeRaw === 'absolute' ? 'absolute' : DEFAULT_AUCTION_END_MODE
 
 	const formData: AuctionFormData = {
 		title: str(fd.title),

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -1,4 +1,15 @@
-import type { AuctionFormData } from '@/publish/auctions'
+import type {
+	AuctionAntiSnipeWindowMinutesPreset,
+	AuctionFormData,
+	AuctionMinBidCurvePeakPreset,
+	AuctionMinBidCurveShape,
+	AuctionSettlementGracePreset,
+} from '@/publish/auctions'
+import {
+	AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES,
+	AUCTION_MIN_BID_CURVE_PEAK_PRESETS,
+	AUCTION_SETTLEMENT_GRACE_PRESETS,
+} from '@/publish/auctions'
 
 type AuctionImage = { imageUrl: string; imageOrder: number }
 type StartMode = 'immediate' | 'scheduled'
@@ -19,6 +30,110 @@ const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
 
 const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
 
+function str(v: unknown, fallback = ''): string {
+	return typeof v === 'string' ? v : fallback
+}
+
+function num(v: unknown, fallback: number): number {
+	return typeof v === 'number' && Number.isFinite(v) ? v : fallback
+}
+
+function strArray(v: unknown): string[] {
+	if (!Array.isArray(v)) return []
+	return v.filter((x): x is string => typeof x === 'string')
+}
+
+function validateDraft(raw: unknown): AuctionFormDraft | null {
+	if (!raw || typeof raw !== 'object') return null
+	const d = raw as Record<string, unknown>
+
+	const pubkey = str(d.pubkey)
+	if (!pubkey) return null
+
+	const savedAt = num(d.savedAt, 0)
+	if (!savedAt) return null
+
+	const fd = d.formData && typeof d.formData === 'object' ? (d.formData as Record<string, unknown>) : {}
+
+	const antiSnipeWindowMinutes = (AUCTION_ANTI_SNIPE_WINDOW_PRESETS_MINUTES as readonly number[]).includes(
+		num(fd.antiSnipeWindowMinutes, 0),
+	)
+		? (num(fd.antiSnipeWindowMinutes, 0) as AuctionAntiSnipeWindowMinutesPreset)
+		: 0
+
+	const minBidCurveShapeOptions: AuctionMinBidCurveShape[] = ['none', 'linear', 'exponential']
+	const minBidCurveShape: AuctionMinBidCurveShape = minBidCurveShapeOptions.includes(fd.minBidCurveShape as AuctionMinBidCurveShape)
+		? (fd.minBidCurveShape as AuctionMinBidCurveShape)
+		: 'none'
+
+	const minBidCurvePeakMultiplier = (AUCTION_MIN_BID_CURVE_PEAK_PRESETS as readonly number[]).includes(num(fd.minBidCurvePeakMultiplier, 2))
+		? (num(fd.minBidCurvePeakMultiplier, 2) as AuctionMinBidCurvePeakPreset)
+		: 2
+
+	const settlementGraceOptions = Object.keys(AUCTION_SETTLEMENT_GRACE_PRESETS) as AuctionSettlementGracePreset[]
+	const settlementGracePreset: AuctionSettlementGracePreset = settlementGraceOptions.includes(
+		fd.settlementGracePreset as AuctionSettlementGracePreset,
+	)
+		? (fd.settlementGracePreset as AuctionSettlementGracePreset)
+		: '1h'
+
+	const rawSpecs = Array.isArray(fd.specs) ? fd.specs : []
+	const specs = rawSpecs
+		.filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+		.map((s) => ({ key: str(s.key), value: str(s.value) }))
+
+	const rawShippings = Array.isArray(fd.shippings) ? fd.shippings : []
+	const shippings = rawShippings
+		.filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+		.map((s) => ({ shippingRef: str(s.shippingRef), extraCost: str(s.extraCost) }))
+
+	const rawImages = Array.isArray(d.images) ? d.images : []
+	const images: AuctionImage[] = rawImages
+		.filter((i): i is Record<string, unknown> => !!i && typeof i === 'object')
+		.map((i) => ({ imageUrl: str(i.imageUrl), imageOrder: num(i.imageOrder, 0) }))
+		.filter((i) => i.imageUrl.length > 0)
+
+	const startModeRaw = str(d.startMode)
+	const startMode: StartMode = startModeRaw === 'scheduled' ? 'scheduled' : 'immediate'
+
+	const endModeRaw = str(d.endMode)
+	const endMode: EndMode = endModeRaw === 'absolute' ? 'absolute' : 'duration'
+
+	const formData: AuctionFormData = {
+		title: str(fd.title),
+		summary: str(fd.summary),
+		description: str(fd.description),
+		startingBid: str(fd.startingBid),
+		bidIncrement: str(fd.bidIncrement, '1'),
+		reserve: str(fd.reserve, '0'),
+		startAt: str(fd.startAt),
+		endAt: str(fd.endAt),
+		antiSnipeWindowMinutes,
+		minBidCurveShape,
+		minBidCurvePeakMultiplier,
+		settlementGracePreset,
+		mainCategory: str(fd.mainCategory),
+		categories: strArray(fd.categories),
+		imageUrls: strArray(fd.imageUrls),
+		specs,
+		shippings,
+		trustedMints: strArray(fd.trustedMints),
+		isNSFW: fd.isNSFW === true,
+		pathIssuerPubkey: str(fd.pathIssuerPubkey),
+	}
+
+	return {
+		pubkey,
+		formData,
+		images,
+		startMode,
+		endMode,
+		durationSeconds: num(d.durationSeconds, 86400),
+		subCategoryInput: str(d.subCategoryInput),
+		savedAt,
+	}
+}
+
 export const saveAuctionFormDraft = (pubkey: string, draft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'>): void => {
 	if (!isBrowser() || !pubkey) return
 	try {
@@ -34,7 +149,7 @@ export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => 
 	try {
 		const raw = localStorage.getItem(storageKey(pubkey))
 		if (!raw) return null
-		return JSON.parse(raw) as AuctionFormDraft
+		return validateDraft(JSON.parse(raw))
 	} catch (error) {
 		console.error('Failed to get auction form draft:', error)
 		return null

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -30,7 +30,13 @@ export type AuctionFormDraft = {
 
 const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
 
-const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+function getLocalStorage(): Storage | null {
+	try {
+		return typeof window !== 'undefined' ? window.localStorage : null
+	} catch {
+		return null
+	}
+}
 
 function str(v: unknown, fallback = ''): string {
 	return typeof v === 'string' ? v : fallback
@@ -137,19 +143,23 @@ function validateDraft(raw: unknown, expectedPubkey: string): AuctionFormDraft |
 }
 
 export const saveAuctionFormDraft = (pubkey: string, draft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'>): void => {
-	if (!isBrowser() || !pubkey) return
+	if (!pubkey) return
+	const storage = getLocalStorage()
+	if (!storage) return
 	try {
 		const record: AuctionFormDraft = { ...draft, pubkey, savedAt: Date.now() }
-		localStorage.setItem(storageKey(pubkey), JSON.stringify(record))
+		storage.setItem(storageKey(pubkey), JSON.stringify(record))
 	} catch (error) {
 		console.error('Failed to save auction form draft:', error)
 	}
 }
 
 export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => {
-	if (!isBrowser() || !pubkey) return null
+	if (!pubkey) return null
+	const storage = getLocalStorage()
+	if (!storage) return null
 	try {
-		const raw = localStorage.getItem(storageKey(pubkey))
+		const raw = storage.getItem(storageKey(pubkey))
 		if (!raw) return null
 		return validateDraft(JSON.parse(raw), pubkey)
 	} catch (error) {
@@ -159,9 +169,11 @@ export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => 
 }
 
 export const clearAuctionFormDraft = (pubkey: string): void => {
-	if (!isBrowser() || !pubkey) return
+	if (!pubkey) return
+	const storage = getLocalStorage()
+	if (!storage) return
 	try {
-		localStorage.removeItem(storageKey(pubkey))
+		storage.removeItem(storageKey(pubkey))
 	} catch (error) {
 		console.error('Failed to clear auction form draft:', error)
 	}

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -1,0 +1,53 @@
+import type { AuctionFormData } from '@/publish/auctions'
+
+type AuctionImage = { imageUrl: string; imageOrder: number }
+type StartMode = 'immediate' | 'scheduled'
+type EndMode = 'duration' | 'absolute'
+
+export type AuctionFormDraft = {
+	pubkey: string
+	formData: AuctionFormData
+	images: AuctionImage[]
+	startMode: StartMode
+	endMode: EndMode
+	durationSeconds: number
+	subCategoryInput: string
+	savedAt: number
+}
+
+const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
+
+const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+
+export const saveAuctionFormDraft = (pubkey: string, draft: Omit<AuctionFormDraft, 'pubkey' | 'savedAt'>): void => {
+	if (!isBrowser() || !pubkey) return
+	try {
+		const record: AuctionFormDraft = { ...draft, pubkey, savedAt: Date.now() }
+		localStorage.setItem(storageKey(pubkey), JSON.stringify(record))
+	} catch (error) {
+		console.error('Failed to save auction form draft:', error)
+	}
+}
+
+export const getAuctionFormDraft = (pubkey: string): AuctionFormDraft | null => {
+	if (!isBrowser() || !pubkey) return null
+	try {
+		const raw = localStorage.getItem(storageKey(pubkey))
+		if (!raw) return null
+		return JSON.parse(raw) as AuctionFormDraft
+	} catch (error) {
+		console.error('Failed to get auction form draft:', error)
+		return null
+	}
+}
+
+export const clearAuctionFormDraft = (pubkey: string): void => {
+	if (!isBrowser() || !pubkey) return
+	try {
+		localStorage.removeItem(storageKey(pubkey))
+	} catch (error) {
+		console.error('Failed to clear auction form draft:', error)
+	}
+}
+
+export const hasAuctionFormDraft = (pubkey: string): boolean => getAuctionFormDraft(pubkey) !== null

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -180,3 +180,20 @@ export const clearAuctionFormDraft = (pubkey: string): void => {
 }
 
 export const hasAuctionFormDraft = (pubkey: string): boolean => getAuctionFormDraft(pubkey) !== null
+
+export function isMeaningfulDraft(formData: AuctionFormData): boolean {
+	return (
+		formData.title.trim().length > 0 ||
+		formData.summary.trim().length > 0 ||
+		formData.description.trim().length > 0 ||
+		formData.startingBid.trim().length > 0 ||
+		(formData.startAt?.trim().length ?? 0) > 0 ||
+		formData.endAt.trim().length > 0 ||
+		formData.mainCategory.trim().length > 0 ||
+		formData.categories.length > 0 ||
+		formData.imageUrls.length > 0 ||
+		formData.specs.length > 0 ||
+		formData.shippings.length > 0 ||
+		formData.isNSFW
+	)
+}

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -23,6 +23,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { v4 as uuidv4 } from 'uuid'
 
+export type AuctionStartMode = 'immediate' | 'scheduled'
+export type AuctionEndMode = 'duration' | 'absolute'
+export const DEFAULT_AUCTION_START_MODE: AuctionStartMode = 'immediate'
+export const DEFAULT_AUCTION_END_MODE: AuctionEndMode = 'duration'
+
 export interface AuctionSpecEntry {
 	key: string
 	value: string


### PR DESCRIPTION
Supplementary tests for #951.

## What this does

Extracts `isMeaningfulDraft` from `AuctionFormContent.tsx` into `auctionFormStorage.ts` so it can be unit-tested alongside the storage layer. The component now imports it from the storage utility.

## Tests added (15 cases)

- Returns false for completely empty form
- Returns false when all fields are whitespace-only
- Returns true when title is set
- Returns true when summary is set
- Returns true when description is set
- Returns true when startingBid is set
- Returns true when startAt is set
- Returns true when endAt is set
- Returns true when mainCategory is set
- Returns true when categories has entries
- Returns true when imageUrls has entries
- Returns true when specs has entries
- Returns true when shippings has entries
- Returns true when isNSFW is toggled (edge case: form is "meaningful" just by toggling NSFW)
- Returns true when all fields are populated

## Motivation

This ensures that when new fields are added to `AuctionFormData`, the `isMeaningfulDraft` check stays consistent — if someone adds a field to the form but forgets to update the meaningfulness check, the existing pattern makes the omission visible.