### PR TITLE
feat(ci): nsite E2E dashboard publishing with sharding

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   e2e-pricing:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
@@ -105,6 +109,7 @@ jobs:
           LOCAL_RELAY_ONLY: 'true'
 
       - name: Run pricing E2E tests
+        id: tests
         run: bun run test:e2e -- --grep 'Product Page - View Only'
 
       - name: Show server logs on failure
@@ -115,6 +120,28 @@ jobs:
           echo ""
           echo "=== Dev server logs ==="
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
+
+      - name: Render E2E dashboard
+        if: ${{ !cancelled() }}
+        id: dashboard
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/render-dashboard@main
+        with:
+          results-dir: test-results
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+
+      - name: Publish dashboard to nsite
+        if: ${{ !cancelled() }}
+        id: nsite
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/publish-nsite@main
+        with:
+          dashboard-dir: ${{ steps.dashboard.outputs.dashboard-dir }}
+          announce-nsec: ${{ secrets.CI_ANNOUNCE_NSEC }}
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+          test-status: ${{ steps.tests.outcome }}
 
       - name: Upload pricing test results
         uses: actions/upload-artifact@v4
@@ -222,6 +249,7 @@ jobs:
           LOCAL_RELAY_ONLY: 'true'
 
       - name: Run remaining E2E tests
+        id: tests
         run: bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
 
       - name: Show server logs on failure
@@ -232,6 +260,28 @@ jobs:
           echo ""
           echo "=== Dev server logs ==="
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
+
+      - name: Render E2E dashboard
+        if: ${{ !cancelled() }}
+        id: dashboard
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/render-dashboard@main
+        with:
+          results-dir: test-results
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+
+      - name: Publish dashboard to nsite
+        if: ${{ !cancelled() }}
+        id: nsite
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/publish-nsite@main
+        with:
+          dashboard-dir: ${{ steps.dashboard.outputs.dashboard-dir }}
+          announce-nsec: ${{ secrets.CI_ANNOUNCE_NSEC }}
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+          test-status: ${{ steps.tests.outcome }}
 
       - name: Upload full test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Run pricing E2E tests
         id: tests
         run: bun run test:e2e -- --grep 'Product Page - View Only'
+        env:
+          PLAYWRIGHT_SCREENSHOT: 'on'
+          PLAYWRIGHT_REPORTER: json
 
       - name: Show server logs on failure
         if: failure()
@@ -120,6 +123,11 @@ jobs:
           echo ""
           echo "=== Dev server logs ==="
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
+
+      - name: Extract test stats
+        if: ${{ !cancelled() }}
+        id: stats
+        run: bun e2e/extract-failures.ts
 
       - name: Render E2E dashboard
         if: ${{ !cancelled() }}
@@ -142,6 +150,9 @@ jobs:
           branch: ${{ github.head_ref || github.ref_name }}
           commit: ${{ github.sha }}
           test-status: ${{ steps.tests.outcome }}
+          passed: ${{ steps.stats.outputs.passed }}
+          failed: ${{ steps.stats.outputs.failed }}
+          duration-ms: ${{ steps.stats.outputs.duration }}
 
       - name: Upload pricing test results
         uses: actions/upload-artifact@v4
@@ -151,13 +162,14 @@ jobs:
           path: test-results/
           retention-days: 7
 
-  e2e-full:
-    # Keep the broader inherited-flaky suite off the pricing PR path.
-    # It remains available for scheduled/manual comparison runs while the
-    # separate test-fix branch carries the inherited failure work.
+  e2e-shard:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - name: Checkout code
@@ -248,9 +260,14 @@ jobs:
           APP_PRIVATE_KEY: e2e0000000000000000000000000000000000000000000000000000000000001
           LOCAL_RELAY_ONLY: 'true'
 
-      - name: Run remaining E2E tests
-        id: tests
-        run: bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+      - name: Run E2E tests (shard ${{ matrix.shard }}/3)
+        run: >
+          bun run test:e2e --
+          --grep-invert 'Product Page - View Only|Collection Management'
+          --shard ${{ matrix.shard }}/3
+        env:
+          PLAYWRIGHT_SCREENSHOT: only-on-failure
+          PLAYWRIGHT_REPORTER: blob
 
       - name: Show server logs on failure
         if: failure()
