### PR TITLE
docs: add maintainer audit and LLM contribution guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,68 @@
+# Pull Request
+
+## Summary
+
+- What changed:
+- Why:
+
+## Change Classification
+
+- [ ] Bug fix
+- [ ] Security hardening
+- [ ] Protocol compatibility change
+- [ ] Payment/wallet change
+- [ ] Refactor
+- [ ] Test-only change
+- [ ] Docs/ops change
+- [ ] UX change
+- [ ] Feature
+
+## Threat Model
+
+- Trusted inputs:
+- Untrusted or attacker-controlled inputs:
+- New or changed abuse cases:
+- Mitigations:
+
+## Protocol Impact
+
+- Nostr event kinds/tags affected:
+- Authors/signatures/relay assumptions changed:
+- Replaceable/addressable/deletion behavior changed:
+- Compatibility risks:
+
+## Payment and Wallet Impact
+
+- Bitcoin/Lightning/Cashu/NWC flows affected:
+- Payment states changed:
+- Custody or bearer-token assumptions changed:
+- Settlement, expiry, refund, or failure handling changed:
+
+## Browser Storage and Rendering Impact
+
+- localStorage/sessionStorage/IndexedDB changes:
+- Signer or wallet material touched:
+- Untrusted content or media rendering touched:
+- XSS/privacy risk notes:
+
+## Secret and Env Impact
+
+- Env files touched:
+- Secrets or credentials touched:
+- Redaction/rotation notes:
+- CI/deploy secret impact:
+
+## Tests and Checks
+
+- Commands run:
+- Commands not run and why:
+- Manual verification:
+
+## Rollback Plan
+
+- How to revert safely:
+- Data/protocol migration rollback notes:
+
+## Non-Goals
+
+- Explicitly out of scope:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,115 @@ Mutating or environment-dependent unless proven otherwise: `bun install`, `bun r
 - A task is done only when the diff summary, checks, remaining risks, rollback notes, and PR framing are reported.
 - Committing and pushing are not part of done unless explicitly requested.
 
-## Review Guidance
+## Review guidelines
 
-Lead reviews with findings ordered by severity. For each finding include file/function, confirmed or inferred status, what can go wrong, why it matters for Nostr/Bitcoin/Lightning/Cashu/user sovereignty, smallest safe fix, and the test that proves it.
+These guidelines apply to AI-assisted reviewers and human reviewers. Reviews should be high-signal, maintainer-safe, and focused on risks that could block a safe merge. Prioritize confirmed P0/P1 correctness, security, protocol, payment, privacy, and data-loss issues over style comments.
+
+### Review output
+
+Lead with findings ordered by severity. For each finding, include:
+
+- File/function or code path.
+- Whether the issue is confirmed from the diff or inferred and needs verification.
+- The broken invariant or trust boundary.
+- What can go wrong for users, sellers, buyers, relays, wallets, payments, or maintainers.
+- Why it matters for Nostr, Bitcoin, Lightning, Cashu, auctions, privacy, or user sovereignty.
+- The smallest safe fix.
+- The test or manual verification that proves the fix.
+
+If there are no blocking findings, say so directly and list residual risks, missing checks, or test gaps.
+
+### Scope and diff hygiene
+
+Flag PRs that:
+
+- Mix behavior changes with broad refactors, formatting churn, generated-file drift, dependency updates, or unrelated cleanup.
+- Change protocol, payment, wallet, signer, relay, storage, or server behavior without naming the source of truth and trust boundary.
+- Add dependencies in security-sensitive paths without a clear reason.
+- Weaken tests, validators, auth checks, type checks, schema checks, or protocol checks to make CI pass.
+- Rely on prior audit notes without re-checking current files.
+
+Prefer the smallest reviewable fix. Ask for follow-up PRs when a change combines unrelated concerns.
+
+### Nostr review priorities
+
+Treat relay data as untrusted unless the code validates it.
+
+Flag changes that:
+
+- Use display names, product titles, labels, array order, route text, or optimistic UI state as canonical identity.
+- Confuse event IDs, coordinates, pubkeys, tags, authors, signers, or profile metadata.
+- Mix query/read flows with publish/signing/write flows.
+- Silently change event kind, tag, author, signature, deletion, replacement, or addressable-event semantics.
+- Assume one relay has complete, fresh, unique, honest, or canonical data.
+- Fail to handle missing, stale, duplicated, malformed, deleted, replaced, or conflicting events.
+- Move protocol parsing or validation into UI components when it belongs in query, schema, helper, or publish modules.
+- Claim NIP compatibility without matching repo code and the relevant NIP behavior.
+
+For Nostr findings, identify the event kind, tags, author/pubkey assumptions, relay behavior, and compatibility impact.
+
+### Bitcoin, Lightning, Cashu, NWC, and payment review priorities
+
+Treat payment state as a lifecycle, not a boolean.
+
+Flag changes that:
+
+- Blur invoice creation, payment attempt, wallet acknowledgement, settlement, confirmation, expiry, refund, failure, delivery, or receipt evidence.
+- Treat zap receipts, preimages, wallet responses, relay events, or UI state as equivalent without validation.
+- Mishandle sats/msats, fiat conversion, rounding, fees, minimums, maximums, or stale exchange rates.
+- Leak sensitive payment metadata, wallet connection data, bearer tokens, Cashu proofs, NWC strings, preimages, private keys, seeds, mnemonics, or credentials.
+- Add implicit custodial assumptions or weaken self-custody boundaries.
+- Grant paid benefits before settlement or receipt verification is sufficient for that feature.
+
+For payment findings, identify the lifecycle state being changed and the evidence required to advance state safely.
+
+### Auction and marketplace review priorities
+
+Flag changes that:
+
+- Use product titles, seller names, bidder display names, or rendered order as identity.
+- Confuse seller, buyer, bidder, winner, auctioneer, oracle, relay, app signer, or settlement authority.
+- Change bid, reserve, start time, effective end time, definite end time, refund time, settlement, participant, or shipping semantics without explicit scope.
+- Present stale or conflicting bid/settlement data as final.
+- Hide refund, lockup, custody, expiry, or failure conditions from the user.
+- Change product, shipping, order, review, collection, auction, bid, settlement, or comment behavior without preserving backward compatibility.
+
+For auction findings, identify the canonical event/state owner and the UI/query/publish boundary involved.
+
+### Browser storage, rendering, and privacy review priorities
+
+Flag changes that:
+
+- Store signer, wallet, NWC, Cashu, token, order, or private user data in browser storage without documenting the threat model.
+- Render relay/user-controlled content into HTML, markdown, media, map popups, CSS URLs, links, or image fields without sanitization or URL policy.
+- Introduce XSS, open redirect, tracking, metadata leakage, or unsafe clipboard/download behavior.
+- Log secrets, tokens, payment details, private order content, or sensitive relay/user data.
+
+### Server, app-signer, admin, and bootstrap review priorities
+
+Flag changes that:
+
+- Expand app-key signing authority without allowlists, schema validation, timestamp checks, role checks, and replay protection.
+- Make bootstrap/admin/editor state depend on ambiguous relay state without fail-closed behavior.
+- Treat the app server as the canonical marketplace database instead of a narrow validation, app-signing, bootstrap, NIP-05, vanity, zap-purchase, and web-delivery boundary.
+- Change NIP-05, vanity, zap purchase, admin, editor, blacklist, relay-list, or app-settings behavior without an explicit authorization model.
+
+### Test expectations
+
+Prefer behavior-focused tests over implementation-detail tests.
+
+Ask for tests when a PR changes:
+
+- Canonical identity resolution.
+- Event parsing, validation, replacement, deletion, or dedupe.
+- Query/cache invalidation.
+- Publish/signing behavior.
+- Payment lifecycle transitions.
+- Auction bid, settlement, or refund behavior.
+- Wallet, storage, or signer flows.
+- Secret handling, rendering sinks, or authorization checks.
+
+For docs-only PRs, formatting checks are usually enough. Do not request app tests unless the docs claim behavior that should be verified against source.
 
 ## Deeper Docs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,55 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+Plebeian Market is a decentralized Nostr marketplace and circular economy tool. Marketplace data should live on Nostr relays; the app server is a validation, app-signing, bootstrap/admin, NIP-05, vanity, zap-purchase, and web-delivery boundary.
 
-## Quick Reference
+## Standing Rules
 
-```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
-bd close <id>         # Complete work
-bd sync               # Sync with git
-```
+- Inspect current files before making claims or patches. Prior audits are leads, not current truth.
+- Do not print secret values. This includes private keys, nsec values, NWC strings, Cashu tokens or proofs, mnemonics, API keys, bearer tokens, preimages, seeds, and credentials.
+- If secret-like material is found, report only path, variable or pattern name, and risk.
+- Do not commit, push, create branches, rewrite history, deploy, release, or mutate GitHub or `bd` issues unless explicitly asked.
+- Do not run `bd update`, `bd close`, `bd sync`, PR creation commands, deploy/release scripts, seed/startup scripts, dev servers, or destructive commands unless explicitly approved.
+- Keep PRs small. Do not mix protocol/security changes with formatting churn, UI cleanup, or unrelated refactors.
+- Treat relay data, wallet responses, user content, media URLs, and browser storage as untrusted.
+- Never use display names, labels, array position, or optimistic UI state as canonical identity.
+- Never treat payment state as a boolean. Preserve invoice lifecycle, expiry, settlement ambiguity, preimage/receipt evidence, refund/failure paths, and custody assumptions.
 
-## Landing the Plane (Session Completion)
+## Repo Map
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+- `src/server/`: app relay bridge, app-key signing, bootstrap/admin/editor validation, NIP-05, vanity, zap purchase flows.
+- `src/lib/`: Nostr helpers, schemas, wallet/payment helpers, browser stores, checkout and order helpers.
+- `src/queries/`: read-side Nostr query factories and parsing.
+- `src/publish/`: write-side event construction and publication.
+- `src/routes/`: TanStack Router route modules.
+- `e2e/`: Playwright flows and local relay/browser test scaffolding.
+- `scripts/`: local relay, seed, startup, wallet, deploy, and maintenance scripts.
 
-**MANDATORY WORKFLOW:**
+## Command Safety
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+Use `docs/llm/command-safety.md` before running anything beyond read-only inspection.
 
-**CRITICAL RULES:**
+Usually read-only: `pwd`, `git status --short`, `git branch --show-current`, `git rev-parse HEAD`, `git remote -v`, `ls`, `rg`, `sed`, `cat`, `git diff`, `git ls-files`, `bun --version`, `node --version`.
 
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+Mutating or environment-dependent unless proven otherwise: `bun install`, `bun run format`, `bun run build`, `bun run generate-routes`, `bun run watch-routes`, `bun run seed`, `bun run startup`, `bun dev`, E2E, deploy/release, and issue-tracker commands.
+
+## Verification and Done
+
+- State the change classification before patching.
+- Identify source of truth and trust boundaries before touching protocol, payment, wallet, signer, admin, or storage code.
+- Show files likely to change before editing.
+- Run the smallest relevant checks and report commands not run.
+- After mutating-capable commands, run `git status --short`.
+- A task is done only when the diff summary, checks, remaining risks, rollback notes, and PR framing are reported.
+- Committing and pushing are not part of done unless explicitly requested.
+
+## Review Guidance
+
+Lead reviews with findings ordered by severity. For each finding include file/function, confirmed or inferred status, what can go wrong, why it matters for Nostr/Bitcoin/Lightning/Cashu/user sovereignty, smallest safe fix, and the test that proves it.
+
+## Deeper Docs
+
+- Maintainer security and AI operations brief: `docs/maintainer/security-ai-ops-brief.md`
+- LLM launch pad: `docs/llm/launch-pad.md`
+- Command safety matrix: `docs/llm/command-safety.md`
+- PR 1 env/secret hygiene playbook: `docs/llm/pr-playbooks/pr-01-env-secret-hygiene.md`
+- Threat model: `docs/security/threat-model.md`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Market Frontend
 
+Plebeian Market is a decentralized Nostr marketplace and circular economic community builder. The app uses Nostr relays as the primary marketplace data layer.
+
 To install dependencies:
 
 ```bash
