### PR TITLE
fix(cart): prevent overwriting local items during remote reconciliation (#964)

### DIFF
--- a/src/lib/stores/cart.ts
+++ b/src/lib/stores/cart.ts
@@ -541,6 +541,18 @@ export const cartActions = {
 			}
 
 			if (shouldAdoptRemote) {
+				const currentLocalItems = Object.keys(cartStore.state.cart.products).length > 0
+				if (currentLocalItems) {
+					cartStore.setState((state) => ({
+						...state,
+						hasRemoteCartHydrated: true,
+						isReconcilingRemoteCart: false,
+						suppressRemotePublish: false,
+						lastRemoteSnapshotUpdatedAt: normalizedRemote.updatedAt,
+					}))
+					return
+				}
+
 				const liveProducts: Record<string, { productRef: string; sellerPubkey: string; productId: string; shippingRefs: string[] }> = {}
 				const liveShipping: Record<string, { shippingRef: string; sellerPubkey: string }> = {}
 


### PR DESCRIPTION
## Problem

When a user adds items to their cart, the `reconcileRemoteCartForUser` function runs asynchronously to fetch the remote cart snapshot. If the remote snapshot arrives after the user has already added items locally, the remote data overwrites the local additions — items disappear.

## Fix

Add a re-read guard in `reconcileRemoteCartForUser`: before applying the remote snapshot, check if the local cart already has products. If it does, skip the remote overwrite and mark the remote cart as hydrated instead.

12 lines of production code in `src/lib/stores/cart.ts`.

Closes #964

## Related
- Decomposed from #960 (see #979 for the plan)