@@ -261,9 +278,75 @@ jobs:
           echo "=== Dev server logs ==="
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
 
-      - name: Render E2E dashboard
+      - name: Upload blob report
         if: ${{ !cancelled() }}
-        id: dashboard
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-shard-${{ matrix.shard }}
+          path: blob-report/
+          retention-days: 1
+
+  e2e-report:
+    needs: e2e-shard
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: bunx playwright install-deps chromium
+
+      - name: Download shard reports
+        uses: actions/download-artifact@v4
+        with:
+          path: all-blob-reports
+          pattern: blob-report-shard-*
+          merge-multiple: true
+
+      - name: Merge blob reports
+        run: |
+          mkdir -p test-results
+          PLAYWRIGHT_JSON_OUTPUT_FILE=test-results/results.json \
+            npx playwright merge-reports --reporter json,list ./all-blob-reports
+
+      - name: Extract failed tests
+        id: failures
+        run: bun e2e/extract-failures.ts
+
+      - name: Render dashboard (green)
+        if: steps.failures.outputs.has_failures != 'true'
+        id: dashboard-green
         uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/render-dashboard@main
         with:
           results-dir: test-results
@@ -271,21 +354,126 @@ jobs:
           branch: ${{ github.head_ref || github.ref_name }}
           commit: ${{ github.sha }}
 
-      - name: Publish dashboard to nsite
-        if: ${{ !cancelled() }}
-        id: nsite
+      - name: Publish dashboard to nsite (green)
+        if: steps.failures.outputs.has_failures != 'true'
+        id: nsite-green
         uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/publish-nsite@main
         with:
-          dashboard-dir: ${{ steps.dashboard.outputs.dashboard-dir }}
+          dashboard-dir: ${{ steps.dashboard-green.outputs.dashboard-dir }}
           announce-nsec: ${{ secrets.CI_ANNOUNCE_NSEC }}
           pr-number: ${{ github.event.pull_request.number || '' }}
           branch: ${{ github.head_ref || github.ref_name }}
           commit: ${{ github.sha }}
-          test-status: ${{ steps.tests.outcome }}
+          test-status: passed
+          passed: ${{ steps.failures.outputs.passed }}
+          failed: ${{ steps.failures.outputs.failed }}
+          duration-ms: ${{ steps.failures.outputs.duration }}
 