@@ -19,6 +21,16 @@ bun start
 ```
 
 This project was created using `bun init` in bun v1.2.4. [Bun](https://bun.sh) is a fast all-in-one JavaScript runtime.
+
+## Maintainer and Contributor Docs
+
+- Agent and maintainer rules: [AGENTS.md](./AGENTS.md)
+- Maintainer security and AI operations brief: [docs/maintainer/security-ai-ops-brief.md](./docs/maintainer/security-ai-ops-brief.md)
+- LLM/Codex launch pad: [docs/llm/launch-pad.md](./docs/llm/launch-pad.md)
+- Command safety matrix: [docs/llm/command-safety.md](./docs/llm/command-safety.md)
+- Security threat model: [docs/security/threat-model.md](./docs/security/threat-model.md)
+
+Keep contributor changes small and reviewable. Do not commit local secrets, private keys, NWC strings, Cashu tokens or proofs, mnemonics, API keys, bearer tokens, preimages, seeds, or credentials.
 
 ## Getting Started
 
@@ -43,14 +55,18 @@ This project was created using `bun init` in bun v1.2.4. [Bun](https://bun.sh) i
    - Update your `.env` file with this relay URL
 
 4. Initialize the application with default settings:
+
    ```bash
    bun run startup
    ```
+
    This will create:
    - Default app settings
    - User roles configuration
    - Ban list
    - Relay list
+
+   This command writes to the configured relay. Do not run it against shared or production infrastructure unless you intend to publish those events.
 
 ### First Run
 
@@ -83,9 +99,32 @@ When you first start the application:
    ```
 
 3. Optional: Seed the relay with test data:
