### PR TITLE
feat: lazy load community page

### DIFF
--- a/e2e/tests/community.progressive-loading.spec.ts
+++ b/e2e/tests/community.progressive-loading.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect, type Page } from '@playwright/test'
+import { devUser1, devUser2 } from '../../src/lib/fixtures'
+import {
+	COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX,
+	COMMUNITY_QUERY_FIXTURE_STORAGE_KEY,
+	type CommunityQueryFixtureStep,
+} from '../../src/lib/tests/communityQueryFixtures'
+
+type CollectionFixtureEvent = {
+	id: string
+	pubkey: string
+	created_at: number
+	kind: number
+	tags: string[][]
+	content: string
+	sig: string
+}
+
+type CommunityQueryFixtures = {
+	collections?: CommunityQueryFixtureStep<CollectionFixtureEvent[]> | CommunityQueryFixtureStep<CollectionFixtureEvent[]>[]
+	merchants?: CommunityQueryFixtureStep<string[]> | CommunityQueryFixtureStep<string[]>[]
+}
+
+function collectionFixture({
+	dTag,
+	title,
+	summary,
+	pubkey = devUser1.pk,
+}: {
+	dTag: string
+	title: string
+	summary: string
+	pubkey?: string
+}): CollectionFixtureEvent {
+	return {
+		id: `fixture-${dTag}`,
+		pubkey,
+		created_at: 1_700_000_000,
+		kind: 30405,
+		tags: [
+			['d', dTag],
+			['title', title],
+			['summary', summary],
+			['image', 'https://placehold.co/600x600/png'],
+		],
+		content: summary,
+		sig: 'fixture',
+	}
+}
+
+async function useCommunityQueryFixtures(page: Page, fixtures: CommunityQueryFixtures) {
+	await page.addInitScript(
+		({ callsStorageKeyPrefix, fixtures, storageKey }) => {
+			if (!window.localStorage.getItem(storageKey)) {
+				window.localStorage.setItem(storageKey, JSON.stringify(fixtures))
+				window.sessionStorage.removeItem(`${callsStorageKeyPrefix}collections`)
+				window.sessionStorage.removeItem(`${callsStorageKeyPrefix}merchants`)
+			}
+		},
+		{
+			callsStorageKeyPrefix: COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX,
+			fixtures,
+			storageKey: COMMUNITY_QUERY_FIXTURE_STORAGE_KEY,
+		},
+	)
+}
+
+async function setCommunityQueryFixtures(page: Page, fixtures: CommunityQueryFixtures) {
+	await page.evaluate(
+		({ callsStorageKeyPrefix, fixtures, storageKey }) => {
+			window.localStorage.setItem(storageKey, JSON.stringify(fixtures))
+			window.sessionStorage.removeItem(`${callsStorageKeyPrefix}collections`)
+			window.sessionStorage.removeItem(`${callsStorageKeyPrefix}merchants`)
+		},
+		{
+			callsStorageKeyPrefix: COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX,
+			fixtures,
+			storageKey: COMMUNITY_QUERY_FIXTURE_STORAGE_KEY,
+		},
+	)
+}
+
+test.describe('Community Tab Progressive Loading', () => {
+	test('renders hero and page shell while collection and merchant queries are pending', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'pending' },
+			merchants: { state: 'pending' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-hero')).toBeVisible()
+		await expect(page.getByRole('heading', { name: 'Browse Collections' })).toBeVisible()
+		await expect(page.getByTestId('community-collections-section')).toBeVisible()
+		await expect(page.getByTestId('community-merchants-section')).toBeVisible()
+	})
+
+	test('displays deterministic skeletons while collection and merchant queries are pending', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'pending' },
+			merchants: { state: 'pending' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-collections-skeleton')).toHaveCount(12)
+		await expect(page.getByTestId('community-collections-skeleton').first()).toBeVisible()
+		await expect(page.getByTestId('community-merchants-skeleton')).toHaveCount(6)
+		await expect(page.getByTestId('community-merchants-skeleton').first()).toBeVisible()
+	})
+
+	test('renders collection cards after a successful collection query', async ({ page }) => {
+		const collections = [
+			collectionFixture({
+				dTag: 'fixture-prints',
+				title: 'Fixture Prints',
+				summary: 'Deterministic collection content',
+			}),
+			collectionFixture({
+				dTag: 'fixture-books',
+				title: 'Fixture Books',
+				summary: 'Another deterministic collection',
+			}),
+		]
+
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'success', data: collections },
+			merchants: { state: 'empty' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-collection-card')).toHaveCount(2)
+		await expect(page.getByText('Fixture Prints')).toBeVisible()
+		await expect(page.getByText('Fixture Books')).toBeVisible()
+		await expect(page.getByTestId('community-collections-empty')).toHaveCount(0)
+	})
+
+	test('renders collection empty state after a successful empty collection query', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'empty' },
+			merchants: { state: 'empty' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-collections-empty')).toHaveText('No collections found')
+		await expect(page.getByTestId('community-collection-card')).toHaveCount(0)
+		await expect(page.getByTestId('community-collections-error')).toHaveCount(0)
+	})
+
+	test('renders collection error state and recovers after retry', async ({ page }) => {
+		const recoveredCollection = collectionFixture({
+			dTag: 'fixture-recovered-collection',
+			title: 'Recovered Collection',
+			summary: 'Loaded after retry',
+		})
+
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'error', errorMessage: 'Fixture collection failure' },
+			merchants: { state: 'empty' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-collections-error')).toContainText('Unable to load collections')
+		await expect(page.getByTestId('community-collections-error')).toContainText('Fixture collection failure')
+		await expect(page.getByTestId('community-collections-retry')).toBeVisible()
+
+		await setCommunityQueryFixtures(page, {
+			collections: { state: 'success', data: [recoveredCollection] },
+			merchants: { state: 'empty' },
+		})
+		await page.getByTestId('community-collections-retry').click()
+
+		await expect(page.getByTestId('community-collection-card')).toHaveCount(1)
+		await expect(page.getByText('Recovered Collection')).toBeVisible()
+		await expect(page.getByTestId('community-collections-error')).toHaveCount(0)
+	})
+
+	test('renders merchant success and empty states distinctly', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'empty' },
+			merchants: { state: 'success', data: [devUser1.pk, devUser2.pk] },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-merchant-card')).toHaveCount(2)
+		await expect(page.getByTestId('community-merchants-empty')).toHaveCount(0)
+
+		await setCommunityQueryFixtures(page, { collections: { state: 'empty' }, merchants: { state: 'empty' } })
+		await page.reload()
+
+		await expect(page.getByTestId('community-merchants-empty')).toHaveText('No merchants found')
+		await expect(page.getByTestId('community-merchant-card')).toHaveCount(0)
+		await expect(page.getByTestId('community-merchants-error')).toHaveCount(0)
+	})
+
+	test('renders merchant error state and recovers after retry', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'empty' },
+			merchants: { state: 'error', errorMessage: 'Fixture merchant failure' },
+		})
+
+		await page.goto('/community/')
+
+		await expect(page.getByTestId('community-merchants-error')).toContainText('Unable to load merchants')
+		await expect(page.getByTestId('community-merchants-error')).toContainText('Fixture merchant failure')
+		await expect(page.getByTestId('community-merchants-retry')).toBeVisible()
+
+		await setCommunityQueryFixtures(page, {
+			collections: { state: 'empty' },
+			merchants: { state: 'success', data: [devUser1.pk] },
+		})
+		await page.getByTestId('community-merchants-retry').click()
+
+		await expect(page.getByTestId('community-merchant-card')).toHaveCount(1)
+		await expect(page.getByTestId('community-merchants-error')).toHaveCount(0)
+	})
+
+	test('page remains interactive while community queries are pending', async ({ page }) => {
+		await useCommunityQueryFixtures(page, {
+			collections: { state: 'pending' },
+			merchants: { state: 'pending' },
+		})
+
+		await page.goto('/community/')
+
+		await page.getByRole('button', { name: 'Start Selling' }).click()
+		await expect(page.getByTestId('login-dialog')).toBeVisible()
+		await expect(page.getByText('Loading...')).toHaveCount(0)
+	})
+})

