### PR TITLE
fix(auctions): clarify visible bid label

### DIFF
--- a/src/components/AuctionBidsContainer.tsx
+++ b/src/components/AuctionBidsContainer.tsx
@@ -97,7 +97,7 @@ export function AuctionBidsContainer({ auctionRootEventId, auctionCoordinates, c
 				<div className="flex flex-col gap-4 rounded-xl border-2 border-secondary bg-secondary/10 px-4 py-4 shadow-sm">
 					<div className="flex flex-wrap items-start justify-between gap-3">
 						<div>
-							<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-secondary">Top bid</p>
+							<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-secondary">Highest visible bid</p>
 							<p className="mt-1 text-3xl font-semibold tracking-tight text-zinc-950">{formatSats(getBidAmount(topBid))} sats</p>
 							<p className="mt-1 text-sm text-zinc-600">Recorded {formatBidRecordedAt(topBid)}</p>
 						</div>


### PR DESCRIPTION
## Summary

- Updates the highlighted bid label from `Top bid` to `Highest visible bid`.
- Aligns the UI copy with the merged #1032 PR description.
- Avoids implying validator-confirmed winner/top-bid status from visible streamed bid events.

## Scope

Follow-up to #1032.

## Not changed

- No bid sorting changes.
- No top-bid reducer changes.
- No bid query, validation, publish, wallet, Cashu, NIP-60, settlement, refund, relay, route generation, package, lockfile, or deploy behavior changes.

## Validation

- `bunx prettier --check 'src/components/AuctionBidsContainer.tsx'`
- `git diff --check`
- `bun run test:unit`
- `bun run build`
- `git restore src/routeTree.gen.ts`