+
    ```bash
    bun seed
    ```
+
+### Command Safety
+
+- `bun run format:check` checks formatting without rewriting files.
+- `bun run test:unit` runs the curated Bun unit baseline used by CI.
+- `bun test` is broad Bun discovery and may pick up Playwright, integration, server, or service-dependent tests.
+- `bun run build` runs route generation before building and may update `src/routeTree.gen.ts` and `dist/`.
+- `bun run generate-routes` and `bun run watch-routes` update the TanStack Router generated route tree.
+- `bun run seed`, `bun run startup`, `bun dev:seed`, E2E scripts, and deploy scripts can mutate local state, relays, reports, or infrastructure.
+
+See [docs/llm/command-safety.md](./docs/llm/command-safety.md) before running mutating, E2E, seed, startup, deploy, release, or issue-tracker commands.
+
+### Testing and Build Baseline
+
+For a local contributor baseline, prefer:
+
+```bash
+bun run format:check
+bun run test:unit
+```
+
+Run `bun run build` when route generation/build output is in scope and check `git status --short` afterward. Run E2E only when the local relay, browser dependencies, env vars, and test data requirements are understood.
 
 ## React Query
 

--- a/docs/llm/command-safety.md
+++ b/docs/llm/command-safety.md
@@ -1,0 +1,247 @@
+# Command Safety
+
+Classify commands before running them. When a command can mutate files or external state, state the expected mutation and run `git status --short` afterward.
+
+## Read-Only Inspection
+
+Usually safe:
+
+```sh
+pwd
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git remote -v
+ls
+rg
+sed
+cat
+git diff
+git ls-files
+bun --version
+node --version
+```
+
+Rules:
+
+- Do not print secret values from env files, workflows, fixtures, local storage dumps, logs, or test output.
+- For env files, list variable names only.
+- For secret scans, output file paths and pattern names only.
+
+## Dependency Install
+
+Commands:
+
+```sh
+bun install
+bun install --frozen-lockfile
+```
+
+Classification:
+
+- dependency install
+- mutating local state
+- network dependent unless dependencies are already cached
+
+Rules:
+
+- Do not install unless dependencies are missing or the task explicitly requires it.
+- Prefer `bun install --frozen-lockfile` for CI parity.
+- Run `git status --short` afterward.
+
+## Formatting
+
+Commands:
+
+```sh
+bun run format:check
+bun run format
+```
+
+Classification:
+
+- `bun run format:check`: formatting check, expected read-only.
+- `bun run format`: mutating local state.
+
+Rules:
+
+- Prefer `format:check` first.
+- If writing format changes, scope them to files already in the task.
+
+## Unit and Bun Tests
+
+Commands:
+
+```sh
+bun run test:unit
+bun test
+```
+
+Classification:
+
+- unit test
+- may be external-service dependent if broad discovery reaches integration-like tests
+
+Notes:
+
+- `bun run test:unit` is the curated CI unit script.
+- `bun test` uses broad Bun discovery and may pick up Playwright specs, integration tests, server startup tests, or network-dependent tests.
+
+Rules:
+
+- Prefer `bun run test:unit` for docs-only preflight.
+- If `bun test` fails because it discovers E2E or service-dependent tests, stop broad execution and report the failure.
+- Do not patch source code only to make a docs-only task pass.
+
+## Integration Tests
+
+Command:
+
+```sh
+bun run test:integration
+```
+
+Classification:
+
+- integration test
+- external-service dependent
+- may require local relay, ContextVM server, env vars, ports, and test keys
+
+Rules:
+
+- State required services and env before running.
+- Do not start services unless explicitly approved or required by the task.
+
+## Build and Generated Code
+
+Commands:
+
+```sh
+bun run generate-routes
+bun run watch-routes
+bun run build
+bun run build:production
+```
+
+Classification:
+
+- generated-code update
+- build
+- mutating local state
+
+Notes:
+
+- `bun run build` runs route generation before building.
+- `src/routeTree.gen.ts` is tracked.
+- Build output may update `dist/`.
+
+Rules:
+
+- Run only when build or generated output is in scope.
+- Run `git status --short` afterward and report generated-file drift.
+
+## E2E Tests
+
+Commands:
+
+```sh
+bun run test:e2e
+bun run test:e2e:headed
+bun run test:e2e:debug
+bun run test:e2e:ui
+```
+
+Classification:
+
+- E2E test
+- mutating local state
+- external-service dependent
+- requires env/local relay/dev server/browser dependencies
+
+Likely mutations:
+
+- `test-results/`
+- `playwright-report/`
+- local relay state
+- seeded test events
+
+Rules:
+
+- Do not run E2E until local service, browser, env, and report-output expectations are stated.
+- Avoid running Playwright specs through broad `bun test`.
+
+## Seed, Startup, and Dev Servers
+
+Commands:
+
+```sh
+bun run seed
+bun run startup
+bun run dev
+bun run dev:local-only
+bun run dev:seed
+bun run start
+bun run start:local-only
+bun run start:staging
+bun run start:production
+./scripts/start-test-env.sh
+```
+
+Classification:
+
+- mutating local state
+- external-service dependent
+- may require secrets/env
+- may publish Nostr events to configured relays
+
+Rules:
+
+- Do not run against shared, staging, production, or unknown relays unless explicitly intended.
+- Confirm ports, env, relay URL, and output directories first.
+
+## Deploy and Release
+
+Commands:
+
+```sh
+bun run deploy:staging
+git tag
+git push
+release workflows
+deploy scripts
+```
+
+Classification:
+
+- deploy/release
+- mutating external state
+- requires secrets/env
+
+Rules:
+
+- Do not run unless explicitly asked.
+- Do not create tags, push branches, or trigger deploy workflows as part of ordinary coding tasks.
+
+## Issue Tracker and GitHub Mutation
+
+Commands:
+
+```sh
+bd update
+bd close
+bd sync
+gh issue edit
+gh pr create
+gh pr merge
+GitHub issue or PR mutation tools
+```
+
+Classification:
+
+- issue-tracker mutation
+- external-state mutation
+
+Rules:
+
+- Do not run unless explicitly asked.
+- Read-only issue or PR inspection is allowed when necessary and within the user request.