--- a/src/lib/tests/communityQueryFixtures.ts
+++ b/src/lib/tests/communityQueryFixtures.ts
@@ -1,0 +1,123 @@
+type CommunityQueryName = 'collections' | 'merchants'
+
+type CommunityFixturePendingStep = {
+	state: 'pending'
+	delayMs?: number
+}
+
+type CommunityFixtureErrorStep = {
+	state: 'error'
+	errorMessage?: string
+	delayMs?: number
+}
+
+type CommunityFixtureEmptyStep = {
+	state: 'empty'
+	delayMs?: number
+}
+
+type CommunityFixtureSuccessStep<T> = {
+	state: 'success'
+	data: T
+	delayMs?: number
+}
+
+export type CommunityQueryFixtureStep<T> =
+	| CommunityFixturePendingStep
+	| CommunityFixtureErrorStep
+	| CommunityFixtureEmptyStep
+	| CommunityFixtureSuccessStep<T>
+
+type CommunityQueryFixtureMap = Partial<
+	Record<CommunityQueryName, CommunityQueryFixtureStep<unknown> | CommunityQueryFixtureStep<unknown>[]>
+>
+
+export const COMMUNITY_QUERY_FIXTURE_STORAGE_KEY = 'plebeian_community_query_fixtures'
+export const COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX = 'plebeian_community_query_fixture_calls:'
+
+const isCommunityFixtureEnvironment = () => process.env.NODE_ENV === 'test' && typeof window !== 'undefined'
+
+const sleep = (delayMs?: number) => {
+	if (!delayMs || delayMs <= 0) return Promise.resolve()
+	return new Promise<void>((resolve) => setTimeout(resolve, delayMs))
+}
+
+function readFixtureMap(): CommunityQueryFixtureMap | null {
+	if (!isCommunityFixtureEnvironment()) return null
+
+	try {
+		const raw = window.localStorage.getItem(COMMUNITY_QUERY_FIXTURE_STORAGE_KEY)
+		if (!raw) return null
+
+		const parsed = JSON.parse(raw)
+		if (!parsed || typeof parsed !== 'object') return null
+
+		return parsed as CommunityQueryFixtureMap
+	} catch {
+		return null
+	}
+}
+
+function readCallIndex(queryName: CommunityQueryName): number {
+	try {
+		const raw = window.sessionStorage.getItem(`${COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX}${queryName}`)
+		const index = Number.parseInt(raw || '0', 10)
+		return Number.isFinite(index) && index >= 0 ? index : 0
+	} catch {
+		return 0
+	}
+}
+
+function writeCallIndex(queryName: CommunityQueryName, index: number) {
+	try {
+		window.sessionStorage.setItem(`${COMMUNITY_QUERY_FIXTURE_CALLS_STORAGE_KEY_PREFIX}${queryName}`, String(index))
+	} catch {
+		// Ignore storage failures; fixtures are best-effort and test-only.
+	}
+}
+
+export function getNextCommunityQueryFixtureStep<T>(queryName: CommunityQueryName): CommunityQueryFixtureStep<T> | null {
+	const fixtureMap = readFixtureMap()
+	const fixture = fixtureMap?.[queryName]
+	if (!fixture) return null
+
+	const steps = Array.isArray(fixture) ? fixture : [fixture]
+	if (steps.length === 0) return null
+
+	const callIndex = readCallIndex(queryName)
+	writeCallIndex(queryName, callIndex + 1)
+
+	return steps[Math.min(callIndex, steps.length - 1)] as CommunityQueryFixtureStep<T>
+}
+
+export function hasCommunityQueryFixture(queryName: CommunityQueryName): boolean {
+	const fixtureMap = readFixtureMap()
+	return !!fixtureMap?.[queryName]
+}
+
+export async function resolveCommunityQueryFixtureStep<T>(
+	queryName: CommunityQueryName,
+	step: CommunityQueryFixtureStep<unknown>,
+	normalizeData: (data: unknown) => T,
+): Promise<T> {
+	await sleep(step.delayMs)
+
+	switch (step.state) {
+		case 'pending':
+			return await new Promise<T>(() => {})
+		case 'error':
+			throw new Error(step.errorMessage || `Unable to load ${queryName}`)
+		case 'empty':
+			return normalizeData([])
+		case 'success':
+			return normalizeData(step.data)
+	}
+}
+
+export function normalizeCommunityArrayFixture<T>(queryName: CommunityQueryName, data: unknown): T[] {
+	if (!Array.isArray(data)) {
+		throw new Error(`Invalid ${queryName} fixture: expected an array`)
+	}
+
+	return data as T[]
+}