-      - name: Upload full test results
+      - name: Upload merged results (green)
+        if: steps.failures.outputs.has_failures != 'true'
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        with:
+          name: test-results-full
+          path: test-results/
+          retention-days: 7
+
+      - name: Generate routes
+        if: steps.failures.outputs.has_failures == 'true'
+        run: bun run generate-routes
+
+      - name: Setup Go
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.22'
+
+      - name: Install nak
+        if: steps.failures.outputs.has_failures == 'true'
+        run: |
+          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          cd /tmp/nak
+          GOBIN="$(go env GOPATH)/bin"
+          mkdir -p "$GOBIN"
+          go build -o "$GOBIN/nak" .
+
+      - name: Start relay
+        if: steps.failures.outputs.has_failures == 'true'
+        run: |
+          nohup nak serve --hostname 0.0.0.0 > /tmp/relay.log 2>&1 &
+          for i in $(seq 1 10); do
+            if (echo > /dev/tcp/localhost/10547) 2>/dev/null; then
+              echo "Relay is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Relay failed to start"
+          cat /tmp/relay.log
+          exit 1
+
+      - name: Seed relay and start dev server
+        if: steps.failures.outputs.has_failures == 'true'
+        run: |
+          bun e2e/seed-relay.ts
+          nohup bun dev > /tmp/devserver.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:34567/api/config > /dev/null 2>&1; then
+              echo "Dev server is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Dev server failed to start"
+          cat /tmp/devserver.log
+          exit 1
+        env:
+          NODE_ENV: test
+          PORT: '34567'
+          APP_RELAY_URL: ws://localhost:10547
+          APP_PRIVATE_KEY: e2e0000000000000000000000000000000000000000000000000000000000001
+          LOCAL_RELAY_ONLY: 'true'
+
+      - name: Re-run failed tests with screenshots
+        if: steps.failures.outputs.has_failures == 'true'
+        run: bun run test:e2e -- --test-list failed-tests.txt
+        env:
+          PLAYWRIGHT_SCREENSHOT: 'on'
+          PLAYWRIGHT_REPORTER: json
+          PLAYWRIGHT_RETRIES: 0
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/rerun-results.json
+
+      - name: Merge first-pass and re-run results
+        if: steps.failures.outputs.has_failures == 'true'
+        run: bun e2e/merge-results.ts
+
+      - name: Render dashboard (red)
+        if: steps.failures.outputs.has_failures == 'true'
+        id: dashboard-red
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/render-dashboard@main
+        with:
+          results-dir: test-results
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+
+      - name: Publish dashboard to nsite (red)
+        if: steps.failures.outputs.has_failures == 'true'
+        id: nsite-red
+        uses: c03rad0r/plebeian-testing-nsite-actions/.github/actions/publish-nsite@main
+        with:
+          dashboard-dir: ${{ steps.dashboard-red.outputs.dashboard-dir }}
+          announce-nsec: ${{ secrets.CI_ANNOUNCE_NSEC }}
+          pr-number: ${{ github.event.pull_request.number || '' }}
+          branch: ${{ github.head_ref || github.ref_name }}
+          commit: ${{ github.sha }}
+          test-status: failed
+          passed: ${{ steps.failures.outputs.passed }}
+          failed: ${{ steps.failures.outputs.failed }}
+          duration-ms: ${{ steps.failures.outputs.duration }}
+
+      - name: Upload merged results (red)
+        if: steps.failures.outputs.has_failures == 'true'
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-full
           path: test-results/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -435,7 +435,9 @@ jobs:
 
       - name: Re-run failed tests with screenshots
         if: steps.failures.outputs.has_failures == 'true'
-        run: bun run test:e2e -- --test-list failed-tests.txt
+        run: |
+          cp test-results/results.json test-results/first-pass-results.json
+          bun run test:e2e -- --test-list failed-tests.txt
         env:
           PLAYWRIGHT_SCREENSHOT: 'on'
           PLAYWRIGHT_REPORTER: json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -436,7 +436,7 @@ jobs:
       - name: Re-run failed tests with screenshots
         if: steps.failures.outputs.has_failures == 'true'
         run: |
-          cp test-results/results.json test-results/first-pass-results.json
+          cp test-results/results.json /tmp/first-pass-results.json
           bun run test:e2e -- --test-list failed-tests.txt
         env:
           PLAYWRIGHT_SCREENSHOT: 'on'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -288,7 +288,7 @@ jobs:
 
   e2e-report:
     needs: e2e-shard
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.e2e-shard.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,13 @@ __pycache__/
 
 .opencode/
 contextvm/
+
+# Session planning documents
+*-PLAN.md
+
+# Published Nostr article drafts (local copies)
+docs/auctions-moving-bound-early-refund-gist.md
+docs/auctions-moving-bound-early-refund.md
+docs/auctions-seller-relay-early-refund-gist.md
+docs/auctions-seller-relay-early-refund.md
+docs/nostr-publications.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,4 @@ bd sync               # Sync with git
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+- **NEVER request PR reviewers** — this is done manually by the project owner. Do not use `gh pr edit --add-reviewer` or any equivalent command.

