### PR TITLE
fix(tests): resolve ContextVM singleton caching (#963)

### DIFF
--- a/src/queries/__tests__/external.test.ts
+++ b/src/queries/__tests__/external.test.ts
@@ -7,13 +7,14 @@ console.error = () => {}
 
 mock.module('@/lib/ctxcn-client', () => ({
 	PlebianCurrencyClient: class {
-		constructor() {
-			throw new Error('mocked: no real relay connections in tests')
+		async callTool() {
+			return { rates: null, error: 'test stub' }
 		}
+		close() {}
 	},
 }))
 
-import { convertCurrencyToSats, fetchBtcExchangeRates } from '../external'
+import { convertCurrencyToSats, fetchBtcExchangeRates, resetCurrencyClient } from '../external'
 
 const ORIGINAL_FETCH = globalThis.fetch
 
@@ -49,6 +50,7 @@ function jsonOk(body: unknown): Response {
 describe('external.tsx - fetchBtcExchangeRates', () => {
 	afterEach(() => {
 		globalThis.fetch = ORIGINAL_FETCH
+		resetCurrencyClient()
 	})
 
 	test('fetches fresh rates from Yadio when ContextVM is unavailable', async () => {
@@ -113,6 +115,7 @@ describe('external.tsx - fetchBtcExchangeRates', () => {
 describe('external.tsx - convertCurrencyToSats', () => {
 	afterEach(() => {
 		globalThis.fetch = ORIGINAL_FETCH
+		resetCurrencyClient()
 	})
 
 	test('returns amount directly for sats currency', async () => {

--- a/src/queries/external.tsx
+++ b/src/queries/external.tsx
@@ -18,6 +18,12 @@ export const CURRENCY_CACHE_CONFIG = {
 let currencyClient: PlebianCurrencyClient | null = null
 let currencyClientInitPromise: Promise<any> | null = null
 
+export function resetCurrencyClient() {
+	currencyClient?.close()
+	currencyClient = null
+	currencyClientInitPromise = null
+}
+
 async function getCurrencyClient(): Promise<PlebianCurrencyClient> {
 	if (currencyClient) return currencyClient
 	if (currencyClientInitPromise) return currencyClientInitPromise


### PR DESCRIPTION
## Problem

`external.test.ts` had a mock that threw in the `PlebianCurrencyClient` constructor, but the real module caches a singleton at module level. When tests run in sequence, the first test to import `external.tsx` creates a real client that persists across tests, breaking isolation.

## Fix

- Export `resetCurrencyClient()` from `external.tsx` — production change is just exposing a function
- Change mock from throwing constructor to stub: `callTool() { return { rates: null, error: 'test stub' } }` — returns non-null to skip the 5s `Promise.race` timeout path in `fetchFromContextVm()`
- Add `afterEach(() => resetCurrencyClient())` in both describe blocks

## Verification

CI verified green: 17/17 unit tests pass in 154ms (was 5003ms for first test due to timeout).

Closes #963

## Related
- Decomposed from #960 (see #979 for the plan)