### PR TITLE
feat: NIP-53 auction live chat (CVM-owned, live_chat opt-in)

### DIFF
--- a/contextvm/server.ts
+++ b/contextvm/server.ts
@@ -4,6 +4,7 @@ import { fetchAllSources, SUPPORTED_FIAT, type AggregatedRates, type FiatCode } 
 import { getBtcPriceInputSchema, getBtcPriceOutputSchema, getBtcPriceSingleInputSchema, getBtcPriceSingleOutputSchema } from './schemas'
 import { RatesCache } from './tools/rates-cache'
 import { startAuctionValidator } from '../src/server/auction-validator'
+import { startLiveActivityWorker, stopLiveActivityWorker } from './tools/live-activity-worker'
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 
@@ -295,8 +296,11 @@ async function main() {
 		name: `Plebeian validator (${STAGE})`,
 	})
 
+	startLiveActivityWorker({ relayPool, signer, issuerPubkey: serverPubkey })
+
 	const shutdown = async (sig: NodeJS.Signals) => {
-		console.log(`\nReceived ${sig}, shutting down auction validator...`)
+		console.log(`\nReceived ${sig}, shutting down...`)
+		stopLiveActivityWorker()
 		await validatorHandle.stop()
 		process.exit(0)
 	}

--- a/contextvm/tools/__tests__/live-activity-worker.test.ts
+++ b/contextvm/tools/__tests__/live-activity-worker.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect, beforeEach } from 'bun:test'
+import { countParticipants, getIntervalMs, getLookbackDays, resetDedupMap, getDedupMap } from '../live-activity-worker'
+import { AUCTION_KIND, buildLiveActivityDTag } from '../../../src/lib/nip53'
+
+const SELLER_A = 'a'.repeat(64)
+const SELLER_B = 'b'.repeat(64)
+
+describe('live-activity-worker', () => {
+	beforeEach(() => {
+		resetDedupMap()
+	})
+
+	describe('countParticipants', () => {
+		test('counts unique authors as total', () => {
+			const now = 1000000
+			const messages = [
+				{ pubkey: 'user1', created_at: now - 10 },
+				{ pubkey: 'user2', created_at: now - 20 },
+				{ pubkey: 'user1', created_at: now - 30 },
+			]
+			const result = countParticipants(messages, now)
+			expect(result.total).toBe(2)
+		})
+
+		test('counts recent authors as current (within 5min window)', () => {
+			const now = 1000000
+			const messages = [
+				{ pubkey: 'user1', created_at: now - 10 },
+				{ pubkey: 'user2', created_at: now - 100 },
+				{ pubkey: 'user3', created_at: now - 200 },
+			]
+			const result = countParticipants(messages, now)
+			expect(result.current).toBe(3)
+		})
+
+		test('excludes participants outside 5min window from current', () => {
+			const now = 1000000
+			const messages = [
+				{ pubkey: 'user1', created_at: now - 10 },
+				{ pubkey: 'user2', created_at: now - 600 },
+			]
+			const result = countParticipants(messages, now)
+			expect(result.current).toBe(1)
+			expect(result.total).toBe(2)
+		})
+
+		test('handles empty message list', () => {
+			const result = countParticipants([], 1000000)
+			expect(result.current).toBe(0)
+			expect(result.total).toBe(0)
+		})
+	})
+
+	describe('dedup key safety', () => {
+		test('different sellers with same d tag do not collide', () => {
+			const dedup = getDedupMap()
+			const dTag = 'my-auction'
+
+			const keyA = `${SELLER_A}:${dTag}`
+			const keyB = `${SELLER_B}:${dTag}`
+
+			dedup.set(keyA, {
+				status: 'live' as const,
+				currentParticipants: 5,
+				totalParticipants: 10,
+				updatedAt: 1000,
+			})
+
+			expect(dedup.has(keyA)).toBe(true)
+			expect(dedup.has(keyB)).toBe(false)
+		})
+	})
+
+	describe('buildLiveActivityDTag collision prevention', () => {
+		test('same d tag from different sellers produces different activity d tags', () => {
+			const coordA = `${AUCTION_KIND}:${SELLER_A}:my-auction`
+			const coordB = `${AUCTION_KIND}:${SELLER_B}:my-auction`
+
+			const dTagA = buildLiveActivityDTag(coordA)
+			const dTagB = buildLiveActivityDTag(coordB)
+
+			expect(dTagA).not.toBe(dTagB)
+		})
+	})
+
+	describe('configuration', () => {
+		test('getIntervalMs returns default when env not set', () => {
+			const orig = process.env.LIVE_ACTIVITY_INTERVAL_MS
+			delete process.env.LIVE_ACTIVITY_INTERVAL_MS
+			expect(getIntervalMs()).toBe(60_000)
+			if (orig) process.env.LIVE_ACTIVITY_INTERVAL_MS = orig
+		})
+
+		test('getIntervalMs returns custom value when env set', () => {
+			const orig = process.env.LIVE_ACTIVITY_INTERVAL_MS
+			process.env.LIVE_ACTIVITY_INTERVAL_MS = '30000'
+			expect(getIntervalMs()).toBe(30_000)
+			if (orig) process.env.LIVE_ACTIVITY_INTERVAL_MS = orig
+		})
+
+		test('getLookbackDays returns default when env not set', () => {
+			const orig = process.env.LIVE_ACTIVITY_LOOKBACK_DAYS
+			delete process.env.LIVE_ACTIVITY_LOOKBACK_DAYS
+			expect(getLookbackDays()).toBe(7)
+			if (orig) process.env.LIVE_ACTIVITY_LOOKBACK_DAYS = orig
+		})
+	})
+})

--- a/contextvm/tools/live-activity-worker.ts
+++ b/contextvm/tools/live-activity-worker.ts
@@ -1,0 +1,369 @@
+import type { ApplesauceRelayPool } from '@contextvm/sdk'
+import type { NostrSigner } from '@contextvm/sdk'
+import type { NostrEvent, EventTemplate, Filter } from 'nostr-tools'
+import {
+	LIVE_ACTIVITY_KIND,
+	LIVE_CHAT_KIND,
+	AUCTION_KIND,
+	buildLiveActivityTags,
+	buildLiveActivityDTag,
+	deriveLiveActivityStatus,
+	type LiveActivityStatus,
+} from '../../src/lib/nip53'
+
+export interface LiveActivityWorkerContext {
+	relayPool: ApplesauceRelayPool
+	signer: NostrSigner
+	issuerPubkey: string
+}
+
+interface LiveActivityState {
+	status: LiveActivityStatus
+	currentParticipants: number
+	totalParticipants: number
+	updatedAt: number
+}
+
+const DEFAULT_INTERVAL_MS = 60_000
+const DEFAULT_LOOKBACK_DAYS = 7
+const PARTICIPANT_ACTIVE_WINDOW_S = 300
+const MAX_AUCTIONS_PER_POLL = 500
+const MAX_CHAT_MESSAGES_PER_ACTIVITY = 500
+
+let dedupMap = new Map<string, LiveActivityState>()
+let intervalHandle: ReturnType<typeof setInterval> | null = null
+let discoveryUnsub: (() => void) | null = null
+
+export function getIntervalMs(): number {
+	const val = process.env.LIVE_ACTIVITY_INTERVAL_MS
+	return val ? parseInt(val, 10) || DEFAULT_INTERVAL_MS : DEFAULT_INTERVAL_MS
+}
+
+export function getLookbackDays(): number {
+	const val = process.env.LIVE_ACTIVITY_LOOKBACK_DAYS
+	return val ? parseInt(val, 10) || DEFAULT_LOOKBACK_DAYS : DEFAULT_LOOKBACK_DAYS
+}
+
+export function resetDedupMap(): void {
+	dedupMap = new Map()
+}
+
+export function getDedupMap(): Map<string, LiveActivityState> {
+	return dedupMap
+}
+
+export function countParticipants(
+	messages: Array<{ pubkey: string; created_at: number }>,
+	now: number,
+): { current: number; total: number } {
+	const authors = new Set<string>()
+	const recentAuthors = new Set<string>()
+	const cutoff = now - PARTICIPANT_ACTIVE_WINDOW_S
+
+	for (const msg of messages) {
+		authors.add(msg.pubkey)
+		if (msg.created_at >= cutoff) {
+			recentAuthors.add(msg.pubkey)
+		}
+	}
+
+	return { current: recentAuthors.size, total: authors.size }
+}
+
+function getTagValue(event: NostrEvent, name: string): string {
+	return event.tags.find((t) => t[0] === name)?.[1] ?? ''
+}
+
+function getTagValues(event: NostrEvent, name: string): string[] {
+	return event.tags.filter((t) => t[0] === name && t[1]).map((t) => t[1] ?? '')
+}
+
+async function fetchEventsUntilEose(
+	relayPool: ApplesauceRelayPool,
+	filters: Filter[],
+	timeoutMs = 5000,
+): Promise<NostrEvent[]> {
+	return new Promise((resolve) => {
+		const collected: NostrEvent[] = []
+		let resolved = false
+
+		const timer = setTimeout(() => {
+			if (!resolved) {
+				resolved = true
+				unsub?.()
+				resolve(collected)
+			}
+		}, timeoutMs)
+
+		let unsub: (() => void) | undefined
+
+		relayPool.subscribe(
+			filters,
+			(event) => {
+				collected.push(event)
+			},
+			() => {
+				if (!resolved) {
+					resolved = true
+					clearTimeout(timer)
+					unsub?.()
+					resolve(collected)
+				}
+			},
+		).then((fn) => {
+			unsub = fn
+		})
+	})
+}
+
+export async function fetchRecentLiveChatAuctions(ctx: LiveActivityWorkerContext): Promise<NostrEvent[]> {
+	const lookbackSeconds = getLookbackDays() * 86400
+	const since = Math.floor(Date.now() / 1000) - lookbackSeconds
+
+	const events = await fetchEventsUntilEose(ctx.relayPool, [
+		{
+			kinds: [AUCTION_KIND],
+			'#live_chat': ['enabled'],
+			since,
+			limit: MAX_AUCTIONS_PER_POLL,
+		},
+	])
+	return events
+}
+
+export async function fetchExistingLiveActivity(
+	ctx: LiveActivityWorkerContext,
+	auctionCoord: string,
+): Promise<NostrEvent | null> {
+	const events = await fetchEventsUntilEose(ctx.relayPool, [
+		{
+			kinds: [LIVE_ACTIVITY_KIND],
+			'#a': [auctionCoord],
+			authors: [ctx.issuerPubkey],
+			limit: 1,
+		},
+	])
+	if (events.length === 0) return null
+
+	events.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
+	return events[0]
+}
+
+export async function fetchChatParticipants(
+	ctx: LiveActivityWorkerContext,
+	liveActivityCoord: string,
+): Promise<Array<{ pubkey: string; created_at: number }>> {
+	const events = await fetchEventsUntilEose(ctx.relayPool, [
+		{
+			kinds: [LIVE_CHAT_KIND],
+			'#a': [liveActivityCoord],
+			limit: MAX_CHAT_MESSAGES_PER_ACTIVITY,
+		},
+	])
+	return events.map((e) => ({
+		pubkey: e.pubkey,
+		created_at: e.created_at ?? 0,
+	}))
+}
+
+export async function publishLiveActivityUpdate(
+	ctx: LiveActivityWorkerContext,
+	params: {
+		dTag: string
+		sellerPubkey: string
+		title: string
+		summary: string
+		image: string | undefined
+		startsAt: number
+		maxEndAt: number
+		status: LiveActivityStatus
+		relays: string[]
+		categories: string[]
+		currentParticipants: number
+		totalParticipants: number
+	},
+): Promise<void> {
+	const tags = buildLiveActivityTags({
+		dTag: params.dTag,
+		sellerPubkey: params.sellerPubkey,
+		title: params.title,
+		summary: params.summary,
+		image: params.image,
+		startsAt: params.startsAt,
+		maxEndAt: params.maxEndAt,
+		status: params.status,
+		relays: params.relays,
+		categories: params.categories,
+	})
+
+	tags.push(['current_participants', String(params.currentParticipants)])
+	tags.push(['total_participants', String(params.totalParticipants)])
+
+	const template: EventTemplate = {
+		kind: LIVE_ACTIVITY_KIND,
+		content: '',
+		created_at: Math.floor(Date.now() / 1000),
+		tags,
+	}
+
+	const signed = await ctx.signer.signEvent(template)
+	await ctx.relayPool.publish(signed)
+}
+
+type PublishFn = (params: {
+	dTag: string
+	sellerPubkey: string
+	title: string
+	summary: string
+	image: string | undefined
+	startsAt: number
+	maxEndAt: number
+	status: LiveActivityStatus
+	relays: string[]
+	categories: string[]
+	currentParticipants: number
+	totalParticipants: number
+}) => Promise<void>
+
+export async function pollAndUpdateLiveActivities(
+	ctx: LiveActivityWorkerContext,
+	opts?: { publishOverride?: PublishFn },
+): Promise<{
+	checked: number
+	created: number
+	updated: number
+	skipped: number
+	errors: number
+}> {
+	const now = Math.floor(Date.now() / 1000)
+	const stats = { checked: 0, created: 0, updated: 0, skipped: 0, errors: 0 }
+
+	let auctions: NostrEvent[]
+	try {
+		auctions = await fetchRecentLiveChatAuctions(ctx)
+	} catch (err) {
+		console.error('[live-activity-worker] Failed to fetch auctions:', err)
+		stats.errors++
+		return stats
+	}
+
+	const publish = opts?.publishOverride ?? ((p) => publishLiveActivityUpdate(ctx, p))
+
+	for (const auction of auctions) {
+		stats.checked++
+		try {
+			const auctionDTag = getTagValue(auction, 'd')
+			if (!auctionDTag) continue
+
+			const sellerPubkey = auction.pubkey
+			const startsAt = parseInt(getTagValue(auction, 'start_at') || '0', 10) || 0
+			const endAt = parseInt(getTagValue(auction, 'end_at') || '0', 10) || 0
+			const maxEndAt = parseInt(getTagValue(auction, 'max_end_at') || '0', 10) || endAt
+			const status = deriveLiveActivityStatus(startsAt, maxEndAt, now)
+			const title = getTagValue(auction, 'title')
+			const summary = getTagValue(auction, 'summary')
+			const images = getTagValues(auction, 'image')
+			const image = images.length > 0 ? images[0] : undefined
+			const categories = getTagValues(auction, 't')
+
+			const auctionCoord = `${AUCTION_KIND}:${sellerPubkey}:${auctionDTag}`
+			const safeDTag = buildLiveActivityDTag(auctionCoord)
+			const liveActivityCoord = `${LIVE_ACTIVITY_KIND}:${ctx.issuerPubkey}:${safeDTag}`
+
+			const dedupKey = `${sellerPubkey}:${auctionDTag}`
+
+			const existing = await fetchExistingLiveActivity(ctx, auctionCoord)
+
+			let currentParticipants = 0
+			let totalParticipants = 0
+			if (existing) {
+				const participants = await fetchChatParticipants(ctx, liveActivityCoord)
+				const counts = countParticipants(participants, now)
+				currentParticipants = counts.current
+				totalParticipants = counts.total
+			}
+
+			const lastKnown = dedupMap.get(dedupKey)
+			if (
+				lastKnown &&
+				lastKnown.status === status &&
+				lastKnown.currentParticipants === currentParticipants &&
+				lastKnown.totalParticipants === totalParticipants
+			) {
+				stats.skipped++
+				continue
+			}
+
+			const relayUrls = ctx.relayPool.getRelayUrls()
+
+			await publish({
+				dTag: safeDTag,
+				sellerPubkey,
+				title,
+				summary,
+				image,
+				startsAt,
+				maxEndAt,
+				status,
+				relays: relayUrls,
+				categories,
+				currentParticipants,
+				totalParticipants,
+			})
+
+			dedupMap.set(dedupKey, {
+				status,
+				currentParticipants,
+				totalParticipants,
+				updatedAt: now,
+			})
+
+			if (existing) {
+				stats.updated++
+			} else {
+				stats.created++
+			}
+		} catch (err) {
+			console.error(`[live-activity-worker] Error processing auction:`, err)
+			stats.errors++
+		}
+	}
+
+	if (stats.created + stats.updated > 0) {
+		console.log(
+			`[live-activity-worker] Poll complete: ${stats.checked} checked, ${stats.created} created, ${stats.updated} updated, ${stats.skipped} skipped, ${stats.errors} errors`,
+		)
+	}
+
+	return stats
+}
+
+export function startLiveActivityWorker(ctx: LiveActivityWorkerContext, intervalMs?: number): void {
+	const interval = intervalMs ?? getIntervalMs()
+
+	console.log(`[live-activity-worker] Starting worker (interval: ${interval}ms, lookback: ${getLookbackDays()} days)`)
+
+	const tick = async () => {
+		try {
+			await pollAndUpdateLiveActivities(ctx)
+		} catch (err) {
+			console.error('[live-activity-worker] Unexpected error in poll cycle:', err)
+		}
+	}
+
+	tick()
+
+	intervalHandle = setInterval(tick, interval)
+}
+
+export function stopLiveActivityWorker(): void {
+	if (discoveryUnsub) {
+		discoveryUnsub()
+		discoveryUnsub = null
+	}
+	if (intervalHandle !== null) {
+		clearInterval(intervalHandle)
+		intervalHandle = null
+		console.log('[live-activity-worker] Stopped')
+	}
+}

