### PR TITLE
fix: make bunker URL secret parameter optional per NIP-46 spec

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -341,11 +341,17 @@ test.describe('Authentication', () => {
 				await page.locator('[data-testid="connect-bunker-button"]').click()
 				await expect(page.getByText(/Invalid pubkey/)).toBeVisible()
 
-				// Test: missing secret
-				const fakePk = 'a'.repeat(64)
-				await page.locator('[data-testid="bunker-url-input"]').fill(`bunker://${fakePk}?relay=wss://relay.test`)
+				// Test: 64 characters but not valid hex
+				const nonHexPk = 'g'.repeat(64)
+				await page.locator('[data-testid="bunker-url-input"]').fill(`bunker://${nonHexPk}?relay=wss://r.test&secret=s`)
 				await page.locator('[data-testid="connect-bunker-button"]').click()
-				await expect(page.getByText(/secret/i)).toBeVisible()
+				await expect(page.getByText(/Invalid pubkey/)).toBeVisible()
+
+				// Test: missing relay parameter
+				const fakePk = 'a'.repeat(64)
+				await page.locator('[data-testid="bunker-url-input"]').fill(`bunker://${fakePk}`)
+				await page.locator('[data-testid="connect-bunker-button"]').click()
+				await expect(page.getByText(/relay/i)).toBeVisible()
 			} finally {
 				await context.close()
 			}
@@ -437,6 +443,110 @@ test.describe('Authentication', () => {
 
 				const signerKey = await page.evaluate(() => localStorage.getItem('nostr_local_signer_key'))
 				expect(signerKey).toBeTruthy()
+			} finally {
+				mock.close()
+				await context.close()
+			}
+		})
+
+		test('secretless bunker URL shows auth challenge and completes with NIP-46 mock', async ({ browser }) => {
+			test.setTimeout(60_000)
+			const context = await browser.newContext()
+			const page = await createFreshPage(context)
+			const mock = new Nip46Mock(devUser2.sk)
+			const authUrl = 'https://signer.test/approve?session=secretless'
+
+			try {
+				await mock.startSignerLoop(RELAY_URL, {
+					requireAuthForSecretless: true,
+					authUrl,
+					authAckDelayMs: 1500,
+				})
+
+				await page.goto('/')
+				await page.waitForLoadState('networkidle')
+				await openLoginDialog(page)
+
+				// Navigate to N-Connect → Bunker URL tab
+				await page.locator('[data-testid="connect-tab"]').click()
+				await page.locator('[data-testid="bunker-tab"]').click()
+
+				const bunkerUrl = `bunker://${mock.pk}?relay=${encodeURIComponent(RELAY_URL)}`
+				await page.locator('[data-testid="bunker-url-input"]').fill(bunkerUrl)
+				await page.locator('[data-testid="connect-bunker-button"]').click()
+
+				await expect(page.locator('[data-testid="bunker-auth-challenge"]')).toBeVisible()
+				await expect(page.locator('[data-testid="bunker-auth-url-link"]')).toHaveAttribute('href', authUrl)
+
+				await expectAuthenticated(page)
+			} finally {
+				mock.close()
+				await context.close()
+			}
+		})
+
+		test('allows IPv6 loopback HTTP signer auth challenge URL in dev/test', async ({ browser }) => {
+			test.setTimeout(60_000)
+			const context = await browser.newContext()
+			const page = await createFreshPage(context)
+			const mock = new Nip46Mock(devUser2.sk)
+			const authUrl = 'http://[::1]:3000/approve?session=secretless'
+
+			try {
+				await mock.startSignerLoop(RELAY_URL, {
+					requireAuthForSecretless: true,
+					authUrl,
+					authAckDelayMs: 5_000,
+				})
+
+				await page.goto('/')
+				await page.waitForLoadState('networkidle')
+				await openLoginDialog(page)
+
+				// Navigate to N-Connect → Bunker URL tab
+				await page.locator('[data-testid="connect-tab"]').click()
+				await page.locator('[data-testid="bunker-tab"]').click()
+
+				const bunkerUrl = `bunker://${mock.pk}?relay=${encodeURIComponent(RELAY_URL)}`
+				await page.locator('[data-testid="bunker-url-input"]').fill(bunkerUrl)
+				await page.locator('[data-testid="connect-bunker-button"]').click()
+
+				await expect(page.locator('[data-testid="bunker-auth-challenge"]')).toBeVisible()
+				await expect(page.locator('[data-testid="bunker-auth-url-link"]')).toHaveAttribute('href', authUrl)
+			} finally {
+				mock.close()
+				await context.close()
+			}
+		})
+
+		test('does not render unsafe signer auth challenge URL as clickable', async ({ browser }) => {
+			test.setTimeout(60_000)
+			const context = await browser.newContext()
+			const page = await createFreshPage(context)
+			const mock = new Nip46Mock(devUser2.sk)
+			const unsafeAuthUrl = 'javascript:alert(1)'
+
+			try {
+				await mock.startSignerLoop(RELAY_URL, {
+					requireAuthForSecretless: true,
+					authUrl: unsafeAuthUrl,
+					authAckDelayMs: 5_000,
+				})
+
+				await page.goto('/')
+				await page.waitForLoadState('networkidle')
+				await openLoginDialog(page)
+
+				// Navigate to N-Connect → Bunker URL tab
+				await page.locator('[data-testid="connect-tab"]').click()
+				await page.locator('[data-testid="bunker-tab"]').click()
+
+				const bunkerUrl = `bunker://${mock.pk}?relay=${encodeURIComponent(RELAY_URL)}`
+				await page.locator('[data-testid="bunker-url-input"]').fill(bunkerUrl)
+				await page.locator('[data-testid="connect-bunker-button"]').click()
+
+				await expect(page.locator('[data-testid="login-dialog"]').getByText(/unsafe approval URL/i)).toBeVisible()
+				await expect(page.locator('[data-testid="bunker-auth-url-link"]')).toHaveCount(0)
 			} finally {
 				mock.close()
 				await context.close()

--- a/e2e/utils/nip46-mock.ts
+++ b/e2e/utils/nip46-mock.ts
@@ -22,6 +22,12 @@ import { v2 as nip44 } from 'nostr-tools/nip44'
 import WebSocket from 'ws'
 import { RELAY_URL } from '../test-config'
 
+interface SignerLoopOptions {
+	requireAuthForSecretless?: boolean
+	authUrl?: string
+	authAckDelayMs?: number
+}
+
 export class Nip46Mock {
 	/** Hex secret key of the "remote signer" user */
 	readonly sk: string
@@ -30,6 +36,7 @@ export class Nip46Mock {
 
 	private ws: WebSocket | null = null
 	private subId: string | null = null
+	private isClosed = false
 
 	// ─── Unified message dispatch ─────────────────────────────
 	// Single handler attached once — routes messages to the right callback.
@@ -94,10 +101,8 @@ export class Nip46Mock {
 			case 'EVENT':
 				if (msg[1] === this.subId) {
 					const event = msg[2]
-					if (this.eventHandler) {
-						this.eventHandler(event).catch((e) => {
-							console.error(`[NIP46-MOCK] Handler error:`, e)
-						})
+					if (this.eventHandler && !this.isClosed) {
+						void this.dispatchEventHandler(event)
 					} else {
 						// Buffer events that arrive before the handler is set
 						this.bufferedEvents.push(event)
@@ -141,9 +146,21 @@ export class Nip46Mock {
 		// Process any events that arrived before the handler was set
 		const buffered = this.bufferedEvents.splice(0)
 		for (const event of buffered) {
-			handler(event).catch((e) => {
-				console.error(`[NIP46-MOCK] Handler error (buffered):`, e)
-			})
+			void this.dispatchEventHandler(event)
+		}
+	}
+
+	private async dispatchEventHandler(event: any): Promise<void> {
+		if (this.isClosed || !this.eventHandler) {
+			return
+		}
+
+		try {
+			await this.eventHandler(event)
+		} catch (e) {
+			if (!this.isClosed) {
+				console.error(`[NIP46-MOCK] Handler error:`, e)
+			}
 		}
 	}
 
@@ -230,7 +247,7 @@ export class Nip46Mock {
 	 *
 	 * Returns a cleanup function.
 	 */
-	async startSignerLoop(relayUrl?: string): Promise<() => void> {
+	async startSignerLoop(relayUrl?: string, options: SignerLoopOptions = {}): Promise<() => void> {
 		await this.connectAndSubscribe(relayUrl || RELAY_URL)
 
 		this.setEventHandler(async (event) => {
@@ -238,7 +255,7 @@ export class Nip46Mock {
 			const msg = JSON.parse(decrypted)
 
 			if (msg.method) {
-				await this.handleSignerRequest(event.pubkey, msg)
+				await this.handleSignerRequest(event.pubkey, msg, options)
 			}
 		})
 
@@ -247,11 +264,19 @@ export class Nip46Mock {
 
 	// ─── Internals ─────────────────────────────────────────────
 
-	private async handleSignerRequest(senderPubkey: string, request: any): Promise<void> {
+	private async handleSignerRequest(senderPubkey: string, request: any, options: SignerLoopOptions = {}): Promise<void> {
 		let response: any
 
 		switch (request.method) {
 			case 'connect':
+				if (options.requireAuthForSecretless && !request.params?.[1]) {
+					await this.sendEncrypted(senderPubkey, {
+						id: request.id,
+						result: 'auth_url',
+						error: options.authUrl || 'https://signer.test/approve',
+					})
+					await new Promise((resolve) => setTimeout(resolve, options.authAckDelayMs ?? 250))
+				}
 				response = { id: request.id, result: 'ack' }
 				break
 
@@ -320,6 +345,8 @@ export class Nip46Mock {
 	}
 
 	close(): void {
+		this.isClosed = true
+
 		if (this.ws && this.subId) {
 			try {
 				if (this.ws.readyState === WebSocket.OPEN) {

--- a/src/components/auth/BunkerConnect.tsx
+++ b/src/components/auth/BunkerConnect.tsx
@@ -4,7 +4,7 @@ import { Label } from '@/components/ui/label'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog'
 import { authActions } from '@/lib/stores/auth'
 import { NDKPrivateKeySigner } from '@nostr-dev-kit/ndk'
-import { Loader2, QrCode } from 'lucide-react'
+import { ExternalLink, Loader2, QrCode } from 'lucide-react'
 import { useState, useCallback } from 'react'
 import { Scanner } from '@yudiel/react-qr-scanner'
 import { toast } from 'sonner'
@@ -14,10 +14,37 @@ interface BunkerConnectProps {
 	onSuccess?: () => void
 }
 
+const NOSTR_PUBKEY_HEX_RE = /^[0-9a-fA-F]{64}$/
+const LOOPBACK_AUTH_URL_HOSTS = new Set(['localhost', '127.0.0.1', '::1'])
+
+function normalizeAuthUrlHostname(hostname: string): string {
+	return hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1')
+}
+
+function getSafeAuthUrl(url: string): string | null {
+	try {
+		const parsedUrl = new URL(url)
+		const hostname = normalizeAuthUrlHostname(parsedUrl.hostname)
+
+		if (parsedUrl.protocol === 'https:') {
+			return parsedUrl.href
+		}
+
+		if (process.env.NODE_ENV !== 'production' && parsedUrl.protocol === 'http:' && LOOPBACK_AUTH_URL_HOSTS.has(hostname)) {
+			return parsedUrl.href
+		}
+	} catch {
+		return null
+	}
+
+	return null
+}
+
 export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 	const [bunkerUrl, setBunkerUrl] = useState('')
 	const [isConnecting, setIsConnecting] = useState(false)
 	const [error, setError] = useState<string | null>(null)
+	const [authUrl, setAuthUrl] = useState<string | null>(null)
 	const [showScanner, setShowScanner] = useState(false)
 	const [scanError, setScanError] = useState<string | null>(null)
 
@@ -31,21 +58,15 @@ export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 
 			const urlObj = new URL(url)
 			const relay = urlObj.searchParams.get('relay')
-			const secret = urlObj.searchParams.get('secret')
 
 			if (!relay) {
 				setError('Bunker URL must contain a relay parameter')
 				return false
 			}
 
-			if (!secret) {
-				setError('Bunker URL must contain a secret parameter')
-				return false
-			}
-
 			// Extract pubkey from bunker://pubkey?...
 			const pubkey = urlObj.hostname
-			if (!pubkey || pubkey.length !== 64) {
+			if (!NOSTR_PUBKEY_HEX_RE.test(pubkey)) {
 				setError('Invalid pubkey in bunker URL')
 				return false
 			}
@@ -61,23 +82,41 @@ export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 	const handleConnect = async () => {
 		if (!bunkerUrl.trim()) {
 			setError('Please enter a bunker URL')
+			setAuthUrl(null)
 			return
 		}
 
 		if (!validateBunkerUrl(bunkerUrl)) {
+			setAuthUrl(null)
 			return
 		}
 
 		try {
 			setIsConnecting(true)
 			setError(null)
+			setAuthUrl(null)
 
 			// Generate a local signer for the connection
 			const localSigner = NDKPrivateKeySigner.generate()
 			await localSigner.blockUntilReady()
 
 			// Connect using the bunker URL
-			await authActions.loginWithNip46(bunkerUrl, localSigner)
+			await authActions.loginWithNip46(bunkerUrl, localSigner, {
+				onAuthUrl: (url) => {
+					const safeAuthUrl = getSafeAuthUrl(url)
+
+					if (!safeAuthUrl) {
+						setAuthUrl(null)
+						setError('Signer returned an unsafe approval URL. Open your signer directly to approve the connection.')
+						toast.error('Signer returned an unsafe approval URL')
+						return
+					}
+
+					setError(null)
+					setAuthUrl(safeAuthUrl)
+					toast.info('Open the signer approval page to finish connecting')
+				},
+			})
 
 			onSuccess?.()
 		} catch (err) {
@@ -102,6 +141,7 @@ export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 			if (result && result.startsWith('bunker://')) {
 				setBunkerUrl(result)
 				setError(null)
+				setAuthUrl(null)
 				setShowScanner(false)
 				toast.success('Bunker URL scanned successfully')
 			} else if (result) {
@@ -131,6 +171,7 @@ export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 						onChange={(e) => {
 							setBunkerUrl(e.target.value)
 							setError(null)
+							setAuthUrl(null)
 						}}
 						onKeyDown={(e) => {
 							if (e.key === 'Enter' && bunkerUrl) {
@@ -157,6 +198,18 @@ export function BunkerConnect({ onError, onSuccess }: BunkerConnectProps) {
 					</Button>
 				</div>
 				{error && <p className="text-sm text-red-500">{error}</p>}
+				{authUrl && (
+					<div className="rounded-md border bg-muted/50 p-3 text-sm space-y-2" data-testid="bunker-auth-challenge">
+						<p className="text-muted-foreground">Your signer needs browser approval before this connection can finish.</p>
+						<p className="text-xs text-muted-foreground break-all">{authUrl}</p>
+						<Button asChild variant="outline" size="sm">
+							<a href={authUrl} target="_blank" rel="noreferrer" data-testid="bunker-auth-url-link">
+								<ExternalLink className="h-4 w-4" />
+								Open approval page
+							</a>
+						</Button>
+					</div>
+				)}
 			</div>
 
 			<Button onClick={handleConnect} disabled={isConnecting || !bunkerUrl.trim()} className="w-full" data-testid="connect-bunker-button">

--- a/src/lib/__tests__/nip46-mock.test.ts
+++ b/src/lib/__tests__/nip46-mock.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { Nip46Mock } from '../../../e2e/utils/nip46-mock'
+
+describe('Nip46Mock', () => {
+	const originalConsoleError = console.error
+
+	afterEach(() => {
+		console.error = originalConsoleError
+	})
+
+	test('does not log teardown errors when an in-flight handler rejects after close', async () => {
+		const mock = new Nip46Mock('11'.repeat(32))
+		const errors: unknown[][] = []
+		console.error = ((...args: unknown[]) => {
+			errors.push(args)
+		}) as typeof console.error
+		;(mock as any).subId = 'sub'
+		;(mock as any).eventHandler = async () => {
+			await Promise.resolve()
+			throw new Error('boom')
+		}
+		;(mock as any).handleMessage(Buffer.from(JSON.stringify(['EVENT', 'sub', {}])))
+		mock.close()
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(errors).toHaveLength(0)
+	})
+})

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -23,6 +23,10 @@ interface AuthState {
 	needsMigration: boolean
 }
 
+interface Nip46LoginOptions {
+	onAuthUrl?: (url: string) => void
+}
+
 const initialState: AuthState = {
 	user: null,
 	isAuthenticated: false,
@@ -231,13 +235,22 @@ export const authActions = {
 		}
 	},
 
-	loginWithNip46: async (bunkerUrl: string, localSigner: NDKPrivateKeySigner) => {
+	loginWithNip46: async (bunkerUrl: string, localSigner: NDKPrivateKeySigner, options?: Nip46LoginOptions) => {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
 
 		try {
 			authStore.setState((state) => ({ ...state, isAuthenticating: true }))
 			const signer = new NDKNip46Signer(ndk, bunkerUrl, localSigner)
+
+			if (options?.onAuthUrl) {
+				signer.on('authUrl', (url) => {
+					if (typeof url === 'string' && url.length > 0) {
+						options.onAuthUrl?.(url)
+					}
+				})
+			}
+
 			await signer.blockUntilReady()
 			ndkActions.setSigner(signer)
 			const user = await signer.user()


### PR DESCRIPTION
Fixes #971 

The NIP-46 specification allows the 'secret' parameter to be optional for bunker://<pubkey> URLs (remote-signer initiated connections). The implementation was incorrectly requiring this parameter, preventing users from connecting with signers like nsec.app and Amber.

Changes:
- Remove secret validation requirement from BunkerConnect
- Update auth validation tests to reflect NIP-46 spec
- Only require: relay parameter and valid 64-char hex pubkey
- Add clarifying comments about optional secret parameter

Now users can connect with bunker URLs like:
  bunker://fa984bd...?relay=wss://relay.test

Without needing an optional secret parameter.