--- a/src/queries/collections.tsx
+++ b/src/queries/collections.tsx
@@ -8,6 +8,12 @@ import { collectionKeys, collectionsKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { FEATURED_ITEMS_CONFIG } from '@/lib/schemas/featured'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
+import {
+	getNextCommunityQueryFixtureStep,
+	hasCommunityQueryFixture,
+	normalizeCommunityArrayFixture,
+	resolveCommunityQueryFixtureStep,
+} from '@/lib/tests/communityQueryFixtures'
 
 // --- DELETED COLLECTIONS TRACKING ---
 // Track deleted collection d-tags with deletion timestamps to filter them from relay responses.
@@ -79,6 +85,13 @@ const filterDeletedCollections = (events: NDKEvent[]): NDKEvent[] => {
  * @returns Array of collection events sorted by creation date (blacklist filtered)
  */
 export const fetchCollections = async () => {
+	const fixtureStep = getNextCommunityQueryFixtureStep<NDKEvent[]>('collections')
+	if (fixtureStep) {
+		return await resolveCommunityQueryFixtureStep('collections', fixtureStep, (data) =>
+			normalizeCommunityArrayFixture<NDKEvent>('collections', data),
+		)
+	}
+
 	const ndk = ndkActions.getNDK()
 	if (!ndk) {
 		console.warn('NDK not ready, returning empty collections list')
@@ -315,6 +328,7 @@ export const collectionByATagQueryOptions = (pubkey: string, dTag: string) =>
 export const collectionsQueryOptions = queryOptions({
 	queryKey: collectionsKeys.all,
 	queryFn: fetchCollections,
+	retry: (failureCount) => !hasCommunityQueryFixture('collections') && failureCount < 3,
 	staleTime: 30000, // Consider fresh for 30 seconds
 	refetchOnMount: 'always', // Always refetch to pick up deletions
 })

--- a/src/queries/v4v.tsx
+++ b/src/queries/v4v.tsx
@@ -6,6 +6,12 @@ import { nip19 } from 'nostr-tools'
 import { v4 as uuidv4 } from 'uuid'
 import { v4vKeys } from './queryKeyFactory'
 import { filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
+import {
+	getNextCommunityQueryFixtureStep,
+	hasCommunityQueryFixture,
+	normalizeCommunityArrayFixture,
+	resolveCommunityQueryFixtureStep,
+} from '@/lib/tests/communityQueryFixtures'
 
 export type V4VConfigurationState = 'unknown' | 'never-configured' | 'configured-zero' | 'configured-nonzero'
 
@@ -285,38 +291,40 @@ export const usePublishV4VShares = () => {
 /**
  * Fetches all users who have configured V4V shares (merchants)
  * Returns an array of unique pubkeys
+ * Throws on relay/network errors to enable error state handling
  */
 export const fetchV4VMerchants = async (): Promise<string[]> => {
-	try {
-		const ndk = ndkActions.getNDK()
-		if (!ndk) {
-			console.warn('NDK not ready, returning empty merchants list')
-			return []
-		}
+	const fixtureStep = getNextCommunityQueryFixtureStep<string[]>('merchants')
+	if (fixtureStep) {
+		return await resolveCommunityQueryFixtureStep('merchants', fixtureStep, (data) =>
+			normalizeCommunityArrayFixture<string>('merchants', data),
+		)
+	}
 
-		const events = await ndk.fetchEvents({
-			kinds: [30078],
-			'#l': ['v4v_share'],
-			limit: 100, // Limit to 100 most recent merchants
-		})
+	const ndk = ndkActions.getNDK()
+	if (!ndk) {
+		throw new Error('NDK not ready, cannot fetch merchants')
+	}
 
-		if (!events || events.size === 0) {
-			return []
-		}
+	const events = await ndk.fetchEvents({
+		kinds: [30078],
+		'#l': ['v4v_share'],
+		limit: 100, // Limit to 100 most recent merchants
+	})
 
-		// Get unique pubkeys from the events and filter out blacklisted ones
-		const pubkeySet = new Set<string>()
-		Array.from(events).forEach((event) => {
-			if (event.pubkey) {
-				pubkeySet.add(event.pubkey)
-			}
-		})
-
-		return filterBlacklistedPubkeys(Array.from(pubkeySet))
-	} catch (error) {
-		console.error('Error fetching V4V merchants:', error)
+	if (!events || events.size === 0) {
 		return []
 	}
+
+	// Get unique pubkeys from the events and filter out blacklisted ones
+	const pubkeySet = new Set<string>()
+	Array.from(events).forEach((event) => {
+		if (event.pubkey) {
+			pubkeySet.add(event.pubkey)
+		}
+	})
+
+	return filterBlacklistedPubkeys(Array.from(pubkeySet))
 }
 
 /**
@@ -326,6 +334,7 @@ export const useV4VMerchants = () => {
 	return useQuery({
 		queryKey: v4vKeys.merchants(),
 		queryFn: fetchV4VMerchants,
+		retry: (failureCount) => !hasCommunityQueryFixture('merchants') && failureCount < 3,
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	})
 }

--- a/src/routes/community.index.tsx
+++ b/src/routes/community.index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { useQueries, useSuspenseQuery } from '@tanstack/react-query'
+import { useQueries, useQuery } from '@tanstack/react-query'
 import { ItemGrid } from '@/components/ItemGrid'
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { uiActions } from '@/lib/stores/ui'
 import { authStore } from '@/lib/stores/auth'
 import { useStore } from '@tanstack/react-store'
@@ -67,24 +68,18 @@ function useFeaturedCollectionEvents(featuredCollections: string[] | undefined) 
 
 export const Route = createFileRoute('/community/')({
 	component: CommunityRoute,
-	errorComponent: ({ error }) => (
-		<div className="flex flex-col justify-center items-center gap-4 px-4 min-h-[50vh] text-center">
-			<h2 className="font-semibold text-xl">Unable to load collections</h2>
-			<p className="max-w-md text-muted-foreground">
-				{error instanceof Error ? error.message : 'There was a problem connecting to relays. Please try again.'}
-			</p>
-			<Button variant="secondary" onClick={() => window.location.reload()}>
-				Retry
-			</Button>
-		</div>
-	),
 })
 
 function CommunityRoute() {
-	const collectionsQuery = useSuspenseQuery(collectionsQueryOptions)
-	const collections = collectionsQuery.data
+	const collectionsQuery = useQuery(collectionsQueryOptions)
+	const collections = collectionsQuery.data || []
+	const isLoadingCollections = collectionsQuery.isLoading
+	const collectionsError = collectionsQuery.error
 
-	const { data: merchantPubkeys = [], isLoading: isLoadingMerchants } = useV4VMerchants()
+	const merchantsQuery = useV4VMerchants()
+	const merchantPubkeys = merchantsQuery.data || []
+	const isLoadingMerchants = merchantsQuery.isLoading
+	const merchantsError = merchantsQuery.error
 
 	// Subscribe to blacklist store for reactive updates when blacklist changes
 	useStore(blacklistStore)
@@ -267,10 +262,11 @@ function CommunityRoute() {
 	)
 
 	return (
-		<div>
+		<div data-testid="community-page">
 			{isHomepageSlide ? (
 				// Homepage hero styling with random collection background
 				<div
+					data-testid="community-hero"
 					className={`relative hero-container ${marketBackgroundImageUrl ? `bg-hero-image ${marketHeroClassName}` : 'bg-gray-700'}`}
 					onTouchStart={handleTouchStart}
 					onTouchMove={handleTouchMove}
@@ -286,6 +282,7 @@ function CommunityRoute() {
 			) : (
 				// Collection hero styling (existing collection page style)
 				<div
+					data-testid="community-hero"
 					className={`relative hero-container ${backgroundImageUrl ? `bg-hero-image ${heroClassName}` : 'bg-gray-700'}`}
 					onTouchStart={handleTouchStart}
 					onTouchMove={handleTouchMove}
@@ -301,21 +298,113 @@ function CommunityRoute() {
 			)}
 
 			<div className="flex flex-col gap-12 px-4 py-4">
-				<ItemGrid title="Collections">
-					{collections.map((collection) => (
-						<CollectionCard key={collection.id} collection={collection} />
-					))}
-				</ItemGrid>
-				<ItemGrid title="Merchants" cols={2} smCols={2} lgCols={2} xlCols={3} gap={16}>
-					{isLoadingMerchants ? (
-						<div className="col-span-full py-8 text-gray-500 text-center">Loading merchants...</div>
-					) : filteredMerchantPubkeys.length === 0 ? (
-						<div className="col-span-full py-8 text-gray-500 text-center">No merchants found</div>
-					) : (
-						filteredMerchantPubkeys.map((pubkey) => <FeaturedUserCard key={pubkey} userPubkey={pubkey} />)
-					)}
-				</ItemGrid>
+				<section aria-label="Community collections" data-testid="community-collections-section">
+					<ItemGrid title="Collections">
+						{isLoadingCollections ? (
+							<CollectionSkeletons count={12} />
+						) : collectionsError ? (
+							<CollectionsError error={collectionsError as Error} onRetry={() => collectionsQuery.refetch()} />
+						) : collections.length === 0 ? (
+							<div className="col-span-full py-8 text-gray-500 text-center" data-testid="community-collections-empty">
+								No collections found
+							</div>
+						) : (
+							collections.map((collection) => (
+								<div key={collection.id} data-testid="community-collection-card">
+									<CollectionCard collection={collection} />
+								</div>
+							))
+						)}
+					</ItemGrid>
+				</section>
+				<section aria-label="Community merchants" data-testid="community-merchants-section">
+					<ItemGrid title="Merchants" cols={2} smCols={2} lgCols={2} xlCols={3} gap={16}>
+						{isLoadingMerchants ? (
+							<MerchantSkeletons count={6} />
+						) : merchantsError ? (
+							<MerchantsError error={merchantsError as Error} onRetry={() => merchantsQuery.refetch()} />
+						) : filteredMerchantPubkeys.length === 0 ? (
+							<div className="col-span-full py-8 text-gray-500 text-center" data-testid="community-merchants-empty">
+								No merchants found
+							</div>
+						) : (
+							filteredMerchantPubkeys.map((pubkey) => (
+								<div key={pubkey} data-testid="community-merchant-card">
+									<FeaturedUserCard userPubkey={pubkey} />
+								</div>
+							))
+						)}
+					</ItemGrid>
+				</section>
 			</div>
+		</div>
+	)
+}
+
+// Skeleton loading component for collections grid
+function CollectionSkeletons({ count = 12 }: { count?: number }) {
+	return (
+		<>
+			{Array.from({ length: count }).map((_, i) => (
+				<div key={i} className="flex flex-col gap-3" data-testid="community-collections-skeleton">
+					<Skeleton className="h-40 w-full rounded-lg" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-3 w-1/2" />
+				</div>
+			))}
+		</>
+	)
+}
+
+// Skeleton loading component for merchants grid
+function MerchantSkeletons({ count = 6 }: { count?: number }) {
+	return (
+		<>
+			{Array.from({ length: count }).map((_, i) => (
+				<div key={i} className="flex flex-col gap-3" data-testid="community-merchants-skeleton">
+					<Skeleton className="h-40 w-full rounded-lg" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-3 w-3/4" />
+				</div>
+			))}
+		</>
+	)
+}
+
+// Render error state for collections
+function CollectionsError({ error, onRetry }: { error: Error | null; onRetry: () => void }) {
+	if (!error) return null
+	return (
+		<div
+			className="col-span-full flex flex-col justify-center items-center gap-4 px-4 py-12 text-center"
+			data-testid="community-collections-error"
+		>
+			<h3 className="font-semibold text-lg">Unable to load collections</h3>
+			<p className="max-w-md text-muted-foreground">
+				{error instanceof Error ? error.message : 'There was a problem connecting to relays.'}
+			</p>
+			<Button variant="secondary" size="sm" onClick={onRetry} data-testid="community-collections-retry">
+				Retry
+			</Button>
+		</div>
+	)
+}
+
+// Render error state for merchants
+function MerchantsError({ error, onRetry }: { error: Error | null; onRetry: () => void }) {
+	if (!error) return null
+	return (
+		<div
+			className="col-span-full flex flex-col justify-center items-center gap-4 px-4 py-12 text-center"
+			data-testid="community-merchants-error"
+		>
+			<h3 className="font-semibold text-lg">Unable to load merchants</h3>
+			<p className="max-w-md text-muted-foreground">
+				{error instanceof Error ? error.message : 'There was a problem connecting to relays.'}
+			</p>
+			<Button variant="secondary" size="sm" onClick={onRetry} data-testid="community-merchants-retry">
+				Retry
+			</Button>
 		</div>
 	)
 }


### PR DESCRIPTION
implement lazy loading for Community tab

Community previously used `useSuspenseQuery` for collections, causing the entire page to block rendering until relay data loaded.

This change switches the page to a progressive loading pattern by replacing `useSuspenseQuery` with `useQuery` and adding loading/error states for collections and merchants.

### Changes

* Replace `useSuspenseQuery` with `useQuery`
* Add skeleton loaders for Collections and Merchants
* Add inline error handling with retry support
* Add e2e coverage for progressive loading behavior
* Allow page content to render immediately while data loads in the background

### Result

The Community tab becomes interactive immediately, with content progressively loading as relay responses arrive instead of showing a blocking loading state.

Solves #874 