--- a/E2E-SHARDING-PLAN.md
+++ b/E2E-SHARDING-PLAN.md
@@ -1,0 +1,100 @@
+# E2E Sharding + Conditional Screenshot Re-run Plan
+
+## Overview
+
+Restructure the E2E test pipeline from a single serial `e2e-full` job (~20 min) into a sharded architecture with 3 parallel shards (~7 min each) plus a conditional screenshot re-run for failures. Dashboard is rendered and published to nsite in all cases.
+
+## Architecture
+
+```
+e2e-pricing (push/PR) — 6 tests, ~1 min, no sharding
+  ├── Start relay + dev server
+  ├── Run pricing tests (screenshot: 'on', reporter: json+github)
+  ├── Render dashboard → publish to nsite
+  └── Upload artifacts
+
+e2e-shard (workflow_dispatch / schedule) — matrix: 3 shards in parallel
+  ├── Start relay + dev server (each shard has its own)
+  ├── Run ~49 tests/shard (screenshot: 'only-on-failure', reporter: blob)
+  └── Upload blob report artifact
+
+e2e-report (depends on e2e-shard) — always runs
+  ├── Minimal setup: checkout + bun + playwright only (~1 min)
+  ├── Download 3 shard blob reports
+  ├── Merge blob reports → results.json
+  ├── Extract failures from results.json
+  │
+  ├── GREEN PATH (no failures):
+  │     ├── Render dashboard from merged results
+  │     └── Publish to nsite → done (~1 min total)
+  │
+  └── RED PATH (has failures):
+        ├── Install nak + Go (conditional)
+        ├── Start relay + dev server (conditional)
+        ├── Re-run failed tests with screenshot: 'on', retries: 0
+        ├── Merge first-pass + re-run results
+        ├── Render dashboard with full screenshots
+        └── Publish to nsite
+```
+
+## Timing
+
+| Path | Time |
+|------|------|
+| **Green** (common) | ~9 min (7 min shards + 2 min merge/publish) |
+| **Red** (failures) | ~16 min (7 min shards + 2 min merge + 5 min re-run + 2 min render/publish) |
+| **Current** | ~20 min (single serial job) |
+
+## Files to Change
+
+### 1. `e2e/playwright.config.ts` — env var overrides
+
+| Env Var | Values | Default | Purpose |
+|---------|--------|---------|---------|
+| `PLAYWRIGHT_SCREENSHOT` | `'on'`, `'only-on-failure'`, `'off'` | `'only-on-failure'` | Screenshot mode |
+| `PLAYWRIGHT_REPORTER` | `'json'`, `'blob'`, `'auto'` | `'auto'` (CI→github, local→list) | Reporter selection |
+| `PLAYWRIGHT_RETRIES` | any number | CI→2, local→0 | Retry count |
+
+### 2. `e2e/extract-failures.ts` — new (~35 lines)
+
+Parses `test-results/results.json`, walks suites/specs/tests/results, finds failures (status in `failed`, `timedOut`, `interrupted`), writes `failed-tests.txt` in `--test-list` format:
+
+```
+tests/auction-live-chat.spec.ts › Auction Live Chat › should display sage in the live chat input
+```
+
+Sets GITHUB_OUTPUT: `has_failures`, `count`, `passed`, `failed`, `duration`.
+
+### 3. `e2e/merge-results.ts` — new (~45 lines)
+
+Merges first-pass (`test-results/results.json`) + re-run (`test-results/rerun-results.json`). For each test that appears in both (matched by `file` + `title`), re-run entry replaces first-pass. Writes merged output to `test-results/results.json`.
+
+### 4. `.github/workflows/e2e.yml` — rewrite jobs section (~240 lines)
+
+- `e2e-pricing`: add env vars to test step, keep render+publish
+- `e2e-shard`: matrix 3-way, blob reporter, upload artifacts
+- `e2e-report`: merge + conditional re-run (Option B — heavy setup only on failures) + render + publish
+
+## Key Details
+
+- **Blob report location**: `blob-report/` (Playwright default), each shard gets unique `.zip`
+- **Merge-reports JSON output**: `PLAYWRIGHT_JSON_OUTPUT_FILE` env var to redirect to file
+- **`--test-list` format**: `file › suite › test title` (line/column ignored by Playwright)
+- **Re-run**: fresh relay+dev server, `retries: 0`, `screenshot: 'on'`
+- **Shard balance**: file-level sharding (`fullyParallel: false`), ~8 files per shard
+
+## Out of Scope / Blocked
+
+- Blossom/relay network accessibility from GitHub Actions
+- `CI_ANNOUNCE_NSEC` secret in fork (user action needed)
+
+## Checklist
+
+- [ ] 1. Checkout `feat/nip53-auction-live-chat` branch and verify sync
+- [ ] 2. Update `e2e/playwright.config.ts` with env var overrides
+- [ ] 3. Create `e2e/extract-failures.ts`
+- [ ] 4. Create `e2e/merge-results.ts`
+- [ ] 5. Rewrite `.github/workflows/e2e.yml` with sharding + conditional re-run
+- [ ] 6. Run Prettier / formatting on all changed files
+- [ ] 7. Commit and push to fork
+- [ ] 8. Trigger workflow and verify

