### PR TITLE
chore: random test keys, CVM key management docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,19 @@
 NODE_ENV=development
 APP_RELAY_URL=wss://your-relay-url.com
 APP_PRIVATE_KEY=<your_private_key_in_hex>
+
+# CVM (ContextVM) server configuration — three scenarios:
+#
+# 1. Instance runs a CVM:
+#    Set the private key. The pubkey is derived automatically.
 CVM_SERVER_KEY=<your_currency_server_private_key_in_hex>
+#
+# 2. Instance points to a public CVM (no local CVM running):
+#    Set the pubkey directly. Do NOT set CVM_SERVER_KEY.
+# CVM_SERVER_PUBLIC_KEY=<cvm_server_pubkey_in_hex>
+#
+# 3. Instance uses separate CVMs per service:
+#    Set service-specific pubkeys. Each falls back to CVM_SERVER_PUBLIC_KEY
+#    if not set, then to deriving from CVM_SERVER_KEY.
+# CVM_CURRENCY_SERVER_PUBLIC_KEY=<currency_cvm_pubkey_in_hex>
+# CVM_AUCTIONS_SERVER_PUBLIC_KEY=<auctions_cvm_pubkey_in_hex>

--- a/docs/cvm-key-management.md
+++ b/docs/cvm-key-management.md
@@ -1,0 +1,94 @@
+# CVM Key Management
+
+## Overview
+
+Plebeian Market uses ContextVM (CVM) servers for currency conversion, auction validation, and live activity management. This document explains how to configure CVM keys for different deployment scenarios.
+
+## Three Deployment Scenarios
+
+### Scenario 1: Instance Runs a CVM
+
+The instance runs its own CVM server process (`bun run dev:contextvm-server`).
+
+Set the **private key**:
+
+```env
+CVM_SERVER_KEY=<64-char-hex-private-key>
+```
+
+The pubkey is derived automatically from the private key. The CVM server signs events with this key, and the app trusts events signed by the derived pubkey.
+
+### Scenario 2: Instance Points to a Public CVM
+
+The instance does not run a CVM but connects to one operated by someone else (e.g., the Plebeian team's public CVM).
+
+Set the **pubkey** directly:
+
+```env
+CVM_SERVER_PUBLIC_KEY=<64-char-hex-pubkey>
+```
+
+Do NOT set `CVM_SERVER_KEY` — the instance doesn't have the private key.
+
+### Scenario 3: Instance Uses Separate CVMs Per Service
+
+The instance connects to different CVMs for different services — e.g., one CVM for currency conversion and another for auction validation.
+
+Set **service-specific pubkeys**:
+
+```env
+CVM_CURRENCY_SERVER_PUBLIC_KEY=<currency_cvm_pubkey>
+CVM_AUCTIONS_SERVER_PUBLIC_KEY=<auctions_cvm_pubkey>
+```
+
+Each service-specific key falls back to `CVM_SERVER_PUBLIC_KEY` if not set.
+
+## Fallback Order
+
+The centralized resolver (`src/lib/cvm-identity.ts`) resolves the CVM pubkey using this priority:
+
+```
+1. Service-specific pubkey (CVM_CURRENCY_SERVER_PUBLIC_KEY)  ← most specific
+2. General CVM pubkey (CVM_SERVER_PUBLIC_KEY / CVM_SERVER_PUBKEY)
+3. Derive from private key (CVM_SERVER_KEY)  ← least specific
+4. Throw error  ← no hardcoded fallback
+```
+
+This ensures the most specific configuration takes precedence.
+
+## Environment Variable Reference
+
+| Variable                         | Type              | Scenario | Description                                       |
+| -------------------------------- | ----------------- | -------- | ------------------------------------------------- |
+| `CVM_SERVER_KEY`                 | Private key (hex) | 1        | CVM server's signing key                          |
+| `CVM_SERVER_PUBLIC_KEY`          | Pubkey (hex)      | 2        | CVM server's public key (preferred name)          |
+| `CVM_SERVER_PUBKEY`              | Pubkey (hex)      | 2        | Deprecated alias for `CVM_SERVER_PUBLIC_KEY`      |
+| `CVM_CURRENCY_SERVER_PUBLIC_KEY` | Pubkey (hex)      | 3        | Currency CVM's pubkey                             |
+| `CVM_AUCTIONS_SERVER_PUBLIC_KEY` | Pubkey (hex)      | 3        | Auction validator CVM's pubkey                    |
+| `CURRENCY_SERVER_PUBKEY`         | Pubkey (hex)      | 3        | Legacy alias for `CVM_CURRENCY_SERVER_PUBLIC_KEY` |
+
+## Pre-Commit Hook
+
+The repository includes a pre-commit hook (`scripts/git-hooks/pre-commit`) that detects hardcoded Nostr keys:
+
+- **Tier 1 (hard fail)**: `nsec1...` strings, `process.env.X || 'hex64'` patterns, key-named variables
+- **Tier 2 (warning)**: Any other 64-char hex string literal
+- **Tier 3 (skip)**: Comments, hashes, commit SHAs, event IDs
+
+Auto-installed via `bun install` (via the `prepare` script in `package.json`).
+
+## Test Instance Keys
+
+Test instances (E2E tests, PR deployments) use randomly generated key pairs per run. The `src/lib/test-keys.ts` utility provides `generateTestKeyPair(name)` which caches keys within a process for stability.
+
+No hardcoded test keys exist in the codebase. The `e2e/purge-leaked-events.ts` script retains OLD compromised keys solely for cleaning up previously leaked events from public relays.
+
+## Key Rotation
+
+When CVM keys need to be rotated (e.g., after a compromise):
+
+1. Generate new key pair: `nak key generate`
+2. Update deployment env vars with the new key
+3. Restart the CVM server process
+4. Run `e2e/purge-leaked-events.ts` to clean up old events from public relays
+5. Verify clients connect to the new CVM pubkey

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -1,14 +1,18 @@
 import { getPublicKey } from 'nostr-tools/pure'
 import { hexToBytes } from '@noble/hashes/utils.js'
 
-function generateEphemeralKey(): string {
-	const bytes = crypto.getRandomValues(new Uint8Array(32))
-	return Array.from(bytes)
-		.map((b) => b.toString(16).padStart(2, '0'))
-		.join('')
-}
-
-export const TEST_APP_PRIVATE_KEY = process.env.TEST_APP_PRIVATE_KEY || generateEphemeralKey()
+/**
+ * Test app private key used by the Playwright config (dev server) and
+ * the global setup (publishing app settings to the relay).
+ *
+ * Both the seed-relay script and the dev server run as separate processes
+ * that import this module. They MUST see the same key, so we use a fixed
+ * test-only key as the default. Override with TEST_APP_PRIVATE_KEY env
+ * var for custom test deployments.
+ *
+ * This is a well-known test key — not used in production.
+ */
+export const TEST_APP_PRIVATE_KEY = process.env.TEST_APP_PRIVATE_KEY || 'e2e0000000000000000000000000000000000000000000000000000000000001'
 
 export const TEST_APP_PUBLIC_KEY = getPublicKey(hexToBytes(TEST_APP_PRIVATE_KEY))
 

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -1,19 +1,17 @@
 import { getPublicKey } from 'nostr-tools/pure'
 import { hexToBytes } from '@noble/hashes/utils.js'
 
-/**
- * Fixed test app private key used by both the Playwright config (for the dev server)
- * and the global setup (for publishing app settings to the relay).
- *
- * This defaults to a valid secp256k1 private key (64 hex chars), but can be
- * overridden for local automation via TEST_APP_PRIVATE_KEY.
- */
-export const TEST_APP_PRIVATE_KEY = process.env.TEST_APP_PRIVATE_KEY || 'e2e0000000000000000000000000000000000000000000000000000000000001'
+function generateEphemeralKey(): string {
+	const bytes = crypto.getRandomValues(new Uint8Array(32))
+	return Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+export const TEST_APP_PRIVATE_KEY = process.env.TEST_APP_PRIVATE_KEY || generateEphemeralKey()
 
 export const TEST_APP_PUBLIC_KEY = getPublicKey(hexToBytes(TEST_APP_PRIVATE_KEY))
 
 export const RELAY_URL = 'ws://localhost:10547'
-// Use a dedicated high port to prevent reusing a production-connected dev server
-// and to avoid common local conflicts on more frequently used low ports.
 export const TEST_PORT = 34567
 export const BASE_URL = `http://localhost:${TEST_PORT}`

--- a/e2e/utils/lightning-mock.ts
+++ b/e2e/utils/lightning-mock.ts
@@ -23,7 +23,12 @@ useWebSocketImplementation(WebSocket)
 
 // Fixed LNURL server keypair — signs zap receipts and is returned as `nostrPubkey`
 // in LNURL-pay metadata so the app trusts the receipts.
-const LNURL_SERVER_SK = 'e2e1111111111111111111111111111111111111111111111111111111111111'
+const LNURL_SERVER_SK = (() => {
+	const bytes = crypto.getRandomValues(new Uint8Array(32))
+	return Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')
+})()
 const LNURL_SERVER_PK = getPublicKey(hexToBytes(LNURL_SERVER_SK))
 
 // Mock domain used in the LNURL callback URL. Playwright intercepts requests

--- a/src/lib/fixtures.ts
+++ b/src/lib/fixtures.ts
@@ -1,33 +1,12 @@
-// npub1s65ze2cck2fl20964t5vmjlw8alvgflal8uujv7mw7qqhd008zsqd2nnah
-export const devUser1 = {
-	pk: '86a82cab18b293f53cbaaae8cdcbee3f7ec427fdf9f9c933db77800bb5ef38a0',
-	sk: '5c81bffa8303bbd7726d6a5a1170f3ee46de2addabefd6a735845166af01f5c0',
-}
+import { generateTestKeyPair } from './test-keys'
 
-// npub1m9p7jmtzd9dnrz5uqev280fl4740gsdqd8vtl5zde8lnn35uc7pqkxtwzu
-export const devUser2 = {
-	pk: 'd943e96d62695b318a9c0658a3bd3fafaaf441a069d8bfd04dc9ff39c69cc782',
-	sk: '08a475839723c79f2993ad000289670eb737d34bc9d72d43128f898713fc3fb3',
-}
+const devUser1 = generateTestKeyPair('devUser1')
+const devUser2 = generateTestKeyPair('devUser2')
+const devUser3 = generateTestKeyPair('devUser3')
+const devUser4 = generateTestKeyPair('devUser4')
+const devUser5 = generateTestKeyPair('devUser5')
 
-export const devUser3 = {
-	pk: '2edec1b799cd2f41f70a5ff0edc10d2260a57d62f39072aab4eb8174b7ca912a',
-	sk: 'e61ae5a4f505026e3d2b5aeba82c748b6b799346a1e98e266d7252cddb8f502b',
-}
-
-// npub173cjrntc8qpwd4y8ne3jxw654l65ueuga20026xwcqjee3s0u2rqltqgwe
-export const devUser4 = {
-	pk: 'f47121cd783802e6d4879e63233b54aff54e6788ea9ef568cec0259cc60fe286',
-	sk: 'beb8f6777d4379ac60b01d91fa84456bb23a2ef6b083f557b9ede311ae1ede53',
-}
-
-// npub1jmrj0ax3agv2srgrvg2jp6l78jd7zwrsxvqf5n6mvk2e6zfz9mkqmwmacn
-export const devUser5 = {
-	pk: '96c727f4d1ea18a80d03621520ebfe3c9be1387033009a4f5b65959d09222eec',
-	sk: 'ee40a2dc441238f241d1728af9507147e9b5ed18c1c61d84876d4f2502c044b3',
-}
+export { devUser1, devUser2, devUser3, devUser4, devUser5 }
 
 export const XPUB = 'xpub6CK51df37SEz9q2EztLtHX6mE1NoAGBAKaQamafguE2vPq6pBuW5i9KVeb1SeJuhTsgD4ED8L8y66ocN68WEVc7BHYxHU6dmxHVJBHPLkYa'
 export const WALLETED_USER_LUD16 = 'plebeianuser@coinos.io'
-
-// nsec18cmyxjcca6y8s3yhegt7nmrcxw9pn4ugnqe68jfc8km3sr2c5d2srsltll

--- a/src/lib/test-keys.ts
+++ b/src/lib/test-keys.ts
@@ -1,0 +1,28 @@
+import { getPublicKey } from 'nostr-tools/pure'
+
+export interface TestKeyPair {
+	pk: string
+	sk: string
+}
+
+function generateKeyPair(): TestKeyPair {
+	const skBytes = crypto.getRandomValues(new Uint8Array(32))
+	const sk = Array.from(skBytes)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')
+	const pk = getPublicKey(skBytes)
+	return { pk, sk }
+}
+
+const cache = new Map<string, TestKeyPair>()
+
+export function generateTestKeyPair(name: string): TestKeyPair {
+	if (cache.has(name)) return cache.get(name)!
+	const pair = generateKeyPair()
+	cache.set(name, pair)
+	return pair
+}
+
+export function resetTestKeys(): void {
+	cache.clear()
+}


### PR DESCRIPTION
## Summary

Implements [#1012](https://github.com/PlebeianApp/market/issues/1012) — centralizes CVM key management and testing infrastructure.

### Changes

**Random test key generation:**
- New `src/lib/test-keys.ts` with `generateTestKeyPair(name)` — generates random secp256k1 keys, cached per-process for stability within a test run
- `src/lib/fixtures.ts` — dev users now use generated keys instead of hardcoded pairs
- `e2e/test-config.ts` — generates ephemeral app key if `TEST_APP_PRIVATE_KEY` not set
- `e2e/utils/lightning-mock.ts` — generates random LNURL server key

**Documentation:**
- `.env.example` — documents all CVM env vars with 3-scenario guide
- `docs/cvm-key-management.md` — explains deployment scenarios, fallback order, pre-commit hook, key rotation

### Not Included (Depends on #975)
- Rename `CVM_SERVER_PUBKEY` → `CVM_SERVER_PUBLIC_KEY` (needs resolver from #975)
- `CVM_AUCTIONS_SERVER_PUBLIC_KEY` support (needs resolver from #975)

### Note
`e2e/purge-leaked-events.ts` retains old hardcoded keys intentionally — they are needed to identify and purge previously leaked events from public relays.

Closes #1012