--- a/docs/llm/launch-pad.md
+++ b/docs/llm/launch-pad.md
@@ -1,0 +1,213 @@
+# LLM Launch Pad
+
+Use this file at the start of LLM/Codex sessions. It is reusable context, not proof that the current checkout still matches any prior audit.
+
+## Role
+
+Act as a veteran open-source maintainer, senior TypeScript/React/Bun engineer, Bitcoin/Lightning/Cashu/Nostr protocol reviewer, and security-first freedom-tech engineer.
+
+Optimize for maintainer trust: small diffs, protocol correctness, user sovereignty, testable behavior, and clear rollback.
+
+## Repo Mission
+
+Plebeian Market is a decentralized Nostr marketplace and circular economic community builder. Marketplace data should live on Nostr relays. The app server coordinates validation, app signing, bootstrap/admin state, NIP-05/vanity flows, zap purchase flows, and web delivery. It must not become an unchecked centralized source of truth.
+
+## Reference Protocol Docs
+
+- Nostr NIPs: <https://nips.nostr.com/>
+- Bitcoin developer guide: <https://developer.bitcoin.org/devguide/index.html>
+- Core Lightning docs: <https://docs.corelightning.org/docs/home>
+- Cashu docs: <https://docs.cashu.space/>
+
+## Prior Audit Snapshot
+
+Prior audits reported:
+
+- Branch: `master`
+- Commit: `32d5c941799f573a13b57a44d7e132883a140d8c`
+- Package manager: Bun
+- `bun.lock` tracked
+- `package-lock.json` also tracked
+- `src/routeTree.gen.ts` tracked
+- `.env.dev` tracked with an `APP_PRIVATE_KEY` variable
+
+Treat this as context only. Re-check the current branch, commit, worktree, and files before relying on it.
+
+## First Actions
+
+Run safe read-only orientation first:
+
+```sh
+pwd
+git status --short
+git branch --show-current
+git rev-parse HEAD
+git remote -v
+ls
+git ls-files | sed -n '1,300p'
+```
+
+Inspect current instructions and project docs:
+
+- `AGENTS.md`
+- `CLAUDE.md`
+- `README.md`
+- `SPEC.md`
+- `gamma_spec.md`
+- `package.json`
+- `.gitignore`
+- env examples, with values redacted
+- `.github/workflows/*`
+- relevant `docs/**`
+
+Inspect relevant source before advising or patching:
+
+- `src/server/`
+- `src/lib/`
+- `src/lib/nostr/`
+- `src/lib/wallet/`
+- `src/lib/payments/`
+- `src/lib/stores/`
+- `src/queries/`
+- `src/publish/`
+- `src/routes/`
+- `e2e/`
+- `scripts/`
+
+## Command Classification
+
+Classify commands before running them. See `docs/llm/command-safety.md`.
+
+Categories:
+
+- read-only
+- dependency install
+- formatting check
+- unit test
+- integration test
+- build
+- generated-code update
+- E2E test
+- external-service dependent
+- mutating local state
+- requires secrets/env
+- deploy/release
+- issue-tracker mutation
+
+Do not run install/build/test/generate/E2E/seed/startup/dev/deploy/issue-tracker commands until the plan is stated and the command exists in `package.json` or repo scripts.
+
+## Strict Global Rules
+
+- Do not invent repo behavior.
+- Re-open current files before making implementation claims.
+- Separate confirmed behavior, inferred risk, recommended fix, and open questions.
+- Do not print secret values. Report only path, variable or pattern name, and risk.
+- Do not push, commit, branch, rewrite history, deploy, release, delete files, overwrite env files, or mutate issues unless explicitly asked.
+- Do not weaken tests, validators, types, auth checks, or protocol rules to make CI pass.
+- Never treat relay data as trusted.
+- Never treat payment state as a boolean.
+- Never use display labels or array position as canonical identity.
+- Never silently change Nostr event semantics.
+- Preserve backwards compatibility unless the task explicitly says otherwise.
+
+## Audit Output Structure
+
+```md
+# Plebeian Market Local Repo Audit
+
+## 1. Executive Summary
+
+## 2. Verified Environment
+
+## 3. Repository Map
+
+## 4. Architecture Map
+
+## 5. Protocol Audit
+
+## 6. Security Findings
+
+## 7. Build/Test Readiness
+
+## 8. UX/Product Risks
+
+## 9. Suggested PR Sequence
+
+## 10. Recommended AGENTS.md Improvements
+
+## 11. Open Questions
+```
+
+For findings, include severity, files, confirmed or inferred status, problem, maintainer-safe exploit scenario, impact, smallest safe fix, and test plan.
+
+## Review Output Structure
+
+```md
+# Review
+
+## Summary
+
+## Findings
+
+## Protocol checklist
+
+## Security checklist
+
+## UX checklist
+
+## Test plan
+```
+
+Lead with findings. If there are no findings, say so and name remaining test gaps or residual risk.
+
+## Patch Plan Structure
+
+```md
+# Patch Plan
+
+## Change classification
+
+## Files to inspect
+
+## Files likely to touch
+
+## Source-of-truth map
+
+## Boundary map
+
+## Risks
+
+## Smallest safe diff
+
+## Tests to add/update
+
+## Commands to run
+
+## Commands not to run
+```
+
+Before editing, show exact files likely to change and state behavior that must be preserved. After editing, report changed files, diff summary, checks run, checks not run, residual risks, and PR framing.
+
+## Recommended PR Sequence
+
+1. Env/secret hygiene.
+2. First-run bootstrap hardening.
+3. NIP-57 zap receipt verifier.
+4. Order event authorization.
+5. XSS/media sink hardening.
+6. NIP-09 deletion and addressable-event dedupe.
+7. Wallet/Cashu/NWC secret-at-rest baseline.
+8. CI/build hygiene.
+
+## PR 1 Boundary
+
+PR 1 is env/secret hygiene only:
+
+- Untrack `.env.dev` without deleting the local developer file.
+- Ignore local env files.
+- Preserve tracked example env files.
+- Add tracked-file secret guard.
+- Optionally add staged-file mode for local pre-commit.
+- Document key rotation risk.
+
+Do not patch bootstrap, NIP-57, wallet storage, Cashu, NWC, orders, XSS/media, package manager policy, route generation, or app behavior in PR 1.

