### PR TITLE
fix(auctions): honor max_end_at bidding cutoff

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -4,6 +4,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
 import { usePublishAuctionBidMutation } from '@/publish/auctions'
 import {
+	getAuctionBiddingCutoffAt,
 	getAuctionEndAt,
 	getAuctionBidIncrement,
 	getAuctionStartAt,
@@ -12,9 +13,7 @@ import {
 	getAuctionMints,
 	getAuctionId,
 	useAuctionBids,
-	getAuctionEffectiveEndAt,
 	getAuctionRootEventId,
-	getAuctionMaxEndAt,
 	getAuctionSettlementGrace,
 	getAuctionCurrentPriceFromBids,
 	getBidAmount,
@@ -118,8 +117,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const bids = bidsProp ?? bidsQuery.data ?? []
 	const endAt = getAuctionEndAt(auction)
 	const startAt = getAuctionStartAt(auction)
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
-	const countdown = useAuctionCountdown(effectiveEndAt, { showSeconds: true })
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const ended = countdown.isEnded
 	// Lower-bound gate: bidding is closed until start_at elapses. Using the
 	// countdown's ticking `now` keeps this reactive — the UI flips from
@@ -163,7 +162,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const flatFloor = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
 	const minBid = Math.max(flatFloor, curveFloor)
-	const inCurveWindow = countdown.now > endAt && countdown.now < (getAuctionMaxEndAt(auction) || endAt)
+	const inCurveWindow = countdown.now > endAt && countdown.now < biddingCutoffAt
 	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
@@ -287,8 +286,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				auctionCoordinates,
 				amount: parsedAmount,
 				auctionStartAt: startAt,
-				auctionEffectiveEndAt: effectiveEndAt,
-				auctionLocktimeAt: getAuctionMaxEndAt(auction),
+				auctionEffectiveEndAt: biddingCutoffAt,
+				auctionLocktimeAt: biddingCutoffAt,
 				settlementGraceSeconds: getAuctionSettlementGrace(auction),
 				sellerPubkey: auction.pubkey,
 				p2pkXpub,
@@ -318,7 +317,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				<div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
 					<p className="font-semibold">Anti-snipe window — minimum bid rising</p>
 					<p className="mt-0.5 text-amber-700">
-						The auction's nominal end has passed. Bids are still accepted until the absolute end, but the floor ramps up{' '}
+						Flat bidding has ended. Bids are still accepted until auction end, but the floor ramps up{' '}
 						<span className="font-semibold">{auctionCurve.shape}</span>ly to {auctionCurve.peakMultiplier}× by then. Floor right now:{' '}
 						<span className="font-semibold">{minBid.toLocaleString()} sats</span>.
 					</p>

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -6,20 +6,17 @@ import { authStore } from '@/lib/stores/auth'
 import { ndkActions } from '@/lib/stores/ndk'
 import { usePublishAuctionBidMutation } from '@/publish/auctions'
 import {
+	getAuctionBiddingCutoffAt,
 	getAuctionBidIncrement,
 	getAuctionBidCountFromBids,
 	getAuctionCurrentPriceFromBids,
-	getAuctionEffectiveEndAt,
-	getAuctionEndAt,
 	getAuctionId,
 	getAuctionImages,
 	getAuctionKeyScheme,
-	getAuctionMaxEndAt,
 	getAuctionMints,
 	getAuctionP2pkXpub,
 	getAuctionPathIssuer,
 	getAuctionRootEventId,
-	getAuctionSettlementGrace,
 	getAuctionStartAt,
 	getAuctionStartingBid,
 	getAuctionTitle,
@@ -51,7 +48,6 @@ export function AuctionCard({
 	const { user: currentUser } = useStore(authStore)
 	const title = getAuctionTitle(auction)
 	const images = getAuctionImages(auction)
-	const endAt = getAuctionEndAt(auction)
 	const startingBid = getAuctionStartingBid(auction)
 	const bidIncrement = getAuctionBidIncrement(auction)
 	const acceptedMints = getAuctionMints(auction)
@@ -73,8 +69,8 @@ export function AuctionCard({
 	)
 	const bids = bidsProp ?? bidsQuery.data ?? []
 	const startAt = getAuctionStartAt(auction)
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
-	const countdown = useAuctionCountdown(effectiveEndAt, { showSeconds: true })
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const bidMutation = usePublishAuctionBidMutation()
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)

--- a/src/components/AuctionCountdown.tsx
+++ b/src/components/AuctionCountdown.tsx
@@ -3,14 +3,7 @@ import { formatAuctionCountdownDetailed, formatAuctionEndTimeLabel, getAuctionCo
 import { useEffect, useMemo, useState } from 'react'
 import ProgressBar from './shared/ProgressBar'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
-import {
-	getAuctionEffectiveEndAt,
-	getAuctionEndAt,
-	getAuctionId,
-	getAuctionRootEventId,
-	getAuctionStartAt,
-	useAuctionBids,
-} from '@/queries/auctions'
+import { getAuctionBiddingCutoffAt, getAuctionStartAt } from '@/queries/auctions'
 
 type AuctionCountdownUrgency = 'calm' | 'lastDay' | 'lastHour' | 'finalBids' | 'ended'
 
@@ -84,35 +77,22 @@ export function useAuctionCountdown(endAt: number, options?: { showSeconds?: boo
 
 export function AuctionCountdown({
 	auction,
-	bids: bidsProp,
 }: {
 	auction: NDKEvent
-	/** Pre-fetched bids from a parent. Skip the internal bid subscription when provided. */
+	/** Retained for source compatibility; fixed-window v1 cutoff no longer depends on bids. */
 	bids?: NDKEvent[]
 }) {
-	const auctionDTag = getAuctionId(auction)
-	const auctionRootEventId = getAuctionRootEventId(auction)
-	const auctionCoordinates = auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
-
-	const shouldFetchBids = bidsProp === undefined
-	const bidsQuery = useAuctionBids(
-		shouldFetchBids ? auctionRootEventId || auction.id : '',
-		500,
-		shouldFetchBids ? auctionCoordinates : undefined,
-	)
-	const bids = bidsProp ?? bidsQuery.data ?? []
-	const endTime = getAuctionEndAt(auction)
-	const endTimeEffective = getAuctionEffectiveEndAt(auction, bids) || endTime
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const currentTime = Date.now() / 1000
 	const startTime = getAuctionStartAt(auction)
 
-	const totalDuration = endTimeEffective - startTime
-	const remaining = endTimeEffective - currentTime
+	const totalDuration = biddingCutoffAt - startTime
+	const remaining = biddingCutoffAt - currentTime
 
 	const urgency = getUrgency(remaining)
 	const color = getProgressColor(urgency)
 	const isEnded = remaining <= 0
-	const centerLabel = isEnded ? formatAuctionEndTimeLabel(endTimeEffective, true) : `${formatAuctionCountdownDetailed(remaining)} left`
+	const centerLabel = isEnded ? formatAuctionEndTimeLabel(biddingCutoffAt, true) : `${formatAuctionCountdownDetailed(remaining)} left`
 
 	// 1. Calculate forward progress so the bar fills from left to right as time runs out.
 	let progress = 0

--- a/src/components/AuctionDisplayComponent.tsx
+++ b/src/components/AuctionDisplayComponent.tsx
@@ -4,14 +4,10 @@ import { Card } from '@/components/ui/card'
 import { getCoordsFromATag } from '@/lib/utils/coords'
 import {
 	auctionByATagQueryOptions,
-	getAuctionEffectiveEndAt,
-	getAuctionEndAt,
-	getAuctionId,
+	getAuctionBiddingCutoffAt,
 	getAuctionImages,
-	getAuctionRootEventId,
 	getAuctionSummary,
 	getAuctionTitle,
-	useAuctionBids,
 } from '@/queries/auctions'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
@@ -50,14 +46,8 @@ export function AuctionDisplayComponent({
 	const summary = auction ? getAuctionSummary(auction) : 'No summary available'
 	const images = auction ? getAuctionImages(auction) : []
 	const imageUrl = images.length > 0 ? images[0][1] : null
-	const auctionDTag = getAuctionId(auction)
-	const auctionCoordinatesValue = auction && auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
-	const auctionRootEventId = getAuctionRootEventId(auction)
-	const bidsQuery = useAuctionBids(auctionRootEventId || '', 500, auctionCoordinatesValue || undefined)
-	const bids = bidsQuery.data ?? []
-	const endAt = auction ? getAuctionEndAt(auction) : 0
-	const effectiveEndAt = auction ? getAuctionEffectiveEndAt(auction, bids) || endAt : 0
-	const endAtLabel = effectiveEndAt ? new Date(effectiveEndAt * 1000).toLocaleString() : 'No end date'
+	const biddingCutoffAt = auction ? getAuctionBiddingCutoffAt(auction) : 0
+	const endAtLabel = biddingCutoffAt ? new Date(biddingCutoffAt * 1000).toLocaleString() : 'No end date'
 
 	return (
 		<Card className="p-4">

--- a/src/components/AuctionTimelineChart.tsx
+++ b/src/components/AuctionTimelineChart.tsx
@@ -24,7 +24,6 @@ import {
 	getAuctionMaxEndAt,
 	getAuctionSettlementGrace,
 } from '@/queries/auctions'
-import { getAuctionEffectiveEndAt } from '@/lib/auctionSettlement'
 
 // Function to generate color from pubkey
 const getPubkeyColor = (pubkey: string) => {
@@ -241,8 +240,8 @@ export default function AuctionTimelineChart({ bids, auction }: AuctionTimelineC
 	const startingBid = getAuctionStartingBid(auction)
 	const reserve = getAuctionReserve(auction)
 	const maxEndAt = getAuctionMaxEndAt(auction)
-	const refundTime = maxEndAt + getAuctionSettlementGrace(auction)
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids)
+	const displayedMaxEndAt = maxEndAt >= endAt ? maxEndAt : endAt
+	const refundTime = displayedMaxEndAt + getAuctionSettlementGrace(auction)
 
 	// Transform bids to chart data format
 	const chartBids = bids.map((bid) => ({
@@ -302,18 +301,17 @@ export default function AuctionTimelineChart({ bids, auction }: AuctionTimelineC
 	]
 
 	// Handle different end timing scenarios:
-	// 1. When all timings are equal, show only one "Auction End"
-	// 2. When maxEndAt !== endAt, show extension window and "Auction End" at endAt
+	// 1. When max_end_at > end_at, end_at starts the anti-snipe ramp and
+	//    max_end_at is the fixed auction end.
+	// 2. Otherwise, show only one "Auction End" at the bidding cutoff.
 
-	const hasExtensionWindow = maxEndAt !== endAt
+	const hasAntiSnipeWindow = maxEndAt > endAt
 
-	if (hasExtensionWindow) {
-		// Show extension window between endAt and maxEndAt
-		// Show "Auction End" at endAt
-		verticalMarkers.push({ label: 'Auction End', ts: endAt * 1000, color: '#ef4444', position: 'insideTopRight' })
-	} else {
-		// All timings are equal, show "Auction End" at maxEndAt
+	if (hasAntiSnipeWindow) {
+		verticalMarkers.push({ label: 'Anti-snipe begins', ts: endAt * 1000, color: '#ef4444', position: 'insideTopRight' })
 		verticalMarkers.push({ label: 'Auction End', ts: maxEndAt * 1000, color: '#ef4444', position: 'insideTopRight' })
+	} else if (displayedMaxEndAt > 0) {
+		verticalMarkers.push({ label: 'Auction End', ts: displayedMaxEndAt * 1000, color: '#ef4444', position: 'insideTopRight' })
 	}
 
 	// Add current time marker if it's within the auction period
@@ -344,7 +342,7 @@ export default function AuctionTimelineChart({ bids, auction }: AuctionTimelineC
 		})
 	}
 
-	const settlementStart = maxEndAt * 1000
+	const settlementStart = displayedMaxEndAt * 1000
 	const settlementEnd = refundTime * 1000
 
 	// Generate custom ticks for x-axis
@@ -405,8 +403,8 @@ export default function AuctionTimelineChart({ bids, auction }: AuctionTimelineC
 					{/* 2. Conditionally Render the "No bids yet" text */}
 					{chartBids.length === 0 && <Label position="center">No bids yet</Label>}
 
-					{/* Extension Window Area */}
-					{hasExtensionWindow && (
+					{/* Anti-snipe Window Area */}
+					{hasAntiSnipeWindow && (
 						<ReferenceArea
 							x1={endAt * 1000}
 							x2={maxEndAt * 1000}
@@ -414,7 +412,7 @@ export default function AuctionTimelineChart({ bids, auction }: AuctionTimelineC
 							fillOpacity={0.15}
 							stroke="#06b6d4"
 							strokeDasharray="4 4"
-							label={{ position: 'center', value: 'Extension Window', fill: '#06b6d4', fontSize: 11, fontWeight: 600, angle: 45 }}
+							label={{ position: 'center', value: 'Anti-snipe Window', fill: '#06b6d4', fontSize: 11, fontWeight: 600, angle: 45 }}
 						/>
 					)}
 

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -499,13 +499,19 @@ function AuctionTimelinePreview({
 		anchor: 'start' | 'middle' | 'end'
 	}> = [
 		{ xPct: 0, color: '#10b981', label: 'start', sub: formatAbsoluteCompact(startAtSeconds), anchor: 'start' },
-		{ xPct: endX, color: '#10b981', label: 'end', sub: formatAbsoluteCompact(endAtSeconds), anchor: 'middle' },
+		{
+			xPct: endX,
+			color: '#10b981',
+			label: hasWindow ? 'ramp begins' : 'auction end',
+			sub: formatAbsoluteCompact(endAtSeconds),
+			anchor: 'middle',
+		},
 		...(hasWindow
 			? [
 					{
 						xPct: maxEndX,
 						color: '#f59e0b',
-						label: 'abs. end',
+						label: 'auction end',
 						sub: formatAbsoluteCompact(maxEndAtSeconds),
 						anchor: 'middle' as const,
 					},
@@ -579,11 +585,11 @@ function AuctionTimelinePreview({
 
 			<div className="mt-2 flex flex-wrap items-baseline justify-between gap-2 text-[11px] text-zinc-600">
 				<p>
-					Floor at <span className="font-semibold text-zinc-900">auction end</span>:{' '}
+					Floor when <span className="font-semibold text-zinc-900">{hasWindow ? 'anti-snipe ramp begins' : 'auction ends'}</span>:{' '}
 					<span className="font-semibold">{baseline.toLocaleString()} sats</span>
 				</p>
 				<p>
-					Floor at <span className="font-semibold text-zinc-900">absolute end</span>:{' '}
+					Floor at <span className="font-semibold text-zinc-900">auction end</span>:{' '}
 					<span className={`font-semibold ${showCurve ? 'text-emerald-700' : 'text-zinc-700'}`}>{peakFloor.toLocaleString()} sats</span>{' '}
 					{showCurve ? (
 						<span className="text-zinc-400">
@@ -674,8 +680,8 @@ function AntiSnipeCurveSettings({
 			<div>
 				<Label className="text-zinc-950">Anti-snipe</Label>
 				<p className="mt-1 text-xs text-zinc-500">
-					After the auction end, late bids can still land in an extra window — but the minimum bid ramps up to make sniping expensive. The
-					absolute end is fixed at publish time.
+					After flat bidding ends, bids can still land during the anti-snipe window — but the minimum bid ramps up to make sniping
+					expensive. The auction end is fixed at publish time.
 				</p>
 			</div>
 
@@ -762,7 +768,7 @@ function AntiSnipeCurveSettings({
 				</div>
 				{!curveDisabled && (
 					<p className="text-[11px] text-zinc-500">
-						Floor at the absolute end will be {formData.minBidCurvePeakMultiplier}× the floor at auction end.
+						Floor at auction end will be {formData.minBidCurvePeakMultiplier}× the floor when the anti-snipe ramp begins.
 					</p>
 				)}
 			</div>
@@ -818,7 +824,7 @@ function SettlementGraceSettings({
 			<div>
 				<Label className="text-zinc-950">Settlement grace</Label>
 				<p className="mt-1 text-xs text-zinc-500">
-					How long after the absolute end you have to publish the settlement before losing bidders can reclaim their funds. Bids carry the
+					How long after the auction end you have to publish the settlement before losing bidders can reclaim their funds. Bids carry the
 					same locktime regardless of how many bids land.
 				</p>
 			</div>
@@ -1721,17 +1727,17 @@ export function AuctionFormContent() {
 
 	const buildPublishFormData = (nowSeconds: number): AuctionFormData => {
 		const effectiveStartAt = startMode === 'immediate' ? '' : (formData.startAt ?? '')
-		let effectiveEndAt = formData.endAt
+		let resolvedEndAt = formData.endAt
 		if (endMode === 'duration') {
 			const parsedStart = formData.startAt ? parseDatetimeLocalSeconds(formData.startAt) : null
 			const startSeconds = startMode === 'immediate' ? nowSeconds : (parsedStart ?? nowSeconds)
-			effectiveEndAt = toDatetimeLocal(new Date((startSeconds + durationSeconds) * 1000))
+			resolvedEndAt = toDatetimeLocal(new Date((startSeconds + durationSeconds) * 1000))
 		}
 
 		return {
 			...formData,
 			startAt: effectiveStartAt,
-			endAt: effectiveEndAt,
+			endAt: resolvedEndAt,
 			imageUrls: images
 				.slice()
 				.sort((a, b) => a.imageOrder - b.imageOrder)

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -5,6 +5,7 @@ import {
 	compareAuctionBidChainPriority,
 	computeAuctionBidFloor,
 	computeAuctionFloorMultiplier,
+	getAuctionBiddingCutoffAt,
 	getAuctionCurrentPrice,
 	getAuctionEffectiveEndAt,
 	getAuctionMinBidCurve,
@@ -183,6 +184,42 @@ describe('auctionSettlement helpers', () => {
 		expect(getAuctionEffectiveEndAt(auction, bids)).toBe(320)
 		expect(getAuctionWindowValidBids(auction, bids).map((bid) => bid.id)).toEqual(['bid-early', 'bid-snipe-1', 'bid-snipe-2'])
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(1300)
+	})
+
+	test('bidding cutoff is max_end_at when max_end_at is after end_at', () => {
+		const auction = makeAuction({
+			id: 'auction-root',
+			startAt: 100,
+			endAt: 200,
+			extensionRule: 'none',
+			maxEndAt: 320,
+		})
+
+		expect(getAuctionBiddingCutoffAt(auction)).toBe(320)
+	})
+
+	test('bidding cutoff falls back to end_at when max_end_at is 0', () => {
+		const auction = makeAuction({
+			id: 'auction-root',
+			startAt: 100,
+			endAt: 200,
+			extensionRule: 'none',
+			maxEndAt: 0,
+		})
+
+		expect(getAuctionBiddingCutoffAt(auction)).toBe(200)
+	})
+
+	test('bidding cutoff falls back to end_at when max_end_at is before end_at', () => {
+		const auction = makeAuction({
+			id: 'auction-root',
+			startAt: 100,
+			endAt: 200,
+			extensionRule: 'none',
+			maxEndAt: 150,
+		})
+
+		expect(getAuctionBiddingCutoffAt(auction)).toBe(200)
 	})
 })
 

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -5,6 +5,7 @@ import {
 	compareAuctionBidChainPriority,
 	computeAuctionBidFloor,
 	computeAuctionFloorMultiplier,
+	getAuctionBidAcceptanceEndAt,
 	getAuctionBiddingCutoffAt,
 	getAuctionCurrentPrice,
 	getAuctionEffectiveEndAt,
@@ -220,6 +221,25 @@ describe('auctionSettlement helpers', () => {
 		})
 
 		expect(getAuctionBiddingCutoffAt(auction)).toBe(200)
+	})
+
+	test('fixed-window v1 bid helpers include bids through max_end_at', () => {
+		const auction = makeAuction({
+			id: 'auction-root',
+			startAt: 100,
+			endAt: 200,
+			extensionRule: 'none',
+			maxEndAt: 320,
+		})
+		const bids = [
+			makeBid({ id: 'bid-before-end-at', pubkey: 'alice', amount: 1100, createdAt: 150 }),
+			makeBid({ id: 'bid-in-anti-snipe-window', pubkey: 'bob', amount: 1400, createdAt: 250 }),
+			makeBid({ id: 'bid-after-max-end-at', pubkey: 'carol', amount: 1800, createdAt: 321 }),
+		]
+
+		expect(getAuctionBidAcceptanceEndAt(auction, bids)).toBe(320)
+		expect(getAuctionWindowValidBids(auction, bids).map((bid) => bid.id)).toEqual(['bid-before-end-at', 'bid-in-anti-snipe-window'])
+		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(1400)
 	})
 })
 

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -327,17 +327,27 @@ export const getAuctionEffectiveEndAt = (auctionEvent: NDKEvent, bids: NDKEvent[
 	return effectiveEndAt
 }
 
+export const getAuctionBidAcceptanceEndAt = (auctionEvent: NDKEvent, bids: NDKEvent[]): number => {
+	const extensionRule = getAuctionExtensionRule(auctionEvent)
+
+	if (extensionRule.kind === 'anti_sniping') {
+		return getAuctionEffectiveEndAt(auctionEvent, bids)
+	}
+
+	return getAuctionBiddingCutoffAt(auctionEvent)
+}
+
 export const getAuctionWindowValidBids = (auctionEvent: NDKEvent, bids: NDKEvent[]): NDKEvent[] => {
 	const auctionRootEventId = getAuctionRootEventId(auctionEvent)
 	const startAt = getAuctionStartAt(auctionEvent)
-	const effectiveEndAt = getAuctionEffectiveEndAt(auctionEvent, bids)
+	const acceptanceEndAt = getAuctionBidAcceptanceEndAt(auctionEvent, bids)
 
 	return [...bids].sort(compareAuctionBidChronologyAscending).filter((bid) => {
 		if (!ACTIVE_AUCTION_BID_STATUSES.has(getAuctionBidStatus(bid))) return false
 		if (getAuctionTagValue(bid, 'e') !== auctionRootEventId) return false
 
 		const bidCreatedAt = bid.created_at || 0
-		return bidCreatedAt >= startAt && bidCreatedAt <= effectiveEndAt
+		return bidCreatedAt >= startAt && bidCreatedAt <= acceptanceEndAt
 	})
 }
 

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -75,6 +75,15 @@ export const getAuctionStartAt = (auctionEvent: NDKEvent): number =>
 export const getAuctionEndAt = (auctionEvent: NDKEvent): number => parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'end_at'), 0)
 export const getAuctionMaxEndAt = (auctionEvent: NDKEvent): number =>
 	parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'max_end_at'), 0)
+export const getAuctionBiddingCutoffAt = (auctionEvent: NDKEvent): number => {
+	const endAt = getAuctionEndAt(auctionEvent)
+	const maxEndAt = getAuctionMaxEndAt(auctionEvent)
+
+	if (!endAt) return 0
+	if (!maxEndAt || maxEndAt < endAt) return endAt
+
+	return maxEndAt
+}
 /**
  * Per-auction settlement grace in seconds (the gap between `max_end_at` and
  * the bid's Cashu locktime — see AUCTIONS.md §4.1 / §6.0). Auctions are

--- a/src/lib/utils/auctions.ts
+++ b/src/lib/utils/auctions.ts
@@ -1,10 +1,4 @@
-import {
-	getAuctionCategories,
-	getAuctionEffectiveEndAt,
-	getAuctionRootEventId,
-	getAuctionStartingBid,
-	getAuctionTitle,
-} from '@/queries/auctions'
+import { getAuctionCategories, getAuctionBiddingCutoffAt, getAuctionStartingBid, getAuctionTitle } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useMemo } from 'react'
 
@@ -74,7 +68,7 @@ export function calculateAppliedFilterCount(filters: AuctionFilterState): number
 	return count
 }
 
-export function useFilteredAuctions({ auctions, bidsByAuctionId, filters, tag }: UseFilteredAuctionsProps) {
+export function useFilteredAuctions({ auctions, filters, tag }: UseFilteredAuctionsProps) {
 	const hideEnded = filters.hideEnded ?? defaultAuctionFilters.hideEnded
 	const sort = filters.sort ?? defaultAuctionFilters.sort
 
@@ -90,9 +84,7 @@ export function useFilteredAuctions({ auctions, bidsByAuctionId, filters, tag }:
 		// 2. Filter by UI State (Hide Ended)
 		if (hideEnded) {
 			filtered = filtered.filter((auction) => {
-				const rootId = getAuctionRootEventId(auction) || auction.id
-				const bids = bidsByAuctionId?.get(rootId) ?? []
-				const visibleEndAt = getAuctionEffectiveEndAt(auction, bids)
+				const visibleEndAt = getAuctionBiddingCutoffAt(auction)
 
 				return visibleEndAt > 0 && visibleEndAt > now
 			})
@@ -107,11 +99,8 @@ export function useFilteredAuctions({ auctions, bidsByAuctionId, filters, tag }:
 
 			case 'ending-soon':
 				sorted.sort((a, b) => {
-					const aBids = bidsByAuctionId?.get(getAuctionRootEventId(a) || a.id) ?? []
-					const bBids = bidsByAuctionId?.get(getAuctionRootEventId(b) || b.id) ?? []
-
-					const aEnd = getAuctionEffectiveEndAt(a, aBids)
-					const bEnd = getAuctionEffectiveEndAt(b, bBids)
+					const aEnd = getAuctionBiddingCutoffAt(a)
+					const bEnd = getAuctionBiddingCutoffAt(b)
 
 					const aEnded = aEnd > 0 && aEnd <= now
 					const bEnded = bEnd > 0 && bEnd <= now
@@ -140,5 +129,5 @@ export function useFilteredAuctions({ auctions, bidsByAuctionId, filters, tag }:
 		}
 
 		return sorted
-	}, [auctions, bidsByAuctionId, filters, tag])
+	}, [auctions, filters, tag])
 }

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -13,6 +13,7 @@ import {
 	AUCTION_KIND,
 	AUCTION_ROOT_EVENT_ID_TAG,
 	AUCTION_SETTLEMENT_KIND,
+	getAuctionBiddingCutoffAt as getAuctionBiddingCutoffAtValue,
 	getAuctionCurrentPrice as computeAuctionCurrentPrice,
 	getAuctionEffectiveEndAt as computeAuctionEffectiveEndAt,
 	getAuctionEndAt as getAuctionEndAtValue,
@@ -539,6 +540,8 @@ export const getAuctionEffectiveEndAt = (event: NDKEvent | null, bids: NDKEvent[
 }
 
 export const getAuctionMaxEndAt = (event: NDKEvent | null): number => (event ? getAuctionMaxEndAtValue(event) : 0)
+
+export const getAuctionBiddingCutoffAt = (event: NDKEvent | null): number => (event ? getAuctionBiddingCutoffAtValue(event) : 0)
 
 export const getAuctionSettlementGrace = (event: NDKEvent | null): number => (event ? getAuctionSettlementGraceValue(event) : 0)
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -17,12 +17,11 @@ import { auctionKeys } from '@/queries/queryKeyFactory'
 import { useQueryClient } from '@tanstack/react-query'
 import {
 	auctionQueryOptions,
+	getAuctionBiddingCutoffAt,
 	getAuctionBidCountFromBids,
 	getAuctionBidIncrement,
 	getAuctionCurrentPriceFromBids,
 	getAuctionCurrency,
-	getAuctionEffectiveEndAt,
-	getAuctionEndAt,
 	getAuctionPathIssuer,
 	getAuctionId,
 	getAuctionImages,
@@ -238,7 +237,6 @@ function DashboardAuctionDetailRoute() {
 	const reserve = getAuctionReserve(auction)
 	const bidIncrement = getAuctionBidIncrement(auction)
 	const startAt = getAuctionStartAt(auction)
-	const endAt = getAuctionEndAt(auction)
 	const auctionType = getAuctionType(auction)
 	const currency = getAuctionCurrency(auction)
 	const trustedMints = getAuctionMints(auction)
@@ -248,10 +246,10 @@ function DashboardAuctionDetailRoute() {
 
 	const bidsQuery = useAuctionBids(auctionRootEventId || auctionId, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
-	const countdown = useAuctionCountdown(effectiveEndAt, { showSeconds: true })
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const now = countdown.now
-	const status = formatAuctionStatus(startAt, effectiveEndAt, now)
+	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const ended = status === 'Ended'
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
 	const bidCount = getAuctionBidCountFromBids(auction, bids)
@@ -501,7 +499,7 @@ function DashboardAuctionDetailRoute() {
 							<OverviewItem label="Auction type" value={auctionType} helper="Primary format shown to buyers." />
 							<OverviewItem label="Currency" value={currency} helper="Display currency for bidding." />
 							<OverviewItem label="Bid increment" value={formatSats(bidIncrement)} helper="Minimum raise between bids." />
-							<OverviewItem label="Schedule" value={`${formatMaybeDate(startAt)} to ${formatMaybeDate(effectiveEndAt)}`} />
+							<OverviewItem label="Schedule" value={`${formatMaybeDate(startAt)} to ${formatMaybeDate(biddingCutoffAt)}`} />
 						</div>
 
 						{/* Parties — pubkeys resolved via AvatarUser for both perspectives */}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -9,10 +9,9 @@ import { uiActions } from '@/lib/stores/ui'
 import { usePublishAuctionSettlementMutation } from '@/publish/auctions'
 import {
 	auctionsByPubkeyQueryOptions,
+	getAuctionBiddingCutoffAt,
 	getAuctionBidCountFromBids,
 	getAuctionCurrentPriceFromBids,
-	getAuctionEffectiveEndAt,
-	getAuctionEndAt,
 	getAuctionId,
 	getAuctionImages,
 	getAuctionReserve,
@@ -83,13 +82,12 @@ function AuctionListBody({
 	const auctionRootEventId = getAuctionRootEventId(auction)
 	const auctionCoordinates = getAuctionCoordinates(auction)
 	const startAt = getAuctionStartAt(auction)
-	const endAt = getAuctionEndAt(auction)
 
 	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const now = Math.floor(Date.now() / 1000)
-	const status = formatAuctionStatus(startAt, effectiveEndAt, now)
+	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const ended = status === 'Ended'
 	const currentBid = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
@@ -144,7 +142,7 @@ function AuctionListBody({
 						Reserve: <span className="font-medium">{reserve.toLocaleString()} sats</span>
 					</p>
 					<p className="text-gray-600 col-span-2">
-						Ends: <span className="font-medium">{formatMaybeDate(effectiveEndAt)}</span>
+						Bidding ends: <span className="font-medium">{formatMaybeDate(biddingCutoffAt)}</span>
 					</p>
 				</div>
 
@@ -192,14 +190,9 @@ function AuctionListItem({
 	isSettling: boolean
 }) {
 	const startAt = getAuctionStartAt(auction)
-	const endAt = getAuctionEndAt(auction)
-	const auctionRootEventId = getAuctionRootEventId(auction)
-	const auctionCoordinates = getAuctionCoordinates(auction)
-	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
-	const bids = bidsQuery.data ?? []
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const now = Math.floor(Date.now() / 1000)
-	const status = formatAuctionStatus(startAt, effectiveEndAt, now)
+	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const images = getAuctionImages(auction)
 	const thumbnailUrl = images.length > 0 ? images[0][1] : null
 

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -35,9 +35,8 @@ import {
 	getAuctionBidIncrement,
 	getAuctionCategories,
 	getAuctionCurrentPriceFromBids,
-	getAuctionEffectiveEndAt,
+	getAuctionBiddingCutoffAt,
 	getAuctionCurrency,
-	getAuctionEndAt,
 	getAuctionId,
 	getAuctionPathIssuer,
 	getAuctionImages,
@@ -372,7 +371,6 @@ function AuctionDetailRoute() {
 	useHeroBackground(backgroundImageUrl, heroClassName)
 
 	const startAt = getAuctionStartAt(auction)
-	const endAt = getAuctionEndAt(auction)
 	const startingBid = getAuctionStartingBid(auction)
 	const bidIncrement = getAuctionBidIncrement(auction)
 	const reserve = getAuctionReserve(auction)
@@ -422,8 +420,8 @@ function AuctionDetailRoute() {
 	)
 
 	const { bids } = useStreamingAuctionBids(auctionRootEventId || auctionId, 500, auctionCoordinates)
-	const effectiveEndAt = getAuctionEffectiveEndAt(auction, bids) || endAt
-	const countdown = useAuctionCountdown(effectiveEndAt, { showSeconds: true })
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const ended = countdown.isEnded
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
@@ -749,7 +747,7 @@ function AuctionDetailRoute() {
 										{bidderStatus.label}
 									</div>
 								)}
-								{!ended && <span className="text-foreground/80 text-end">{formatAuctionEndTimeLabel(effectiveEndAt, false)}</span>}
+								{!ended && <span className="text-foreground/80 text-end">{formatAuctionEndTimeLabel(biddingCutoffAt, false)}</span>}
 							</div>
 							<AuctionBidder auction={auction} currentUserPubkey={activeUserPubkey} bids={bids} />
 						</div>


### PR DESCRIPTION
Fixes #1006 under the current v1 fixed-window anti-snipe model.

In v1:
- `end_at` is when flat-floor bidding ends and the anti-snipe ramp begins
- `max_end_at` is the auction end / hard bidding cutoff
- `min_bid_curve` defines the ramp in `(end_at, max_end_at]`
- bid locktime remains `max_end_at + settlement_grace`

Before this change, several UI/callsite paths still used legacy effective-end logic, causing auctions with an anti-snipe window to appear ended at raw `end_at`.

This PR adds a dedicated bidding cutoff helper, uses it for active bidding UI/callsite logic, and updates chart/form wording so the UI no longer presents `end_at` as the auction end when an anti-snipe window exists.

This does not reintroduce dynamic bid-triggered `extension_rule` behavior.

Validation:
- `bun test src/lib/__tests__/auctionSettlement.test.ts`
- `bun test src/lib/__tests__/auctionBidValidation.test.ts`
- `bun test src/lib/__tests__/auctionValidatorLifecycle.test.ts`
- `bun run test:unit`
- `bun run format:check`
- `git diff --check`
- Local smoke-tested create-auction form and auction detail chart