--- a/e2e/tests/auction-live-chat-ui.spec.ts
+++ b/e2e/tests/auction-live-chat-ui.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from '../fixtures'
+import { finalizeEvent } from 'nostr-tools/pure'
+import { Relay } from 'nostr-tools/relay'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import { devUser1 } from '../../src/lib/fixtures'
+
+test.use({ scenario: 'merchant' })
+
+const RELAY_URL = 'ws://localhost:10547'
+
+async function seedAuctionAndGetId() {
+	const relay = await Relay.connect(RELAY_URL)
+	const skBytes = hexToBytes(devUser1.sk)
+	const now = Math.floor(Date.now() / 1000)
+	const dTag = `test-chat-${Date.now()}`
+
+	const event = finalizeEvent(
+		{
+			kind: 30408,
+			created_at: now,
+			content: 'Test auction for live chat E2E',
+			tags: [
+				['d', dTag],
+				['title', 'Live Chat E2E Auction'],
+				['summary', 'Test auction for verifying live chat UI'],
+				['image', 'https://placehold.co/400x400'],
+				['price', '1000', 'SATS'],
+				['status', 'on-sale'],
+				['start_at', String(now)],
+				['end_at', String(now + 86400)],
+				['max_end_at', String(now + 172800)],
+				['settlement_grace', '3600'],
+				['t', 'art'],
+				['mint', 'https://mint.minibits.cash/Bitcoin'],
+			],
+		},
+		skBytes,
+	)
+	await relay.publish(event)
+	await relay.close()
+
+	return { eventId: event.id, dTag }
+}
+
+async function seedLiveActivity(dTag: string) {
+	const relay = await Relay.connect(RELAY_URL)
+	const skBytes = hexToBytes(devUser1.sk)
+	const now = Math.floor(Date.now() / 1000)
+
+	const liveEvent = finalizeEvent(
+		{
+			kind: 30311,
+			created_at: now,
+			content: '',
+			tags: [
+				['d', dTag],
+				['a', `30408:${devUser1.pk}:${dTag}`],
+				['title', 'Live Chat E2E Auction'],
+				['status', 'live'],
+				['client', 'plebeian.market'],
+				['p', devUser1.pk, '', 'Host'],
+				['starts', String(now)],
+				['ends', String(now + 86400)],
+				['relays', RELAY_URL],
+			],
+		},
+		skBytes,
+	)
+	await relay.publish(liveEvent)
+	await relay.close()
+
+	return liveEvent
+}
+
+async function waitForAuctionPage(page: import('@playwright/test').Page, eventId: string) {
+	await page.goto(`/auctions/${eventId}`)
+	await page.waitForLoadState('networkidle')
+	await expect(
+		page
+			.locator('h1')
+			.or(page.locator('text=Live chat not available'))
+			.or(page.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ }))
+			.first(),
+	).toBeVisible({ timeout: 30_000 })
+}
+
+test.describe('Auction Live Chat UI Components', () => {
+	test('chat panel shows "not available" when no 30311 live activity exists', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId } = await seedAuctionAndGetId()
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		const notAvailable = merchantPage.getByText('Live chat not available for this auction')
+		const chatLabel = merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })
+		await expect(notAvailable.first().or(chatLabel)).toBeVisible({ timeout: 15_000 })
+	})
+
+	test('chat panel is hidden on mobile viewport width', async ({ browser }) => {
+		test.setTimeout(60_000)
+
+		const { eventId } = await seedAuctionAndGetId()
+
+		const context = await browser.newContext({
+			viewport: { width: 375, height: 667 },
+		})
+		const mobilePage = await context.newPage()
+
+		await mobilePage.goto(`http://localhost:34567/auctions/${eventId}`)
+		await mobilePage.waitForLoadState('networkidle')
+		await mobilePage.waitForTimeout(3000)
+
+		const chatContainer = mobilePage.locator('.hidden.w-80.shrink-0.lg\\:block')
+		await expect(chatContainer).not.toBeVisible()
+
+		await context.close()
+	})
+
+	test('chat panel container is visible on desktop viewport width with live activity', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		await expect(merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('unauthenticated user sees login prompt when live activity exists', async ({ unauthenticatedPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await unauthenticatedPage.goto(`/auctions/${eventId}`)
+		await unauthenticatedPage.waitForLoadState('networkidle')
+		await expect(unauthenticatedPage.locator('header')).toBeVisible({ timeout: 15_000 })
+
+		const loginPrompt = unauthenticatedPage.getByText(/log in to join/i)
+		const notAvailable = unauthenticatedPage.getByText('Live chat not available for this auction')
+		await expect(loginPrompt.or(notAvailable)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('live chat panel shows empty state and message input', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		await expect(merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })).toBeVisible({ timeout: 20_000 })
+
+		const emptyState = merchantPage.getByText('No messages yet. Be the first!')
+		if (await emptyState.isVisible().catch(() => false)) {
+			await expect(emptyState).toBeVisible()
+		}
+
+		const messageInput = merchantPage.getByPlaceholder('Type a message...')
+		if (await messageInput.isVisible().catch(() => false)) {
+			await messageInput.fill('Hello from E2E test!')
+			await messageInput.press('Enter')
+
+			await expect(merchantPage.getByText('Hello from E2E test!')).toBeVisible({ timeout: 10_000 })
+		}
+	})
+
+	test('message count shows correct count', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		await expect(merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })).toBeVisible({ timeout: 20_000 })
+
+		const messageCount = merchantPage.getByText(/\d+ messages/)
+		if (await messageCount.isVisible().catch(() => false)) {
+			const text = await messageCount.textContent()
+			expect(text).toMatch(/^\d+ messages$/)
+		}
+	})
+})