--- a/docs/llm/launch-pad.md
+++ b/docs/llm/launch-pad.md
@@ -15,6 +15,7 @@ Plebeian Market is a decentralized Nostr marketplace and circular economic commu
 ## Reference Protocol Docs
 
 - Nostr NIPs: <https://nips.nostr.com/>
+- Gamma Markets marketplace protocol spec: <https://github.com/GammaMarkets/market-spec/blob/main/spec.md>
 - Bitcoin developer guide: <https://developer.bitcoin.org/devguide/index.html>
 - Core Lightning docs: <https://docs.corelightning.org/docs/home>
 - Cashu docs: <https://docs.cashu.space/>

--- a/docs/llm/pr-playbooks/pr-01-env-secret-hygiene.md
+++ b/docs/llm/pr-playbooks/pr-01-env-secret-hygiene.md
@@ -1,0 +1,102 @@
+# PR 1 Playbook: Env and Secret Hygiene
+
+This playbook defines PR 1 only. Do not include bootstrap, NIP-57, wallet storage, order lifecycle, XSS/media, package-manager policy, route generation, or app behavior changes.
+
+## Goal
+
+Stop tracking local env material, prevent new tracked secrets, and document rotation risk without deleting developer files or rewriting history.
+
+## Scope
+
+- Untrack `.env.dev` while preserving the local file for developers.
+- Ignore `.env.dev` and local env variants that should not be committed.
+- Preserve `.env.example`, `.env.dev.example`, and `.env.local.example`.
+- Add a lightweight secret guard that scans tracked files in CI.
+- Optionally add a staged-file scanning mode for local pre-commit usage.
+- Document that any committed app key must be treated as exposed unless maintainers confirm it was disposable test-only material.
+
+## Non-Goals
+
+- Do not delete local env files.
+- Do not print secret values.
+- Do not clean git history.
+- Do not rotate keys automatically.
+- Do not modify bootstrap/admin setup.
+- Do not modify NIP-57 zap receipt verification.
+- Do not modify wallet, Cashu, NWC, order, XSS/media, payment, package manager, generated-route, or app behavior.
+- Do not mutate issue trackers.
+
+## Source-of-Truth Map
+
+- Git tracked files define what can leak in future commits.
+- Example env files define documented configuration names and must remain safe to publish.
+- Maintainers own the decision to rotate or retire any previously committed key material.
+- CI owns the minimum tracked-file secret guard.
+
+## Boundary Map
+
+- Local env files: developer machine state, not source of truth.
+- Example env files: public documentation, allowed only with placeholders.
+- CI secret guard: detection boundary, not a rotation tool.
+- Git history: out of scope for PR 1.
+
+## Suggested Implementation
+
+1. Confirm current state with read-only commands:
+
+   ```sh
+   git status --short
+   git ls-files .env.dev .env.example .env.dev.example .env.local.example
+   git grep -l "APP_PRIVATE_KEY"
+   ```
+
+   Redact values. Report only paths and variable names.
+
+2. Untrack `.env.dev` without deleting the local file.
+
+   Use an approach equivalent to:
+
+   ```sh
+   git rm --cached .env.dev
+   ```
+
+3. Update ignore rules for local env files while preserving tracked examples.
+
+4. Add a secret guard script or CI step that scans tracked files and fails on high-risk patterns.
+
+5. Add a narrow allowlist for example placeholders and intentional test fixtures. Do not allow real-looking secrets in examples.
+
+6. Document rotation risk in maintainer-facing docs.
+
+## Acceptance Criteria
+
+- `.env.dev` is no longer tracked.
+- The local `.env.dev` file is not deleted by the patch.
+- Local env variants are ignored.
+- Example env files remain tracked and contain placeholders only.
+- CI fails if tracked files contain private-key, nsec, NWC, Cashu token/proof, mnemonic, API key, bearer token, preimage, seed, or credential patterns outside the allowlist.
+- The guard reports path and pattern only, not values.
+- Rotation risk is documented without implying automated rotation happened.
+- No app behavior changes are included.
+
+## Suggested Checks
+
+```sh
+git status --short
+git diff --stat
+bun run format:check
+```
+
+If a secret guard script is added, run it locally and include its redacted output summary.
+
+## Review Focus
+
+- Confirm `.env.dev` is removed from tracking but not deleted from the developer machine.
+- Confirm ignore rules do not hide example files.
+- Confirm the guard cannot print secret values.
+- Confirm allowlists are narrow and documented.
+- Confirm no unrelated source, package, lockfile, route, bootstrap, payment, wallet, order, or XSS changes slipped in.
+
+## Rollback
+
+Revert the PR. If maintainers decide `.env.dev` must remain tracked temporarily, replace real values with safe placeholders first and keep the secret guard.

