### PR TITLE
feat(auctions): polish latest bids presentation

### DIFF
--- a/src/components/AuctionBidsContainer.tsx
+++ b/src/components/AuctionBidsContainer.tsx
@@ -3,12 +3,10 @@ import { getBidAmount, getBidMint, getBidStatus, useStreamingAuctionBids } from 
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { cn } from '@/lib/utils'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from './ui/accordion'
-import { AvatarUser } from './AvatarUser'
-import { formatSats } from '@/lib/wallet'
+import { formatSats, getMintHostname } from '@/lib/wallet'
 import { Badge } from './ui/badge'
 import type { ReactNode } from 'react'
 import { UserCard } from './UserCard'
-import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip'
 import { Check, Landmark } from 'lucide-react'
 
 function TechnicalDataRow({ label, value }: { label: string; value: ReactNode }) {
@@ -26,67 +24,131 @@ interface Props {
 	className?: string
 }
 
+function formatBidRecordedAt(bidEvent: NDKEvent): string {
+	return bidEvent.created_at ? new Date(bidEvent.created_at * 1000).toLocaleString() : 'Unknown time'
+}
+
+function BidMintRow({ mint }: { mint: string }) {
+	return (
+		<div className="flex flex-wrap items-center gap-2 text-sm text-zinc-700">
+			<div className="relative flex h-6 cursor-default items-center px-2">
+				<Landmark className="size-4 text-primary" />
+				<span className="absolute -bottom-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-pink-500 text-[9px] font-bold leading-none text-white">
+					<Check className="h-2 w-2 text-white stroke-[3]" />
+				</span>
+			</div>
+			<p>Mint: {mint ? getMintHostname(mint) : 'N/A'}</p>
+		</div>
+	)
+}
+
+function BidEventDetails({ bidEvent }: { bidEvent: NDKEvent }) {
+	const locktime = bidEvent.tags.find((tag) => tag[0] === 'locktime')?.[1]
+	const bidKeyScheme = bidEvent.tags.find((tag) => tag[0] === 'key_scheme')?.[1] || 'hd_p2pk'
+
+	return (
+		<Accordion type="single" collapsible className="rounded-xl border border-zinc-200 bg-white px-4">
+			<AccordionItem value={`bid-${bidEvent.id}`} className="border-none">
+				<AccordionTrigger className="py-4 text-sm font-semibold text-zinc-900 hover:no-underline">Bid event details</AccordionTrigger>
+				<AccordionContent className="space-y-3 pb-4">
+					<TechnicalDataRow label="Bidder pubkey" value={bidEvent.pubkey} />
+					<TechnicalDataRow label="Mint" value={getBidMint(bidEvent) || 'N/A'} />
+					<TechnicalDataRow label="Key scheme" value={bidKeyScheme} />
+					<TechnicalDataRow label="Locktime" value={locktime ? new Date(parseInt(locktime, 10) * 1000).toLocaleString() : 'N/A'} />
+					<TechnicalDataRow label="Bid event ID" value={bidEvent.id} />
+				</AccordionContent>
+			</AccordionItem>
+		</Accordion>
+	)
+}
+
 export function AuctionBidsContainer({ auctionRootEventId, auctionCoordinates, className }: Props) {
 	const { bids } = useStreamingAuctionBids(auctionRootEventId, 500, auctionCoordinates)
 
-	// Sort bids by amount (highest first) then by time
-	const sortedBids = [...bids].sort((a, b) => {
-		const amountDiff = getBidAmount(b) - getBidAmount(a)
-		if (amountDiff !== 0) return amountDiff
-		return (b.created_at || 0) - (a.created_at || 0)
-	})
+	const topBid = bids.reduce<NDKEvent | null>((best, bid) => {
+		if (!best) return bid
+
+		const amountDiff = getBidAmount(bid) - getBidAmount(best)
+		if (amountDiff > 0) return bid
+		if (amountDiff < 0) return best
+
+		const createdAtDiff = (bid.created_at ?? 0) - (best.created_at ?? 0)
+		if (createdAtDiff < 0) return bid
+		if (createdAtDiff > 0) return best
+
+		return bid.id.localeCompare(best.id) < 0 ? bid : best
+	}, null)
+
+	const latestBids = [...bids]
+		.filter((bid) => bid.id !== topBid?.id)
+		.sort((a, b) => {
+			const createdAtDiff = (b.created_at || 0) - (a.created_at || 0)
+			if (createdAtDiff !== 0) return createdAtDiff
+			return b.id.localeCompare(a.id)
+		})
 
 	return bids.length === 0 ? (
-		<div className="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-5 py-6 text-sm text-zinc-500">No bids yet.</div>
+		<div className={cn('rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-5 py-6 text-sm text-zinc-500', className)}>
+			No bids yet. The latest bids will appear here once bidders lock funds.
+		</div>
 	) : (
 		<div className="space-y-4">
-			{sortedBids.map((bidEvent) => {
-				const mint = getBidMint(bidEvent)
-				const locktime = bidEvent.tags.find((tag) => tag[0] === 'locktime')?.[1]
-				const bidKeyScheme = bidEvent.tags.find((tag) => tag[0] === 'key_scheme')?.[1] || 'hd_p2pk'
-				return (
-					<div key={bidEvent.id} className="flex flex-col gap-2 rounded-xl border border-zinc-200 bg-zinc-50/70 px-4 py-4">
-						<div className="flex flex-wrap items-start justify-between gap-3">
-							<div>
-								<p className="text-2xl font-semibold tracking-tight text-zinc-950">{formatSats(getBidAmount(bidEvent))}</p>
-								<p className="mt-1 text-sm text-zinc-500">
-									Recorded {bidEvent.created_at ? new Date(bidEvent.created_at * 1000).toLocaleString() : 'at an unknown time'}
-								</p>
-							</div>
-							<Badge variant="outline" className="border-zinc-300 bg-white text-zinc-700">
-								{getBidStatus(bidEvent)}
-							</Badge>
+			{topBid && (
+				<div className="flex flex-col gap-4 rounded-xl border-2 border-secondary bg-secondary/10 px-4 py-4 shadow-sm">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div>
+							<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-secondary">Top bid</p>
+							<p className="mt-1 text-3xl font-semibold tracking-tight text-zinc-950">{formatSats(getBidAmount(topBid))} sats</p>
+							<p className="mt-1 text-sm text-zinc-600">Recorded {formatBidRecordedAt(topBid)}</p>
 						</div>
-
-						<UserCard pubkey={bidEvent.pubkey} />
-
-						<div className="flex flex-wrap items-center gap-2 text-sm text-zinc-700">
-							<div className="relative flex items-center px-2 h-6 cursor-default">
-								<Landmark className="size-4 text-primary" />
-								<span className="absolute -bottom-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-pink-500 text-[9px] font-bold leading-none text-white">
-									<Check className="h-2 w-2 text-white stroke-[3]" />
-								</span>
-							</div>
-							<p>Mint: {mint.slice(8)}</p>
-						</div>
-
-						<Accordion type="single" collapsible className="mt-4 rounded-xl border border-zinc-200 bg-white px-4">
-							<AccordionItem value={`bid-${bidEvent.id}`} className="border-none">
-								<AccordionTrigger className="py-4 text-sm font-semibold text-zinc-900 hover:no-underline">
-									Bid event details
-								</AccordionTrigger>
-								<AccordionContent className="space-y-3 pb-4">
-									<TechnicalDataRow label="Bidder pubkey" value={bidEvent.pubkey} />
-									<TechnicalDataRow label="Mint" value={getBidMint(bidEvent) || 'N/A'} />
-									<TechnicalDataRow label="Key scheme" value={bidKeyScheme} />
-									<TechnicalDataRow label="Locktime" value={locktime ? new Date(parseInt(locktime, 10) * 1000).toLocaleString() : 'N/A'} />
-									<TechnicalDataRow label="Bid event ID" value={bidEvent.id} />
-								</AccordionContent>
-							</AccordionItem>
-						</Accordion>
+						<Badge variant="outline" className="border-secondary bg-white text-secondary">
+							{getBidStatus(topBid)}
+						</Badge>
 					</div>
-				)
-			})}
+
+					<UserCard pubkey={topBid.pubkey} size="md" />
+					<BidMintRow mint={getBidMint(topBid)} />
+					<BidEventDetails bidEvent={topBid} />
+				</div>
+			)}
+
+			<div className="space-y-3">
+				<div className="flex items-center justify-between gap-3">
+					<h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-zinc-500">Latest bids</h3>
+					<p className="text-xs text-zinc-500">
+						{latestBids.length} more bid{latestBids.length === 1 ? '' : 's'}
+					</p>
+				</div>
+
+				<div className={cn('max-h-[500px] space-y-3 overflow-y-auto pr-1', className)}>
+					{latestBids.length === 0 ? (
+						<div className="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-4 py-4 text-sm text-zinc-500">
+							No other bids yet.
+						</div>
+					) : (
+						latestBids.map((bidEvent) => (
+							<div
+								key={bidEvent.id}
+								className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-zinc-50/70 px-4 py-4 animate-in fade-in-0 slide-in-from-bottom-1 duration-200"
+							>
+								<div className="flex flex-wrap items-start justify-between gap-3">
+									<div>
+										<p className="text-xl font-semibold tracking-tight text-zinc-950">{formatSats(getBidAmount(bidEvent))} sats</p>
+										<p className="mt-1 text-sm text-zinc-500">Recorded {formatBidRecordedAt(bidEvent)}</p>
+									</div>
+									<Badge variant="outline" className="border-zinc-300 bg-white text-zinc-700">
+										{getBidStatus(bidEvent)}
+									</Badge>
+								</div>
+
+								<UserCard pubkey={bidEvent.pubkey} size="sm" />
+								<BidMintRow mint={getBidMint(bidEvent)} />
+								<BidEventDetails bidEvent={bidEvent} />
+							</div>
+						))
+					)}
+				</div>
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary

- Polishes the existing Latest Bids / Bids tab from #1017 for #1009.
- Highlights the highest visible bid separately.
- Shows remaining bids newest-first in a constrained scrollable list.
- Keeps bid event details available in the existing collapsible accordion.
- Preserves deterministic ordering for the highlighted highest visible bid: highest amount, earliest `created_at`, then lexical smallest bid event ID.

## Scope

Part of #881.  
Closes #1009.

## Not changed

- No NIP-53 live feed.
- No chat, messages, or reactions.
- No bid placement, validation, query, or publish behavior changes.
- No mint selection changes.
- No settlement, refund, Cashu, NIP-60, oracle, path release, claim dialog, route generation, package, lockfile, or deploy workflow changes.

## Validation

- `bunx prettier --check 'src/components/AuctionBidsContainer.tsx'`
- `git diff --check`
- `bun run test:unit`
- `bun run build`
- `git restore src/routeTree.gen.ts`

## Smoke test

Checked locally with:

- no-bid auction
- one-bid auction
- multi-bid auction
- expanded bid event details
- mobile viewport


