### PR TITLE
feat(auctions): add bid rules confirmation modal

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -359,7 +359,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 					<DialogHeader>
 						<DialogTitle>Review auction rules before bidding</DialogTitle>
 						<DialogDescription>
-							Placing an auction bid may lock Cashu funds until the auction ends and the settlement/refund window has passed.
+							Auction bids use Cashu e-cash with P2PK locks. Review what can happen to your funds before placing this bid.
 						</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-3 py-2 text-sm text-muted-foreground">
@@ -369,11 +369,26 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							</p>
 						)}
 						<ul className="list-disc space-y-2 pl-5">
-							<li>Auctions are timed. The highest valid bid may win, but bids are not guaranteed.</li>
-							<li>Your bid may lock funds using the auction's Cashu/P2PK flow.</li>
-							<li>If you win, settlement may require a later action from you and the seller.</li>
-							<li>If you lose or settlement does not complete, funds may only become available through the refund path after locktime.</li>
-							<li>Relay data, validator/auditor review, mint state, and settlement events can affect what the app shows.</li>
+							<li>
+								Your bid may lock Cashu e-cash to an auction-derived P2PK key, with a refund path that only opens after the auction and
+								settlement window.
+							</li>
+							<li>
+								The lock is designed so the seller cannot redeem the bid from public relay data alone before settlement; settlement requires
+								the bid-specific path secret.
+							</li>
+							<li>
+								If you win, settlement may require you to reveal or transfer the bid's path secret so the seller can redeem the funds.
+							</li>
+							<li>
+								If the winning bid is not settled before the settlement window closes, it may be invalidated or move to the refund/fallback
+								path.
+							</li>
+							<li>If you lose, or settlement does not complete, your funds may only become refundable after the refund window opens.</li>
+							<li>
+								This auction still relies on trust assumptions: Cashu mints custody the bitcoin behind e-cash, validator/auditor and relay
+								data affect what the app shows, and bidders/sellers must complete settlement and delivery honestly.
+							</li>
 						</ul>
 					</div>
 					<DialogFooter>

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -35,6 +35,8 @@ import { uiActions } from '@/lib/stores/ui'
 import { normalizeMintUrl } from '@/lib/wallet'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
 