--- a/docs/maintainer/security-ai-ops-brief.md
+++ b/docs/maintainer/security-ai-ops-brief.md
@@ -38,7 +38,7 @@ Primary principle: marketplace data lives on Nostr relays. The app server must r
 Confirmed protocol areas include:
 
 - NIP-99 product/classified listings, especially kind `30402`.
-- Gamma and legacy marketplace-style product, collection, shipping, and order events.
+- Gamma-style marketplace compatibility references: kind `30402` product listings, kind `30405` product collections, kind `30406` shipping options, merchant preferences, NIP-17 encrypted order communication, kind `14` general order communication, kind `16` order creation/payment request/status update/shipping information messages, kind `17` payment receipts and verification, and kind `31555` product reviews.
 - Private order details using NIP-59 gift wrap/seal/rumor flows and order-related kind `16` messages.
 - NIP-57 zap requests and receipts for paid features.
 - NIP-46 remote signing and NIP-07 extension signing.
@@ -51,6 +51,7 @@ Confirmed protocol areas include:
 Reference docs:
 
 - Nostr NIPs: <https://nips.nostr.com/>
+- Gamma Markets marketplace protocol spec: <https://github.com/GammaMarkets/market-spec/blob/main/spec.md>
 - Bitcoin developer guide: <https://developer.bitcoin.org/devguide/index.html>
 - Core Lightning docs: <https://docs.corelightning.org/docs/home>
 - Cashu docs: <https://docs.cashu.space/>

