### PR TITLE
ci(e2e): add optional test_grep input to e2e-full workflow_dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, master, 'auctions/**']
   workflow_dispatch:
+    inputs:
+      test_grep:
+        description: 'Optional grep filter (runs only matching tests). Empty = default full run.'
+        required: false
+        default: ''
   schedule:
     - cron: '0 6 * * 1'
 
@@ -224,7 +229,12 @@ jobs:
           LOCAL_RELAY_ONLY: 'true'
 
       - name: Run remaining E2E tests
-        run: bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+        run: |
+          if [ -n "${{ inputs.test_grep }}" ]; then
+            bun run test:e2e -- --grep "${{ inputs.test_grep }}"
+          else
+            bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+          fi
 
       - name: Show server logs on failure
         if: failure()


### PR DESCRIPTION
## What

Adds an optional `test_grep` input to the `e2e-full` workflow_dispatch on `e2e.yml`, so an isolated subset of the full e2e suite can be run on demand. Tiny CI-only change.

## Why

`e2e-full` is only reachable on the weekly cron or a bare `workflow_dispatch`, and it always runs the whole inverted suite (`--grep-invert 'Product Page - View Only|Collection Management'`). There is no way to run an **isolated subset** of the full e2e suite on demand — which is exactly what's needed to classify failing specs (e.g. is `cart`/`buyer-purchase` NDK-flakiness vs. full-run state-leakage?) and to validate individual fixes without a 34-minute run. Came out of the NDK→applesauce diagnosis (epic #1028 / #1005).

## Changes

- **`.github/workflows/e2e.yml`** — add an optional `test_grep` input to `workflow_dispatch`:
  - **Empty (default)** → unchanged behavior (full inverted suite).
  - **Set** → `bun run test:e2e -- --grep "<value>"` (only matching tests).

No behavior change for the cron run or PRs. Backward compatible.

## Test plan

- [x] Workflow YAML validated (`python3 yaml.safe_load`)
- [ ] Will be exercised by an isolated fork run of `cart` + `buyer-purchase` immediately after this PR merges

## Impact

- **Diagnostics:** `gh workflow run e2e.yml -f test_grep="Cart - Multiple Merchants|Buyer Purchase Flow"` answers "do these specs fail in isolation?" in ~3 min instead of 34.
- **Per-wave validation:** the migration (and any feature) can target the specs it affects via CI, which the PR-triggered `e2e-pricing` smoke test (one test) cannot do.
