### PR TITLE
feat(wallet) : wallet sheet slider

### DIFF
--- a/src/components/SheetRegistry.tsx
+++ b/src/components/SheetRegistry.tsx
@@ -1,4 +1,5 @@
 import CartSheetContent from '@/components/sheet-contents/CartSheetContent'
+import WalletSheetContent from '@/components/sheet-contents/WalletSheetContent'
 import { NewProductContent } from '@/components/sheet-contents/NewProductContent'
 import { NewCollectionContent } from '@/components/sheet-contents/NewCollectionContent'
 import { ConversationSheetContent } from '@/components/sheet-contents/ConversationSheetContent'
@@ -11,6 +12,7 @@ export function SheetRegistry() {
 	const { drawers, conversationPubkey } = useStore(uiStore)
 
 	const activeDrawer = useMemo(() => {
+		if (drawers.wallet) return 'wallet'
 		if (drawers.cart) return 'cart'
 		if (drawers.createProduct) return 'createProduct'
 		if (drawers.createCollection) return 'createCollection'
@@ -45,6 +47,10 @@ export function SheetRegistry() {
 	if (!activeDrawer) return null
 
 	const sheetConfig = {
+		wallet: {
+			side: 'right' as const,
+			content: <WalletSheetContent />,
+		},
 		cart: {
 			side: 'right' as const,
 			content: <CartSheetContent title="Your Cart" description="Review and manage your cart items" />,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,9 +2,7 @@ import { CurrencyDropdown } from '@/components/CurrencyDropdown'
 import { MobileMenu } from '@/components/layout/MobileMenu'
 import { ProductSearch } from '@/components/ProductSearch'
 import { Button } from '@/components/ui/button'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Nip60Wallet } from '@/feature/wallet/components/Nip60Wallet'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { authActions, authStore } from '@/lib/stores/auth'
 import { notificationStore } from '@/lib/stores/notifications'
@@ -147,21 +145,14 @@ const DashboardButton = forwardRef<HTMLButtonElement, DashboardButtonProps>((pro
 
 function WalletButton() {
 	return (
-		<Popover>
-			<PopoverTrigger asChild>
-				<TooltipButton
-					tooltip="Wallet"
-					className="relative p-2 btn-border-highlight w-11 h-10 hover:[&>svg]:text-secondary"
-					data-testid="wallet-button"
-				>
-					<Wallet className="size-4" />
-				</TooltipButton>
-			</PopoverTrigger>
-
-			<PopoverContent className="bg-primary rounded-lg w-[calc(100vw-2rem)] md:w-96" align="end">
-				<Nip60Wallet />
-			</PopoverContent>
-		</Popover>
+		<TooltipButton
+			tooltip="Wallet"
+			className="relative p-2 btn-border-highlight w-11 h-10 hover:[&>svg]:text-secondary"
+			data-testid="wallet-button"
+			onClick={() => uiActions.openWalletPage('wallet')}
+		>
+			<Wallet className="size-4" />
+		</TooltipButton>
 	)
 }
 

--- a/src/components/sheet-contents/WalletSheetContent.tsx
+++ b/src/components/sheet-contents/WalletSheetContent.tsx
@@ -1,0 +1,653 @@
+import { useEffect, useState } from 'react'
+import { SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Nip60Wallet } from '@/feature/wallet/components/Nip60Wallet'
+import { Button } from '@/components/ui/button'
+import { useStore } from '@tanstack/react-store'
+import { uiStore } from '@/lib/stores/ui'
+import { nip60Store, nip60Actions } from '@/lib/stores/nip60'
+import { cashuStore, cashuActions } from '@/lib/stores/cashu'
+import { toast } from 'sonner'
+import { QRCodeSVG } from 'qrcode.react'
+import { Loader2, Check, Copy, Zap, QrCode, Send, ScanLine, ArrowLeft } from 'lucide-react'
+import { Scanner } from '@yudiel/react-qr-scanner'
+
+type WalletPage = 'wallet' | 'manageMints' | 'proofs' | 'deposit' | 'withdraw' | 'send' | 'receive'
+
+const PAGE_TITLES: Record<WalletPage, string> = {
+	wallet: 'Wallet',
+	deposit: 'Deposit Lightning',
+	withdraw: 'Withdraw to Lightning',
+	send: 'Send eCash',
+	receive: 'Receive eCash',
+	manageMints: 'Manage Mints',
+	proofs: 'Proofs',
+}
+
+const walletSheetClassName =
+	'flex h-dvh max-h-dvh w-[100vw] flex-col gap-0 overflow-hidden p-0 sm:w-[85vw] sm:max-w-none md:w-[55vw] xl:w-[35vw]'
+
+export default function WalletSheetContent() {
+	const [page, setPage] = useState<WalletPage>('wallet')
+	const walletPage = useStore(uiStore, (state) => state.walletPage)
+
+	const { mints, depositInvoice, depositStatus, balance: nip60Balance, mintBalances } = useStore(nip60Store)
+	const { status: cashuStatus, balances: cashuBalances } = useStore(cashuStore)
+
+	const [amount, setAmount] = useState('')
+	const [selectedMint, setSelectedMint] = useState('')
+	const [isGenerating, setIsGenerating] = useState(false)
+	const [copied, setCopied] = useState(false)
+	const [view, setView] = useState<'form' | 'token'>('form')
+	const [generatedToken, setGeneratedToken] = useState<string | null>(null)
+	const [isWithdrawing, setIsWithdrawing] = useState(false)
+	const [isSuccess, setIsSuccess] = useState(false)
+	const [showScanner, setShowScanner] = useState(false)
+	const [error, setError] = useState<string | null>(null)
+
+	useEffect(() => {
+		if (walletPage) {
+			if (walletPage === 'mints' || walletPage === 'manageMints') setPage('manageMints')
+			else if (walletPage === 'proofs') setPage('proofs')
+			else if (walletPage === 'deposit') setPage('deposit')
+			else if (walletPage === 'withdraw') setPage('withdraw')
+			else if (walletPage === 'send') setPage('send')
+			else if (walletPage === 'receive') setPage('receive')
+			else setPage('wallet')
+		}
+	}, [walletPage])
+
+	const goBack = () => setPage('wallet')
+
+	return (
+		<SheetContent side="right" className={walletSheetClassName}>
+			<SheetHeader className="shrink-0 pr-12">
+				<div className="flex items-center gap-2">
+					{page !== 'wallet' && (
+						<Button variant="ghost" size="icon" className="-ml-1 shrink-0" onClick={goBack}>
+							<ArrowLeft className="w-4 h-4" />
+						</Button>
+					)}
+					<div className="flex-1 min-w-0">
+						<SheetTitle className="text-xl">{PAGE_TITLES[page]}</SheetTitle>
+						<SheetDescription className="hidden">Manage your Cashu wallet</SheetDescription>
+					</div>
+				</div>
+			</SheetHeader>
+
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+				{page === 'wallet' ? (
+					<div className="flex-1 overflow-y-auto flex flex-col">
+						<div className="my-auto pt-1 pb-8 px-4 w-full">
+							<Nip60Wallet />
+						</div>
+					</div>
+				) : (
+					<ScrollArea className="flex-1">
+						<div className="mx-auto max-w-lg p-4">
+							{page === 'deposit' && (
+								<div className="space-y-4">
+									<div>
+										<p className="text-sm text-muted-foreground">Generate a Lightning invoice to mint eCash</p>
+									</div>
+
+									{depositStatus === 'success' ? (
+										<div className="py-6 text-center">
+											<div className="w-12 h-12 mx-auto mb-4 rounded-full bg-green-100 flex items-center justify-center">
+												<Check className="w-6 h-6 text-green-600" />
+											</div>
+											<p className="text-lg font-medium text-green-600">Deposit Successful!</p>
+											<p className="text-sm text-muted-foreground mt-2">Your eCash has been minted</p>
+											<div className="flex justify-end mt-4">
+												<Button onClick={goBack}>Done</Button>
+											</div>
+										</div>
+									) : depositInvoice ? (
+										<div className="space-y-4">
+											<div className="flex justify-center">
+												<div className="p-4 bg-white rounded-lg">
+													<QRCodeSVG value={depositInvoice} size={200} />
+												</div>
+											</div>
+											<div className="space-y-2">
+												<p className="text-sm font-medium">Lightning Invoice</p>
+												<div className="flex gap-2">
+													<input
+														type="text"
+														value={depositInvoice}
+														readOnly
+														className="flex-1 px-3 py-2 text-sm bg-muted rounded-md font-mono truncate"
+													/>
+													<Button
+														variant="outline"
+														size="icon"
+														onClick={async () => {
+															try {
+																await navigator.clipboard.writeText(depositInvoice)
+																setCopied(true)
+																toast.success('Invoice copied to clipboard')
+																setTimeout(() => setCopied(false), 2000)
+															} catch {
+																toast.error('Failed to copy invoice')
+															}
+														}}
+													>
+														{copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+													</Button>
+												</div>
+											</div>
+											<p className="text-sm text-muted-foreground text-center">Waiting for payment...</p>
+											<div className="flex justify-center">
+												<Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+											</div>
+											<div className="flex justify-end gap-2">
+												<Button
+													variant="outline"
+													onClick={() => {
+														nip60Actions.cancelDeposit()
+														goBack()
+													}}
+												>
+													Cancel
+												</Button>
+											</div>
+										</div>
+									) : (
+										<div className="space-y-4">
+											<div className="space-y-2">
+												<label className="text-sm font-medium">Amount (sats)</label>
+												<input
+													type="number"
+													value={amount}
+													onChange={(e) => setAmount(e.target.value)}
+													placeholder="Enter amount in sats"
+													className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+													min="1"
+												/>
+											</div>
+											<div className="space-y-2">
+												<label className="text-sm font-medium">Mint</label>
+												<select
+													value={selectedMint}
+													onChange={(e) => setSelectedMint(e.target.value)}
+													className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+												>
+													{mints.map((mint) => (
+														<option key={mint} value={mint}>
+															{new URL(mint).hostname}
+														</option>
+													))}
+												</select>
+											</div>
+											{depositStatus === 'error' && (
+												<p className="text-sm text-destructive">Failed to generate invoice. Please try again.</p>
+											)}
+											<div className="flex justify-end gap-2">
+												<Button variant="outline" onClick={goBack}>
+													Cancel
+												</Button>
+												<Button
+													onClick={async () => {
+														const amountNum = parseInt(amount, 10)
+														if (isNaN(amountNum) || amountNum <= 0) {
+															toast.error('Please enter a valid amount')
+															return
+														}
+														if (!selectedMint) {
+															toast.error('Please select a mint')
+															return
+														}
+														setIsGenerating(true)
+														try {
+															await nip60Actions.startDeposit(amountNum, selectedMint)
+														} finally {
+															setIsGenerating(false)
+														}
+													}}
+													disabled={isGenerating || !amount || !selectedMint}
+												>
+													{isGenerating ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Zap className="w-4 h-4 mr-2" />}
+													Generate Invoice
+												</Button>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							{page === 'withdraw' && (
+								<div className="space-y-4">
+									<div>
+										<p className="text-sm text-muted-foreground">
+											Pay a Lightning invoice using your eCash (Balance: {nip60Balance.toLocaleString()} sats)
+										</p>
+									</div>
+
+									{isSuccess ? (
+										<div className="py-6 text-center">
+											<div className="w-12 h-12 mx-auto mb-4 rounded-full bg-green-100 flex items-center justify-center">
+												<Check className="w-6 h-6 text-green-600" />
+											</div>
+											<p className="text-lg font-medium text-green-600">Withdrawal Successful!</p>
+											<p className="text-sm text-muted-foreground mt-2">Your Lightning invoice has been paid</p>
+											<div className="flex justify-end mt-4">
+												<Button onClick={goBack}>Done</Button>
+											</div>
+										</div>
+									) : showScanner ? (
+										<div className="space-y-4">
+											<div className="relative w-full aspect-square overflow-hidden rounded-lg">
+												<Scanner
+													onScan={(codes) => {
+														if (codes && codes.length > 0) {
+															const result = codes[0].rawValue
+															const clean = result.replace(/^lightning:/i, '').trim()
+															setAmount(clean)
+															setShowScanner(false)
+															toast.success('Invoice scanned')
+														}
+													}}
+													onError={() => toast.error('Camera error')}
+													constraints={{ facingMode: 'environment' }}
+												/>
+											</div>
+											<div className="flex justify-end">
+												<Button variant="outline" onClick={() => setShowScanner(false)}>
+													Cancel
+												</Button>
+											</div>
+										</div>
+									) : (
+										<div className="space-y-4">
+											<div className="space-y-2">
+												<label className="text-sm font-medium">From Mint</label>
+												<select
+													value={selectedMint}
+													onChange={(e) => setSelectedMint(e.target.value)}
+													className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+												>
+													{mints
+														.filter((mint) => (mintBalances[mint] ?? 0) > 0)
+														.map((mint) => (
+															<option key={mint} value={mint}>
+																{new URL(mint).hostname} ({(mintBalances[mint] ?? 0).toLocaleString()} sats)
+															</option>
+														))}
+												</select>
+											</div>
+
+											<div className="space-y-2">
+												<label className="text-sm font-medium">Lightning Invoice</label>
+												<textarea
+													value={amount}
+													onChange={(e) => setAmount(e.target.value)}
+													placeholder="lnbc..."
+													className="flex-1 w-full px-3 py-2 text-sm border rounded-md bg-background font-mono resize-none h-24"
+												/>
+												<div className="flex justify-end">
+													<Button variant="ghost" size="sm" onClick={() => setShowScanner(true)} className="gap-2">
+														<ScanLine className="w-4 h-4" />
+														Scan QR
+													</Button>
+												</div>
+											</div>
+
+											{cashuStatus === 'initializing' && (
+												<p className="text-sm text-muted-foreground flex items-center gap-2">
+													<Loader2 className="w-4 h-4 animate-spin" />
+													Initializing wallet...
+												</p>
+											)}
+											{error && <p className="text-sm text-destructive">{error}</p>}
+
+											<div className="flex justify-end gap-2">
+												<Button variant="outline" onClick={goBack}>
+													Cancel
+												</Button>
+												<Button
+													onClick={async () => {
+														if (!amount.trim()) {
+															toast.error('Please enter a Lightning invoice')
+															return
+														}
+														const normalized = amount.toLowerCase().trim()
+														if (!normalized.startsWith('lnbc') && !normalized.startsWith('lightning:')) {
+															toast.error('Invalid Lightning invoice format')
+															return
+														}
+														if (!selectedMint) {
+															toast.error('Please select a mint')
+															return
+														}
+														setIsWithdrawing(true)
+														setError(null)
+														try {
+															const cashuMintBalance = cashuBalances[selectedMint] ?? 0
+															const useCoco = cashuStatus === 'ready' && cashuMintBalance > 0
+															const cleanInvoice = amount.replace(/^lightning:/i, '').trim()
+															if (useCoco) {
+																await cashuActions.melt(selectedMint, cleanInvoice)
+															} else {
+																await nip60Actions.withdrawLightning(cleanInvoice)
+															}
+															setIsSuccess(true)
+															toast.success('Withdrawal successful!')
+														} catch (err) {
+															const message = err instanceof Error ? err.message : 'Withdrawal failed'
+															setError(message)
+															toast.error(message)
+														} finally {
+															setIsWithdrawing(false)
+														}
+													}}
+													disabled={isWithdrawing || !amount.trim() || !selectedMint || cashuStatus === 'initializing'}
+												>
+													{isWithdrawing ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+													Withdraw
+												</Button>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							{page === 'receive' && (
+								<div className="space-y-4">
+									<div>
+										<p className="text-sm text-muted-foreground">Scan or paste a Cashu token to receive eCash</p>
+									</div>
+
+									{isSuccess ? (
+										<div className="py-6 text-center">
+											<div className="w-12 h-12 mx-auto mb-4 rounded-full bg-green-100 flex items-center justify-center">
+												<Check className="w-6 h-6 text-green-600" />
+											</div>
+											<p className="text-lg font-medium text-green-600">eCash Received!</p>
+											<p className="text-sm text-muted-foreground mt-2">The tokens have been added to your wallet</p>
+											<div className="flex justify-end mt-4">
+												<Button onClick={goBack}>Done</Button>
+											</div>
+										</div>
+									) : showScanner ? (
+										<div className="space-y-4">
+											<div className="relative w-full aspect-square overflow-hidden rounded-lg">
+												<Scanner
+													onScan={(codes) => {
+														if (codes && codes.length > 0) {
+															const result = codes[0].rawValue
+															if (result && (result.startsWith('cashuA') || result.startsWith('cashuB'))) {
+																setGeneratedToken(result)
+																setShowScanner(false)
+																toast.success('Token scanned')
+															} else if (result) {
+																toast.error('Invalid Cashu token')
+															}
+														}
+													}}
+													onError={() => toast.error('Camera error')}
+													constraints={{ facingMode: 'environment' }}
+												/>
+											</div>
+											<div className="flex justify-end">
+												<Button variant="outline" onClick={() => setShowScanner(false)}>
+													Cancel
+												</Button>
+											</div>
+										</div>
+									) : (
+										<div className="space-y-4">
+											<div className="space-y-2">
+												<label className="text-sm font-medium">Cashu Token</label>
+												<textarea
+													value={generatedToken ?? ''}
+													onChange={(e) => setGeneratedToken(e.target.value)}
+													placeholder="cashuA..."
+													className="w-full px-3 py-2 text-sm border rounded-md bg-background font-mono resize-none h-24"
+												/>
+												<div className="flex justify-end">
+													<Button variant="ghost" size="sm" onClick={() => setShowScanner(true)} className="gap-2">
+														<ScanLine className="w-4 h-4" />
+														Scan QR
+													</Button>
+												</div>
+											</div>
+											{cashuStatus === 'initializing' && (
+												<p className="text-sm text-muted-foreground flex items-center gap-2">
+													<Loader2 className="w-4 h-4 animate-spin" />
+													Initializing wallet...
+												</p>
+											)}
+											{error && <p className="text-sm text-destructive">{error}</p>}
+											<div className="flex justify-end gap-2">
+												<Button variant="outline" onClick={goBack}>
+													Cancel
+												</Button>
+												<Button
+													onClick={async () => {
+														if (!generatedToken || !generatedToken.trim()) {
+															toast.error('Please enter a Cashu token')
+															return
+														}
+														const normalizedToken = generatedToken.trim()
+														if (!normalizedToken.startsWith('cashuA') && !normalizedToken.startsWith('cashuB')) {
+															toast.error('Invalid Cashu token format')
+															return
+														}
+														setIsGenerating(true)
+														setError(null)
+														try {
+															await nip60Actions.receiveEcash(normalizedToken)
+															setIsSuccess(true)
+															toast.success('eCash received successfully!')
+														} catch (err) {
+															const message = err instanceof Error ? err.message : 'Failed to receive eCash'
+															setError(message)
+															toast.error(message)
+														} finally {
+															setIsGenerating(false)
+														}
+													}}
+													disabled={isGenerating || cashuStatus === 'initializing'}
+												>
+													{isGenerating ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <QrCode className="w-4 h-4 mr-2" />}
+													Receive
+												</Button>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							{page === 'send' && (
+								<div className="space-y-4">
+									<div>
+										<p className="text-sm text-muted-foreground">
+											Generate a Cashu token to send eCash (Balance: {nip60Balance.toLocaleString()} sats)
+										</p>
+									</div>
+
+									{view === 'token' && generatedToken ? (
+										<div className="space-y-4">
+											<div className="flex justify-center">
+												<div className="p-4 bg-white rounded-lg">
+													<QRCodeSVG value={generatedToken} size={200} />
+												</div>
+											</div>
+											<div className="space-y-2">
+												<p className="text-sm font-medium">Cashu Token</p>
+												<textarea
+													value={generatedToken}
+													readOnly
+													className="flex-1 w-full px-3 py-2 text-sm bg-muted rounded-md font-mono resize-none h-24"
+												/>
+												<div className="flex justify-end">
+													<Button
+														variant="outline"
+														size="sm"
+														onClick={async () => {
+															try {
+																await navigator.clipboard.writeText(generatedToken as string)
+																setCopied(true)
+																toast.success('Token copied to clipboard')
+																setTimeout(() => setCopied(false), 2000)
+															} catch {
+																toast.error('Failed to copy token')
+															}
+														}}
+														className="gap-2"
+													>
+														{copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+														{copied ? 'Copied!' : 'Copy Token'}
+													</Button>
+												</div>
+											</div>
+											<p className="text-sm text-muted-foreground text-center">
+												Share this token with the recipient. It can only be redeemed once.
+											</p>
+											<p className="text-xs text-muted-foreground text-center">
+												Token saved to pending list. You can reclaim it if the recipient doesn't claim it.
+											</p>
+											<div className="flex justify-end gap-2">
+												<Button
+													variant="outline"
+													onClick={() => {
+														setView('form')
+														setGeneratedToken(null)
+													}}
+												>
+													Send Another
+												</Button>
+												<Button onClick={goBack}>Done</Button>
+											</div>
+										</div>
+									) : (
+										<div className="space-y-4">
+											<div className="space-y-2">
+												<label className="text-sm font-medium">Amount (sats)</label>
+												<input
+													type="number"
+													value={amount}
+													onChange={(e) => setAmount(e.target.value)}
+													placeholder="Enter amount in sats"
+													className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+													min="1"
+													max={nip60Balance}
+												/>
+											</div>
+											{mints.filter((mint) => (mintBalances[mint] ?? 0) > 0).length > 0 && (
+												<div className="space-y-2">
+													<label className="text-sm font-medium">From Mint</label>
+													<select
+														value={selectedMint}
+														onChange={(e) => setSelectedMint(e.target.value)}
+														className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+													>
+														{mints
+															.filter((mint) => (mintBalances[mint] ?? 0) > 0)
+															.map((mint) => (
+																<option key={mint} value={mint}>
+																	{new URL(mint).hostname} ({(mintBalances[mint] ?? 0).toLocaleString()} sats)
+																</option>
+															))}
+													</select>
+												</div>
+											)}
+											{cashuStatus === 'initializing' && (
+												<p className="text-sm text-muted-foreground flex items-center gap-2">
+													<Loader2 className="w-4 h-4 animate-spin" />
+													Initializing wallet...
+												</p>
+											)}
+											{error && <p className="text-sm text-destructive">{error}</p>}
+											<div className="flex justify-end gap-2">
+												<Button variant="outline" onClick={goBack}>
+													Cancel
+												</Button>
+												<Button
+													onClick={async () => {
+														const amountNum = parseInt(amount, 10)
+														if (isNaN(amountNum) || amountNum <= 0) {
+															toast.error('Please enter a valid amount')
+															return
+														}
+														const mintBalance = selectedMint ? (mintBalances[selectedMint] ?? 0) : nip60Balance
+														if (amountNum > mintBalance) {
+															toast.error('Insufficient balance')
+															return
+														}
+														setIsGenerating(true)
+														setError(null)
+														try {
+															const cashuMintBalance = cashuBalances[selectedMint] ?? 0
+															const useCoco = cashuStatus === 'ready' && selectedMint && cashuMintBalance >= amountNum
+															let token: string | null = null
+															if (useCoco) {
+																token = await cashuActions.send(selectedMint, amountNum)
+															} else {
+																token = await nip60Actions.sendEcash(amountNum, selectedMint || undefined)
+															}
+															if (token) {
+																setGeneratedToken(token)
+																setView('token')
+																toast.success('eCash token generated!')
+															} else {
+																throw new Error('Failed to generate token')
+															}
+														} catch (err) {
+															const message = err instanceof Error ? err.message : 'Failed to generate eCash token'
+															setError(message)
+															toast.error(message)
+														} finally {
+															setIsGenerating(false)
+														}
+													}}
+													disabled={isGenerating || !amount || !selectedMint || cashuStatus === 'initializing'}
+												>
+													{isGenerating ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : <Send className="w-4 h-4 mr-2" />}
+													Generate Token
+												</Button>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							{page === 'manageMints' && (
+								<div className="space-y-4">
+									<p className="text-sm text-muted-foreground">Add, remove, and configure Cashu mints for your wallet.</p>
+									<div className="space-y-3">
+										{mints.length === 0 ? (
+											<p className="text-sm text-muted-foreground">No mints configured.</p>
+										) : (
+											mints.map((mint) => (
+												<div key={mint} className="flex items-center justify-between gap-2 rounded-lg border p-3 text-sm">
+													<div className="min-w-0">
+														<p className="font-medium truncate">{new URL(mint).hostname}</p>
+														<p className="text-xs text-muted-foreground truncate">{mint}</p>
+														{mintBalances[mint] !== undefined && (
+															<p className="text-xs text-muted-foreground mt-0.5">{mintBalances[mint].toLocaleString()} sats</p>
+														)}
+													</div>
+												</div>
+											))
+										)}
+									</div>
+									<p className="text-xs text-muted-foreground">Use the Wallet tab to add or remove mints.</p>
+								</div>
+							)}
+
+							{page === 'proofs' && (
+								<div className="space-y-4">
+									<p className="text-sm text-muted-foreground">Raw Cashu proofs stored in your wallet.</p>
+									<p className="text-xs text-muted-foreground">
+										Expand the Proofs section in the Wallet tab to view and manage individual proofs.
+									</p>
+								</div>
+							)}
+						</div>
+					</ScrollArea>
+				)}
+			</div>
+		</SheetContent>
+	)
+}

--- a/src/feature/wallet/components/DepositLightningModal.tsx
+++ b/src/feature/wallet/components/DepositLightningModal.tsx
@@ -19,12 +19,15 @@ export function DepositLightningModal({ open, onClose }: DepositLightningModalPr
 	const [isGenerating, setIsGenerating] = useState(false)
 	const [copied, setCopied] = useState(false)
 
-	// Sync selectedMint with defaultMint when modal opens or defaultMint changes
+	// Reset state when modal opens
 	useEffect(() => {
 		if (open) {
 			setSelectedMint(defaultMint ?? mints[0] ?? '')
+			setAmount('')
+			setCopied(false)
+			nip60Actions.cancelDeposit()
 		}
-	}, [open, defaultMint, mints])
+	}, [open])
 
 	const handleGenerateInvoice = async () => {
 		const amountNum = parseInt(amount, 10)

--- a/src/feature/wallet/components/Nip60Wallet.tsx
+++ b/src/feature/wallet/components/Nip60Wallet.tsx
@@ -185,17 +185,17 @@ export function Nip60Wallet() {
 
 	// Button appearance class definitions
 
-	const classNameGhost = 'hover:bg-white/10 text-gray-400 hover:text-white'
-	const classNameSubtle = 'bg-white/5 hover:bg-white/10 text-gray-400 hover:text-white'
-	const classNameMuted = 'bg-white/10 hover:bg-white/20 text-white'
-	const classNameActive = 'bg-white/20 text-white'
+	const classNameGhost = 'hover:bg-accent text-muted-foreground hover:text-foreground'
+	const classNameSubtle = 'bg-accent/50 hover:bg-accent text-muted-foreground hover:text-foreground'
+	const classNameMuted = 'bg-accent hover:bg-accent/80 text-foreground'
+	const classNameActive = 'bg-accent text-foreground font-medium'
 	const classNameSuccess = 'bg-green-600 hover:bg-green-700 text-white'
 	const classNameWarning = 'bg-orange-600 hover:bg-orange-700 text-white'
-	const classNameDestructive = 'bg-transparent hover:bg-red-500/20 text-red-400 hover:text-red-300'
+	const classNameDestructive = 'bg-transparent hover:bg-red-50 text-red-500 hover:text-red-600'
 
 	if (!isAuthenticated) {
 		return (
-			<div className="bg-primary p-4 rounded-lg text-gray-400 text-center">
+			<div className="p-6 text-muted-foreground text-center flex items-center justify-center min-h-[200px]">
 				<p>Please log in to view your wallet</p>
 			</div>
 		)
@@ -203,15 +203,15 @@ export function Nip60Wallet() {
 
 	if (status === 'idle' || status === 'initializing') {
 		return (
-			<div className="flex justify-center items-center bg-primary p-4 rounded-lg">
-				<Loader2 className="w-6 h-6 text-gray-400 animate-spin" />
+			<div className="flex items-center justify-center p-6 min-h-[200px]">
+				<Loader2 className="w-6 h-6 text-muted-foreground animate-spin" />
 			</div>
 		)
 	}
 
 	if (status === 'error') {
 		return (
-			<div className="bg-primary p-4 rounded-lg text-red-400 text-center">
+			<div className="p-6 text-destructive text-center flex items-center justify-center min-h-[200px]">
 				<p>{error}</p>
 			</div>
 		)
@@ -219,8 +219,8 @@ export function Nip60Wallet() {
 
 	if (status === 'no_wallet') {
 		return (
-			<div className="bg-primary p-4 rounded-lg w-80 text-center">
-				<p className="mb-4 text-gray-400">No Cashu wallet found</p>
+			<div className="p-6 text-center flex flex-col items-center justify-center min-h-[200px] gap-4">
+				<p className="text-muted-foreground">No Cashu wallet found</p>
 				<Button onClick={handleCreateWallet} disabled={isCreating} variant="secondary">
 					{isCreating ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
 					Create Wallet
@@ -230,15 +230,15 @@ export function Nip60Wallet() {
 	}
 
 	return (
-		<div className="bg-primary p-4 rounded-lg max-w-full overflow-hidden text-white">
+		<div className="w-full overflow-hidden p-4">
 			<div className="relative mb-4 text-center">
 				<div className="top-0 right-0 absolute flex gap-1">
 					<Button className={classNameGhost} size="icon" onClick={handleRefresh} disabled={isRefreshing} title="Refresh & sync wallet">
 						<RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
 					</Button>
 				</div>
-				<p className="mb-1 text-gray-400 text-sm">Balance</p>
-				<p className="font-bold text-white text-2xl">{balance.toLocaleString()} sats</p>
+				<p className="mb-1 text-muted-foreground text-base font-medium">Balance</p>
+				<p className="font-bold text-foreground text-5xl">{balance.toLocaleString()} sats</p>
 			</div>
 
 			{/* Action Buttons */}
@@ -263,17 +263,17 @@ export function Nip60Wallet() {
 
 			{/* Default Mint Selector */}
 			<div className="mb-2 pt-2 overflow-hidden">
-				<p className="mb-2 font-medium text-gray-300 text-sm">Default Mint</p>
+				<p className="mb-2 font-medium text-foreground text-sm">Default Mint</p>
 				{mints.length > 0 ? (
 					<Select value={defaultMint ?? ''} onValueChange={(value) => nip60Actions.setDefaultMint(value || null)}>
-						<SelectTrigger className="bg-white/10 hover:bg-white/15 border-white/20 w-full text-white">
+						<SelectTrigger className="w-full">
 							<SelectValue placeholder="Select a default mint">
 								{defaultMint ? (
 									<span className="flex items-center gap-2 truncate">
 										<Star className="fill-current w-4 h-4 text-yellow-500 shrink-0" />
 										<span className="truncate">{getMintHostname(defaultMint)}</span>
 										{mintBalances[defaultMint] !== undefined && (
-											<span className="text-gray-400 shrink-0">({mintBalances[defaultMint].toLocaleString()})</span>
+											<span className="text-muted-foreground shrink-0">({mintBalances[defaultMint].toLocaleString()})</span>
 										)}
 									</span>
 								) : (
@@ -281,14 +281,14 @@ export function Nip60Wallet() {
 								)}
 							</SelectValue>
 						</SelectTrigger>
-						<SelectContent className="bg-primary border-white/20 max-w-[calc(100vw-2rem)]">
+						<SelectContent className="max-w-[calc(100vw-2rem)]">
 							{mints.map((mint) => (
-								<SelectItem key={mint} value={mint} className="hover:bg-white/10 focus:bg-white/10 text-white focus:text-white">
+								<SelectItem key={mint} value={mint}>
 									<div className="flex items-center gap-2">
 										<Landmark className="w-4 h-4 shrink-0" />
 										<span className="truncate">{getMintHostname(mint)}</span>
 										{mintBalances[mint] !== undefined && (
-											<span className="text-gray-400 shrink-0">({mintBalances[mint].toLocaleString()})</span>
+											<span className="text-muted-foreground shrink-0">({mintBalances[mint].toLocaleString()})</span>
 										)}
 									</div>
 								</SelectItem>
@@ -296,7 +296,7 @@ export function Nip60Wallet() {
 						</SelectContent>
 					</Select>
 				) : (
-					<p className="text-gray-400 text-sm">No mints configured</p>
+					<p className="text-muted-foreground text-sm">No mints configured</p>
 				)}
 			</div>
 
@@ -346,14 +346,16 @@ export function Nip60Wallet() {
 
 				{/* Content panels */}
 				{openSection === 'mints' && (
-					<div className="space-y-2 pt-2 border-white/10 border-t overflow-hidden">
+					<div className="space-y-2 pt-2 border-t overflow-hidden">
 						{mints.map((mint) => (
 							<div key={mint} className="flex justify-between items-center gap-2 text-sm">
-								<span className="min-w-0 text-gray-300 truncate" title={mint}>
+								<span className="min-w-0 text-foreground truncate" title={mint}>
 									{getMintHostname(mint)}
 								</span>
 								<div className="flex items-center gap-1 shrink-0">
-									{mintBalances[mint] !== undefined && <span className="text-gray-400 text-xs">{mintBalances[mint].toLocaleString()}</span>}
+									{mintBalances[mint] !== undefined && (
+										<span className="text-muted-foreground text-xs">{mintBalances[mint].toLocaleString()}</span>
+									)}
 									<Button className={cn(classNameGhost, 'w-6 h-6')} size="icon" onClick={() => handleRemoveMint(mint)} title="Remove mint">
 										<X className="w-3 h-3" />
 									</Button>
@@ -367,7 +369,7 @@ export function Nip60Wallet() {
 								onChange={(e) => setNewMintUrl(e.target.value)}
 								onKeyDown={(e) => e.key === 'Enter' && handleAddMint()}
 								placeholder="https://mint.example.com"
-								className="flex-1 bg-white/10 border-white/20 min-w-0 h-8 text-white placeholder:text-gray-500 text-sm"
+								className="flex-1 min-w-0 h-8 text-sm"
 							/>
 							<Button className={cn(classNameMuted, 'px-2 h-8 shrink-0')} size="sm" onClick={handleAddMint} disabled={!newMintUrl.trim()}>
 								<Plus className="w-4 h-4" />
@@ -381,9 +383,9 @@ export function Nip60Wallet() {
 				)}
 
 				{openSection === 'transactions' && (
-					<div className="pt-2 border-white/10 border-t overflow-hidden">
+					<div className="pt-2 border-t overflow-hidden">
 						{transactions.length > 0 ? (
-							<div className="space-y-2 max-h-48 overflow-y-auto">
+							<div className="space-y-2">
 								{transactions.map((tx) => (
 									<div key={tx.id} className="flex justify-between items-center gap-2 text-sm">
 										<div className="flex items-center gap-2 min-w-0">
@@ -392,7 +394,7 @@ export function Nip60Wallet() {
 											) : (
 												<ArrowUpRight className="w-4 h-4 text-red-400 shrink-0" />
 											)}
-											<span className="text-gray-400 truncate">{new Date(tx.timestamp * 1000).toLocaleDateString()}</span>
+											<span className="text-muted-foreground truncate">{new Date(tx.timestamp * 1000).toLocaleDateString()}</span>
 										</div>
 										<span className={`shrink-0 ${tx.direction === 'in' ? 'text-green-400' : 'text-red-400'}`}>
 											{tx.direction === 'in' ? '+' : '-'}
@@ -402,24 +404,24 @@ export function Nip60Wallet() {
 								))}
 							</div>
 						) : (
-							<p className="text-gray-400 text-sm">No transactions yet</p>
+							<p className="text-muted-foreground text-sm">No transactions yet</p>
 						)}
 					</div>
 				)}
 
 				{openSection === 'proofs' && (
-					<div className="space-y-2 pt-2 border-white/10 border-t max-h-48 overflow-x-hidden overflow-y-auto">
+					<div className="space-y-2 pt-2 border-t overflow-x-hidden">
 						{proofsByMint.size === 0 ? (
-							<p className="text-gray-400 text-sm">No proofs in wallet</p>
+							<p className="text-muted-foreground text-sm">No proofs in wallet</p>
 						) : (
 							Array.from(proofsByMint.entries()).map(([mint, proofs]) => (
 								<Collapsible key={mint} open={expandedMints.has(mint)} onOpenChange={() => toggleMintExpanded(mint)}>
-									<div className="bg-white/5 p-2 rounded-md overflow-hidden">
+									<div className="bg-muted/50 p-2 rounded-md overflow-hidden">
 										<CollapsibleTrigger asChild>
 											<Button className={cn(classNameGhost, 'justify-start gap-2 px-1 py-1 w-full h-auto overflow-hidden')} size="sm">
 												<ChevronRight className="w-3 h-3 [[data-state=open]>&]:rotate-90 transition-transform shrink-0" />
-												<span className="flex-1 min-w-0 font-medium text-white text-left truncate">{getMintHostname(mint)}</span>
-												<span className="text-gray-400 text-xs whitespace-nowrap shrink-0">
+												<span className="flex-1 min-w-0 font-medium text-foreground text-left truncate">{getMintHostname(mint)}</span>
+												<span className="text-muted-foreground text-xs whitespace-nowrap shrink-0">
 													{proofs.length} • {proofs.reduce((s, p) => s + p.amount, 0).toLocaleString()}
 												</span>
 											</Button>
@@ -429,12 +431,12 @@ export function Nip60Wallet() {
 												{proofs.map((proof, idx) => (
 													<div
 														key={`${proof.id}-${proof.secret.slice(0, 8)}-${idx}`}
-														className="flex justify-between items-center gap-2 bg-white/10 px-2 py-1 rounded text-xs"
+														className="flex justify-between items-center gap-2 bg-muted px-2 py-1 rounded text-xs"
 													>
-														<span className="min-w-0 font-mono text-gray-400 truncate" title={`Keyset: ${proof.id}`}>
+														<span className="min-w-0 font-mono text-muted-foreground truncate" title={`Keyset: ${proof.id}`}>
 															{proof.id.slice(0, 8)}...
 														</span>
-														<span className="font-medium text-white shrink-0">{proof.amount}</span>
+														<span className="font-medium text-foreground shrink-0">{proof.amount}</span>
 													</div>
 												))}
 											</div>
@@ -447,12 +449,12 @@ export function Nip60Wallet() {
 				)}
 
 				{openSection === 'pending' && (
-					<div className="space-y-2 pt-2 border-white/10 border-t max-h-48 overflow-y-auto">
+					<div className="space-y-2 pt-2 border-t">
 						{activePendingTokens.map((token) => (
-							<div key={token.id} className="flex justify-between items-center gap-2 bg-white/5 p-2 rounded-lg">
+							<div key={token.id} className="flex justify-between items-center gap-2 bg-muted/50 p-2 rounded-lg">
 								<div className="min-w-0">
-									<p className="font-medium text-white text-sm">{token.amount.toLocaleString()} sats</p>
-									<p className="text-gray-400 text-xs truncate">
+									<p className="font-medium text-foreground text-sm">{token.amount.toLocaleString()} sats</p>
+									<p className="text-muted-foreground text-xs truncate">
 										{getMintHostname(token.mintUrl)} • {new Date(token.createdAt).toLocaleDateString()}
 									</p>
 								</div>

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -2,7 +2,7 @@ import { Store } from '@tanstack/store'
 import { CURRENCIES } from '@/lib/constants'
 
 // Define types for different UI elements
-export type DrawerType = 'cart' | 'createProduct' | 'createCollection' | 'conversation'
+export type DrawerType = 'cart' | 'createProduct' | 'createCollection' | 'conversation' | 'wallet'
 export type DialogType = 'login' | 'signup' | 'checkout' | 'product-details' | 'scan-qr' | 'v4v-setup' | 'terms' | 'nsfw-confirmation'
 export type ToastType = 'success' | 'error' | 'warning' | 'info'
 export type SupportedCurrency = (typeof CURRENCIES)[number]
@@ -41,6 +41,7 @@ export interface UIState {
 	selectedCurrency: SupportedCurrency
 	conversationPubkey: string | null // Track which conversation to open
 	showNSFWContent: boolean // Whether to show NSFW/adult content
+	walletPage?: string | null
 }
 
 const getSelectedCurrency = (): SupportedCurrency => {
@@ -60,6 +61,7 @@ const initialState: UIState = {
 		createProduct: false,
 		createCollection: false,
 		conversation: false,
+		wallet: false,
 	},
 	conversationPubkey: null,
 	dialogs: {
@@ -380,6 +382,18 @@ export const uiActions = {
 				...state.dialogs,
 				'nsfw-confirmation': true,
 			},
+		}))
+	},
+
+	openWalletPage: (page?: string | null) => {
+		uiStore.setState((state) => ({
+			...state,
+			drawers: {
+				...state.drawers,
+				wallet: true,
+			},
+			walletPage: page ?? null,
+			activeElement: 'drawer-wallet',
 		}))
 	},
 }


### PR DESCRIPTION
# Summary

- This PR Replaces the header wallet popover with a right-sliding sheet.
- The wallet icon now opens WalletSheetContent via a new wallet drawer 
- The Nip60Wallet component is re-themed to a white background and centered within the sheet.

# Screenshots
[wip-wallet-sheet-slider.webm](https://github.com/user-attachments/assets/5e36ad01-5af6-422e-a266-7bfe209e0c36)