--- a/docs/maintainer/security-ai-ops-brief.md
+++ b/docs/maintainer/security-ai-ops-brief.md
@@ -1,0 +1,132 @@
+# Security and AI Operations Brief
+
+Classification: maintainer-facing security and AI operations guidance. Keep this document safe for a public repository: no secret values, exploit payloads, or step-by-step abuse instructions.
+
+## Snapshot Warning
+
+Audit notes are snapshots, not gospel. Re-check the current branch, commit, worktree, docs, scripts, env examples, workflows, and relevant source files before relying on any finding.
+
+Current local audit context captured on 2026-06-08:
+
+- Branch: `docs/maintainer-audit-llm-guidance`
+- Commit: `c4b9b15995f128d5e61f9175c3fbd59a6356fa27`
+- Package manager signal: Bun with `bun.lock`; `package-lock.json` is also tracked.
+- Generated-file signal: `src/routeTree.gen.ts` is tracked; route generation and build can mutate it.
+- Secret-hygiene signal: tracked `.env.dev` contains an `APP_PRIVATE_KEY` variable. Values must never be printed.
+
+## Architecture Map
+
+```text
+Browser UI
+  -> TanStack Router routes in src/routes
+  -> TanStack Query read models in src/queries
+  -> TanStack Store/localStorage/IndexedDB wallet, auth, cart, and app state in src/lib/stores
+  -> NDK/nostr-tools signer and relay clients
+  -> Nostr relays for listings, orders, app data, metadata, lists, zaps, wallets, and comments
+
+Bun app server
+  -> src/index.tsx HTTP, WebSocket, static serving, zap purchase endpoint, NIP-05
+  -> src/server EventHandler, EventValidator, EventSigner, BootstrapManager
+  -> app relay publishes app-signed accepted events
+  -> zap purchase managers consume zap receipts and publish paid-feature registry events
+```
+
+Primary principle: marketplace data lives on Nostr relays. The app server must remain a narrow signer/validator/coordinator, not an opaque canonical database.
+
+## Protocol Surface
+
+Confirmed protocol areas include:
+
+- NIP-99 product/classified listings, especially kind `30402`.
+- Gamma and legacy marketplace-style product, collection, shipping, and order events.
+- Private order details using NIP-59 gift wrap/seal/rumor flows and order-related kind `16` messages.
+- NIP-57 zap requests and receipts for paid features.
+- NIP-46 remote signing and NIP-07 extension signing.
+- NIP-05 names and paid/vanity names.
+- NIP-47/NWC wallet connection strings and wallet interactions.
+- NIP-51-style admin, editor, blacklist, relay, and app lists.
+- Replaceable/addressable events, deletion events, and tombstone-sensitive read models.
+- NIP-60/Cashu-style ecash wallet state and bearer-token handling.
+
+Reference docs:
+
+- Nostr NIPs: <https://nips.nostr.com/>
+- Bitcoin developer guide: <https://developer.bitcoin.org/devguide/index.html>
+- Core Lightning docs: <https://docs.corelightning.org/docs/home>
+- Cashu docs: <https://docs.cashu.space/>
+
+## Current Security Posture
+
+Confirmed in the 2026-06-08 local audit:
+
+- `.env.dev` is tracked and contains an `APP_PRIVATE_KEY` variable. Treat this as a rotation and secret-hygiene risk until PR 1 resolves tracking and ignore policy.
+- First-run setup enters bootstrap behavior when no admin state is found. Setup signer and configured owner need stricter binding before setup is safe for unattended shared relays.
+- Zap purchase receipt handling parses and correlates receipts, but additional NIP-57 verification is needed before paid benefits should be treated as settled.
+- Browser storage contains signer, NWC, Cashu/NIP-60, cart, and pending-token state. Any XSS can become a wallet and identity risk.
+- Some order lifecycle read paths correlate events by order tags and participants. Authorization and authorship checks need tightening for status, payment, shipping, and receipt events.
+- Untrusted marketplace and location content reaches media, dynamic style, and map popup boundaries. These sinks need explicit sanitization and URL policy.
+- Product/payment deletion has local deletion tracking and kind `5` publication, but read-side remote tombstone and addressable-event replacement policy needs a focused audit.
+- Build and route generation can mutate tracked generated files. Treat build output changes as reviewable artifacts.
+
+## Critical and High Work Queue
+
+1. Env/secret hygiene: untrack local env material without deleting developer files, ignore local env variants, add a tracked-file secret guard, and document key rotation risk.
+2. First-run bootstrap hardening: bind setup authority to maintainer-controlled identity or deployment state and fail closed for ambiguous bootstrap conditions.
+3. NIP-57 zap receipt verification: verify receipt authorship, request identity, invoice correlation, amount, recipient, timestamp, and replay behavior before granting paid benefits.
+4. Order event authorization: require participant/authorship and event-shape checks for order lifecycle events.
+5. XSS/media sink hardening: sanitize or escape untrusted relay/user content before HTML, style URL, image/media, map popup, or rich rendering boundaries.
+6. NIP-09 deletion and addressable-event dedupe: respect tombstones and reduce replaceable/addressable events by canonical coordinate and latest valid timestamp.
+7. Wallet/Cashu/NWC secret-at-rest baseline: reduce plaintext persistence where possible and document remaining browser threat model.
+8. CI/build hygiene: clarify package manager policy, runtime pinning, generated-file policy, and focused CI scripts.
+
+## Bottlenecks
+
+- Payment evidence is multi-state. Wallet ACK, invoice creation, zap receipt, preimage, mempool observation, and confirmation are not equivalent.
+- Relay data is eventually consistent, adversarial, and replayable. Query code must validate identity, tags, timestamps, deletion state, and replacement semantics.
+- Browser storage is convenient but high impact for wallets and signers. XSS hardening and storage minimization are prerequisites for safer payment UX.
+- App-key signing is powerful. Re-signing paths need narrow allowlists, schema validation, timestamp checks, and role checks.
+
+## AI and Automation Opportunities
+
+- Tracked-file secret scanning with explicit allowlists for examples and intentional test fixtures.
+- Static checks for unsafe rendering sinks, dynamic CSS URLs, HTML insertion, and untrusted media fields.
+- Protocol fixture tests for NIP-99, NIP-57, NIP-59, NIP-09, NIP-47, and NIP-60 boundaries.
+- Payment-state regression tests that distinguish pending, acknowledged, settled, expired, failed, refunded, zero-conf, and confirmed states.
+- LLM-assisted issue drafting and PR review summaries, limited to redacted outputs and current-file evidence.
+
+## LLM Workflow Policy
+
+- Use prior audits as leads only. Verify current files first.
+- Separate confirmed behavior, inferred risk, recommended fix, and open questions.
+- Do not mutate issues, branches, commits, pushes, deploys, env files, or generated code unless explicitly asked.
+- Keep patches small enough for human review and rollback.
+- Prefer tests over assertions. For security work, include a regression test that fails before the fix when practical.
+
+## Maintainer Decision Log
+
+Open decisions:
+
+- Whether `.env.dev` contained only disposable test material or requires rotation of a real app key.
+- Whether `package-lock.json` remains intentionally tracked or should be removed in a separate tooling PR.
+- Whether `src/routeTree.gen.ts` should remain tracked and what build-generated drift policy reviewers should enforce.
+- What exact setup authority model should replace first-run bootstrap.
+- What payment evidence is sufficient for each paid feature and marketplace order state.
+- Which wallet materials may remain in browser storage and under what warnings or encryption gates.
+
+## Immediate PR 1 Boundary
+
+PR 1 should be only env/secret hygiene:
+
+- Untrack `.env.dev` without deleting local developer files.
+- Ignore local env files.
+- Preserve `.env.example`, `.env.dev.example`, and `.env.local.example`.
+- Add a lightweight tracked-file secret guard in CI.
+- Optionally support staged-file scanning for local pre-commit usage.
+- Document key rotation risk.
+
+PR 1 non-goals:
+
+- Do not clean git history.
+- Do not rotate keys automatically.
+- Do not patch bootstrap, NIP-57, wallet/Cashu/NWC storage, order lifecycle, XSS/media, package manager policy, route generation, or app behavior.
+- Do not mutate issue trackers.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,142 @@
+# Threat Model
+
+This document is a maintainer-safe threat model. It avoids exploit payloads and secret values. Re-check current code before treating any item as current behavior.
+
+## Assets
+
+- User signing authority and delegated signing sessions.
+- App-server private key and app-signed event authority.
+- Admin, editor, blacklist, relay, and setup state.
+- Listings, collections, shipping options, orders, private order details, comments, and payment requests.
+- NWC strings, wallet permissions, Cashu/NIP-60 seeds, proofs, tokens, and pending wallet state.
+- NIP-05, vanity, auction, zap-purchased, and paid-feature state.
+- Browser storage, local relay state, CI secrets, deployment secrets, and logs.
+
+## Trust Boundaries
+
+```text
+Browser UI
+  -> untrusted relay content
+  -> localStorage/sessionStorage/IndexedDB
+  -> NIP-07 extension or NIP-46 signer
+  -> NWC wallet and Cashu mint
+
+App server
+  -> WebSocket event ingestion
+  -> app-key validation and signing
+  -> relay publication
+  -> zap receipt subscription
+  -> NIP-05 and vanity endpoints
+
+External systems
+  -> Nostr relays
+  -> Lightning services and LNURL endpoints
+  -> NWC wallets
+  -> Cashu mints
+  -> mempool and exchange-rate APIs
+  -> CI/deploy infrastructure
+```
+
+Default stance: relays, wallet responses, zap receipts, user content, media URLs, and external APIs are untrusted until validated for the specific workflow.
+
+## Threat Actors
+
+- Malicious buyer.
+- Malicious seller.
+- Malicious relay.
+- Malicious or compromised admin/editor.
+- Compromised browser extension.
+- Compromised NIP-46 signer.
+- Malicious NWC wallet.
+- Malicious Cashu mint.
+- Malicious zapper.
+- Replay attacker.
+- Spammer, crawler, or scraper.
+- Supply-chain attacker.
+- Compromised app-server key.
+- Confused first-run bootstrap user.
+
+## Nostr Protocol Risks
+
+- Invalid event shape accepted or re-signed by the app key.
+- Wrong author or participant accepted for order/payment/status events.
+- Replaceable or addressable events read without canonical coordinate and latest-valid timestamp policy.
+- Kind `5` deletion/tombstone events ignored by read models.
+- Relay inconsistency causing stale, duplicated, or replayed state.
+- Paid-feature events granted from insufficiently verified zap receipts.
+- NIP-05 or vanity names bound to the wrong identity.
+
+Mitigations:
+
+- Schema-validate all accepted event kinds and tags.
+- Treat event id, pubkey, signature, kind, `d` tag, `a` tag, timestamp, and role list membership as explicit inputs.
+- Fail closed when participant, relay, timestamp, deletion, replacement, or payment evidence is ambiguous.
+- Add regression fixtures for accepted and rejected events.
+
+## Bitcoin, Lightning, NWC, and Cashu Risks
+
+- Treating wallet ACK, invoice creation, zap receipt, preimage, mempool observation, and confirmation as the same state.
+- Granting paid benefits before settlement evidence is sufficient for that feature.
+- Storing bearer Cashu tokens/proofs or NWC strings in plaintext browser storage.
+- Leaking wallet permissions, payment metadata, preimages, or token material through logs.
+- Trusting a malicious wallet or mint response without workflow-specific validation.
+
+Mitigations:
+
+- Model payment states explicitly.
+- Keep custody and trust assumptions visible in UI and docs.
+- Minimize persisted wallet material and redact logs.
+- Verify amount, invoice binding, recipient, expiry, and settlement evidence before irreversible benefits.
+- Treat Cashu tokens/proofs as bearer assets.
+
+## Browser and Rendering Risks
+
+- XSS through untrusted listing text, profile metadata, map popups, markdown-like content, media URLs, or dynamic CSS.
+- Wallet/signing compromise through browser storage exposure after XSS.
+- Privacy leaks through third-party media, avatars, maps, and payment endpoints.
+
+Mitigations:
+
+- Escape or sanitize untrusted content at every rendering sink.
+- Forbid unsafe URL schemes for media and styles.
+- Prefer text APIs over HTML APIs for untrusted fields.
+- Add tests around known rendering sinks.
+- Keep wallet material out of persistent storage where practical.
+
+## Admin and Bootstrap Risks
+
+- First user on an empty relay becomes admin unintentionally.
+- Setup events accepted from the wrong signer.
+- App-key re-signing grants authority beyond intended event kinds.
+- Admin/editor lists are replayed or replaced unexpectedly.
+
+Mitigations:
+
+- Bind bootstrap authority to maintainer-controlled deployment state.
+- Validate setup signer, owner identity, event kind, tags, and timestamp.
+- Restrict app-key signing to narrow allowlists.
+- Log decisions without logging secrets.
+
+## CI and Supply-Chain Risks
+
+- Unpinned runtimes and mixed package-manager artifacts causing drift.
+- CI secrets exposed through logs.
+- Test fixtures containing real-looking credentials.
+- Build and route generation mutating tracked output unexpectedly.
+
+Mitigations:
+
+- Pin or document runtime policy.
+- Use Bun consistently unless maintainers choose otherwise.
+- Add tracked-file secret scanning.
+- Redact CI logs.
+- Treat generated-file changes as reviewable output.
+
+## Open Decisions
+
+- Exact rotation policy for any previously committed app key material.
+- Final package-manager and runtime pinning policy.
+- Whether generated route files remain tracked.
+- Bootstrap authority design.
+- Paid-feature settlement evidence per feature.
+- Browser wallet storage baseline.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -65,6 +65,7 @@ Default stance: relays, wallet responses, zap receipts, user content, media URLs
 - Relay inconsistency causing stale, duplicated, or replayed state.
 - Paid-feature events granted from insufficiently verified zap receipts.
 - NIP-05 or vanity names bound to the wrong identity.
