### PR TITLE
fix(payment): bypass Alby LNURL proxy (#703)

### DIFF
--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -306,10 +306,8 @@ export const ndkActions = {
 			},
 		})
 
-		// Always monitor zap receipts on public ZAP_RELAYS (plus the app relay).
-		// LSPs publish zap receipts to their own public relays, not the local/app relay,
-		// so we must subscribe there to detect paid invoices.
-		const zapNdk = new NDK({ explicitRelayUrls: [...new Set([...ZAP_RELAYS, ...explicitRelays])] })
+		const zapRelayUrls = localRelayOnly ? explicitRelays : [...new Set([...ZAP_RELAYS, ...explicitRelays])]
+		const zapNdk = new NDK({ explicitRelayUrls: zapRelayUrls })
 
 		// Determine write relays - staging only writes to main relay, others write to all
 		const mainRelay = getMainRelay()

--- a/src/queries/payment.tsx
+++ b/src/queries/payment.tsx
@@ -1005,7 +1005,7 @@ export const generateInvoice = async (params: GenerateInvoiceParams): Promise<Ge
 	// Generate the invoice using the resolved lightning address
 	try {
 		console.log(`⚡ Generating invoice for ${lnAddress} (${amountSats} sats)`)
-		const ln = new LightningAddress(lnAddress)
+		const ln = new LightningAddress(lnAddress, { proxy: false })
 		await ln.fetch()
 
 		const zapSupported = (ln.lnurlpData?.allowsNostr ?? ln.lnurlpData?.rawData?.allowsNostr ?? false) && !!ln.nostrPubkey


### PR DESCRIPTION
## Problem

The `@getalby/lightning-tools` `LightningAddress` class routes all LNURL requests through `api.getalby.com` by default. Playwright `page.route()` mocks intercept `**/.well-known/lnurlp/*` on the actual domain, so the proxy bypasses the mocks entirely.

## Fix

- Pass `{ proxy: false }` to `LightningAddress` constructor — 1 line change in `src/queries/payment.tsx`
- Skip public `ZAP_RELAYS` when `LOCAL_RELAY_ONLY` is set — test isolation in `src/lib/stores/ndk.ts`

Addresses #703 (partial — remaining payment test failures are from #772)

## Related
- Decomposed from #960 (see #979 for the plan)
- Payment tests remain skipped until #772 is fixed