### PR TITLE
feat(auctions): add comments tab to auction detail

### DIFF
--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -8,7 +8,7 @@ import {
 import { usePublishCommentMutation } from '@/publish/comments'
 import { authStore, useAuth } from '@/lib/stores/auth'
 import { useStore } from '@tanstack/react-store'
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import { Button } from './ui/button'
 import { Textarea } from './ui/textarea'
 import { CircleX, MessageSquare, Reply, X } from 'lucide-react'
@@ -31,16 +31,20 @@ interface CommentThreadProps {
 	replyingTo?: Comment
 	setReplyingTo: (comment?: Comment) => void
 	depth?: number
+	entityLabel?: string
 }
 
 interface AddCommentProps {
 	targetEvent: NDKEvent
 	parentComment?: Comment
 	onCancel?: () => void
+	entityLabel?: string
 }
 
 interface CommentsProps {
 	targetEvent: NDKEvent
+	entityLabel?: string
+	testId?: string
 }
 
 function formatDate(timestamp: number): string {
@@ -96,11 +100,11 @@ function CommentItem({ comment, onPressReply }: CommentItemProps) {
 	)
 }
 
-function CommentThread({ comments, replyingTo, eventRoot, setReplyingTo, depth = 0 }: CommentThreadProps) {
+function CommentThread({ comments, replyingTo, eventRoot, setReplyingTo, depth = 0, entityLabel }: CommentThreadProps) {
 	return (
 		<>
 			{comments.map((commentChild) => (
-				<>
+				<Fragment key={commentChild.id}>
 					<CommentItem key={'comment-' + commentChild.id} comment={commentChild} onPressReply={() => setReplyingTo(commentChild)} />
 					{replyingTo && replyingTo.id === commentChild.id ? (
 						<AddCommentForm
@@ -108,6 +112,7 @@ function CommentThread({ comments, replyingTo, eventRoot, setReplyingTo, depth =
 							targetEvent={eventRoot}
 							parentComment={commentChild}
 							onCancel={() => setReplyingTo()}
+							entityLabel={entityLabel}
 						/>
 					) : null}
 					{commentChild.children && commentChild.children.length > 0 && depth < MAX_COMMENT_THREAD_DEPTH - 1 ? (
@@ -118,16 +123,17 @@ function CommentThread({ comments, replyingTo, eventRoot, setReplyingTo, depth =
 								eventRoot={eventRoot}
 								setReplyingTo={setReplyingTo}
 								depth={depth + 1}
+								entityLabel={entityLabel}
 							/>
 						</div>
 					) : null}
-				</>
+				</Fragment>
 			))}
 		</>
 	)
 }
 
-function AddCommentForm({ targetEvent, parentComment, onCancel }: AddCommentProps) {
+function AddCommentForm({ targetEvent, parentComment, onCancel, entityLabel = 'product' }: AddCommentProps) {
 	const [content, setContent] = useState('')
 	const publishMutation = usePublishCommentMutation()
 
@@ -181,7 +187,7 @@ function AddCommentForm({ targetEvent, parentComment, onCancel }: AddCommentProp
 				id="comment-input"
 				value={content}
 				onChange={(e) => setContent(e.target.value)}
-				placeholder={parentComment ? 'Write your reply...' : 'Share your thoughts about this product...'}
+				placeholder={parentComment ? 'Write your reply...' : `Share your thoughts about this ${entityLabel}...`}
 				rows={4}
 				className="resize-none"
 			/>
@@ -198,7 +204,7 @@ function AddCommentForm({ targetEvent, parentComment, onCancel }: AddCommentProp
 	)
 }
 
-export function Comments({ targetEvent }: CommentsProps) {
+export function Comments({ targetEvent, entityLabel = 'product', testId = 'product-comments' }: CommentsProps) {
 	const { isAuthenticated } = useStore(authStore)
 	const { data: comments, isLoading, error } = useComments(targetEvent)
 	const [showAll, setShowAll] = useState(false)
@@ -212,7 +218,7 @@ export function Comments({ targetEvent }: CommentsProps) {
 		<div className="space-y-6" id="comments-section">
 			{/* Add Comment Form - only show for authenticated users */}
 			{isAuthenticated ? (
-				<AddCommentForm targetEvent={targetEvent} />
+				<AddCommentForm targetEvent={targetEvent} entityLabel={entityLabel} />
 			) : (
 				<div className="bg-gray-50 p-4 rounded-lg text-center">
 					<p className="text-gray-600">Please log in to leave a comment.</p>
@@ -220,7 +226,7 @@ export function Comments({ targetEvent }: CommentsProps) {
 			)}
 
 			{/* Comments List */}
-			<div data-testid="product-comments">
+			<div data-testid={testId}>
 				{isLoading && <p className="text-gray-500 text-center py-4">Loading comments...</p>}
 
 				{error && <p className="text-red-600 text-center py-4">Failed to load comments</p>}
@@ -234,7 +240,13 @@ export function Comments({ targetEvent }: CommentsProps) {
 
 				{displayedComments && displayedComments.length > 0 && (
 					<div>
-						<CommentThread comments={displayedComments} eventRoot={targetEvent} setReplyingTo={setReplyingTo} replyingTo={replyingTo} />
+						<CommentThread
+							comments={displayedComments}
+							eventRoot={targetEvent}
+							setReplyingTo={setReplyingTo}
+							replyingTo={replyingTo}
+							entityLabel={entityLabel}
+						/>
 
 						{hasMoreComments && !showAll && (
 							<Button

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -1,6 +1,7 @@
 import { AuctionCard } from '@/components/AuctionCard'
 import { AuctionClaimDialog } from '@/components/AuctionClaimDialog'
 import { AuctionCountdown, useAuctionCountdown } from '@/components/AuctionCountdown'
+import { Comments } from '@/components/Comments'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Badge } from '@/components/ui/badge'
 import { ImageCarousel } from '@/components/ImageCarousel'
@@ -455,6 +456,12 @@ function AuctionDetailRoute() {
 							Bids
 						</TabsTrigger>
 						<TabsTrigger
+							value="comments"
+							className="rounded-none px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black"
+						>
+							Comments
+						</TabsTrigger>
+						<TabsTrigger
 							value="seller"
 							className="rounded-none px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black"
 						>
@@ -724,6 +731,12 @@ function AuctionDetailRoute() {
 									})}
 								</div>
 							)}
+						</div>
+					</TabsContent>
+
+					<TabsContent value="comments" className="mt-4 border-t-3 border-secondary bg-tertiary">
+						<div className="rounded-lg bg-white p-6 shadow-md">
+							<Comments targetEvent={auction} entityLabel="auction" testId="auction-comments" />
 						</div>
 					</TabsContent>
 


### PR DESCRIPTION
## Summary
Adds a Comments tab to the auction detail page using the existing NIP-22 comments component.

## Scope
- Adds auction comments UI to `/auctions/$auctionId`
- Makes the shared `Comments` component label/test-id aware
- Preserves existing product comments defaults
- Fixes an existing React key warning in `CommentThread` by keying the mapped fragment

## Not included
- No auction header changes
- No auction form changes
- No NIP-53 live feed
- No bid rendering changes
- No settlement/refund/Cashu/path-oracle changes
- No auction event semantics changes
- No comments query/publish protocol changes

## Test plan
- `bunx prettier --check src/components/Comments.tsx 'src/routes/auctions.$auctionId.tsx'` ✅
- `git diff --check` ✅
- `bun run test:unit` ✅ — 175 tests passed
- Local smoke test ✅
  - Auction detail shows Comments tab between Bids and Seller
  - Auction placeholder says “Share your thoughts about this auction...”
  - Auction comment renders under `auction-comments`
  - Product comments still use product copy and `product-comments`
  - React key warning resolved
- `bun run format:check` ⚠️ fails on existing out-of-scope `src/server/runtime.ts` formatting issue

## Screenshots

- <img width="1626" height="976" alt="Screenshot 2026-06-03 161038" src="https://github.com/user-attachments/assets/f2b59f15-0517-45f1-9a90-ec6f73779633" />

- <img width="1626" height="976" alt="Screenshot 2026-06-03 164909" src="https://github.com/user-attachments/assets/e01551c8-d620-4d0b-81d9-835f00b099dc" />


Closes #978
Part of #881