+- Gamma marketplace compatibility requires validating product, collection, shipping, order, payment receipt, and review event shapes against expected kind/tag semantics before accepting, rendering, or acting on relay data.
 
 Mitigations:
 


### PR DESCRIPTION
## Summary

Adds maintainer-grade contribution, security, and LLM/Codex guidance for the repo.

This PR:

- replaces unsafe agent push / issue-mutation instructions in `AGENTS.md`
- adds contributor-facing command safety and docs links to `README.md`
- adds an LLM/Codex launch pad
- adds a command safety matrix
- adds a PR 1 env/secret hygiene playbook
- adds a maintainer security/AI operations brief
- adds a maintainer-safe threat model
- adds a PR template with protocol, payment, storage, secret, test, and rollback prompts

## Why

Existing guidance conflicted across `AGENTS.md`, `CLAUDE.md`, and `README.md`, and did not clearly document high-risk Nostr/payment/wallet/security boundaries for contributors or LLM-assisted work.

This docs-only preflight is intended to make future security PRs smaller, safer, and easier to review.

## Scope

Docs/instructions only.

Changed files:

- `.github/pull_request_template.md`
- `AGENTS.md`
- `README.md`
- `docs/llm/command-safety.md`
- `docs/llm/launch-pad.md`
- `docs/llm/pr-playbooks/pr-01-env-secret-hygiene.md`
- `docs/maintainer/security-ai-ops-brief.md`
- `docs/security/threat-model.md`

## Checks

- `bun run format:check` ✅
- `bun run test:unit` ✅

Also verified:

- `git diff --cached --check` ✅
- working tree clean after commit ✅

## Non-goals

This PR does not:

- untrack `.env.dev`
- edit `.gitignore`
- add a secret guard
- change app/source behavior
- touch package files or locks
- run route generation
- modify bootstrap, NIP-57, wallet/Cashu/NWC storage, order lifecycle, or XSS/media handling
- mutate issue trackers
- deploy or release

## Risk

Low. Docs-only. The main review focus is whether the new guidance should become standing maintainer/contributor/LLM policy.

## Rollback

Revert the docs commit. No runtime behavior or data migration involved.