--- a/e2e/extract-failures.ts
+++ b/e2e/extract-failures.ts
@@ -14,7 +14,7 @@ interface TestResult {
 
 interface TestEntry {
 	projectName: string
-	results: TestResult[]
+	results?: TestResult[]
 }
 
 interface Spec {
@@ -22,13 +22,13 @@ interface Spec {
 	file: string
 	line?: number
 	column?: number
-	tests: TestEntry[]
+	tests?: TestEntry[]
 }
 
 interface Suite {
 	title: string
-	specs: Spec[]
-	suites: Suite[]
+	specs?: Spec[]
+	suites?: Suite[]
 }
 
 interface Results {
@@ -39,15 +39,17 @@ function collectFailedTests(suite: Suite, ancestors: string[] = []): string[] {
 	const lines: string[] = []
 	const suitePath = [...ancestors, suite.title].filter(Boolean)
 
-	for (const spec of suite.specs) {
-		const hasFailure = spec.tests.some((t) => t.results.some((r) => ['failed', 'timedOut', 'interrupted'].includes(r.status)))
+	for (const spec of suite.specs || []) {
+		const hasFailure = (spec.tests || []).some((t) =>
+			(t.results || []).some((r) => ['failed', 'timedOut', 'interrupted'].includes(r.status)),
+		)
 		if (hasFailure) {
 			const parts = [spec.file, ...suitePath, spec.title].filter(Boolean)
 			lines.push(parts.join(' › '))
 		}
 	}
 
-	for (const child of suite.suites) {
+	for (const child of suite.suites || []) {
 		lines.push(...collectFailedTests(child, suitePath))
 	}
 
@@ -59,9 +61,9 @@ function collectStats(suite: Suite): { passed: number; failed: number; duration:
 	let failed = 0
 	let duration = 0
 
-	for (const spec of suite.specs) {
-		for (const test of spec.tests) {
-			for (const result of test.results) {
+	for (const spec of suite.specs || []) {
+		for (const test of spec.tests || []) {
+			for (const result of test.results || []) {
 				if (result.status === 'passed') passed++
 				else if (['failed', 'timedOut', 'interrupted'].includes(result.status)) failed++
 				duration += result.duration || 0
@@ -69,7 +71,7 @@ function collectStats(suite: Suite): { passed: number; failed: number; duration:
 		}
 	}
 
-	for (const child of suite.suites) {
+	for (const child of suite.suites || []) {
 		const childStats = collectStats(child)
 		passed += childStats.passed
 		failed += childStats.failed

--- a/e2e/extract-failures.ts
+++ b/e2e/extract-failures.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const RESULTS_DIR = path.resolve(import.meta.dirname, '..', 'test-results')
+const RESULTS_FILE = path.join(RESULTS_DIR, 'results.json')
+const FAILURES_FILE = path.resolve(import.meta.dirname, '..', 'failed-tests.txt')
+
+interface TestResult {
+	status: string
+	duration: number
+	error?: string
+	attachments?: Array<{ contentType: string; path?: string }>
+}
+
+interface TestEntry {
+	projectName: string
+	results: TestResult[]
+}
+
+interface Spec {
+	title: string
+	file: string
+	line?: number
+	column?: number
+	tests: TestEntry[]
+}
+
+interface Suite {
+	title: string
+	specs: Spec[]
+	suites: Suite[]
+}
+
+interface Results {
+	suites: Suite[]
+}
+
+function collectFailedTests(suite: Suite, ancestors: string[] = []): string[] {
+	const lines: string[] = []
+	const suitePath = [...ancestors, suite.title].filter(Boolean)
+
+	for (const spec of suite.specs) {
+		const hasFailure = spec.tests.some((t) => t.results.some((r) => ['failed', 'timedOut', 'interrupted'].includes(r.status)))
+		if (hasFailure) {
+			const parts = [spec.file, ...suitePath, spec.title].filter(Boolean)
+			lines.push(parts.join(' › '))
+		}
+	}
+
+	for (const child of suite.suites) {
+		lines.push(...collectFailedTests(child, suitePath))
+	}
+
+	return lines
+}
+
+function collectStats(suite: Suite): { passed: number; failed: number; duration: number } {
+	let passed = 0
+	let failed = 0
+	let duration = 0
+
+	for (const spec of suite.specs) {
+		for (const test of spec.tests) {
+			for (const result of test.results) {
+				if (result.status === 'passed') passed++
+				else if (['failed', 'timedOut', 'interrupted'].includes(result.status)) failed++
+				duration += result.duration || 0
+			}
+		}
+	}
+
+	for (const child of suite.suites) {
+		const childStats = collectStats(child)
+		passed += childStats.passed
+		failed += childStats.failed
+		duration += childStats.duration
+	}
+
+	return { passed, failed, duration }
+}
+
+if (!fs.existsSync(RESULTS_FILE)) {
+	console.error(`No results.json found at ${RESULTS_FILE}`)
+	process.exit(1)
+}
+
+const data: Results = JSON.parse(fs.readFileSync(RESULTS_FILE, 'utf-8'))
+
+let allPassed = 0
+let allFailed = 0
+let allDuration = 0
+const allFailureLines: string[] = []
+
+for (const suite of data.suites) {
+	const stats = collectStats(suite)
+	allPassed += stats.passed
+	allFailed += stats.failed
+	allDuration += stats.duration
+	allFailureLines.push(...collectFailedTests(suite))
+}
+
+const hasFailures = allFailed > 0
+
+if (hasFailures) {
+	fs.writeFileSync(FAILURES_FILE, allFailureLines.join('\n') + '\n')
+	console.log(`Found ${allFailureLines.length} failed test(s):`)
+	for (const line of allFailureLines) {
+		console.log(`  ${line}`)
+	}
+} else {
+	console.log('All tests passed!')
+}
+
+const ghOutput = process.env.GITHUB_OUTPUT
+if (ghOutput) {
+	const lines = [
+		`has_failures=${hasFailures}`,
+		`count=${allFailed}`,
+		`passed=${allPassed}`,
+		`failed=${allFailed}`,
+		`duration=${allDuration}`,
+	]
+	fs.appendFileSync(ghOutput, lines.join('\n') + '\n')
+}

--- a/e2e/merge-results.ts
+++ b/e2e/merge-results.ts
@@ -1,0 +1,88 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const RESULTS_DIR = path.resolve(import.meta.dirname, '..', 'test-results')
+const FIRST_PASS = path.join(RESULTS_DIR, 'results.json')
+const RERUN = path.join(RESULTS_DIR, 'rerun-results.json')
+
+interface TestResult {
+	status: string
+	duration: number
+	error?: string
+	attachments?: Array<{ contentType: string; path?: string }>
+}
+
+interface TestEntry {
+	projectName: string
+	results: TestResult[]
+}
+
+interface Spec {
+	title: string
+	file: string
+	tests: TestEntry[]
+}
+
+interface Suite {
+	title: string
+	specs: Spec[]
+	suites: Suite[]
+}
+
+interface Results {
+	suites: Suite[]
+}
+
+function specKey(spec: Spec): string {
+	return `${spec.file}::${spec.title}`
+}
+
+function buildRerunMap(suite: Suite, map: Map<string, Spec>): void {
+	for (const spec of suite.specs) {
+		map.set(specKey(spec), spec)
+	}
+	for (const child of suite.suites) {
+		buildRerunMap(child, map)
+	}
+}
+
+function mergeSuite(suite: Suite, rerunMap: Map<string, Spec>): Suite {
+	const mergedSpecs = suite.specs.map((spec) => {
+		const rerunSpec = rerunMap.get(specKey(spec))
+		if (rerunSpec) {
+			return rerunSpec
+		}
+		return spec
+	})
+
+	const mergedSuites = suite.suites.map((child) => mergeSuite(child, rerunMap))
+
+	return { ...suite, specs: mergedSpecs, suites: mergedSuites }
+}
+
+if (!fs.existsSync(FIRST_PASS)) {
+	console.error(`No first-pass results at ${FIRST_PASS}`)
+	process.exit(1)
+}
+
+if (!fs.existsSync(RERUN)) {
+	console.log('No re-run results found, keeping first-pass results as-is.')
+	process.exit(0)
+}
+
+const firstPass: Results = JSON.parse(fs.readFileSync(FIRST_PASS, 'utf-8'))
+const rerun: Results = JSON.parse(fs.readFileSync(RERUN, 'utf-8'))
+
+const rerunMap = new Map<string, Spec>()
+for (const suite of rerun.suites) {
+	buildRerunMap(suite, rerunMap)
+}
+
+console.log(`Re-run contained ${rerunMap.size} test(s)`)
+
+const merged: Results = {
+	suites: firstPass.suites.map((suite) => mergeSuite(suite, rerunMap)),
+}
+
+fs.writeFileSync(FIRST_PASS, JSON.stringify(merged, null, 2))
+console.log(`Merged results written to ${FIRST_PASS}`)

--- a/e2e/merge-results.ts
+++ b/e2e/merge-results.ts
@@ -2,8 +2,9 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const RESULTS_DIR = path.resolve(import.meta.dirname, '..', 'test-results')
-const FIRST_PASS = path.join(RESULTS_DIR, 'results.json')
+const FIRST_PASS = path.join(RESULTS_DIR, 'first-pass-results.json')
 const RERUN = path.join(RESULTS_DIR, 'rerun-results.json')
+const OUTPUT = path.join(RESULTS_DIR, 'results.json')
 
 interface TestResult {
 	status: string
@@ -84,5 +85,5 @@ const merged: Results = {
 	suites: firstPass.suites.map((suite) => mergeSuite(suite, rerunMap)),
 }
 
-fs.writeFileSync(FIRST_PASS, JSON.stringify(merged, null, 2))
-console.log(`Merged results written to ${FIRST_PASS}`)
+fs.writeFileSync(OUTPUT, JSON.stringify(merged, null, 2))
+console.log(`Merged results written to ${OUTPUT}`)

--- a/e2e/merge-results.ts
+++ b/e2e/merge-results.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const RESULTS_DIR = path.resolve(import.meta.dirname, '..', 'test-results')
-const FIRST_PASS = path.join(RESULTS_DIR, 'first-pass-results.json')
+const FIRST_PASS = '/tmp/first-pass-results.json'
 const RERUN = path.join(RESULTS_DIR, 'rerun-results.json')
 const OUTPUT = path.join(RESULTS_DIR, 'results.json')
 

--- a/e2e/merge-results.ts
+++ b/e2e/merge-results.ts
@@ -26,8 +26,8 @@ interface Spec {
 
 interface Suite {
 	title: string
-	specs: Spec[]
-	suites: Suite[]
+	specs?: Spec[]
+	suites?: Suite[]
 }
 
 interface Results {
@@ -39,16 +39,16 @@ function specKey(spec: Spec): string {
 }
 
 function buildRerunMap(suite: Suite, map: Map<string, Spec>): void {
-	for (const spec of suite.specs) {
+	for (const spec of suite.specs || []) {
 		map.set(specKey(spec), spec)
 	}
-	for (const child of suite.suites) {
+	for (const child of suite.suites || []) {
 		buildRerunMap(child, map)
 	}
 }
 
 function mergeSuite(suite: Suite, rerunMap: Map<string, Spec>): Suite {
-	const mergedSpecs = suite.specs.map((spec) => {
+	const mergedSpecs = (suite.specs || []).map((spec) => {
 		const rerunSpec = rerunMap.get(specKey(spec))
 		if (rerunSpec) {
 			return rerunSpec
@@ -56,7 +56,7 @@ function mergeSuite(suite: Suite, rerunMap: Map<string, Spec>): Suite {
 		return spec
 	})
 
-	const mergedSuites = suite.suites.map((child) => mergeSuite(child, rerunMap))
+	const mergedSuites = (suite.suites || []).map((child) => mergeSuite(child, rerunMap))
 
 	return { ...suite, specs: mergedSpecs, suites: mergedSuites }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -5,22 +5,30 @@ import { TEST_APP_PRIVATE_KEY, RELAY_URL, BASE_URL, TEST_PORT } from './test-con
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
+const reporterMode = process.env.PLAYWRIGHT_REPORTER || 'auto'
+const reporter: any =
+	reporterMode === 'blob'
+		? [['blob'], ['github']]
+		: reporterMode === 'json'
+			? [['json', { outputFile: path.join(PROJECT_ROOT, 'test-results', 'results.json') }], ['github']]
+			: process.env.CI
+				? 'github'
+				: 'list'
+
 export default defineConfig({
 	testDir: './tests',
 	fullyParallel: false,
 	forbidOnly: !!process.env.CI,
-	retries: process.env.CI ? 2 : 0,
+	retries: process.env.PLAYWRIGHT_RETRIES !== undefined ? Number(process.env.PLAYWRIGHT_RETRIES) : process.env.CI ? 2 : 0,
 	workers: 1,
-	reporter: process.env.CI
-		? [['json', { outputFile: path.join(PROJECT_ROOT, 'test-results', 'results.json') }], ['github']]
-		: 'list',
+	reporter,
 	testMatch: /.*\.spec\.ts$/,
 	outputDir: path.join(PROJECT_ROOT, 'test-results'),
 
 	use: {
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
-		screenshot: 'on',
+		screenshot: (process.env.PLAYWRIGHT_SCREENSHOT || 'only-on-failure') as 'on' | 'only-on-failure' | 'off',
 		video: 'retain-on-failure',
 	},
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -11,13 +11,16 @@ export default defineConfig({
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 0,
 	workers: 1,
-	reporter: process.env.CI ? 'github' : 'list',
+	reporter: process.env.CI
+		? [['json', { outputFile: path.join(PROJECT_ROOT, 'test-results', 'results.json') }], ['github']]
+		: 'list',
 	testMatch: /.*\.spec\.ts$/,
+	outputDir: path.join(PROJECT_ROOT, 'test-results'),
 
 	use: {
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
-		screenshot: 'only-on-failure',
+		screenshot: 'on',
 		video: 'retain-on-failure',
 	},
 


### PR DESCRIPTION
## Summary

Extracts nsite CI infrastructure from #947 into its own PR for independent review.

## What This Does

### Nsite Dashboard Publishing
- Playwright config: `screenshot: "on"` + JSON reporter for CI artifact generation
- `render-dashboard` composite action: generates visual HTML dashboard from test results
- `publish-nsite` composite action: deploys dashboard to Blossom via nsyte + announces via Kind 1985
- PR comment integration: CI posts nsite dashboard URL back to PRs

### 3-Way Sharding
- Restructure e2e-full into `e2e-shard` (3-way matrix) + `e2e-report`
- `e2e-report` merges blob reports, extracts failures, conditionally re-runs failed tests with full screenshots
- `e2e/extract-failures.ts` for failure extraction and stats
- `e2e/merge-results.ts` for merging first-pass + re-run results

## Files Changed
- `.github/workflows/e2e.yml` — sharding, render-dashboard, publish-nsite steps
- `e2e/playwright.config.ts` — screenshot/reporter config
- `e2e/extract-failures.ts` — new file
- `e2e/merge-results.ts` — new file
- `E2E-SHARDING-PLAN.md` — design doc

## Dependencies
- Requires `CI_ANNOUNCE_NSEC` secret (already set in repo secrets)
- Uses composite actions from `c03rad0r/plebeian-testing-nsite-actions` (public repo)
- No source code changes — only CI/test infrastructure

## Related
- Split from #947 (NIP-53 auction live chat)
- Tracked in #979 (merge order checklist)