### PR TITLE
feat: countdown for auctions before start time

### DIFF
--- a/src/components/AuctionCountdown.tsx
+++ b/src/components/AuctionCountdown.tsx
@@ -1,16 +1,22 @@
 import { cn } from '@/lib/utils'
-import { formatAuctionCountdownDetailed, formatAuctionEndTimeLabel, getAuctionCountdownLabels } from '@/lib/auctionCountdownLabels'
+import {
+	formatAuctionCountdownDetailed,
+	formatAuctionEndTimeLabel,
+	formatAuctionStartsIn,
+	getAuctionCountdownLabels,
+} from '@/lib/auctionCountdownLabels'
 import { useEffect, useMemo, useState } from 'react'
 import ProgressBar from './shared/ProgressBar'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { getAuctionBiddingCutoffAt, getAuctionStartAt } from '@/queries/auctions'
 
-type AuctionCountdownUrgency = 'calm' | 'lastDay' | 'lastHour' | 'finalBids' | 'ended'
+type AuctionCountdownUrgency = 'calm' | 'lastDay' | 'lastHour' | 'finalBids' | 'ended' | 'scheduled'
 
 export interface AuctionCountdownState {
 	now: number
 	secondsRemaining: number
 	isEnded: boolean
+	isScheduled: boolean
 	urgency: AuctionCountdownUrgency
 	displayLabel: string
 	absoluteLabel: string
@@ -25,6 +31,17 @@ function getUrgency(secondsRemaining: number): AuctionCountdownUrgency {
 	return 'calm' // 24h+
 }
 
+/**
+ * Calculates pre-start fill progress: 0 at publish time, 1 when auction opens.
+ * Exported so it can be unit-tested in isolation.
+ */
+export function computePreStartProgress(now: number, startAt: number, createdAt: number): number {
+	if (startAt <= 0 || createdAt <= 0) return 0
+	const total = startAt - createdAt
+	if (total <= 0) return 0
+	return Math.min(Math.max((now - createdAt) / total, 0), 1)
+}
+
 // Helper to get the specific color based on urgency
 function getProgressColor(urgency: AuctionCountdownUrgency): string {
 	switch (urgency) {
@@ -37,27 +54,31 @@ function getProgressColor(urgency: AuctionCountdownUrgency): string {
 		case 'finalBids':
 			return '#ff3eb5' // Pink
 		case 'ended':
-			return '#e7e3e8' // White/Light Grey
+		case 'scheduled':
+			return '#e7e3e8' // Neutral grey
 		default:
 			return '#18b9fe'
 	}
 }
 
-export function useAuctionCountdown(endAt: number, options?: { showSeconds?: boolean }): AuctionCountdownState {
+export function useAuctionCountdown(endAt: number, options?: { showSeconds?: boolean; startAt?: number }): AuctionCountdownState {
 	const showSeconds = options?.showSeconds ?? false
+	const startAt = options?.startAt ?? 0
 	const [now, setNow] = useState(() => Math.floor(Date.now() / 1000))
 
 	useEffect(() => {
-		if (!endAt) return
+		// Keep ticking while the auction is active (end) or still counting down to open (start)
+		if (!endAt && !startAt) return
 
 		const timer = window.setInterval(() => {
 			setNow(Math.floor(Date.now() / 1000))
 		}, 1000)
 
 		return () => window.clearInterval(timer)
-	}, [endAt])
+	}, [endAt, startAt])
 
 	return useMemo(() => {
+		const isScheduled = startAt > 0 && now < startAt
 		const countdownLabels = getAuctionCountdownLabels(endAt, now, { showSeconds })
 		const secondsRemaining = countdownLabels.secondsRemaining
 		const totalDuration = endAt > 0 ? endAt - (Math.floor(Date.now() / 1000) - secondsRemaining) : 0
@@ -67,12 +88,13 @@ export function useAuctionCountdown(endAt: number, options?: { showSeconds?: boo
 			now,
 			secondsRemaining,
 			isEnded: countdownLabels.isEnded,
-			urgency: endAt > 0 ? getUrgency(secondsRemaining) : 'ended',
+			isScheduled,
+			urgency: isScheduled ? 'scheduled' : endAt > 0 ? getUrgency(secondsRemaining) : 'ended',
 			displayLabel: countdownLabels.displayLabel,
 			absoluteLabel: countdownLabels.absoluteLabel,
 			totalDuration: safeTotalDuration,
 		}
-	}, [endAt, now, showSeconds])
+	}, [endAt, startAt, now, showSeconds])
 }
 
 export function AuctionCountdown({
@@ -83,28 +105,49 @@ export function AuctionCountdown({
 	bids?: NDKEvent[]
 }) {
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-	const currentTime = Date.now() / 1000
 	const startTime = getAuctionStartAt(auction)
+	const createdAt = auction.created_at ?? 0
+	const now = Math.floor(Date.now() / 1000)
 
+	const isScheduled = startTime > 0 && now < startTime
+	const remaining = biddingCutoffAt - now
 	const totalDuration = biddingCutoffAt - startTime
-	const remaining = biddingCutoffAt - currentTime
+	const isEnded = !isScheduled && remaining <= 0
 
-	const urgency = getUrgency(remaining)
-	const color = getProgressColor(urgency)
-	const isEnded = remaining <= 0
-	const centerLabel = isEnded ? formatAuctionEndTimeLabel(biddingCutoffAt, true) : `${formatAuctionCountdownDetailed(remaining)} left`
-
-	// 1. Calculate forward progress so the bar fills from left to right as time runs out.
+	// Pre-start: fill toward 100% as publish→startAt window closes.
+	// Live: fill left→right as biddingCutoffAt approaches.
 	let progress = 0
-	if (totalDuration > 0) {
+	if (isScheduled) {
+		progress = computePreStartProgress(now, startTime, createdAt)
+	} else if (totalDuration > 0) {
 		const elapsed = totalDuration - remaining
 		progress = Math.min(Math.max(elapsed / totalDuration, 0), 1)
 	}
-	if (remaining < 0) progress = 1
+	if (!isScheduled && remaining < 0) progress = 1
 
-	// 2. Configure ProgressBar Props based on Urgency
+	const urgency: AuctionCountdownUrgency = isScheduled ? 'scheduled' : isEnded ? 'ended' : getUrgency(remaining)
+	const color = getProgressColor(urgency)
+
+	const centerLabel = isScheduled
+		? formatAuctionStartsIn(startTime - now)
+		: isEnded
+			? formatAuctionEndTimeLabel(biddingCutoffAt, true)
+			: `${formatAuctionCountdownDetailed(remaining)} left`
+
+	// Configure ProgressBar props based on urgency
 	const progressConfig = useMemo(() => {
 		switch (urgency) {
+			case 'scheduled':
+				return {
+					glow: false,
+					stripeWidth: 0,
+					stripeGap: 10,
+					stripeOpacity: 0,
+					stripeSpeed: 0,
+					stripeAngle: 0,
+					backgroundColor: '#EEEEEE',
+					textOnDark: false,
+				}
 			case 'calm':
 				return { glow: false, stripeWidth: 26, stripeGap: 18, stripeOpacity: 0.15, stripeSpeed: 2.5, stripeHeight: 38 }
 			case 'lastDay':

--- a/src/lib/__tests__/auctionCountdownPreStart.test.ts
+++ b/src/lib/__tests__/auctionCountdownPreStart.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test'
+import { formatAuctionStartsIn } from '../auctionCountdownLabels'
+import { computePreStartProgress } from '@/components/AuctionCountdown'
+
+// ---------------------------------------------------------------------------
+// formatAuctionStartsIn
+// ---------------------------------------------------------------------------
+
+describe('formatAuctionStartsIn', () => {
+	test('zero or negative seconds → "Starting now"', () => {
+		expect(formatAuctionStartsIn(0)).toBe('Starting now')
+		expect(formatAuctionStartsIn(-5)).toBe('Starting now')
+	})
+
+	test('under 60 seconds → singular and plural second labels', () => {
+		expect(formatAuctionStartsIn(1)).toBe('Starts in 1s')
+		expect(formatAuctionStartsIn(59)).toBe('Starts in 59s')
+	})
+
+	test('under 1 hour → MM:SS format', () => {
+		expect(formatAuctionStartsIn(65)).toBe('Starts in 01:05')
+		expect(formatAuctionStartsIn(3599)).toBe('Starts in 59:59')
+	})
+
+	test('under 1 day → X Hour(s) MM:SS format', () => {
+		expect(formatAuctionStartsIn(3600)).toBe('Starts in 1 Hour 00:00')
+		expect(formatAuctionStartsIn(7325)).toBe('Starts in 2 Hours 02:05')
+		expect(formatAuctionStartsIn(86399)).toBe('Starts in 23 Hours 59:59')
+	})
+
+	test('1 day or more → X Day(s) Y Hour(s) MM:SS format', () => {
+		expect(formatAuctionStartsIn(86400)).toBe('Starts in 1 Day 0 Hours 00:00')
+		expect(formatAuctionStartsIn(90000)).toBe('Starts in 1 Day 1 Hour 00:00')
+		expect(formatAuctionStartsIn(172800)).toBe('Starts in 2 Days 0 Hours 00:00')
+		expect(formatAuctionStartsIn(180065)).toBe('Starts in 2 Days 2 Hours 01:05')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// computePreStartProgress
+// ---------------------------------------------------------------------------
+
+describe('computePreStartProgress', () => {
+	test('returns 0 when startAt is 0 (no scheduled start)', () => {
+		expect(computePreStartProgress(1_000_100, 0, 1_000_000)).toBe(0)
+	})
+
+	test('returns 0 when createdAt is 0 (missing creation time)', () => {
+		expect(computePreStartProgress(1_000_100, 1_001_000, 0)).toBe(0)
+	})
+
+	test('returns 0 when now is at or before createdAt', () => {
+		expect(computePreStartProgress(1_000_000, 1_001_000, 1_000_000)).toBe(0)
+		expect(computePreStartProgress(999_999, 1_001_000, 1_000_000)).toBe(0)
+	})
+
+	test('returns 1 when now has reached or passed startAt', () => {
+		expect(computePreStartProgress(1_001_000, 1_001_000, 1_000_000)).toBe(1)
+		expect(computePreStartProgress(1_002_000, 1_001_000, 1_000_000)).toBe(1)
+	})
+
+	test('returns fractional progress between createdAt and startAt', () => {
+		// total wait = 1000s, elapsed = 500s → 50%
+		const result = computePreStartProgress(1_000_500, 1_001_000, 1_000_000)
+		expect(result).toBeCloseTo(0.5)
+	})
+
+	test('returns near-zero when auction was just published', () => {
+		// total wait = 86400s, elapsed = 1s → ~0.001%
+		const result = computePreStartProgress(1_000_001, 1_086_400, 1_000_000)
+		expect(result).toBeCloseTo(1 / 86400)
+	})
+
+	test('returns near-full when only seconds remain before start', () => {
+		// total wait = 3600s, elapsed = 3599s → ~99.97%
+		const result = computePreStartProgress(1_003_599, 1_003_600, 1_000_000)
+		expect(result).toBeCloseTo(3599 / 3600)
+	})
+
+	test('is always clamped to [0, 1]', () => {
+		// all edge variants
+		const cases: [number, number, number][] = [
+			[0, 100, 50], // now before createdAt
+			[200, 100, 50], // now past startAt
+			[75, 100, 50], // normal midpoint
+		]
+		for (const [now, startAt, createdAt] of cases) {
+			const result = computePreStartProgress(now, startAt, createdAt)
+			expect(result).toBeGreaterThanOrEqual(0)
+			expect(result).toBeLessThanOrEqual(1)
+		}
+	})
+})

--- a/src/lib/auctionCountdownLabels.ts
+++ b/src/lib/auctionCountdownLabels.ts
@@ -98,6 +98,40 @@ export function formatAuctionEndTimeLabel(endTimestamp: number, isEnded: boolean
 	return `Ends on ${endDate.toLocaleDateString()} at ${timeStr}`
 }
 
+/**
+ * Formats a pre-start countdown into "Starts in …" copy, mirroring the
+ * shape of formatAuctionCountdownDetailed but with a "Starts in" prefix.
+ */
+export function formatAuctionStartsIn(seconds: number): string {
+	if (seconds <= 0) return 'Starting now'
+
+	const days = Math.floor(seconds / 86400)
+	const hours = Math.floor((seconds % 86400) / 3600)
+	const minutes = Math.floor((seconds % 3600) / 60)
+	const secs = Math.round(seconds % 60)
+
+	const mm = minutes.toString().padStart(2, '0')
+	const ss = secs.toString().padStart(2, '0')
+	const coreTime = `${mm}:${ss}`
+
+	if (days > 0) {
+		const dayLabel = days === 1 ? 'Day' : 'Days'
+		const hourLabel = hours === 1 ? 'Hour' : 'Hours'
+		return `Starts in ${days} ${dayLabel} ${hours} ${hourLabel} ${coreTime}`
+	}
+
+	if (hours > 0) {
+		const hourLabel = hours === 1 ? 'Hour' : 'Hours'
+		return `Starts in ${hours} ${hourLabel} ${coreTime}`
+	}
+
+	if (seconds < 60) {
+		return `Starts in ${Math.round(seconds)}s`
+	}
+
+	return `Starts in ${coreTime}`
+}
+
 export function getAuctionCountdownLabels(endAt: number, now: number, options?: AuctionCountdownLabelOptions): AuctionCountdownLabels {
 	if (endAt <= 0) {
 		return {


### PR DESCRIPTION
# Description

Adds a **scheduled** state to `AuctionCountdown` for auctions that have not yet started (`start_at > now`).

In the scheduled state:

* The countdown displays **"Starts in X"** instead of time remaining until the auction ends.
* The progress bar uses a neutral grey style (matching ended auctions).
* Progress fills from 0% → 100% between `created_at` and `start_at`.
* The component automatically transitions to the normal live countdown once `start_at` is reached, without requiring a page reload.

This change applies to all existing `<AuctionCountdown>` usages with no caller changes required. Existing scheduled badges and bid-gating behavior remain unchanged.

# Changes

* Added `formatAuctionStartsIn()` formatter for pre-start countdown labels.
* Added `scheduled` urgency state to `AuctionCountdown`.
* Added `computePreStartProgress()` helper for pre-start progress calculation.
* Updated `useAuctionCountdown()` to support `startAt` and expose `isScheduled`.
* Added test coverage for countdown formatting and pre-start progress calculations.

# Screenshots
<img width="1678" height="684" alt="auciton-starts-in" src="https://github.com/user-attachments/assets/b377322f-1a17-4123-a292-b7087ee7c3da" />


https://github.com/user-attachments/assets/59bea40e-fb0c-45e9-a1f7-1dca8e1c3fff



# Test Plan

* Schedule an auction with a future `start_at` and verify:

  * Grey progress bar is shown.
  * Countdown displays **"Starts in X"**.
* Verify the countdown automatically transitions to the normal live state after `start_at`.
* Verify auctions without `start_at` behave as before.
* Verify ended auctions remain unchanged.
* Run:

  ```bash
  bun test src/lib/__tests__/auctionCountdownPreStart.test.ts
  ```
closes #1027 