### PR TITLE
feat: sort auctions with newest first

### DIFF
--- a/src/lib/utils/auctions.ts
+++ b/src/lib/utils/auctions.ts
@@ -44,7 +44,7 @@ export interface UseFilteredAuctionsProps {
 
 export const defaultAuctionFilters: AuctionFilterState = {
 	hideEnded: false,
-	sort: 'ending-soon',
+	sort: 'newest',
 }
 
 /**


### PR DESCRIPTION
# Summary
Changed the default auction list sort from Ending Soon to Newest First, so newly published auctions appear at the top of the list immediately after creation

## Change
One line in `src/lib/utils/auctions.ts` — defaultAuctionFilters.sort changed from 'ending-soon' to 'newest'.

## How to Test
1. Log in and create a new auction via the "Create Auction" button
2. After publishing, confirm you are redirected to /auctions
3. Confirm the newly created auction appears at the top of the list without changing any filters

Screenshot

https://github.com/user-attachments/assets/8363853b-672b-46c9-b908-030c8b898f48




closes #1033