--- a/e2e/tests/auction-live-chat.spec.ts
+++ b/e2e/tests/auction-live-chat.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from '../fixtures'
+import { finalizeEvent } from 'nostr-tools/pure'
+import { Relay } from 'nostr-tools/relay'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import { devUser1 } from '../../src/lib/fixtures'
+
+test.use({ scenario: 'merchant' })
+
+const RELAY_URL = 'ws://localhost:10547'
+
+async function seedAuctionAndGetId() {
+	const relay = await Relay.connect(RELAY_URL)
+	const skBytes = hexToBytes(devUser1.sk)
+	const now = Math.floor(Date.now() / 1000)
+	const dTag = `test-nip53-${Date.now()}`
+
+	const event = finalizeEvent(
+		{
+			kind: 30408,
+			created_at: now,
+			content: 'Test auction for live chat',
+			tags: [
+				['d', dTag],
+				['title', 'NIP-53 Protocol Test Auction'],
+				['summary', 'Test auction for verifying NIP-53 protocol'],
+				['image', 'https://placehold.co/400x400'],
+				['price', '5000', 'SATS'],
+				['status', 'on-sale'],
+				['start_at', String(now)],
+				['end_at', String(now + 86400)],
+				['max_end_at', String(now + 172800)],
+				['settlement_grace', '3600'],
+				['t', 'art'],
+				['mint', 'https://mint.minibits.cash/Bitcoin'],
+			],
+		},
+		skBytes,
+	)
+	await relay.publish(event)
+	await relay.close()
+
+	return { eventId: event.id, dTag }
+}
+
+async function seedLiveActivity(dTag: string) {
+	const relay = await Relay.connect(RELAY_URL)
+	const skBytes = hexToBytes(devUser1.sk)
+	const now = Math.floor(Date.now() / 1000)
+
+	const liveEvent = finalizeEvent(
+		{
+			kind: 30311,
+			created_at: now,
+			content: '',
+			tags: [
+				['d', dTag],
+				['a', `30408:${devUser1.pk}:${dTag}`],
+				['title', 'NIP-53 Protocol Test Auction'],
+				['status', 'live'],
+				['client', 'plebeian.market'],
+				['p', devUser1.pk, '', 'Host'],
+				['relays', RELAY_URL],
+			],
+		},
+		skBytes,
+	)
+	await relay.publish(liveEvent)
+	await relay.close()
+
+	return liveEvent
+}
+
+async function waitForAuctionPage(page: import('@playwright/test').Page, eventId: string) {
+	await page.goto(`/auctions/${eventId}`)
+	await page.waitForLoadState('networkidle')
+	await expect(
+		page
+			.locator('h1')
+			.or(page.locator('text=Live chat not available'))
+			.or(page.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ }))
+			.first(),
+	).toBeVisible({ timeout: 30_000 })
+}
+
+test.describe('Auction Live Chat', () => {
+	test('live chat panel shows fallback when no 30311 exists', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId } = await seedAuctionAndGetId()
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		const notAvailable = merchantPage.getByText('Live chat not available for this auction')
+		const chatVisible = merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })
+		await expect(notAvailable.or(chatVisible)).toBeVisible({ timeout: 15_000 })
+	})
+
+	test('live chat panel shows login prompt for unauthenticated users', async ({ unauthenticatedPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await unauthenticatedPage.goto(`/auctions/${eventId}`)
+		await unauthenticatedPage.waitForLoadState('networkidle')
+		await expect(unauthenticatedPage.locator('header')).toBeVisible({ timeout: 15_000 })
+
+		const loginPrompt = unauthenticatedPage.getByText(/log in to join/i)
+		const notAvailable = unauthenticatedPage.getByText('Live chat not available for this auction')
+		await expect(loginPrompt.or(notAvailable)).toBeVisible({ timeout: 20_000 })
+	})
+
+	test('merchant can type a message in the live chat input', async ({ merchantPage }) => {
+		test.setTimeout(60_000)
+
+		const { eventId, dTag } = await seedAuctionAndGetId()
+		await seedLiveActivity(dTag)
+
+		await waitForAuctionPage(merchantPage, eventId)
+
+		await expect(merchantPage.locator('span.text-sm.font-medium', { hasText: /^Live Chat$/ })).toBeVisible({ timeout: 20_000 })
+
+		const messageInput = merchantPage.getByPlaceholder('Type a message...')
+		await expect(messageInput).toBeVisible({ timeout: 10_000 })
+
+		await messageInput.fill('Hello from test!')
+		expect(await messageInput.inputValue()).toBe('Hello from test!')
+	})
+
+	test('30311 live activity event has correct tags', async () => {
+		const { dTag } = await seedAuctionAndGetId()
+		const liveEvent = await seedLiveActivity(dTag)
+
+		expect(liveEvent.kind).toBe(30311)
+		expect(liveEvent.tags.some((t) => t[0] === 'd')).toBe(true)
+		expect(liveEvent.tags.some((t) => t[0] === 'a' && t[1].startsWith('30408:'))).toBe(true)
+		expect(liveEvent.tags.some((t) => t[0] === 'title')).toBe(true)
+		expect(liveEvent.tags.some((t) => t[0] === 'status')).toBe(true)
+		expect(liveEvent.tags.some((t) => t[0] === 'client' && t[1] === 'plebeian.market')).toBe(true)
+	})
+})

--- a/src/components/LiveChatMessage.tsx
+++ b/src/components/LiveChatMessage.tsx
@@ -1,0 +1,28 @@
+import type { LiveChatMessage } from '@/lib/nip53'
+import { UserCard } from '@/components/UserCard'
+
+function formatRelativeTime(timestamp: number): string {
+	const seconds = Math.floor(Date.now() / 1000) - timestamp
+	if (seconds < 60) return 'just now'
+	if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+	if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
+	return `${Math.floor(seconds / 86400)}d`
+}
+
+interface LiveChatMessageProps {
+	message: LiveChatMessage
+}
+
+export function LiveChatMessageBubble({ message }: LiveChatMessageProps) {
+	return (
+		<div className="flex gap-2 px-3 py-2 hover:bg-zinc-50">
+			<div className="min-w-0 flex-1">
+				<div className="flex items-baseline justify-between gap-2">
+					<UserCard pubkey={message.authorPubkey} size="xs" />
+					<span className="text-[10px] text-zinc-400">{formatRelativeTime(message.createdAt)}</span>
+				</div>
+				<p className="text-sm text-zinc-800 break-words">{message.content}</p>
+			</div>
+		</div>
+	)
+}