+const AUCTION_RULES_ACK_VERSION = 'v1'
+
 interface AuctionBidderProps {
 	auction: NDKEvent
 	/** Pre-fetched bids from a parent. Skip the internal bid subscription when provided. */
@@ -167,6 +169,12 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
+	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
+	const auctionRulesAuctionIdentity = auctionRootEventId || auction.id
+	const auctionRulesAckKey =
+		hasSignedInBidder && auctionRulesBidderPubkey && auctionRulesAuctionIdentity
+			? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}:${auctionRulesAuctionIdentity}`
+			: null
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
@@ -175,7 +183,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
 	const [isRulesDialogOpen, setIsRulesDialogOpen] = useState(false)
-	const [rulesDialogBidAmount, setRulesDialogBidAmount] = useState<number | null>(null)
+	const [hasAcknowledgedAuctionRules, setHasAcknowledgedAuctionRules] = useState(false)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -201,6 +209,19 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	useEffect(() => {
 		setBidAmountInput(String(minBid))
 	}, [minBid])
+
+	useEffect(() => {
+		if (!auctionRulesAckKey || typeof window === 'undefined') {
+			setHasAcknowledgedAuctionRules(false)
+			return
+		}
+
+		try {
+			setHasAcknowledgedAuctionRules(window.localStorage.getItem(auctionRulesAckKey) === 'true')
+		} catch {
+			setHasAcknowledgedAuctionRules(false)
+		}
+	}, [auctionRulesAckKey])
 
 	// Disable logic
 	const isDisabledInput = ended || notStarted || isOwnAuction || bidMutation.isPending
@@ -309,41 +330,36 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		}
 	}
 
-	const handleSubmitBid = () => {
+	const handleSubmitBid = async () => {
 		const bidData = prepareBidSubmission()
 		if (!bidData) return
 
-		setRulesDialogBidAmount(bidData.amount)
-		setIsRulesDialogOpen(true)
+		if (!hasAcknowledgedAuctionRules) {
+			setIsRulesDialogOpen(true)
+			return
+		}
+
+		await submitPreparedBid(bidData)
 	}
 
 	const handleRulesDialogOpenChange = (open: boolean) => {
 		setIsRulesDialogOpen(open)
-		if (!open) {
-			setRulesDialogBidAmount(null)
-		}
 	}
 
-	const handleConfirmBid = async () => {
-		if (bidMutation.isPending || rulesDialogBidAmount === null) return
-
-		const bidData = prepareBidSubmission()
-		if (!bidData) {
-			setIsRulesDialogOpen(false)
-			setRulesDialogBidAmount(null)
-			return
+	const handleConfirmRules = () => {
+		if (auctionRulesAckKey) {
+			try {
+				if (typeof window !== 'undefined') {
+					window.localStorage.setItem(auctionRulesAckKey, 'true')
+				}
+			} catch {
+				// Local persistence failed; keep the acknowledgment in memory for this mounted session.
+			}
 		}
 
-		if (rulesDialogBidAmount !== null && bidData.amount !== rulesDialogBidAmount) {
-			setIsRulesDialogOpen(false)
-			setRulesDialogBidAmount(null)
-			toast.info('The bid amount changed while you were reviewing the rules. Please review the updated amount and try again.')
-			return
-		}
-
+		setHasAcknowledgedAuctionRules(true)
 		setIsRulesDialogOpen(false)
-		setRulesDialogBidAmount(null)
-		await submitPreparedBid(bidData)
+		toast.info('Auction rules reviewed. Check the current bid amount before placing your bid.')
 	}
 
 	return (
@@ -359,15 +375,10 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 					<DialogHeader>
 						<DialogTitle>Review auction rules before bidding</DialogTitle>
 						<DialogDescription>
-							Auction bids use Cashu e-cash with P2PK locks. Review what can happen to your funds before placing this bid.
+							Auction bids use Cashu e-cash with P2PK locks. Review what can happen to your funds before placing bids in this auction.
 						</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-3 py-2 text-sm text-muted-foreground">
-						{rulesDialogBidAmount !== null && (
-							<p className="rounded-md bg-muted px-3 py-2 text-sm font-medium text-foreground">
-								You are confirming a bid of {rulesDialogBidAmount.toLocaleString()} sats.
-							</p>
-						)}
 						<ul className="list-disc space-y-2 pl-5">
 							<li>
 								Your bid may lock Cashu e-cash to an auction-derived P2PK key, with a refund path that only opens after the auction and
@@ -386,7 +397,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							</li>
 							<li>If you lose, or settlement does not complete, your funds may only become refundable after the refund window opens.</li>
 							<li>
-								This auction still relies on trust assumptions: Cashu mints custody the bitcoin behind e-cash, validator/auditor and relay
+								This auction still relies on trusted parties: Cashu mints custody the bitcoin behind e-cash, validators/auditors and relay
 								data affect what the app shows, and bidders/sellers must complete settlement and delivery honestly.
 							</li>
 						</ul>
@@ -395,8 +406,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 						<Button variant="outline" onClick={() => handleRulesDialogOpenChange(false)} disabled={bidMutation.isPending}>
 							Cancel
 						</Button>
-						<Button onClick={handleConfirmBid} disabled={bidMutation.isPending || rulesDialogBidAmount === null}>
-							{bidMutation.isPending ? 'Submitting...' : 'I understand, place bid'}
+						<Button onClick={handleConfirmRules} disabled={bidMutation.isPending}>
+							I understand these rules
 						</Button>
 					</DialogFooter>
 				</DialogContent>
@@ -545,6 +556,17 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 			{/* Minimum Bid Info */}
 			{!compact && !ended && <div className="text-xs text-foreground/80 pl-1">Minimum allowed bid: {minBid.toLocaleString()} sats</div>}
+			{hasAcknowledgedAuctionRules && hasSignedInBidder && !isOwnAuction && (
+				<Button
+					type="button"
+					variant="link"
+					size="sm"
+					onClick={() => setIsRulesDialogOpen(true)}
+					className="h-auto justify-start p-0 text-xs text-muted-foreground"
+				>
+					Review auction rules
+				</Button>
+			)}
 		</div>
 	)
 }

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -1,8 +1,9 @@
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
-import { usePublishAuctionBidMutation } from '@/publish/auctions'
+import { usePublishAuctionBidMutation, type AuctionBidFormData } from '@/publish/auctions'
 import {
 	getAuctionBiddingCutoffAt,
 	getAuctionEndAt,
@@ -173,6 +174,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const [isDepositOpen, setIsDepositOpen] = useState(false)
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
+	const [isRulesDialogOpen, setIsRulesDialogOpen] = useState(false)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -232,73 +234,102 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		return 'Place Bid'
 	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
 
-	const handleSubmitBid = async () => {
-		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return
+	const prepareBidSubmission = (): AuctionBidFormData | null => {
+		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return null
 
 		const parsedAmount = parseInt(bidAmountInput || '0', 10)
 		if (!Number.isFinite(parsedAmount) || parsedAmount < minBid) {
 			toast.error(`Bid must be at least ${minBid.toLocaleString()} sats`)
-			return
+			return null
 		}
 
 		if (!hasSignedInBidder) {
 			uiActions.openDialog('login')
-			return
+			return null
 		}
 
 		if (isNip60Loading) {
 			toast.info('Wallet is still loading. Try again in a moment.')
-			return
+			return null
 		}
 
 		if (hasInsufficientBidFunds) {
 			if (!depositMint) {
 				toast.error(mintError || 'No suitable mint available for bidding.')
-				return
+				return null
 			}
 
 			setDepositAmount(Math.ceil(deltaAmount))
 			setPreferredDepositMint(depositMint)
 			setIsDepositOpen(true)
-			return
+			return null
 		}
 
+		// Under `cashu_p2pk_bidder_path_v1` the bidder generates the
+		// derivation path locally and never consults a "path issuer"
+		// oracle - that was the v1 CVM-coordinator scheme. The only
+		// auction tag the bidder actually needs is `p2pk_xpub`; if
+		// it's absent the auction isn't biddable.
+		if (!p2pkXpub) {
+			toast.error('This auction is missing a p2pk_xpub and cannot accept bids.')
+			return null
+		}
+		if (!selectedMint) {
+			toast.error(mintError || 'No suitable mint available for bidding.')
+			return null
+		}
+		if (!canFund) {
+			toast.error('Insufficient balance on selected mint to cover the required delta.')
+			return null
+		}
+
+		return {
+			auctionEventId: auctionRootEventId || auction.id,
+			auctionCoordinates,
+			amount: parsedAmount,
+			auctionStartAt: startAt,
+			auctionEffectiveEndAt: biddingCutoffAt,
+			auctionLocktimeAt: biddingCutoffAt,
+			settlementGraceSeconds: getAuctionSettlementGrace(auction),
+			sellerPubkey: auction.pubkey,
+			p2pkXpub,
+			mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
+		}
+	}
+
+	const submitPreparedBid = async (bidData: AuctionBidFormData) => {
 		try {
-			// Under `cashu_p2pk_bidder_path_v1` the bidder generates the
-			// derivation path locally and never consults a "path issuer"
-			// oracle — that was the v1 CVM-coordinator scheme. The only
-			// auction tag the bidder actually needs is `p2pk_xpub`; if
-			// it's absent the auction isn't biddable.
-			if (!p2pkXpub) {
-				toast.error('This auction is missing a p2pk_xpub and cannot accept bids.')
-				return
-			}
-			if (!selectedMint) {
-				toast.error(mintError || 'No suitable mint available for bidding.')
-				return
-			}
-			if (!canFund) {
-				toast.error('Insufficient balance on selected mint to cover the required delta.')
-				return
-			}
-			await bidMutation.mutateAsync({
-				auctionEventId: auctionRootEventId || auction.id,
-				auctionCoordinates,
-				amount: parsedAmount,
-				auctionStartAt: startAt,
-				auctionEffectiveEndAt: biddingCutoffAt,
-				auctionLocktimeAt: biddingCutoffAt,
-				settlementGraceSeconds: getAuctionSettlementGrace(auction),
-				sellerPubkey: auction.pubkey,
-				p2pkXpub,
-				mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
-			})
+			await bidMutation.mutateAsync(bidData)
 			toast.success('Bid placed successfully')
 			setIsEditing(false)
 			onBidSuccess?.()
 		} catch {
 			// Error handled by mutation
 		}
+	}
+
+	const handleSubmitBid = () => {
+		const bidData = prepareBidSubmission()
+		if (!bidData) return
+
+		setIsRulesDialogOpen(true)
+	}
+
+	const handleRulesDialogOpenChange = (open: boolean) => {
+		setIsRulesDialogOpen(open)
+	}
+
+	const handleConfirmBid = async () => {
+		if (bidMutation.isPending) return
+
+		const bidData = prepareBidSubmission()
+		if (!bidData) {
+			setIsRulesDialogOpen(false)
+			return
+		}
+
+		setIsRulesDialogOpen(false)
+		await submitPreparedBid(bidData)
 	}
 
 	return (
@@ -309,6 +340,33 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				initialAmount={depositAmount}
 				preferredMint={preferredDepositMint}
 			/>
+			<Dialog open={isRulesDialogOpen} onOpenChange={handleRulesDialogOpenChange}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Review auction rules before bidding</DialogTitle>
+						<DialogDescription>
+							Placing an auction bid may lock Cashu funds until the auction ends and the settlement/refund window has passed.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-3 py-2 text-sm text-muted-foreground">
+						<ul className="list-disc space-y-2 pl-5">
+							<li>Auctions are timed. The highest valid bid may win, but bids are not guaranteed.</li>
+							<li>Your bid may lock funds using the auction's Cashu/P2PK flow.</li>
+							<li>If you win, settlement may require a later action from you and the seller.</li>
+							<li>If you lose or settlement does not complete, funds may only become available through the refund path after locktime.</li>
+							<li>Relay data, validator/auditor review, mint state, and settlement events can affect what the app shows.</li>
+						</ul>
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => handleRulesDialogOpenChange(false)} disabled={bidMutation.isPending}>
+							Cancel
+						</Button>
+						<Button onClick={handleConfirmBid} disabled={bidMutation.isPending}>
+							{bidMutation.isPending ? 'Submitting...' : 'I understand, place bid'}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 			{/* Anti-snipe curve banner — visible only when we're inside
 			    `(end_at, max_end_at]` AND the auction has a non-`none` curve.
 			    Tells the bidder why the floor is higher than they'd expect

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -175,6 +175,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
 	const [isRulesDialogOpen, setIsRulesDialogOpen] = useState(false)
+	const [rulesDialogBidAmount, setRulesDialogBidAmount] = useState<number | null>(null)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -312,23 +313,36 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		const bidData = prepareBidSubmission()
 		if (!bidData) return
 
+		setRulesDialogBidAmount(bidData.amount)
 		setIsRulesDialogOpen(true)
 	}
 
 	const handleRulesDialogOpenChange = (open: boolean) => {
 		setIsRulesDialogOpen(open)
+		if (!open) {
+			setRulesDialogBidAmount(null)
+		}
 	}
 
 	const handleConfirmBid = async () => {
-		if (bidMutation.isPending) return
+		if (bidMutation.isPending || rulesDialogBidAmount === null) return
 
 		const bidData = prepareBidSubmission()
 		if (!bidData) {
 			setIsRulesDialogOpen(false)
+			setRulesDialogBidAmount(null)
+			return
+		}
+
+		if (rulesDialogBidAmount !== null && bidData.amount !== rulesDialogBidAmount) {
+			setIsRulesDialogOpen(false)
+			setRulesDialogBidAmount(null)
+			toast.info('The bid amount changed while you were reviewing the rules. Please review the updated amount and try again.')
 			return
 		}
 
 		setIsRulesDialogOpen(false)
+		setRulesDialogBidAmount(null)
 		await submitPreparedBid(bidData)
 	}
 
@@ -349,6 +363,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 						</DialogDescription>
 					</DialogHeader>
 					<div className="space-y-3 py-2 text-sm text-muted-foreground">
+						{rulesDialogBidAmount !== null && (
+							<p className="rounded-md bg-muted px-3 py-2 text-sm font-medium text-foreground">
+								You are confirming a bid of {rulesDialogBidAmount.toLocaleString()} sats.
+							</p>
+						)}
 						<ul className="list-disc space-y-2 pl-5">
 							<li>Auctions are timed. The highest valid bid may win, but bids are not guaranteed.</li>
 							<li>Your bid may lock funds using the auction's Cashu/P2PK flow.</li>
@@ -361,7 +380,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 						<Button variant="outline" onClick={() => handleRulesDialogOpenChange(false)} disabled={bidMutation.isPending}>
 							Cancel
 						</Button>
-						<Button onClick={handleConfirmBid} disabled={bidMutation.isPending}>
+						<Button onClick={handleConfirmBid} disabled={bidMutation.isPending || rulesDialogBidAmount === null}>
 							{bidMutation.isPending ? 'Submitting...' : 'I understand, place bid'}
 						</Button>
 					</DialogFooter>


### PR DESCRIPTION
## Summary

- Adds an auction rules acknowledgment dialog before a bidder's first ready-to-submit bid on an auction.
- Preserves existing login, wallet-loading, deposit, mint, and local validation gates before showing the dialog.
- Changes the rules dialog into an acknowledgment gate: confirming the dialog does not submit a bid.
- After acknowledging, the user returns to the live bid UI and submits through the existing auction bid mutation path.
- Stores local-only acknowledgment scoped by rules version, bidder pubkey, and auction identity.
- Adds a small “Review auction rules” action so users can reopen the explanation.
- Updates the copy to explain Cashu/P2PK locking, path-secret settlement, refund timing, and trust assumptions around mints, validators/auditors, relay-derived UI state, bidders, and sellers.

Closes #1010.
Part of #881.
Related to #922.

## UX note

This avoids requiring users to review the rules before every bid while still showing the rules once per bidder/auction/rules-version. The rules modal is intentionally separated from bid submission so bid amounts remain reviewed in the live bid UI, where the minimum bid can change.

## Not changed

- Bid validation semantics
- Bid event kind/tags/content
- Nostr publish/signing behavior
- Wallet/NIP-60/Cashu/P2PK behavior
- Settlement/refund/path release behavior
- Claim, winner, or tie-break logic
- Route generation
- Package files, lockfiles, workflows, env files, deploy files, docs, or unrelated auction UI
- Server-side persistence

## Validation

- `bunx prettier --check 'src/components/AuctionBidder.tsx'`
- `git diff --check`
- `bun run test:unit`
- `bun run build`
- `git restore src/routeTree.gen.ts`

## Smoke test

- First ready-to-submit bid opens the auction rules dialog.
- Cancel/close submits nothing.
- Confirming the rules stores local acknowledgment and submits nothing.
- After acknowledgment, the user can place the bid from the live bid UI.
- Repeat bids on the same auction/user/rules-version skip the dialog.
- “Review auction rules” reopens the dialog manually.