--- a/src/components/LiveChatPanel.tsx
+++ b/src/components/LiveChatPanel.tsx
@@ -1,0 +1,131 @@
+import { useRef, useEffect, useState } from 'react'
+import { Send, MessageCircle } from 'lucide-react'
+import { useLiveChatMessages, useLiveActivity } from '@/queries/liveChat'
+import { usePublishLiveChatMessageMutation } from '@/publish/liveChat'
+import { deriveLiveActivityStatus, type LiveActivityStatus } from '@/lib/nip53'
+import { getAuctionId } from '@/queries/auctions'
+import { getAuctionStartAt, getAuctionMaxEndAt } from '@/lib/auctionSettlement'
+import { LiveChatMessageBubble } from './LiveChatMessage'
+import { NDKEvent } from '@nostr-dev-kit/ndk'
+import { useStore } from '@tanstack/react-store'
+import { authStore } from '@/lib/stores/auth'
+import { Button } from './ui/button'
+
+interface LiveChatPanelProps {
+	auctionEvent: NDKEvent
+}
+
+function getInputPlaceholder(status: LiveActivityStatus): string {
+	switch (status) {
+		case 'planned':
+			return 'Chat opens when the auction starts...'
+		case 'ended':
+			return 'Auction has ended'
+		case 'live':
+			return 'Type a message...'
+	}
+}
+
+export function LiveChatPanel({ auctionEvent }: LiveChatPanelProps) {
+	const { user } = useStore(authStore)
+	const dTag = getAuctionId(auctionEvent)
+
+	const liveActivityQuery = useLiveActivity(auctionEvent)
+	const liveActivity = liveActivityQuery.data
+	const liveActivityCoord = liveActivity?.coord ?? ''
+
+	const startsAt = getAuctionStartAt(auctionEvent)
+	const maxEndAt = getAuctionMaxEndAt(auctionEvent)
+	const status = deriveLiveActivityStatus(startsAt, maxEndAt)
+	const isLive = status === 'live'
+	const canChat = isLive
+
+	const chatQuery = useLiveChatMessages(liveActivityCoord, isLive)
+	const messages = chatQuery.data ?? []
+
+	const sendMessageMutation = usePublishLiveChatMessageMutation()
+	const [input, setInput] = useState('')
+	const chatContainerRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const container = chatContainerRef.current
+		if (!container) return
+		const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100
+		if (isNearBottom) {
+			container.scrollTop = container.scrollHeight
+		}
+	}, [messages.length])
+
+	if (!liveActivity) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center">
+				<MessageCircle className="h-8 w-8 text-zinc-300" />
+				<p className="text-sm text-zinc-400">Live chat not available for this auction</p>
+			</div>
+		)
+	}
+
+	const handleSend = () => {
+		const trimmed = input.trim()
+		if (!trimmed || sendMessageMutation.isPending || !liveActivityCoord || !canChat) return
+		sendMessageMutation.mutate({ liveActivityCoord, content: trimmed }, { onSuccess: () => setInput('') })
+	}
+
+	const handleKeyDown = (e: React.KeyboardEvent) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault()
+			handleSend()
+		}
+	}
+
+	return (
+		<div className="flex h-full flex-col bg-white">
+			<div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3">
+				<div className="flex items-center gap-2">
+					<div className={`h-2 w-2 rounded-full ${isLive ? 'bg-green-500 animate-pulse' : 'bg-zinc-300'}`} />
+					<span className="text-sm font-medium text-zinc-700">Live Chat</span>
+				</div>
+				<span className="text-xs text-zinc-400">{messages.length} messages</span>
+			</div>
+
+			<div ref={chatContainerRef} className="flex-1 overflow-y-auto">
+				{messages.length === 0 ? (
+					<div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
+						<p className="text-sm text-zinc-400">
+							{isLive ? 'No messages yet. Be the first!' : 'Messages will appear here during the auction.'}
+						</p>
+					</div>
+				) : (
+					<div className="divide-y divide-zinc-100">
+						{messages.map((msg) => (
+							<LiveChatMessageBubble key={msg.id} message={msg} />
+						))}
+					</div>
+				)}
+			</div>
+
+			{user ? (
+				<div className="border-t border-zinc-200 p-3">
+					<div className="flex gap-2">
+						<input
+							type="text"
+							value={input}
+							onChange={(e) => setInput(e.target.value)}
+							onKeyDown={handleKeyDown}
+							placeholder={getInputPlaceholder(status)}
+							disabled={!canChat || sendMessageMutation.isPending}
+							className="flex-1 rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm outline-none focus:border-zinc-400 disabled:opacity-50 disabled:cursor-not-allowed"
+						/>
+						<Button size="sm" onClick={handleSend} disabled={!canChat || !input.trim() || sendMessageMutation.isPending}>
+							<Send className="h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			) : (
+				<div className="border-t border-zinc-200 p-3 text-center">
+					<p className="text-xs text-zinc-400">Log in to join the chat</p>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -70,6 +70,7 @@ const INITIAL_FORM: AuctionFormData = {
 	shippings: [],
 	trustedMints: [],
 	isNSFW: false,
+	enableLiveChat: true,
 	// Empty string defers auditor selection to the app's configured
 	// default (`config.cvmServerPubkey`). The auction publish path
 	// resolves this via `getAuctionAuditorsOrThrow` — the seller never

--- a/src/lib/__tests__/nip53.test.ts
+++ b/src/lib/__tests__/nip53.test.ts
@@ -1,0 +1,306 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	LIVE_ACTIVITY_KIND,
+	AUCTION_KIND,
+	deriveLiveActivityStatus,
+	parseAuctionCoordFromATag,
+	buildLiveActivityDTag,
+	buildLiveActivityCoord,
+	buildLiveActivityTags,
+	parseLiveActivity,
+	parseLiveChatMessage,
+} from '../nip53'
+
+const SELLER_PUBKEY = 'a'.repeat(64)
+const CVM_PUBKEY = 'b'.repeat(64)
+const AUCTION_DTAG = 'my-auction-123'
+const AUCTION_COORD = `${AUCTION_KIND}:${SELLER_PUBKEY}:${AUCTION_DTAG}`
+
+describe('nip53', () => {
+	describe('deriveLiveActivityStatus', () => {
+		test('returns planned when now < startsAt', () => {
+			expect(deriveLiveActivityStatus(1000, 2000, 500)).toBe('planned')
+		})
+
+		test('returns ended when now >= maxEndAt', () => {
+			expect(deriveLiveActivityStatus(1000, 2000, 2500)).toBe('ended')
+		})
+
+		test('returns live when startsAt <= now < maxEndAt', () => {
+			expect(deriveLiveActivityStatus(1000, 2000, 1500)).toBe('live')
+		})
+
+		test('returns live when startsAt is 0 (no start constraint)', () => {
+			expect(deriveLiveActivityStatus(0, 2000, 1000)).toBe('live')
+		})
+
+		test('returns live when both are 0 (no constraints)', () => {
+			expect(deriveLiveActivityStatus(0, 0, 1000)).toBe('live')
+		})
+
+		test('uses current time when now is not provided', () => {
+			const now = Math.floor(Date.now() / 1000)
+			expect(deriveLiveActivityStatus(0, 0)).toBe('live')
+			expect(deriveLiveActivityStatus(now + 100, now + 200)).toBe('planned')
+		})
+	})
+
+	describe('parseAuctionCoordFromATag', () => {
+		test('extracts auction coordinate from a tag', () => {
+			const event = {
+				tags: [['a', AUCTION_COORD]],
+			}
+			expect(parseAuctionCoordFromATag(event)).toBe(AUCTION_COORD)
+		})
+
+		test('returns null when no a tag', () => {
+			const event = { tags: [] }
+			expect(parseAuctionCoordFromATag(event)).toBeNull()
+		})
+
+		test('returns null when a tag does not start with auction kind', () => {
+			const event = {
+				tags: [['a', `99999:${SELLER_PUBKEY}:something`]],
+			}
+			expect(parseAuctionCoordFromATag(event)).toBeNull()
+		})
+
+		test('returns null when tags are undefined', () => {
+			expect(parseAuctionCoordFromATag({})).toBeNull()
+		})
+	})
+
+	describe('buildLiveActivityDTag', () => {
+		test('derives safe d tag from full auction coordinate', () => {
+			const dTag = buildLiveActivityDTag(AUCTION_COORD)
+			expect(dTag).toBe(`auction:${SELLER_PUBKEY.slice(0, 16)}:${AUCTION_DTAG}`)
+		})
+
+		test('includes truncated seller pubkey to prevent collisions', () => {
+			const dTag = buildLiveActivityDTag(AUCTION_COORD)
+			expect(dTag).toContain(SELLER_PUBKEY.slice(0, 16))
+		})
+
+		test('handles auction d tags with colons', () => {
+			const coord = `${AUCTION_KIND}:${SELLER_PUBKEY}:my:complex:tag`
+			const dTag = buildLiveActivityDTag(coord)
+			expect(dTag).toBe(`auction:${SELLER_PUBKEY.slice(0, 16)}:my:complex:tag`)
+		})
+	})
+
+	describe('buildLiveActivityCoord', () => {
+		test('builds coordinate with activity owner pubkey (not seller)', () => {
+			const coord = buildLiveActivityCoord(CVM_PUBKEY, AUCTION_COORD)
+			expect(coord).toContain(CVM_PUBKEY)
+			expect(coord).not.toContain(SELLER_PUBKEY)
+		})
+
+		test('uses safe d tag derived from auction coordinate', () => {
+			const coord = buildLiveActivityCoord(CVM_PUBKEY, AUCTION_COORD)
+			const expectedDTag = buildLiveActivityDTag(AUCTION_COORD)
+			expect(coord).toBe(`${LIVE_ACTIVITY_KIND}:${CVM_PUBKEY}:${expectedDTag}`)
+		})
+	})
+
+	describe('buildLiveActivityTags', () => {
+		test('includes required tags', () => {
+			const tags = buildLiveActivityTags({
+				dTag: buildLiveActivityDTag(AUCTION_COORD),
+				sellerPubkey: SELLER_PUBKEY,
+				title: 'Test Auction',
+				summary: 'A test auction',
+				image: 'https://example.com/img.png',
+				startsAt: 1000,
+				maxEndAt: 2000,
+				status: 'live',
+				relays: ['wss://relay.example.com'],
+				categories: ['bitcoin'],
+			})
+
+			const tagNames = tags.map((t) => t[0])
+			expect(tagNames).toContain('d')
+			expect(tagNames).toContain('a')
+			expect(tagNames).toContain('title')
+			expect(tagNames).toContain('status')
+			expect(tagNames).toContain('client')
+			expect(tagNames).toContain('p')
+			expect(tagNames).toContain('summary')
+			expect(tagNames).toContain('image')
+			expect(tagNames).toContain('starts')
+			expect(tagNames).toContain('ends')
+			expect(tagNames).toContain('relays')
+			expect(tagNames).toContain('t')
+		})
+
+		test('a tag links to auction coordinate with seller pubkey', () => {
+			const tags = buildLiveActivityTags({
+				dTag: buildLiveActivityDTag(AUCTION_COORD),
+				sellerPubkey: SELLER_PUBKEY,
+				title: 'Test',
+				summary: '',
+				image: undefined,
+				startsAt: 0,
+				maxEndAt: 0,
+				status: 'planned',
+				relays: [],
+				categories: [],
+			})
+
+			const aTag = tags.find((t) => t[0] === 'a')
+			expect(aTag).toBeDefined()
+			expect(aTag![1]).toContain(SELLER_PUBKEY)
+		})
+
+		test('p tag marks seller as Host', () => {
+			const tags = buildLiveActivityTags({
+				dTag: buildLiveActivityDTag(AUCTION_COORD),
+				sellerPubkey: SELLER_PUBKEY,
+				title: 'Test',
+				summary: '',
+				image: undefined,
+				startsAt: 0,
+				maxEndAt: 0,
+				status: 'planned',
+				relays: [],
+				categories: [],
+			})
+
+			const pTag = tags.find((t) => t[0] === 'p')
+			expect(pTag).toBeDefined()
+			expect(pTag![1]).toBe(SELLER_PUBKEY)
+			expect(pTag![3]).toBe('Host')
+		})
+
+		test('omits optional tags when not provided', () => {
+			const tags = buildLiveActivityTags({
+				dTag: 'test',
+				sellerPubkey: SELLER_PUBKEY,
+				title: 'Test',
+				summary: '',
+				image: undefined,
+				startsAt: 0,
+				maxEndAt: 0,
+				status: 'planned',
+				relays: [],
+				categories: [],
+			})
+
+			const tagNames = tags.map((t) => t[0])
+			expect(tagNames).not.toContain('summary')
+			expect(tagNames).not.toContain('image')
+			expect(tagNames).not.toContain('starts')
+			expect(tagNames).not.toContain('ends')
+			expect(tagNames).not.toContain('relays')
+		})
+	})
+
+	describe('parseLiveActivity', () => {
+		test('separates activityOwnerPubkey from sellerPubkey', () => {
+			const event = {
+				pubkey: CVM_PUBKEY,
+				tags: [
+					['d', buildLiveActivityDTag(AUCTION_COORD)],
+					['status', 'live'],
+					['title', 'Test Auction'],
+					['p', SELLER_PUBKEY, '', 'Host'],
+				],
+			}
+
+			const result = parseLiveActivity(event)
+			expect(result.activityOwnerPubkey).toBe(CVM_PUBKEY)
+			expect(result.sellerPubkey).toBe(SELLER_PUBKEY)
+		})
+
+		test('falls back to event.pubkey for sellerPubkey when no Host tag', () => {
+			const event = {
+				pubkey: SELLER_PUBKEY,
+				tags: [
+					['d', 'test-d'],
+					['status', 'live'],
+					['title', 'Self-hosted'],
+				],
+			}
+
+			const result = parseLiveActivity(event)
+			expect(result.sellerPubkey).toBe(SELLER_PUBKEY)
+			expect(result.activityOwnerPubkey).toBe(SELLER_PUBKEY)
+		})
+
+		test('builds coord from activityOwnerPubkey (not seller)', () => {
+			const dTag = buildLiveActivityDTag(AUCTION_COORD)
+			const event = {
+				pubkey: CVM_PUBKEY,
+				tags: [
+					['d', dTag],
+					['status', 'live'],
+					['title', 'Test'],
+					['p', SELLER_PUBKEY, '', 'Host'],
+				],
+			}
+
+			const result = parseLiveActivity(event)
+			expect(result.coord).toBe(`${LIVE_ACTIVITY_KIND}:${CVM_PUBKEY}:${dTag}`)
+		})
+
+		test('parses all optional fields', () => {
+			const event = {
+				pubkey: CVM_PUBKEY,
+				tags: [
+					['d', 'test'],
+					['status', 'ended'],
+					['title', 'Finished Auction'],
+					['summary', 'It is over'],
+					['image', 'https://example.com/pic.png'],
+					['starts', '1000'],
+					['ends', '2000'],
+					['relays', 'wss://relay1.com', 'wss://relay2.com'],
+					['p', SELLER_PUBKEY, '', 'Host'],
+				],
+			}
+
+			const result = parseLiveActivity(event)
+			expect(result.summary).toBe('It is over')
+			expect(result.image).toBe('https://example.com/pic.png')
+			expect(result.starts).toBe(1000)
+			expect(result.ends).toBe(2000)
+			expect(result.relays).toEqual(['wss://relay1.com', 'wss://relay2.com'])
+		})
+	})
+
+	describe('parseLiveChatMessage', () => {
+		test('extracts message fields', () => {
+			const event = {
+				id: 'abc123',
+				pubkey: SELLER_PUBKEY,
+				content: 'Hello world!',
+				created_at: 1700000000,
+			}
+
+			const msg = parseLiveChatMessage(event)
+			expect(msg.id).toBe('abc123')
+			expect(msg.authorPubkey).toBe(SELLER_PUBKEY)
+			expect(msg.content).toBe('Hello world!')
+			expect(msg.createdAt).toBe(1700000000)
+		})
+
+		test('handles missing content gracefully', () => {
+			const event = {
+				id: 'abc',
+				pubkey: SELLER_PUBKEY,
+				created_at: 1700000000,
+			}
+
+			const msg = parseLiveChatMessage(event)
+			expect(msg.content).toBe('')
+		})
+
+		test('handles missing created_at by using current time', () => {
+			const before = Math.floor(Date.now() / 1000)
+			const event = { id: 'abc', pubkey: SELLER_PUBKEY, content: 'test' }
+			const msg = parseLiveChatMessage(event)
+			const after = Math.floor(Date.now() / 1000)
+			expect(msg.createdAt).toBeGreaterThanOrEqual(before)
+			expect(msg.createdAt).toBeLessThanOrEqual(after)
+		})
+	})
+})

--- a/src/lib/nip53.ts
+++ b/src/lib/nip53.ts
@@ -1,0 +1,123 @@
+export const LIVE_ACTIVITY_KIND = 30311
+export const LIVE_CHAT_KIND = 1311
+export const AUCTION_KIND = 30408
+export type LiveActivityStatus = 'planned' | 'live' | 'ended'
+
+export interface LiveActivity {
+	coord: string
+	activityOwnerPubkey: string
+	sellerPubkey: string
+	dTag: string
+	title: string
+	summary: string
+	image: string | undefined
+	status: LiveActivityStatus
+	starts: number
+	ends: number
+	relays: string[]
+}
+
+export interface LiveChatMessage {
+	id: string
+	authorPubkey: string
+	content: string
+	createdAt: number
+	event: any
+}
+
+export function deriveLiveActivityStatus(startsAt: number, maxEndAt: number, now?: number): LiveActivityStatus {
+	const t = now ?? Math.floor(Date.now() / 1000)
+	if (startsAt > 0 && t < startsAt) return 'planned'
+	if (maxEndAt > 0 && t >= maxEndAt) return 'ended'
+	return 'live'
+}
+
+export function parseAuctionCoordFromATag(event: any): string | null {
+	const aTag = event.tags?.find((t: string[]) => t[0] === 'a')
+	if (!aTag?.[1]) return null
+	const coord = aTag[1]
+	if (!coord.startsWith(`${AUCTION_KIND}:`)) return null
+	return coord
+}
+
+export function buildLiveActivityDTag(auctionCoord: string): string {
+	const parts = auctionCoord.split(':')
+	const sellerPubkey = parts[1] || ''
+	const auctionDTag = parts.slice(2).join(':')
+	return `auction:${sellerPubkey.slice(0, 16)}:${auctionDTag}`
+}
+
+export function buildLiveActivityCoord(activityOwnerPubkey: string, auctionCoord: string): string {
+	const dTag = buildLiveActivityDTag(auctionCoord)
+	return `${LIVE_ACTIVITY_KIND}:${activityOwnerPubkey}:${dTag}`
+}
+
+export function buildLiveActivityTags(params: {
+	dTag: string
+	sellerPubkey: string
+	title: string
+	summary: string
+	image: string | undefined
+	startsAt: number
+	maxEndAt: number
+	status: LiveActivityStatus
+	relays: string[]
+	categories: string[]
+}): string[][] {
+	const tags: string[][] = [
+		['d', params.dTag],
+		['a', `${AUCTION_KIND}:${params.sellerPubkey}:${params.dTag.split(':').slice(2).join(':') || params.dTag}`],
+		['title', params.title],
+		['status', params.status],
+		['client', 'plebeian.market'],
+		['p', params.sellerPubkey, '', 'Host'],
+	]
+
+	if (params.summary) tags.push(['summary', params.summary])
+	if (params.image) tags.push(['image', params.image])
+	if (params.startsAt > 0) tags.push(['starts', String(params.startsAt)])
+	if (params.maxEndAt > 0) tags.push(['ends', String(params.maxEndAt)])
+	if (params.relays.length > 0) tags.push(['relays', ...params.relays])
+	for (const cat of params.categories) {
+		tags.push(['t', cat])
+	}
+
+	return tags
+}
+
+export function parseLiveActivity(event: any): LiveActivity {
+	const dTag = event.tags.find((t: string[]) => t[0] === 'd')?.[1] ?? ''
+	const status = (event.tags.find((t: string[]) => t[0] === 'status')?.[1] as LiveActivityStatus) ?? 'planned'
+	const title = event.tags.find((t: string[]) => t[0] === 'title')?.[1] ?? ''
+	const summary = event.tags.find((t: string[]) => t[0] === 'summary')?.[1] ?? ''
+	const image = event.tags.find((t: string[]) => t[0] === 'image')?.[1]
+	const starts = parseInt(event.tags.find((t: string[]) => t[0] === 'starts')?.[1] ?? '0', 10) || 0
+	const ends = parseInt(event.tags.find((t: string[]) => t[0] === 'ends')?.[1] ?? '0', 10) || 0
+	const relays = event.tags.find((t: string[]) => t[0] === 'relays')?.slice(1) ?? []
+	const sellerPubkey = event.tags.find((t: string[]) => t[0] === 'p' && t[3] === 'Host')?.[1] ?? event.pubkey
+	const activityOwnerPubkey = event.pubkey
+
+	return {
+		coord: `${LIVE_ACTIVITY_KIND}:${activityOwnerPubkey}:${dTag}`,
+		activityOwnerPubkey,
+		sellerPubkey,
+		dTag,
+		title,
+		summary,
+		image,
+		status,
+		starts,
+		ends,
+		relays,
+	}
+}
+
+export function parseLiveChatMessage(event: any): LiveChatMessage {
+	return {
+		id: event.id,
+		authorPubkey: event.pubkey,
+		content: event.content ?? '',
+		createdAt: event.created_at ?? Math.floor(Date.now() / 1000),
+		event,
+	}
+}

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -102,6 +102,7 @@ export interface AuctionFormData {
 	shippings: ProductShippingSelectionInput[]
 	trustedMints: string[]
 	isNSFW: boolean
+	enableLiveChat: boolean
 	/**
 	 * Pubkey of the validator (auditor) the seller wants listed on the
 	 * auction's `auditors` tag. Empty string = "use the app's configured
@@ -313,6 +314,7 @@ export const createAuctionEvent = async (formData: AuctionFormData, signer: NDKS
 		...specTags,
 		...shippingTags,
 		...(formData.isNSFW ? ([['content-warning', 'nsfw'] as NDKTag] as NDKTag[]) : []),
+		...(formData.enableLiveChat ? ([['live_chat', 'enabled'] as NDKTag] as NDKTag[]) : []),
 	]
 
 	return event

--- a/src/publish/liveChat.tsx
+++ b/src/publish/liveChat.tsx
@@ -1,0 +1,56 @@
+import { ndkActions } from '@/lib/stores/ndk'
+import { NDKEvent } from '@nostr-dev-kit/ndk'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { LIVE_CHAT_KIND } from '@/lib/nip53'
+import { liveActivityKeys } from '@/queries/queryKeyFactory'
+
+interface PublishLiveChatMessageParams {
+	liveActivityCoord: string
+	content: string
+}
+
+export const publishLiveChatMessage = async ({ liveActivityCoord, content }: PublishLiveChatMessageParams): Promise<NDKEvent> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	if (!ndk.signer) throw new Error('No signer available')
+
+	const user = await ndk.signer.user()
+	if (!user) throw new Error('No active user')
+
+	const connectedRelays = ndk.pool?.connectedRelays() || []
+	if (connectedRelays.length === 0) {
+		throw new Error('No connected relays')
+	}
+
+	const relayHint = connectedRelays[0]?.url ?? ''
+
+	const event = new NDKEvent(ndk)
+	event.kind = LIVE_CHAT_KIND
+	event.content = content
+	event.created_at = Math.floor(Date.now() / 1000)
+	event.pubkey = user.pubkey
+	event.tags = [['a', liveActivityCoord, relayHint, 'root']]
+
+	await event.sign(ndk.signer)
+	await ndkActions.publishEvent(event)
+
+	return event
+}
+
+export const usePublishLiveChatMessageMutation = () => {
+	const queryClient = useQueryClient()
+
+	return useMutation({
+		mutationFn: publishLiveChatMessage,
+		onSuccess: async (_event, variables) => {
+			await queryClient.invalidateQueries({
+				queryKey: liveActivityKeys.chatMessages(variables.liveActivityCoord),
+			})
+		},
+		onError: (error) => {
+			console.error('Failed to send chat message:', error)
+			toast.error('Failed to send message')
+		},
+	})
+}

--- a/src/queries/__tests__/liveChat.test.ts
+++ b/src/queries/__tests__/liveChat.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect, mock, spyOn } from 'bun:test'
+import { getPublicKey, finalizeEvent } from 'nostr-tools/pure'
+import { parseLiveActivity, LIVE_ACTIVITY_KIND } from '@/lib/nip53'
+
+describe('liveChat queries', () => {
+	describe('fetchLiveActivity anti-spoofing', () => {
+		test('parseLiveActivity uses CVM-authored event correctly', () => {
+			const cvmPriv = crypto.getRandomValues(new Uint8Array(32))
+			const cvmPub = getPublicKey(cvmPriv)
+			const sellerPriv = crypto.getRandomValues(new Uint8Array(32))
+			const sellerPub = getPublicKey(sellerPriv)
+
+			const event = {
+				pubkey: cvmPub,
+				tags: [
+					['d', 'auction:abcd:test'],
+					['status', 'live'],
+					['title', 'Test'],
+					['p', sellerPub, '', 'Host'],
+				],
+			}
+
+			const result = parseLiveActivity(event)
+			expect(result.activityOwnerPubkey).toBe(cvmPub)
+			expect(result.sellerPubkey).toBe(sellerPub)
+			expect(result.coord).toContain(cvmPub)
+			expect(result.coord).not.toContain(sellerPub)
+		})
+
+		test('spoofed event from non-CVM author would have different activityOwnerPubkey', () => {
+			const attackerPriv = crypto.getRandomValues(new Uint8Array(32))
+			const attackerPub = getPublicKey(attackerPriv)
+			const sellerPriv = crypto.getRandomValues(new Uint8Array(32))
+			const sellerPub = getPublicKey(sellerPriv)
+
+			const spoofedEvent = {
+				pubkey: attackerPub,
+				tags: [
+					['d', 'auction:abcd:test'],
+					['status', 'live'],
+					['title', 'Fake'],
+					['p', sellerPub, '', 'Host'],
+				],
+			}
+
+			const result = parseLiveActivity(spoofedEvent)
+			expect(result.activityOwnerPubkey).toBe(attackerPub)
+			expect(result.activityOwnerPubkey).not.toBe(sellerPub)
+		})
+	})
+})

--- a/src/queries/liveChat.tsx
+++ b/src/queries/liveChat.tsx
@@ -1,0 +1,90 @@
+import { ndkActions } from '@/lib/stores/ndk'
+import { type NDKFilter, NDKEvent } from '@nostr-dev-kit/ndk'
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { liveActivityKeys } from './queryKeyFactory'
+import {
+	LIVE_ACTIVITY_KIND,
+	LIVE_CHAT_KIND,
+	AUCTION_KIND,
+	parseLiveActivity,
+	parseLiveChatMessage,
+	type LiveActivity,
+	type LiveChatMessage,
+} from '@/lib/nip53'
+
+type NDKKind = NonNullable<NDKFilter['kinds']>[number]
+const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NDKKind
+const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NDKKind
+import { getAuctionId } from './auctions'
+import { configStore } from '@/lib/stores/config'
+
+export const fetchLiveActivity = async (auctionEvent: NDKEvent): Promise<LiveActivity | null> => {
+	const dTag = getAuctionId(auctionEvent)
+	if (!dTag) return null
+
+	const ndk = ndkActions.getNDK()
+	if (!ndk) return null
+
+	const auctionCoord = `${AUCTION_KIND}:${auctionEvent.pubkey}:${dTag}`
+
+	const cvmServerPubkey = configStore.state.config.cvmServerPubkey
+
+	const filter: NDKFilter = {
+		kinds: [LIVE_ACTIVITY_KIND_NDK],
+		'#a': [auctionCoord],
+		limit: 10,
+	}
+
+	if (cvmServerPubkey) {
+		filter.authors = [cvmServerPubkey]
+	}
+
+	const events = await ndkActions.fetchEventsWithTimeout([filter], { timeoutMs: 5000 })
+	if (events.size === 0) return null
+
+	const sorted = Array.from(events).sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
+	return parseLiveActivity(sorted[0])
+}
+
+export const fetchLiveChatMessages = async (liveActivityCoord: string): Promise<LiveChatMessage[]> => {
+	const ndk = ndkActions.getNDK()
+	if (!ndk) return []
+
+	const filters: NDKFilter[] = [
+		{
+			kinds: [LIVE_CHAT_KIND_NDK],
+			'#a': [liveActivityCoord],
+			limit: 200,
+		},
+	]
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters, { timeoutMs: 5000 })
+	return Array.from(events)
+		.map(parseLiveChatMessage)
+		.sort((a, b) => a.createdAt - b.createdAt)
+}
+
+export const useLiveActivity = (auctionEvent: NDKEvent | null) => {
+	const dTag = auctionEvent ? getAuctionId(auctionEvent) : ''
+	const auctionCoord = auctionEvent && dTag ? `${AUCTION_KIND}:${auctionEvent.pubkey}:${dTag}` : ''
+
+	return useQuery(
+		queryOptions({
+			queryKey: liveActivityKeys.byCoord(auctionCoord),
+			queryFn: () => (auctionEvent ? fetchLiveActivity(auctionEvent) : null),
+			enabled: !!auctionEvent && !!dTag,
+			refetchInterval: 60_000,
+		}),
+	)
+}
+
+export const useLiveChatMessages = (liveActivityCoord: string, isActive: boolean) => {
+	return useQuery(
+		queryOptions({
+			queryKey: liveActivityKeys.chatMessages(liveActivityCoord),
+			queryFn: () => fetchLiveChatMessages(liveActivityCoord),
+			enabled: !!liveActivityCoord,
+			refetchInterval: isActive ? 3_000 : 15_000,
+		}),
+	)
+}

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -172,3 +172,9 @@ export const zapKeys = {
 	byEvent: (eventId: string, recipientPubkey: string) => [...zapKeys.all, 'byEvent', eventId, recipientPubkey] as const,
 	byProvider: (userPubkey: string, targetEventId?: string) => [...zapKeys.all, 'provider', userPubkey, targetEventId || 'all'] as const,
 } as const
+
+export const liveActivityKeys = {
+	all: ['liveActivities'] as const,
+	byCoord: (auctionCoord: string) => [...liveActivityKeys.all, 'byCoord', auctionCoord] as const,
+	chatMessages: (liveActivityCoord: string) => [...liveActivityKeys.all, 'chat', liveActivityCoord] as const,
+} as const

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,994 +57,1063 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-	id: '/setup',
-	path: '/setup',
-	getParentRoute: () => rootRouteImport,
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-	id: '/checkout',
-	path: '/checkout',
-	getParentRoute: () => rootRouteImport,
+  id: '/checkout',
+  path: '/checkout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-	id: '/_dashboard-layout',
-	getParentRoute: () => rootRouteImport,
+  id: '/_dashboard-layout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-	id: '/$vanityName',
-	path: '/$vanityName',
-	getParentRoute: () => rootRouteImport,
+  id: '/$vanityName',
+  path: '/$vanityName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-	id: '/products/',
-	path: '/products/',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/',
+  path: '/products/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-	id: '/posts/',
-	path: '/posts/',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/',
+  path: '/posts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-	id: '/nostr/',
-	path: '/nostr/',
-	getParentRoute: () => rootRouteImport,
+  id: '/nostr/',
+  path: '/nostr/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-	id: '/community/',
-	path: '/community/',
-	getParentRoute: () => rootRouteImport,
+  id: '/community/',
+  path: '/community/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-	id: '/auctions/',
-	path: '/auctions/',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/',
+  path: '/auctions/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-	id: '/search/products',
-	path: '/search/products',
-	getParentRoute: () => rootRouteImport,
+  id: '/search/products',
+  path: '/search/products',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-	id: '/profile/$profileId',
-	path: '/profile/$profileId',
-	getParentRoute: () => rootRouteImport,
+  id: '/profile/$profileId',
+  path: '/profile/$profileId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-	id: '/products/$productId',
-	path: '/products/$productId',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/$productId',
+  path: '/products/$productId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-	id: '/posts/$postId',
-	path: '/posts/$postId',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/$postId',
+  path: '/posts/$postId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-	id: '/collection/$collectionId',
-	path: '/collection/$collectionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/collection/$collectionId',
+  path: '/collection/$collectionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-	id: '/auctions/$auctionId',
-	path: '/auctions/$auctionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/$auctionId',
+  path: '/auctions/$auctionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
-	id: '/dashboard/',
-	path: '/dashboard/',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
-	id: '/dashboard/about',
-	path: '/dashboard/about',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
-	id: '/dashboard/sales/sales',
-	path: '/dashboard/sales/sales',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
-	id: '/dashboard/sales/messages',
-	path: '/dashboard/sales/messages',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-	id: '/dashboard/sales/circular-economy',
-	path: '/dashboard/sales/circular-economy',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-	id: '/dashboard/products/shipping-options',
-	path: '/dashboard/products/shipping-options',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
-	id: '/dashboard/products/products',
-	path: '/dashboard/products/products',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-	id: '/dashboard/products/migration-tool',
-	path: '/dashboard/products/migration-tool',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-	id: '/dashboard/products/collections',
-	path: '/dashboard/products/collections',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
-	id: '/dashboard/products/bids',
-	path: '/dashboard/products/bids',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-	id: '/dashboard/products/auctions',
-	path: '/dashboard/products/auctions',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-	id: '/dashboard/orders/$orderId',
-	path: '/dashboard/orders/$orderId',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-	id: '/dashboard/app-settings/team',
-	path: '/dashboard/app-settings/team',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-	id: '/dashboard/app-settings/featured-items',
-	path: '/dashboard/app-settings/featured-items',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-	id: '/dashboard/app-settings/blacklists',
-	path: '/dashboard/app-settings/blacklists',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-	id: '/dashboard/app-settings/app-miscelleneous',
-	path: '/dashboard/app-settings/app-miscelleneous',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-	id: '/dashboard/account/your-purchases',
-	path: '/dashboard/account/your-purchases',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-	id: '/dashboard/account/vanity-url',
-	path: '/dashboard/account/vanity-url',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-	id: '/dashboard/account/receiving-payments',
-	path: '/dashboard/account/receiving-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
-	id: '/dashboard/account/profile',
-	path: '/dashboard/account/profile',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-	id: '/dashboard/account/preferences',
-	path: '/dashboard/account/preferences',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-	id: '/dashboard/account/nostr-address',
-	path: '/dashboard/account/nostr-address',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
-	id: '/dashboard/account/network',
-	path: '/dashboard/account/network',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-	id: '/dashboard/account/making-payments',
-	path: '/dashboard/account/making-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-	id: '/$pubkey',
-	path: '/$pubkey',
-	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-	id: '/$productId',
-	path: '/$productId',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-} as any)
+const DashboardLayoutDashboardIndexRoute =
+  DashboardLayoutDashboardIndexRouteImport.update({
+    id: '/dashboard/',
+    path: '/dashboard/',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAboutRoute =
+  DashboardLayoutDashboardAboutRouteImport.update({
+    id: '/dashboard/about',
+    path: '/dashboard/about',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesSalesRoute =
+  DashboardLayoutDashboardSalesSalesRouteImport.update({
+    id: '/dashboard/sales/sales',
+    path: '/dashboard/sales/sales',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesRoute =
+  DashboardLayoutDashboardSalesMessagesRouteImport.update({
+    id: '/dashboard/sales/messages',
+    path: '/dashboard/sales/messages',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute =
+  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+    id: '/dashboard/sales/circular-economy',
+    path: '/dashboard/sales/circular-economy',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute =
+  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+    id: '/dashboard/products/shipping-options',
+    path: '/dashboard/products/shipping-options',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsRoute =
+  DashboardLayoutDashboardProductsProductsRouteImport.update({
+    id: '/dashboard/products/products',
+    path: '/dashboard/products/products',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute =
+  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+    id: '/dashboard/products/migration-tool',
+    path: '/dashboard/products/migration-tool',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsRoute =
+  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+    id: '/dashboard/products/collections',
+    path: '/dashboard/products/collections',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsBidsRoute =
+  DashboardLayoutDashboardProductsBidsRouteImport.update({
+    id: '/dashboard/products/bids',
+    path: '/dashboard/products/bids',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsRoute =
+  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+    id: '/dashboard/products/auctions',
+    path: '/dashboard/products/auctions',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute =
+  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+    id: '/dashboard/orders/$orderId',
+    path: '/dashboard/orders/$orderId',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute =
+  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+    id: '/dashboard/app-settings/team',
+    path: '/dashboard/app-settings/team',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+    id: '/dashboard/app-settings/featured-items',
+    path: '/dashboard/app-settings/featured-items',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
+  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+    id: '/dashboard/app-settings/blacklists',
+    path: '/dashboard/app-settings/blacklists',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+    id: '/dashboard/app-settings/app-miscelleneous',
+    path: '/dashboard/app-settings/app-miscelleneous',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute =
+  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+    id: '/dashboard/account/your-purchases',
+    path: '/dashboard/account/your-purchases',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute =
+  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+    id: '/dashboard/account/vanity-url',
+    path: '/dashboard/account/vanity-url',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
+  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+    id: '/dashboard/account/receiving-payments',
+    path: '/dashboard/account/receiving-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountProfileRoute =
+  DashboardLayoutDashboardAccountProfileRouteImport.update({
+    id: '/dashboard/account/profile',
+    path: '/dashboard/account/profile',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountPreferencesRoute =
+  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+    id: '/dashboard/account/preferences',
+    path: '/dashboard/account/preferences',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute =
+  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+    id: '/dashboard/account/nostr-address',
+    path: '/dashboard/account/nostr-address',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNetworkRoute =
+  DashboardLayoutDashboardAccountNetworkRouteImport.update({
+    id: '/dashboard/account/network',
+    path: '/dashboard/account/network',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute =
+  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+    id: '/dashboard/account/making-payments',
+    path: '/dashboard/account/making-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
+  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+    id: '/$pubkey',
+    path: '/$pubkey',
+    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsNewRoute =
+  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute =
+  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+    id: '/$productId',
+    path: '/$productId',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute =
+  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-		id: '/$collectionId',
-		path: '/$collectionId',
-		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-	} as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-	id: '/$auctionId',
-	path: '/$auctionId',
-	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-} as any)
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+    id: '/$collectionId',
+    path: '/$collectionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+    id: '/$auctionId',
+    path: '/$auctionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions': typeof AuctionsIndexRoute
-	'/community': typeof CommunityIndexRoute
-	'/nostr': typeof NostrIndexRoute
-	'/posts': typeof PostsIndexRoute
-	'/products': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions': typeof AuctionsIndexRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/dashboard/about'
-		| '/dashboard/'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions'
-		| '/community'
-		| '/nostr'
-		| '/posts'
-		| '/products'
-		| '/dashboard/about'
-		| '/dashboard'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	id:
-		| '__root__'
-		| '/'
-		| '/$vanityName'
-		| '/_dashboard-layout'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/_dashboard-layout/dashboard/about'
-		| '/_dashboard-layout/dashboard/'
-		| '/_dashboard-layout/dashboard/account/making-payments'
-		| '/_dashboard-layout/dashboard/account/network'
-		| '/_dashboard-layout/dashboard/account/nostr-address'
-		| '/_dashboard-layout/dashboard/account/preferences'
-		| '/_dashboard-layout/dashboard/account/profile'
-		| '/_dashboard-layout/dashboard/account/receiving-payments'
-		| '/_dashboard-layout/dashboard/account/vanity-url'
-		| '/_dashboard-layout/dashboard/account/your-purchases'
-		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-		| '/_dashboard-layout/dashboard/app-settings/blacklists'
-		| '/_dashboard-layout/dashboard/app-settings/featured-items'
-		| '/_dashboard-layout/dashboard/app-settings/team'
-		| '/_dashboard-layout/dashboard/orders/$orderId'
-		| '/_dashboard-layout/dashboard/products/auctions'
-		| '/_dashboard-layout/dashboard/products/bids'
-		| '/_dashboard-layout/dashboard/products/collections'
-		| '/_dashboard-layout/dashboard/products/migration-tool'
-		| '/_dashboard-layout/dashboard/products/products'
-		| '/_dashboard-layout/dashboard/products/shipping-options'
-		| '/_dashboard-layout/dashboard/sales/circular-economy'
-		| '/_dashboard-layout/dashboard/sales/messages'
-		| '/_dashboard-layout/dashboard/sales/sales'
-		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
-		| '/_dashboard-layout/dashboard/products/collections/new'
-		| '/_dashboard-layout/dashboard/products/products/$productId'
-		| '/_dashboard-layout/dashboard/products/products/new'
-		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/dashboard/about'
+    | '/dashboard/'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  id:
+    | '__root__'
+    | '/'
+    | '/$vanityName'
+    | '/_dashboard-layout'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/_dashboard-layout/dashboard/about'
+    | '/_dashboard-layout/dashboard/'
+    | '/_dashboard-layout/dashboard/account/making-payments'
+    | '/_dashboard-layout/dashboard/account/network'
+    | '/_dashboard-layout/dashboard/account/nostr-address'
+    | '/_dashboard-layout/dashboard/account/preferences'
+    | '/_dashboard-layout/dashboard/account/profile'
+    | '/_dashboard-layout/dashboard/account/receiving-payments'
+    | '/_dashboard-layout/dashboard/account/vanity-url'
+    | '/_dashboard-layout/dashboard/account/your-purchases'
+    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+    | '/_dashboard-layout/dashboard/app-settings/blacklists'
+    | '/_dashboard-layout/dashboard/app-settings/featured-items'
+    | '/_dashboard-layout/dashboard/app-settings/team'
+    | '/_dashboard-layout/dashboard/orders/$orderId'
+    | '/_dashboard-layout/dashboard/products/auctions'
+    | '/_dashboard-layout/dashboard/products/bids'
+    | '/_dashboard-layout/dashboard/products/collections'
+    | '/_dashboard-layout/dashboard/products/migration-tool'
+    | '/_dashboard-layout/dashboard/products/products'
+    | '/_dashboard-layout/dashboard/products/shipping-options'
+    | '/_dashboard-layout/dashboard/sales/circular-economy'
+    | '/_dashboard-layout/dashboard/sales/messages'
+    | '/_dashboard-layout/dashboard/sales/sales'
+    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
+    | '/_dashboard-layout/dashboard/products/collections/new'
+    | '/_dashboard-layout/dashboard/products/products/$productId'
+    | '/_dashboard-layout/dashboard/products/products/new'
+    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	VanityNameRoute: typeof VanityNameRoute
-	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-	CheckoutRoute: typeof CheckoutRoute
-	SetupRoute: typeof SetupRoute
-	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-	PostsPostIdRoute: typeof PostsPostIdRoute
-	ProductsProductIdRoute: typeof ProductsProductIdRoute
-	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-	SearchProductsRoute: typeof SearchProductsRoute
-	AuctionsIndexRoute: typeof AuctionsIndexRoute
-	CommunityIndexRoute: typeof CommunityIndexRoute
-	NostrIndexRoute: typeof NostrIndexRoute
-	PostsIndexRoute: typeof PostsIndexRoute
-	ProductsIndexRoute: typeof ProductsIndexRoute
+  IndexRoute: typeof IndexRoute
+  VanityNameRoute: typeof VanityNameRoute
+  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+  CheckoutRoute: typeof CheckoutRoute
+  SetupRoute: typeof SetupRoute
+  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+  PostsPostIdRoute: typeof PostsPostIdRoute
+  ProductsProductIdRoute: typeof ProductsProductIdRoute
+  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+  SearchProductsRoute: typeof SearchProductsRoute
+  AuctionsIndexRoute: typeof AuctionsIndexRoute
+  CommunityIndexRoute: typeof CommunityIndexRoute
+  NostrIndexRoute: typeof NostrIndexRoute
+  PostsIndexRoute: typeof PostsIndexRoute
+  ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/setup': {
-			id: '/setup'
-			path: '/setup'
-			fullPath: '/setup'
-			preLoaderRoute: typeof SetupRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/checkout': {
-			id: '/checkout'
-			path: '/checkout'
-			fullPath: '/checkout'
-			preLoaderRoute: typeof CheckoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout': {
-			id: '/_dashboard-layout'
-			path: ''
-			fullPath: '/'
-			preLoaderRoute: typeof DashboardLayoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/$vanityName': {
-			id: '/$vanityName'
-			path: '/$vanityName'
-			fullPath: '/$vanityName'
-			preLoaderRoute: typeof VanityNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/': {
-			id: '/'
-			path: '/'
-			fullPath: '/'
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/': {
-			id: '/products/'
-			path: '/products'
-			fullPath: '/products/'
-			preLoaderRoute: typeof ProductsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/': {
-			id: '/posts/'
-			path: '/posts'
-			fullPath: '/posts/'
-			preLoaderRoute: typeof PostsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/nostr/': {
-			id: '/nostr/'
-			path: '/nostr'
-			fullPath: '/nostr/'
-			preLoaderRoute: typeof NostrIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/community/': {
-			id: '/community/'
-			path: '/community'
-			fullPath: '/community/'
-			preLoaderRoute: typeof CommunityIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/': {
-			id: '/auctions/'
-			path: '/auctions'
-			fullPath: '/auctions/'
-			preLoaderRoute: typeof AuctionsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/search/products': {
-			id: '/search/products'
-			path: '/search/products'
-			fullPath: '/search/products'
-			preLoaderRoute: typeof SearchProductsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/profile/$profileId': {
-			id: '/profile/$profileId'
-			path: '/profile/$profileId'
-			fullPath: '/profile/$profileId'
-			preLoaderRoute: typeof ProfileProfileIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/$productId': {
-			id: '/products/$productId'
-			path: '/products/$productId'
-			fullPath: '/products/$productId'
-			preLoaderRoute: typeof ProductsProductIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/$postId': {
-			id: '/posts/$postId'
-			path: '/posts/$postId'
-			fullPath: '/posts/$postId'
-			preLoaderRoute: typeof PostsPostIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/collection/$collectionId': {
-			id: '/collection/$collectionId'
-			path: '/collection/$collectionId'
-			fullPath: '/collection/$collectionId'
-			preLoaderRoute: typeof CollectionCollectionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/$auctionId': {
-			id: '/auctions/$auctionId'
-			path: '/auctions/$auctionId'
-			fullPath: '/auctions/$auctionId'
-			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout/dashboard/': {
-			id: '/_dashboard-layout/dashboard/'
-			path: '/dashboard'
-			fullPath: '/dashboard/'
-			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/about': {
-			id: '/_dashboard-layout/dashboard/about'
-			path: '/dashboard/about'
-			fullPath: '/dashboard/about'
-			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/sales': {
-			id: '/_dashboard-layout/dashboard/sales/sales'
-			path: '/dashboard/sales/sales'
-			fullPath: '/dashboard/sales/sales'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages': {
-			id: '/_dashboard-layout/dashboard/sales/messages'
-			path: '/dashboard/sales/messages'
-			fullPath: '/dashboard/sales/messages'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/circular-economy': {
-			id: '/_dashboard-layout/dashboard/sales/circular-economy'
-			path: '/dashboard/sales/circular-economy'
-			fullPath: '/dashboard/sales/circular-economy'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/shipping-options': {
-			id: '/_dashboard-layout/dashboard/products/shipping-options'
-			path: '/dashboard/products/shipping-options'
-			fullPath: '/dashboard/products/shipping-options'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/products': {
-			id: '/_dashboard-layout/dashboard/products/products'
-			path: '/dashboard/products/products'
-			fullPath: '/dashboard/products/products'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/migration-tool': {
-			id: '/_dashboard-layout/dashboard/products/migration-tool'
-			path: '/dashboard/products/migration-tool'
-			fullPath: '/dashboard/products/migration-tool'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections': {
-			id: '/_dashboard-layout/dashboard/products/collections'
-			path: '/dashboard/products/collections'
-			fullPath: '/dashboard/products/collections'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/bids': {
-			id: '/_dashboard-layout/dashboard/products/bids'
-			path: '/dashboard/products/bids'
-			fullPath: '/dashboard/products/bids'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions': {
-			id: '/_dashboard-layout/dashboard/products/auctions'
-			path: '/dashboard/products/auctions'
-			fullPath: '/dashboard/products/auctions'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/orders/$orderId': {
-			id: '/_dashboard-layout/dashboard/orders/$orderId'
-			path: '/dashboard/orders/$orderId'
-			fullPath: '/dashboard/orders/$orderId'
-			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/team': {
-			id: '/_dashboard-layout/dashboard/app-settings/team'
-			path: '/dashboard/app-settings/team'
-			fullPath: '/dashboard/app-settings/team'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/featured-items': {
-			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-			path: '/dashboard/app-settings/featured-items'
-			fullPath: '/dashboard/app-settings/featured-items'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/blacklists': {
-			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-			path: '/dashboard/app-settings/blacklists'
-			fullPath: '/dashboard/app-settings/blacklists'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-			path: '/dashboard/app-settings/app-miscelleneous'
-			fullPath: '/dashboard/app-settings/app-miscelleneous'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/your-purchases': {
-			id: '/_dashboard-layout/dashboard/account/your-purchases'
-			path: '/dashboard/account/your-purchases'
-			fullPath: '/dashboard/account/your-purchases'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/vanity-url': {
-			id: '/_dashboard-layout/dashboard/account/vanity-url'
-			path: '/dashboard/account/vanity-url'
-			fullPath: '/dashboard/account/vanity-url'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/receiving-payments': {
-			id: '/_dashboard-layout/dashboard/account/receiving-payments'
-			path: '/dashboard/account/receiving-payments'
-			fullPath: '/dashboard/account/receiving-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/profile': {
-			id: '/_dashboard-layout/dashboard/account/profile'
-			path: '/dashboard/account/profile'
-			fullPath: '/dashboard/account/profile'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/preferences': {
-			id: '/_dashboard-layout/dashboard/account/preferences'
-			path: '/dashboard/account/preferences'
-			fullPath: '/dashboard/account/preferences'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/nostr-address': {
-			id: '/_dashboard-layout/dashboard/account/nostr-address'
-			path: '/dashboard/account/nostr-address'
-			fullPath: '/dashboard/account/nostr-address'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/network': {
-			id: '/_dashboard-layout/dashboard/account/network'
-			path: '/dashboard/account/network'
-			fullPath: '/dashboard/account/network'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/making-payments': {
-			id: '/_dashboard-layout/dashboard/account/making-payments'
-			path: '/dashboard/account/making-payments'
-			fullPath: '/dashboard/account/making-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-			path: '/$pubkey'
-			fullPath: '/dashboard/sales/messages/$pubkey'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/new': {
-			id: '/_dashboard-layout/dashboard/products/products/new'
-			path: '/new'
-			fullPath: '/dashboard/products/products/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/$productId': {
-			id: '/_dashboard-layout/dashboard/products/products/$productId'
-			path: '/$productId'
-			fullPath: '/dashboard/products/products/$productId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/new': {
-			id: '/_dashboard-layout/dashboard/products/collections/new'
-			path: '/new'
-			fullPath: '/dashboard/products/collections/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
-			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-			path: '/$collectionId'
-			fullPath: '/dashboard/products/collections/$collectionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-			path: '/$auctionId'
-			fullPath: '/dashboard/products/auctions/$auctionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-		}
-	}
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/checkout': {
+      id: '/checkout'
+      path: '/checkout'
+      fullPath: '/checkout'
+      preLoaderRoute: typeof CheckoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout': {
+      id: '/_dashboard-layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DashboardLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$vanityName': {
+      id: '/$vanityName'
+      path: '/$vanityName'
+      fullPath: '/$vanityName'
+      preLoaderRoute: typeof VanityNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/': {
+      id: '/products/'
+      path: '/products'
+      fullPath: '/products/'
+      preLoaderRoute: typeof ProductsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/posts'
+      fullPath: '/posts/'
+      preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nostr/': {
+      id: '/nostr/'
+      path: '/nostr'
+      fullPath: '/nostr/'
+      preLoaderRoute: typeof NostrIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/community/': {
+      id: '/community/'
+      path: '/community'
+      fullPath: '/community/'
+      preLoaderRoute: typeof CommunityIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/': {
+      id: '/auctions/'
+      path: '/auctions'
+      fullPath: '/auctions/'
+      preLoaderRoute: typeof AuctionsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search/products': {
+      id: '/search/products'
+      path: '/search/products'
+      fullPath: '/search/products'
+      preLoaderRoute: typeof SearchProductsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile/$profileId': {
+      id: '/profile/$profileId'
+      path: '/profile/$profileId'
+      fullPath: '/profile/$profileId'
+      preLoaderRoute: typeof ProfileProfileIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/$productId': {
+      id: '/products/$productId'
+      path: '/products/$productId'
+      fullPath: '/products/$productId'
+      preLoaderRoute: typeof ProductsProductIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/posts/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collection/$collectionId': {
+      id: '/collection/$collectionId'
+      path: '/collection/$collectionId'
+      fullPath: '/collection/$collectionId'
+      preLoaderRoute: typeof CollectionCollectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/$auctionId': {
+      id: '/auctions/$auctionId'
+      path: '/auctions/$auctionId'
+      fullPath: '/auctions/$auctionId'
+      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout/dashboard/': {
+      id: '/_dashboard-layout/dashboard/'
+      path: '/dashboard'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/about': {
+      id: '/_dashboard-layout/dashboard/about'
+      path: '/dashboard/about'
+      fullPath: '/dashboard/about'
+      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/sales': {
+      id: '/_dashboard-layout/dashboard/sales/sales'
+      path: '/dashboard/sales/sales'
+      fullPath: '/dashboard/sales/sales'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages': {
+      id: '/_dashboard-layout/dashboard/sales/messages'
+      path: '/dashboard/sales/messages'
+      fullPath: '/dashboard/sales/messages'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/circular-economy': {
+      id: '/_dashboard-layout/dashboard/sales/circular-economy'
+      path: '/dashboard/sales/circular-economy'
+      fullPath: '/dashboard/sales/circular-economy'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/shipping-options': {
+      id: '/_dashboard-layout/dashboard/products/shipping-options'
+      path: '/dashboard/products/shipping-options'
+      fullPath: '/dashboard/products/shipping-options'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/products': {
+      id: '/_dashboard-layout/dashboard/products/products'
+      path: '/dashboard/products/products'
+      fullPath: '/dashboard/products/products'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/migration-tool': {
+      id: '/_dashboard-layout/dashboard/products/migration-tool'
+      path: '/dashboard/products/migration-tool'
+      fullPath: '/dashboard/products/migration-tool'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections': {
+      id: '/_dashboard-layout/dashboard/products/collections'
+      path: '/dashboard/products/collections'
+      fullPath: '/dashboard/products/collections'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/bids': {
+      id: '/_dashboard-layout/dashboard/products/bids'
+      path: '/dashboard/products/bids'
+      fullPath: '/dashboard/products/bids'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions': {
+      id: '/_dashboard-layout/dashboard/products/auctions'
+      path: '/dashboard/products/auctions'
+      fullPath: '/dashboard/products/auctions'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/orders/$orderId': {
+      id: '/_dashboard-layout/dashboard/orders/$orderId'
+      path: '/dashboard/orders/$orderId'
+      fullPath: '/dashboard/orders/$orderId'
+      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/team': {
+      id: '/_dashboard-layout/dashboard/app-settings/team'
+      path: '/dashboard/app-settings/team'
+      fullPath: '/dashboard/app-settings/team'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/featured-items': {
+      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+      path: '/dashboard/app-settings/featured-items'
+      fullPath: '/dashboard/app-settings/featured-items'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/blacklists': {
+      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+      path: '/dashboard/app-settings/blacklists'
+      fullPath: '/dashboard/app-settings/blacklists'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+      path: '/dashboard/app-settings/app-miscelleneous'
+      fullPath: '/dashboard/app-settings/app-miscelleneous'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/your-purchases': {
+      id: '/_dashboard-layout/dashboard/account/your-purchases'
+      path: '/dashboard/account/your-purchases'
+      fullPath: '/dashboard/account/your-purchases'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/vanity-url': {
+      id: '/_dashboard-layout/dashboard/account/vanity-url'
+      path: '/dashboard/account/vanity-url'
+      fullPath: '/dashboard/account/vanity-url'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/receiving-payments': {
+      id: '/_dashboard-layout/dashboard/account/receiving-payments'
+      path: '/dashboard/account/receiving-payments'
+      fullPath: '/dashboard/account/receiving-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/profile': {
+      id: '/_dashboard-layout/dashboard/account/profile'
+      path: '/dashboard/account/profile'
+      fullPath: '/dashboard/account/profile'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/preferences': {
+      id: '/_dashboard-layout/dashboard/account/preferences'
+      path: '/dashboard/account/preferences'
+      fullPath: '/dashboard/account/preferences'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/nostr-address': {
+      id: '/_dashboard-layout/dashboard/account/nostr-address'
+      path: '/dashboard/account/nostr-address'
+      fullPath: '/dashboard/account/nostr-address'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/network': {
+      id: '/_dashboard-layout/dashboard/account/network'
+      path: '/dashboard/account/network'
+      fullPath: '/dashboard/account/network'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/making-payments': {
+      id: '/_dashboard-layout/dashboard/account/making-payments'
+      path: '/dashboard/account/making-payments'
+      fullPath: '/dashboard/account/making-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+      path: '/$pubkey'
+      fullPath: '/dashboard/sales/messages/$pubkey'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/new': {
+      id: '/_dashboard-layout/dashboard/products/products/new'
+      path: '/new'
+      fullPath: '/dashboard/products/products/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/$productId': {
+      id: '/_dashboard-layout/dashboard/products/products/$productId'
+      path: '/$productId'
+      fullPath: '/dashboard/products/products/$productId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/new': {
+      id: '/_dashboard-layout/dashboard/products/collections/new'
+      path: '/new'
+      fullPath: '/dashboard/products/collections/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
+      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+      path: '/$collectionId'
+      fullPath: '/dashboard/products/collections/$collectionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+      path: '/$auctionId'
+      fullPath: '/dashboard/products/auctions/$auctionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+    }
+  }
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-}
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
+      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+  }
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsAuctionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
+  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsAuctionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
-}
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
+      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+    DashboardLayoutDashboardProductsCollectionsNewRoute:
+      DashboardLayoutDashboardProductsCollectionsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsCollectionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
+  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsCollectionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
-	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
-}
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsProductsProductIdRoute:
+      DashboardLayoutDashboardProductsProductsProductIdRoute,
+    DashboardLayoutDashboardProductsProductsNewRoute:
+      DashboardLayoutDashboardProductsProductsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsProductsRouteChildren,
-)
+const DashboardLayoutDashboardProductsProductsRouteWithChildren =
+  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsProductsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-}
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
+  {
+    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
+      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+  }
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-	DashboardLayoutDashboardSalesMessagesRouteChildren,
-)
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
+  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+    DashboardLayoutDashboardSalesMessagesRouteChildren,
+  )
 
 interface DashboardLayoutRouteChildren {
-	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
-	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
-	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
-	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
-	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
-	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
-	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
-	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
-	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
-	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
-	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
-	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
-	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
+  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+  DashboardLayoutDashboardAccountMakingPaymentsRoute:
+    DashboardLayoutDashboardAccountMakingPaymentsRoute,
+  DashboardLayoutDashboardAccountNetworkRoute:
+    DashboardLayoutDashboardAccountNetworkRoute,
+  DashboardLayoutDashboardAccountNostrAddressRoute:
+    DashboardLayoutDashboardAccountNostrAddressRoute,
+  DashboardLayoutDashboardAccountPreferencesRoute:
+    DashboardLayoutDashboardAccountPreferencesRoute,
+  DashboardLayoutDashboardAccountProfileRoute:
+    DashboardLayoutDashboardAccountProfileRoute,
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
+    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+  DashboardLayoutDashboardAccountVanityUrlRoute:
+    DashboardLayoutDashboardAccountVanityUrlRoute,
+  DashboardLayoutDashboardAccountYourPurchasesRoute:
+    DashboardLayoutDashboardAccountYourPurchasesRoute,
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
+    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
+    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
+    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+  DashboardLayoutDashboardAppSettingsTeamRoute:
+    DashboardLayoutDashboardAppSettingsTeamRoute,
+  DashboardLayoutDashboardOrdersOrderIdRoute:
+    DashboardLayoutDashboardOrdersOrderIdRoute,
+  DashboardLayoutDashboardProductsAuctionsRoute:
+    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+  DashboardLayoutDashboardProductsBidsRoute:
+    DashboardLayoutDashboardProductsBidsRoute,
+  DashboardLayoutDashboardProductsCollectionsRoute:
+    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+  DashboardLayoutDashboardProductsMigrationToolRoute:
+    DashboardLayoutDashboardProductsMigrationToolRoute,
+  DashboardLayoutDashboardProductsProductsRoute:
+    DashboardLayoutDashboardProductsProductsRouteWithChildren,
+  DashboardLayoutDashboardProductsShippingOptionsRoute:
+    DashboardLayoutDashboardProductsShippingOptionsRoute,
+  DashboardLayoutDashboardSalesCircularEconomyRoute:
+    DashboardLayoutDashboardSalesCircularEconomyRoute,
+  DashboardLayoutDashboardSalesMessagesRoute:
+    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+  DashboardLayoutDashboardSalesSalesRoute:
+    DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
+  DashboardLayoutRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	VanityNameRoute: VanityNameRoute,
-	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-	CheckoutRoute: CheckoutRoute,
-	SetupRoute: SetupRoute,
-	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-	PostsPostIdRoute: PostsPostIdRoute,
-	ProductsProductIdRoute: ProductsProductIdRoute,
-	ProfileProfileIdRoute: ProfileProfileIdRoute,
-	SearchProductsRoute: SearchProductsRoute,
-	AuctionsIndexRoute: AuctionsIndexRoute,
-	CommunityIndexRoute: CommunityIndexRoute,
-	NostrIndexRoute: NostrIndexRoute,
-	PostsIndexRoute: PostsIndexRoute,
-	ProductsIndexRoute: ProductsIndexRoute,
+  IndexRoute: IndexRoute,
+  VanityNameRoute: VanityNameRoute,
+  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+  CheckoutRoute: CheckoutRoute,
+  SetupRoute: SetupRoute,
+  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+  PostsPostIdRoute: PostsPostIdRoute,
+  ProductsProductIdRoute: ProductsProductIdRoute,
+  ProfileProfileIdRoute: ProfileProfileIdRoute,
+  SearchProductsRoute: SearchProductsRoute,
+  AuctionsIndexRoute: AuctionsIndexRoute,
+  CommunityIndexRoute: CommunityIndexRoute,
+  NostrIndexRoute: NostrIndexRoute,
+  PostsIndexRoute: PostsIndexRoute,
+  ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -68,11 +68,12 @@ import { useQueries } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { ArrowLeft, Check, Gavel, Landmark, Trophy, Truck, UserRound } from 'lucide-react'
+import { ArrowLeft, Check, Gavel, Landmark, Radio, Trophy, Truck, UserRound } from 'lucide-react'
 import { type ReactNode, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { AvatarUser } from '@/components/AvatarUser'
 import { AuctionBidder } from '@/components/AuctionBidder'
+import { LiveChatPanel } from '@/components/LiveChatPanel'
 import { UserCard } from '@/components/UserCard'
 import { AuctionVerdictPanel } from '@/components/AuctionVerdictPanel'
 import { formatAuctionEndTimeLabel } from '@/lib/auctionCountdownLabels'
@@ -869,6 +870,13 @@ function AuctionDetailRoute() {
 							Participants
 						</TabsTrigger>
 						<TabsTrigger
+							value="live"
+							className="rounded-none px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black"
+						>
+							<Radio className="mr-1 h-4 w-4" />
+							Live
+						</TabsTrigger>
+						<TabsTrigger
 							value="seller"
 							className="rounded-none px-4 py-2 text-sm font-medium data-[state=active]:bg-secondary data-[state=active]:text-white data-[state=inactive]:bg-gray-100 data-[state=inactive]:text-black"
 						>
@@ -1236,6 +1244,14 @@ function AuctionDetailRoute() {
 									</div>
 								)}
 							</section>
+						</div>
+					</TabsContent>
+
+					<TabsContent value="live" className="mt-4 border-t-3 border-secondary bg-tertiary">
+						<div className="rounded-lg bg-white p-6 shadow-md">
+							<div className="h-[500px]">
+								<LiveChatPanel auctionEvent={auction} />
+							</div>
 						</div>
 					</TabsContent>
 


### PR DESCRIPTION
## NIP-53 Auction Live Chat — CVM-Owned with live_chat Opt-In

Replaces #947 (closed due to GitHub force-push sync issue — same code, fresh PR).

### Architecture

**CVM-owned live activities**: The live activity worker (started alongside `startAuctionValidator`) creates and updates kind-30311 events signed by the CVM server key using `ApplesauceRelayPool`.

**`live_chat` opt-in tag**: Sellers explicitly opt in by adding `['live_chat', 'enabled']` to their auction event. The worker only processes opted-in auctions.

**Safe coordinate derivation**: The live activity `d` tag is derived from the full auction coordinate (`auction:<sellerPubkey>:<dTag>`) to prevent collisions.

### maximotodev Issues Addressed

| # | Issue | Fix |
|---|---|---|
| 1 | Not mergeable against base | ✅ Rebased onto `auctions/p2pk-buyer-path-custody-v1` |
| 2 | Ownership model inconsistent | ✅ `activityOwnerPubkey` separate from `sellerPubkey` |
| 3 | Worker signs for untrusted data | ✅ `live_chat` opt-in tag |
| 4 | Discovery spoofable | ✅ `authors` filter on `fetchLiveActivity` |
| 5 | Dedup uses raw `d` | ✅ Keyed by `${sellerPubkey}:${dTag}` |
| 6 | Coordinate helpers assume same pubkey | ✅ Parse `a` tag, safe `d` derivation |
| 7 | Chat sendability not gated | ✅ Input disabled in `planned`/`ended` |
| 8 | Shipping/Comments changes | ✅ Live tab purely additive |

### Tests
37 tests covering ownership model, anti-spoofing, dedup safety, and worker configuration.

### Franchovy Feedback Addressed
- `marketplace` tag → `client: plebeian.market`
- UserCard for message authors
- Auto-scroll behavior
- Radio icon on Live tab