### PR TITLE
fix(auctions): enforce minimum bid legs before settlement

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -17,9 +17,11 @@ import {
 	getAuctionRootEventId,
 	getAuctionSettlementGrace,
 	getAuctionCurrentPriceFromBids,
+	getAuctionBidCountFromBids,
 	getBidAmount,
 } from '@/queries/auctions'
-import { computeAuctionBidFloor, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
+import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
@@ -129,6 +131,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const notStarted = startAt > 0 && countdown.now < startAt
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const bidsCount = getAuctionBidCountFromBids(auction, bids)
+	const hasPriorBids = bidsCount > 0
+	const bidStep = Math.max(bidIncrement, AUCTION_MIN_BID_LEG_SATS)
 	const signedInBidderPubkey = isAuthenticated ? user?.pubkey || currentUserPubkey || '' : ''
 	const hasSignedInBidder = !!signedInBidderPubkey
 	const isNip60Ready = nip60Status === 'ready'
@@ -149,6 +154,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// Ref to store the last computed curve floor value
 	const lastCurveFloorRef = useRef<number>(0)
 
+	const flatFloor = hasPriorBids ? currentPrice + bidStep : Math.max(startingBid, AUCTION_MIN_BID_SATS)
+	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
+
 	const curveFloor = useMemo(() => {
 		// Only update the curve floor if the auction hasn't ended
 		// This prevents the minBid value from changing after the auction ends
@@ -157,16 +165,21 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			return lastCurveFloorRef.current
 		}
 
-		const computedFloor = computeAuctionBidFloor(auction, currentPrice, countdown.now)
+		const multiplier = computeAuctionFloorMultiplier({
+			atSeconds: countdown.now,
+			endAt,
+			maxEndAt: biddingCutoffAt,
+			shape: auctionCurve.shape,
+			peakMultiplier: auctionCurve.peakMultiplier,
+		})
+		const computedFloor = Math.max(0, Math.ceil(flatFloor * multiplier))
 		// Store the computed value for use when auction ends
 		lastCurveFloorRef.current = computedFloor
 		return computedFloor
-	}, [auction, currentPrice, countdown.now, ended])
+	}, [auctionCurve, biddingCutoffAt, countdown.now, endAt, ended, flatFloor])
 
-	const flatFloor = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
 	const minBid = Math.max(flatFloor, curveFloor)
 	const inCurveWindow = countdown.now > endAt && countdown.now < biddingCutoffAt
-	const auctionCurve = useMemo(() => getAuctionMinBidCurve(auction), [auction])
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
@@ -232,11 +245,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		// Check for invalid result
 		if (!Number.isFinite(parsedBidAmount)) return ''
 
-		if (parsedBidAmount === currentPrice + bidIncrement) return 'inc1'
+		if (parsedBidAmount === minBid) return 'inc1'
 
 		// Only return these values as selected if the options are showing.
 		if (!compact) {
-			if (parsedBidAmount === currentPrice + bidIncrement * 2) return 'inc2'
+			if (parsedBidAmount === minBid + bidStep) return 'inc2'
 			if (parsedBidAmount === Math.max(currentPrice * 2, minBid)) return 'mult2'
 		}
 
@@ -261,7 +274,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 		const parsedAmount = parseInt(bidAmountInput || '0', 10)
 		if (!Number.isFinite(parsedAmount) || parsedAmount < minBid) {
-			toast.error(`Bid must be at least ${minBid.toLocaleString()} sats`)
+			toast.error(
+				hasPriorBids
+					? `Minimum raise is ${bidStep.toLocaleString()} sats; bid at least ${minBid.toLocaleString()} sats`
+					: `Minimum bid is ${minBid.toLocaleString()} sats`,
+			)
 			return null
 		}
 
@@ -415,7 +432,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			{/* Anti-snipe curve banner — visible only when we're inside
 			    `(end_at, max_end_at]` AND the auction has a non-`none` curve.
 			    Tells the bidder why the floor is higher than they'd expect
-			    from the flat `currentPrice + bidIncrement`. AUCTIONS.md §6.1. */}
+			    from the flat minimum bid / raise. AUCTIONS.md §6.1. */}
 			{!ended && inCurveWindow && auctionCurve.shape !== 'none' && (
 				<div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
 					<p className="font-semibold">Anti-snipe window — minimum bid rising</p>
@@ -465,7 +482,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							<InputGroupInput
 								type="number"
 								min={minBid}
-								step={Math.max(1, bidIncrement)}
+								step={bidStep}
 								value={bidAmountInput}
 								onChange={(e) => setBidAmountInput(e.target.value)}
 								placeholder={`Min: ${minBid.toLocaleString()}`}
@@ -484,9 +501,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							onValueChange={(val) => {
 								if (!val) return
 								if (val === 'inc1') {
-									setBidAmountInput(String(currentPrice + bidIncrement))
+									setBidAmountInput(String(minBid))
 								} else if (val === 'inc2') {
-									setBidAmountInput(String(currentPrice + bidIncrement * 2))
+									setBidAmountInput(String(minBid + bidStep))
 								} else if (val === 'mult2') {
 									setBidAmountInput(String(Math.max(currentPrice * 2, minBid)))
 								} else if (val === 'edit') {
@@ -499,7 +516,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 								value="inc1"
 								variant="outline"
 								size="sm"
-								tooltip="Minimum Bid Increment"
+								tooltip={hasPriorBids ? 'Minimum Raise' : 'Minimum Bid'}
 								disabled={isDisabledInput}
 								className={cn('cursor-pointer flex')}
 							>
@@ -510,11 +527,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 								value="inc2"
 								variant="outline"
 								size="sm"
-								tooltip="2x Minimum Bid Increment"
+								tooltip="Minimum bid plus one raise"
 								disabled={isDisabledInput}
 								className="flex cursor-pointer"
 							>
-								{(minBid + bidIncrement).toLocaleString()} sats
+								{(minBid + bidStep).toLocaleString()} sats
 							</TooltipToggleGroupItem>
 							<TooltipToggleGroupItem
 								value="mult2"

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -28,6 +28,7 @@ import { useStore } from '@tanstack/react-store'
 import { useEffect, useMemo, useState } from 'react'
 import { AuctionBidder } from './AuctionBidder'
 import { cn } from '@/lib/utils'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 
 const bidderStatusClassName = (status: AuctionBidderStatusKind): string => {
 	switch (status) {
@@ -93,9 +94,9 @@ export function AuctionCard({
 	)
 
 	const minBid = useMemo(() => {
-		const floorBid = currentPrice + Math.max(1, bidIncrement)
-		return Math.max(startingBid, floorBid)
-	}, [bidIncrement, currentPrice, startingBid])
+		const bidStep = Math.max(bidIncrement, AUCTION_MIN_BID_LEG_SATS)
+		return bidsCount > 0 ? currentPrice + bidStep : Math.max(startingBid, AUCTION_MIN_BID_SATS)
+	}, [bidIncrement, bidsCount, currentPrice, startingBid])
 
 	useEffect(() => {
 		const checkIfOwnAuction = async () => {

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -33,6 +33,7 @@ import {
 	type AuctionSettlementGracePreset,
 	type AuctionSpecEntry,
 } from '@/publish/auctions'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 import { createShippingReference, getShippingInfo, isShippingDeleted, useShippingOptionsByPubkey } from '@/queries/shipping'
 import { clearAuctionFormDraft, getAuctionFormDraft, saveAuctionFormDraft } from '@/lib/utils/auctionFormStorage'
 import { useNavigate } from '@tanstack/react-router'
@@ -52,7 +53,7 @@ const INITIAL_FORM: AuctionFormData = {
 	summary: '',
 	description: '',
 	startingBid: '',
-	bidIncrement: '1',
+	bidIncrement: String(AUCTION_MIN_BID_LEG_SATS),
 	reserve: undefined,
 	startAt: '',
 	endAt: '',
@@ -1108,7 +1109,8 @@ function AuctionTabContent({
 					<Input
 						id="auction-starting-bid"
 						type="number"
-						min="0"
+						min={AUCTION_MIN_BID_SATS}
+						step="1"
 						value={formData.startingBid}
 						onChange={(e) => setFormData((prev) => ({ ...prev, startingBid: e.target.value }))}
 					/>
@@ -1121,7 +1123,8 @@ function AuctionTabContent({
 					<Input
 						id="auction-bid-increment"
 						type="number"
-						min="1"
+						min={AUCTION_MIN_BID_LEG_SATS}
+						step="1"
 						value={formData.bidIncrement}
 						onFocus={(e) => e.target.select()}
 						onChange={(e) => setFormData((prev) => ({ ...prev, bidIncrement: e.target.value.replace(/^0+(\d)/, '$1') }))}

--- a/src/lib/__tests__/auctionBidValidation.test.ts
+++ b/src/lib/__tests__/auctionBidValidation.test.ts
@@ -101,6 +101,7 @@ interface BidOverrides {
 	auctionCoordinate?: string
 	sellerPubkey?: string
 	lockSecrets?: string[]
+	prevBidId?: string
 }
 
 const buildLockSecret = (params: { childPubkey: string; locktime: number; refundPubkey: string }): string => {
@@ -151,6 +152,7 @@ const buildBid = (auction: ParsedAuctionEvent, overrides: BidOverrides = {}): Pa
 		bidNonce: 'test-bid-nonce',
 		keyScheme: 'hd_p2pk',
 		status: 'locked',
+		prevBidId: overrides.prevBidId,
 	}
 }
 
@@ -418,6 +420,74 @@ describe('validateBid — amount and floor', () => {
 		const bid = buildBid(auction, { amount: currentTopBid + AUCTION_MIN_BID_LEG_SATS })
 		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent', currentTopBid })
 		expect(verdict).toEqual({ claim: 'valid_bid_placed' })
+	})
+
+	test('rejects rebid when own replacement-chain delta is below AUCTION_MIN_BID_LEG_SATS', () => {
+		const auction = buildAuction({ startingBid: AUCTION_MIN_BID_SATS, bidIncrement: 1 })
+		const previousBidAmount = AUCTION_MIN_BID_SATS
+		const rebidAmount = previousBidAmount + AUCTION_MIN_BID_LEG_SATS - 1
+		const bid = buildBid(auction, { amount: rebidAmount, prevBidId: '3'.repeat(64) })
+		const verdict = validateBid({
+			auction,
+			bid,
+			observedAt: bid.createdAt,
+			nut7State: 'unspent',
+			currentTopBid: 0,
+			bidChainLegAmount: rebidAmount - previousBidAmount,
+		})
+		expect(verdict.claim).toBe('bid_invalid')
+		if (verdict.claim === 'bid_invalid') {
+			expect(verdict.reason).toBe('under_increment')
+			expect(verdict.detail).toMatch(/replacement-chain delta/)
+		}
+	})
+
+	test('accepts rebid when own replacement-chain delta equals AUCTION_MIN_BID_LEG_SATS', () => {
+		const auction = buildAuction({ startingBid: AUCTION_MIN_BID_SATS, bidIncrement: 1 })
+		const previousBidAmount = AUCTION_MIN_BID_SATS
+		const rebidAmount = previousBidAmount + AUCTION_MIN_BID_LEG_SATS
+		const bid = buildBid(auction, { amount: rebidAmount, prevBidId: '3'.repeat(64) })
+		const verdict = validateBid({
+			auction,
+			bid,
+			observedAt: bid.createdAt,
+			nut7State: 'unspent',
+			currentTopBid: 0,
+			bidChainLegAmount: rebidAmount - previousBidAmount,
+		})
+		expect(verdict).toEqual({ claim: 'valid_bid_placed' })
+	})
+
+	test('rejects rebid when previous-bid context is missing', () => {
+		const auction = buildAuction({ startingBid: AUCTION_MIN_BID_SATS, bidIncrement: 1 })
+		const bid = buildBid(auction, {
+			amount: AUCTION_MIN_BID_SATS + AUCTION_MIN_BID_LEG_SATS,
+			prevBidId: '3'.repeat(64),
+		})
+		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent', currentTopBid: 0 })
+		expect(verdict.claim).toBe('bid_invalid')
+		if (verdict.claim === 'bid_invalid') {
+			expect(verdict.reason).toBe('replacement_chain_invalid')
+		}
+	})
+
+	test('rejects rebid when replacement-chain delta is not a safe integer', () => {
+		const auction = buildAuction({ startingBid: AUCTION_MIN_BID_SATS, bidIncrement: 1 })
+		const previousBidAmount = AUCTION_MIN_BID_SATS
+		const rebidAmount = previousBidAmount + AUCTION_MIN_BID_LEG_SATS + 0.5
+		const bid = buildBid(auction, { amount: rebidAmount, prevBidId: '3'.repeat(64) })
+		const verdict = validateBid({
+			auction,
+			bid,
+			observedAt: bid.createdAt,
+			nut7State: 'unspent',
+			currentTopBid: 0,
+			bidChainLegAmount: rebidAmount - previousBidAmount,
+		})
+		expect(verdict.claim).toBe('bid_invalid')
+		if (verdict.claim === 'bid_invalid') {
+			expect(verdict.reason).toBe('under_increment')
+		}
 	})
 
 	test('curve behavior applies on top of the minimum baseline', () => {

--- a/src/lib/__tests__/auctionBidValidation.test.ts
+++ b/src/lib/__tests__/auctionBidValidation.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
-import { validateBid } from '../auction/validation'
+import { computeBidFloor, validateBid } from '../auction/validation'
 import type { ParsedAuctionEvent, ParsedBidEvent, MinBidCurve } from '../auction/events'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '../auction/constants'
 
 // =============================================================================
 // Fixture helpers
@@ -383,6 +384,56 @@ describe('validateBid — lock secret structure', () => {
 // =============================================================================
 
 describe('validateBid — amount and floor', () => {
+	test('rejects first bid below AUCTION_MIN_BID_SATS', () => {
+		const auction = buildAuction({ startingBid: 1, bidIncrement: 1 })
+		const bid = buildBid(auction, { amount: AUCTION_MIN_BID_SATS - 1 })
+		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent' })
+		expect(verdict.claim).toBe('bid_invalid')
+		if (verdict.claim === 'bid_invalid') {
+			expect(verdict.reason).toBe('under_increment')
+		}
+	})
+
+	test('accepts first bid exactly AUCTION_MIN_BID_SATS', () => {
+		const auction = buildAuction({ startingBid: 1, bidIncrement: 1 })
+		const bid = buildBid(auction, { amount: AUCTION_MIN_BID_SATS })
+		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent' })
+		expect(verdict).toEqual({ claim: 'valid_bid_placed' })
+	})
+
+	test('rejects subsequent bid when raise is below AUCTION_MIN_BID_LEG_SATS', () => {
+		const auction = buildAuction({ startingBid: 1, bidIncrement: 1 })
+		const currentTopBid = 100
+		const bid = buildBid(auction, { amount: currentTopBid + AUCTION_MIN_BID_LEG_SATS - 1 })
+		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent', currentTopBid })
+		expect(verdict.claim).toBe('bid_invalid')
+		if (verdict.claim === 'bid_invalid') {
+			expect(verdict.reason).toBe('under_increment')
+		}
+	})
+
+	test('accepts subsequent bid when raise equals AUCTION_MIN_BID_LEG_SATS', () => {
+		const auction = buildAuction({ startingBid: 1, bidIncrement: 1 })
+		const currentTopBid = 100
+		const bid = buildBid(auction, { amount: currentTopBid + AUCTION_MIN_BID_LEG_SATS })
+		const verdict = validateBid({ auction, bid, observedAt: bid.createdAt, nut7State: 'unspent', currentTopBid })
+		expect(verdict).toEqual({ claim: 'valid_bid_placed' })
+	})
+
+	test('curve behavior applies on top of the minimum baseline', () => {
+		const auction = buildAuction({
+			startAt: 1_000,
+			endAt: 2_000,
+			maxEndAt: 2_100,
+			startingBid: 1,
+			bidIncrement: 1,
+			minBidCurve: { shape: 'linear', peakMultiplier: 2, raw: 'linear:2' },
+		})
+
+		expect(computeBidFloor({ auction, topBid: 0, atSeconds: auction.maxEndAt })).toBe(AUCTION_MIN_BID_SATS * 2)
+		expect(computeBidFloor({ auction, topBid: 100, atSeconds: auction.maxEndAt })).toBe((100 + AUCTION_MIN_BID_LEG_SATS) * 2)
+	})
+
 	test('under_increment when amount < starting_bid (no prior bid)', () => {
 		const auction = buildAuction({ startingBid: 5_000 })
 		const bid = buildBid(auction, { amount: 4_000 })

--- a/src/lib/__tests__/auctionPublishValidation.test.ts
+++ b/src/lib/__tests__/auctionPublishValidation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { AUCTION_MIN_DURATION_SECONDS, validateAuctionPublishInput } from '@/lib/auctionPublishValidation'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 
 const NOW_SECONDS = 1_800_000_000
 
@@ -37,8 +38,16 @@ describe('auction publish validation', () => {
 		expect(() => validate({ reserve: '99' })).toThrow('Reserve must be greater than or equal to the starting bid')
 	})
 
-	test('invalid bid increment is rejected', () => {
-		expect(() => validate({ bidIncrement: '0' })).toThrow('Bid increment must be greater than 0')
+	test('starting bid below auction minimum is rejected', () => {
+		expect(() => validate({ startingBid: String(AUCTION_MIN_BID_SATS - 1) })).toThrow(
+			`Starting bid must be at least ${AUCTION_MIN_BID_SATS} sats`,
+		)
+	})
+
+	test('bid increment below bid-leg minimum is rejected', () => {
+		expect(() => validate({ bidIncrement: String(AUCTION_MIN_BID_LEG_SATS - 1) })).toThrow(
+			`Bid increment must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`,
+		)
 	})
 
 	test('end time at or before max start/current time is rejected', () => {

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -2,15 +2,14 @@ import { describe, expect, test } from 'bun:test'
 import { HDKey } from '@scure/bip32'
 import { getEncodedToken, type Proof } from '@cashu/cashu-ts'
 import { deriveAuctionChildP2pkPubkeyFromXpub } from '@/lib/auctionP2pk'
-import { preflightAuctionSettlementP2pk } from '@/lib/auctionSettlementP2pk'
+import { preflightAuctionSettlementP2pk, preflightAuctionSettlementP2pkChain } from '@/lib/auctionSettlementP2pk'
 
-const makeFixture = () => {
+const makeFixture = (derivationPath = '7/11/13/17/19') => {
 	const seed = Uint8Array.from({ length: 32 }, (_, index) => index + 1)
 	const account = HDKey.fromMasterSeed(seed).derive("m/30408'/0'/0'")
 	const xpub = account.publicExtendedKey
 	if (!xpub) throw new Error('Failed to derive test xpub')
 
-	const derivationPath = '7/11/13/17/19'
 	const childPubkey = deriveAuctionChildP2pkPubkeyFromXpub(xpub, derivationPath)
 
 	return {
@@ -32,10 +31,10 @@ const makeP2pkSecret = (lockPubkey: string): string =>
 		},
 	])
 
-const makeToken = (secret: string): string => {
+const makeToken = (secret: string, amount = 1): string => {
 	const proof: Proof = {
 		id: '009a1f293253e41e',
-		amount: 1,
+		amount,
 		secret,
 		C: '02'.padEnd(66, '1'),
 	}
@@ -45,6 +44,12 @@ const makeToken = (secret: string): string => {
 		proofs: [proof],
 	})
 }
+
+const makeEmptyToken = (): string =>
+	getEncodedToken({
+		mint: 'https://mint.example',
+		proofs: [],
+	})
 
 describe('auction settlement P2PK preflight', () => {
 	test('accepts compressed token lock pubkey matching derived child key', () => {
@@ -136,5 +141,148 @@ describe('auction settlement P2PK preflight', () => {
 				token: makeToken(makeP2pkSecret(fixture.childPubkeyXOnly)),
 			}),
 		).toThrow('Winner token P2PK lock pubkey is not compressed; cannot settle this bid safely')
+	})
+})
+
+describe('auction settlement P2PK chain preflight', () => {
+	test('rejects chain leg token with no proofs', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: fixture.xpub,
+				legs: [
+					{
+						bidEventId: 'a'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeEmptyToken(),
+						derivationPath: fixture.derivationPath,
+						bidChildPubkey: fixture.childPubkey,
+						releaseChildPubkey: fixture.childPubkey,
+						expectedAmount: 10,
+					},
+				],
+			}),
+		).toThrow('Winner token contains no proofs')
+	})
+
+	test('rejects chain leg token whose proof sum does not equal expected legAmount', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: fixture.xpub,
+				legs: [
+					{
+						bidEventId: 'b'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(fixture.childPubkey), 9),
+						derivationPath: fixture.derivationPath,
+						bidChildPubkey: fixture.childPubkey,
+						releaseChildPubkey: fixture.childPubkey,
+						expectedAmount: 10,
+					},
+				],
+			}),
+		).toThrow('token proof sum 9 sats does not equal expected leg amount 10 sats')
+	})
+
+	test('rejects chain if any leg has a mismatched P2PK lock pubkey', () => {
+		const first = makeFixture('7/11/13/17/19')
+		const second = makeFixture('2/3/5/7/11')
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: first.xpub,
+				legs: [
+					{
+						bidEventId: 'c'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+						derivationPath: first.derivationPath,
+						bidChildPubkey: first.childPubkey,
+						releaseChildPubkey: first.childPubkey,
+						expectedAmount: 10,
+					},
+					{
+						bidEventId: 'd'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(first.childPubkey), 15),
+						derivationPath: second.derivationPath,
+						bidChildPubkey: second.childPubkey,
+						releaseChildPubkey: second.childPubkey,
+						expectedAmount: 15,
+					},
+				],
+			}),
+		).toThrow('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')
+	})
+
+	test('accepts a multi-leg chain when all structural checks pass', () => {
+		const first = makeFixture('7/11/13/17/19')
+		const second = makeFixture('2/3/5/7/11')
+
+		const result = preflightAuctionSettlementP2pkChain({
+			auctionP2pkXpub: first.xpub,
+			legs: [
+				{
+					bidEventId: 'e'.repeat(64),
+					mintUrl: 'https://mint.example',
+					token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+					derivationPath: first.derivationPath,
+					bidChildPubkey: first.childPubkey,
+					releaseChildPubkey: first.childPubkey,
+					expectedAmount: 10,
+				},
+				{
+					bidEventId: 'f'.repeat(64),
+					mintUrl: 'https://mint.example',
+					token: makeToken(makeP2pkSecret(second.childPubkey), 15),
+					derivationPath: second.derivationPath,
+					bidChildPubkey: second.childPubkey,
+					releaseChildPubkey: second.childPubkey,
+					expectedAmount: 15,
+				},
+			],
+		})
+
+		expect(result.totalAmount).toBe(25)
+		expect(result.legs).toHaveLength(2)
+		expect(result.legs.map((leg) => leg.tokenAmount)).toEqual([10, 15])
+	})
+
+	test('preflight failure happens before a caller would redeem any leg', () => {
+		const first = makeFixture('7/11/13/17/19')
+		const second = makeFixture('2/3/5/7/11')
+		let wouldRedeem = false
+
+		expect(() => {
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: first.xpub,
+				legs: [
+					{
+						bidEventId: '1'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+						derivationPath: first.derivationPath,
+						bidChildPubkey: first.childPubkey,
+						releaseChildPubkey: first.childPubkey,
+						expectedAmount: 10,
+					},
+					{
+						bidEventId: '2'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(second.childPubkey), 9),
+						derivationPath: second.derivationPath,
+						bidChildPubkey: second.childPubkey,
+						releaseChildPubkey: second.childPubkey,
+						expectedAmount: 10,
+					},
+				],
+			})
+			wouldRedeem = true
+		}).toThrow('token proof sum 9 sats does not equal expected leg amount 10 sats')
+
+		expect(wouldRedeem).toBe(false)
 	})
 })

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -231,6 +231,27 @@ describe('auction settlement P2PK chain preflight', () => {
 		).toThrow('token mint URL https://other-mint.example does not match expected mint URL https://mint.example')
 	})
 
+	test('accepts chain leg token mint with equivalent trailing-slash spelling', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: fixture.xpub,
+				legs: [
+					{
+						bidEventId: '4'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(fixture.childPubkey), AUCTION_MIN_BID_LEG_SATS, 'https://mint.example/'),
+						derivationPath: fixture.derivationPath,
+						bidChildPubkey: fixture.childPubkey,
+						releaseChildPubkey: fixture.childPubkey,
+						expectedAmount: AUCTION_MIN_BID_LEG_SATS,
+					},
+				],
+			}),
+		).not.toThrow()
+	})
+
 	test('rejects chain if any leg has a mismatched P2PK lock pubkey', () => {
 		const first = makeFixture('7/11/13/17/19')
 		const second = makeFixture('2/3/5/7/11')

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -148,6 +148,7 @@ describe('auction settlement P2PK preflight', () => {
 describe('auction settlement P2PK chain preflight', () => {
 	test('rejects chain leg token with no proofs', () => {
 		const fixture = makeFixture()
+		const expectedAmount = AUCTION_MIN_BID_LEG_SATS
 
 		expect(() =>
 			preflightAuctionSettlementP2pkChain({
@@ -160,7 +161,7 @@ describe('auction settlement P2PK chain preflight', () => {
 						derivationPath: fixture.derivationPath,
 						bidChildPubkey: fixture.childPubkey,
 						releaseChildPubkey: fixture.childPubkey,
-						expectedAmount: 10,
+						expectedAmount,
 					},
 				],
 			}),
@@ -169,6 +170,8 @@ describe('auction settlement P2PK chain preflight', () => {
 
 	test('rejects chain leg token whose proof sum does not equal expected legAmount', () => {
 		const fixture = makeFixture()
+		const expectedAmount = AUCTION_MIN_BID_LEG_SATS
+		const proofAmount = expectedAmount - 1
 
 		expect(() =>
 			preflightAuctionSettlementP2pkChain({
@@ -177,15 +180,15 @@ describe('auction settlement P2PK chain preflight', () => {
 					{
 						bidEventId: 'b'.repeat(64),
 						mintUrl: 'https://mint.example',
-						token: makeToken(makeP2pkSecret(fixture.childPubkey), 9),
+						token: makeToken(makeP2pkSecret(fixture.childPubkey), proofAmount),
 						derivationPath: fixture.derivationPath,
 						bidChildPubkey: fixture.childPubkey,
 						releaseChildPubkey: fixture.childPubkey,
-						expectedAmount: 10,
+						expectedAmount,
 					},
 				],
 			}),
-		).toThrow('token proof sum 9 sats does not equal expected leg amount 10 sats')
+		).toThrow(`token proof sum ${proofAmount} sats does not equal expected leg amount ${expectedAmount} sats`)
 	})
 
 	test('rejects chain leg below AUCTION_MIN_BID_LEG_SATS even when token sum matches', () => {
@@ -255,6 +258,8 @@ describe('auction settlement P2PK chain preflight', () => {
 	test('rejects chain if any leg has a mismatched P2PK lock pubkey', () => {
 		const first = makeFixture('7/11/13/17/19')
 		const second = makeFixture('2/3/5/7/11')
+		const expectedAmount = AUCTION_MIN_BID_LEG_SATS
+		const secondLegAmount = expectedAmount + 5
 
 		expect(() =>
 			preflightAuctionSettlementP2pkChain({
@@ -263,29 +268,63 @@ describe('auction settlement P2PK chain preflight', () => {
 					{
 						bidEventId: 'c'.repeat(64),
 						mintUrl: 'https://mint.example',
-						token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+						token: makeToken(makeP2pkSecret(first.childPubkey), expectedAmount),
 						derivationPath: first.derivationPath,
 						bidChildPubkey: first.childPubkey,
 						releaseChildPubkey: first.childPubkey,
-						expectedAmount: 10,
+						expectedAmount,
 					},
 					{
 						bidEventId: 'd'.repeat(64),
 						mintUrl: 'https://mint.example',
-						token: makeToken(makeP2pkSecret(first.childPubkey), 15),
+						token: makeToken(makeP2pkSecret(first.childPubkey), secondLegAmount),
 						derivationPath: second.derivationPath,
 						bidChildPubkey: second.childPubkey,
 						releaseChildPubkey: second.childPubkey,
-						expectedAmount: 15,
+						expectedAmount: secondLegAmount,
 					},
 				],
 			}),
 		).toThrow('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')
 	})
 
+	test('rejects duplicate bid event IDs in a settlement chain', () => {
+		const first = makeFixture('7/11/13/17/19')
+		const second = makeFixture('2/3/5/7/11')
+		const duplicateBidEventId = '5'.repeat(64)
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: first.xpub,
+				legs: [
+					{
+						bidEventId: duplicateBidEventId,
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(first.childPubkey), AUCTION_MIN_BID_LEG_SATS),
+						derivationPath: first.derivationPath,
+						bidChildPubkey: first.childPubkey,
+						releaseChildPubkey: first.childPubkey,
+						expectedAmount: AUCTION_MIN_BID_LEG_SATS,
+					},
+					{
+						bidEventId: duplicateBidEventId,
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(second.childPubkey), AUCTION_MIN_BID_LEG_SATS),
+						derivationPath: second.derivationPath,
+						bidChildPubkey: second.childPubkey,
+						releaseChildPubkey: second.childPubkey,
+						expectedAmount: AUCTION_MIN_BID_LEG_SATS,
+					},
+				],
+			}),
+		).toThrow(`Chain leg ${duplicateBidEventId.slice(0, 8)}… reuses bid event ID ${duplicateBidEventId}`)
+	})
+
 	test('accepts a multi-leg chain when all structural checks pass', () => {
 		const first = makeFixture('7/11/13/17/19')
 		const second = makeFixture('2/3/5/7/11')
+		const firstLegAmount = AUCTION_MIN_BID_LEG_SATS
+		const secondLegAmount = AUCTION_MIN_BID_LEG_SATS + 5
 
 		const result = preflightAuctionSettlementP2pkChain({
 			auctionP2pkXpub: first.xpub,
@@ -293,32 +332,34 @@ describe('auction settlement P2PK chain preflight', () => {
 				{
 					bidEventId: 'e'.repeat(64),
 					mintUrl: 'https://mint.example',
-					token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+					token: makeToken(makeP2pkSecret(first.childPubkey), firstLegAmount),
 					derivationPath: first.derivationPath,
 					bidChildPubkey: first.childPubkey,
 					releaseChildPubkey: first.childPubkey,
-					expectedAmount: 10,
+					expectedAmount: firstLegAmount,
 				},
 				{
 					bidEventId: 'f'.repeat(64),
 					mintUrl: 'https://mint.example',
-					token: makeToken(makeP2pkSecret(second.childPubkey), 15),
+					token: makeToken(makeP2pkSecret(second.childPubkey), secondLegAmount),
 					derivationPath: second.derivationPath,
 					bidChildPubkey: second.childPubkey,
 					releaseChildPubkey: second.childPubkey,
-					expectedAmount: 15,
+					expectedAmount: secondLegAmount,
 				},
 			],
 		})
 
-		expect(result.totalAmount).toBe(25)
+		expect(result.totalAmount).toBe(firstLegAmount + secondLegAmount)
 		expect(result.legs).toHaveLength(2)
-		expect(result.legs.map((leg) => leg.tokenAmount)).toEqual([10, 15])
+		expect(result.legs.map((leg) => leg.tokenAmount)).toEqual([firstLegAmount, secondLegAmount])
 	})
 
 	test('preflight failure happens before a caller would redeem any leg', () => {
 		const first = makeFixture('7/11/13/17/19')
 		const second = makeFixture('2/3/5/7/11')
+		const expectedAmount = AUCTION_MIN_BID_LEG_SATS
+		const proofAmount = expectedAmount - 1
 		let wouldRedeem = false
 
 		expect(() => {
@@ -328,25 +369,25 @@ describe('auction settlement P2PK chain preflight', () => {
 					{
 						bidEventId: '1'.repeat(64),
 						mintUrl: 'https://mint.example',
-						token: makeToken(makeP2pkSecret(first.childPubkey), 10),
+						token: makeToken(makeP2pkSecret(first.childPubkey), expectedAmount),
 						derivationPath: first.derivationPath,
 						bidChildPubkey: first.childPubkey,
 						releaseChildPubkey: first.childPubkey,
-						expectedAmount: 10,
+						expectedAmount,
 					},
 					{
 						bidEventId: '2'.repeat(64),
 						mintUrl: 'https://mint.example',
-						token: makeToken(makeP2pkSecret(second.childPubkey), 9),
+						token: makeToken(makeP2pkSecret(second.childPubkey), proofAmount),
 						derivationPath: second.derivationPath,
 						bidChildPubkey: second.childPubkey,
 						releaseChildPubkey: second.childPubkey,
-						expectedAmount: 10,
+						expectedAmount,
 					},
 				],
 			})
 			wouldRedeem = true
-		}).toThrow('token proof sum 9 sats does not equal expected leg amount 10 sats')
+		}).toThrow(`token proof sum ${proofAmount} sats does not equal expected leg amount ${expectedAmount} sats`)
 
 		expect(wouldRedeem).toBe(false)
 	})

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -32,7 +32,7 @@ const makeP2pkSecret = (lockPubkey: string): string =>
 		},
 	])
 
-const makeToken = (secret: string, amount = 1): string => {
+const makeToken = (secret: string, amount = 1, mint = 'https://mint.example'): string => {
 	const proof: Proof = {
 		id: '009a1f293253e41e',
 		amount,
@@ -41,7 +41,7 @@ const makeToken = (secret: string, amount = 1): string => {
 	}
 
 	return getEncodedToken({
-		mint: 'https://mint.example',
+		mint,
 		proofs: [proof],
 	})
 }
@@ -208,6 +208,27 @@ describe('auction settlement P2PK chain preflight', () => {
 				],
 			}),
 		).toThrow(`expected leg amount must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
+	})
+
+	test('rejects chain leg token whose decoded mint does not match bid mint', () => {
+		const fixture = makeFixture()
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: fixture.xpub,
+				legs: [
+					{
+						bidEventId: '3'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(fixture.childPubkey), AUCTION_MIN_BID_LEG_SATS, 'https://other-mint.example'),
+						derivationPath: fixture.derivationPath,
+						bidChildPubkey: fixture.childPubkey,
+						releaseChildPubkey: fixture.childPubkey,
+						expectedAmount: AUCTION_MIN_BID_LEG_SATS,
+					},
+				],
+			}),
+		).toThrow('token mint URL https://other-mint.example does not match expected mint URL https://mint.example')
 	})
 
 	test('rejects chain if any leg has a mismatched P2PK lock pubkey', () => {

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from 'bun:test'
 import { HDKey } from '@scure/bip32'
 import { getEncodedToken, type Proof } from '@cashu/cashu-ts'
 import { deriveAuctionChildP2pkPubkeyFromXpub } from '@/lib/auctionP2pk'
-import { preflightAuctionSettlementP2pk, preflightAuctionSettlementP2pkChain } from '@/lib/auctionSettlementP2pk'
+import {
+	addAuctionSettlementProofAmount,
+	preflightAuctionSettlementP2pk,
+	preflightAuctionSettlementP2pkChain,
+} from '@/lib/auctionSettlementP2pk'
 import { AUCTION_MIN_BID_LEG_SATS } from '@/lib/auction/constants'
 
 const makeFixture = (derivationPath = '7/11/13/17/19') => {
@@ -142,6 +146,10 @@ describe('auction settlement P2PK preflight', () => {
 				token: makeToken(makeP2pkSecret(fixture.childPubkeyXOnly)),
 			}),
 		).toThrow('Winner token P2PK lock pubkey is not compressed; cannot settle this bid safely')
+	})
+
+	test('rejects unsafe accumulated proof sums', () => {
+		expect(() => addAuctionSettlementProofAmount(Number.MAX_SAFE_INTEGER, 1)).toThrow('Winner token proof sum is malformed')
 	})
 })
 

--- a/src/lib/__tests__/auctionSettlementP2pk.test.ts
+++ b/src/lib/__tests__/auctionSettlementP2pk.test.ts
@@ -3,6 +3,7 @@ import { HDKey } from '@scure/bip32'
 import { getEncodedToken, type Proof } from '@cashu/cashu-ts'
 import { deriveAuctionChildP2pkPubkeyFromXpub } from '@/lib/auctionP2pk'
 import { preflightAuctionSettlementP2pk, preflightAuctionSettlementP2pkChain } from '@/lib/auctionSettlementP2pk'
+import { AUCTION_MIN_BID_LEG_SATS } from '@/lib/auction/constants'
 
 const makeFixture = (derivationPath = '7/11/13/17/19') => {
 	const seed = Uint8Array.from({ length: 32 }, (_, index) => index + 1)
@@ -185,6 +186,28 @@ describe('auction settlement P2PK chain preflight', () => {
 				],
 			}),
 		).toThrow('token proof sum 9 sats does not equal expected leg amount 10 sats')
+	})
+
+	test('rejects chain leg below AUCTION_MIN_BID_LEG_SATS even when token sum matches', () => {
+		const fixture = makeFixture()
+		const tinyAmount = AUCTION_MIN_BID_LEG_SATS - 1
+
+		expect(() =>
+			preflightAuctionSettlementP2pkChain({
+				auctionP2pkXpub: fixture.xpub,
+				legs: [
+					{
+						bidEventId: '9'.repeat(64),
+						mintUrl: 'https://mint.example',
+						token: makeToken(makeP2pkSecret(fixture.childPubkey), tinyAmount),
+						derivationPath: fixture.derivationPath,
+						bidChildPubkey: fixture.childPubkey,
+						releaseChildPubkey: fixture.childPubkey,
+						expectedAmount: tinyAmount,
+					},
+				],
+			}),
+		).toThrow(`expected leg amount must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
 	})
 
 	test('rejects chain if any leg has a mismatched P2PK lock pubkey', () => {

--- a/src/lib/__tests__/auctionValidatorLifecycle.test.ts
+++ b/src/lib/__tests__/auctionValidatorLifecycle.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import type { ParsedAuctionEvent, ParsedBidEvent, ParsedPathReleaseEvent } from '../auction/events'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '../auction/constants'
 import {
 	deriveVerdict,
 	assignCloseRoles,
@@ -125,6 +126,7 @@ const buildBid = (
 		bidNonce: 'test-bid-nonce',
 		keyScheme: 'hd_p2pk',
 		status: 'locked',
+		prevBidId: overrides.prevBidId,
 	}
 }
 
@@ -232,6 +234,22 @@ describe('deriveVerdict — pre-close', () => {
 
 		const v = deriveVerdict({ auctionState, bidState, now: bid.createdAt })
 		expect(v.claim).toBe('valid_bid_placed')
+	})
+
+	test('rebid with sub-minimum own delta cannot become valid_bid_placed', () => {
+		const auction = buildAuction({ startingBid: AUCTION_MIN_BID_SATS, bidIncrement: 1 })
+		const previousBid = buildBid(auction, { id: 'a'.repeat(64), amount: AUCTION_MIN_BID_SATS })
+		const rebidAmount = AUCTION_MIN_BID_SATS + AUCTION_MIN_BID_LEG_SATS - 1
+		const rebid = buildBid(auction, { id: 'b'.repeat(64), amount: rebidAmount, prevBidId: previousBid.id })
+		const auctionState = buildAuctionState(auction)
+		auctionState.bids.set(previousBid.id, buildBidState(previousBid, previousBid.createdAt, { currentClaim: 'bid_pending_review' }))
+		const rebidState = buildBidState(rebid, rebid.createdAt)
+		auctionState.bids.set(rebid.id, rebidState)
+		recordNut7State(rebidState, rebid.proofYs[0], 'unspent', rebid.createdAt)
+
+		const v = deriveVerdict({ auctionState, bidState: rebidState, now: rebid.createdAt, currentTopBid: 0 })
+		expect(v.claim).toBe('bid_invalid')
+		expect(v.reason).toBe('under_increment')
 	})
 })
 

--- a/src/lib/auction/constants.ts
+++ b/src/lib/auction/constants.ts
@@ -60,6 +60,12 @@ export const BIDDER_AGGREGATE_REPUTATION_KIND = 30442 as unknown as AuctionKind
 
 // ---------- Floor / curve / clock tolerances -----------------------------
 
+/** Project-level minimum cumulative bid amount. Keeps tiny bids above Cashu mint-fee / proof edge cases. */
+export const AUCTION_MIN_BID_SATS = 10
+
+/** Minimum amount any bid-chain leg must lock. Applies to rebid deltas. */
+export const AUCTION_MIN_BID_LEG_SATS = AUCTION_MIN_BID_SATS
+
 /**
  * Server-side lag tolerance for the bid floor computation — see §6.1.
  *

--- a/src/lib/auction/validation.ts
+++ b/src/lib/auction/validation.ts
@@ -88,6 +88,12 @@ export interface ValidateBidInput {
 	 * "no prior bid" → starting_bid is the baseline.
 	 */
 	currentTopBid?: number
+	/**
+	 * For a `prev_bid` continuation, the bidder's own replacement-chain
+	 * delta (`bid.amount - previous bid amount`). Supplied by callers
+	 * that hold the per-auction bid graph.
+	 */
+	bidChainLegAmount?: number
 	/** Optional validator policy hook. */
 	policy?: PolicyHook
 }
@@ -140,7 +146,7 @@ export const computeBidFloor = (input: { auction: ParsedAuctionEvent; topBid: nu
  * module docstring on short-circuiting.
  */
 export const validateBid = (input: ValidateBidInput): BidValidationVerdict => {
-	const { auction, bid, observedAt, nut7State, currentTopBid = 0, policy } = input
+	const { auction, bid, observedAt, nut7State, currentTopBid = 0, bidChainLegAmount, policy } = input
 
 	// --- Step 1: cross-event reference integrity -----------------------------
 
@@ -244,6 +250,22 @@ export const validateBid = (input: ValidateBidInput): BidValidationVerdict => {
 			claim: 'bid_invalid',
 			reason: inCurveWindow ? 'under_curve' : 'under_increment',
 			detail: `amount=${bid.amount} < required=${minRequired} (top_bid=${currentTopBid}, t=${effectiveT})`,
+		}
+	}
+	if (bid.prevBidId) {
+		if (bidChainLegAmount === undefined) {
+			return {
+				claim: 'bid_invalid',
+				reason: 'replacement_chain_invalid',
+				detail: `prev_bid=${bid.prevBidId} context unavailable for replacement-chain validation`,
+			}
+		}
+		if (!Number.isSafeInteger(bidChainLegAmount) || bidChainLegAmount < AUCTION_MIN_BID_LEG_SATS) {
+			return {
+				claim: 'bid_invalid',
+				reason: 'under_increment',
+				detail: `replacement-chain delta=${bidChainLegAmount} must be an integer of at least ${AUCTION_MIN_BID_LEG_SATS} sats`,
+			}
 		}
 	}
 

--- a/src/lib/auction/validation.ts
+++ b/src/lib/auction/validation.ts
@@ -26,7 +26,14 @@
  * type-guard.
  */
 
-import { BID_FLOOR_TIME_GRACE_SECONDS, type Nut7ProofState, type ValidatorClaim, type ValidatorReason } from './constants'
+import {
+	AUCTION_MIN_BID_LEG_SATS,
+	AUCTION_MIN_BID_SATS,
+	BID_FLOOR_TIME_GRACE_SECONDS,
+	type Nut7ProofState,
+	type ValidatorClaim,
+	type ValidatorReason,
+} from './constants'
 import type { ParsedAuctionEvent, ParsedBidEvent } from './events'
 import { parseAuctionLockSecret } from '../cashu/p2pkSecret'
 
@@ -111,7 +118,8 @@ const computeFloorMultiplier = (
  */
 export const computeBidFloor = (input: { auction: ParsedAuctionEvent; topBid: number; atSeconds: number }): number => {
 	const { auction, topBid, atSeconds } = input
-	const baseline = topBid > 0 ? topBid + auction.bidIncrement : auction.startingBid
+	const baseline =
+		topBid > 0 ? topBid + Math.max(auction.bidIncrement, AUCTION_MIN_BID_LEG_SATS) : Math.max(auction.startingBid, AUCTION_MIN_BID_SATS)
 	const multiplier = computeFloorMultiplier(
 		atSeconds,
 		auction.endAt,

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -3,6 +3,7 @@ import {
 	type ProductShippingSelection,
 	type ProductShippingSelectionInput,
 } from './utils/productShippingSelections'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from './auction/constants'
 
 export const AUCTION_MIN_DURATION_SECONDS = 60
 
@@ -136,22 +137,27 @@ const parseNonNegativeInteger = (
 	return parsed
 }
 
-const parsePositiveInteger = (
+const parseIntegerAtLeast = (
 	value: string | number | null | undefined,
 	field: AuctionPublishValidationField,
 	label: string,
+	minimumSats: number,
 	issues: AuctionPublishValidationIssue[],
 ): number | undefined => {
-	const parsed = parseNonNegativeInteger(value, field, label, issues)
-	// `if (!parsed) return` was the prior bug: falsy on 0 means the
-	// "must be > 0" check below was never reached for `bidIncrement: '0'`
-	// (the validator returned undefined silently, the form thought it
-	// was valid, and 0-sat increments slipped through). Distinguish
-	// "couldn't parse" (undefined) from "parsed as 0" explicitly.
-	if (parsed === undefined) return
+	const text = toTrimmedString(value)
+	if (!SIGNED_INTEGER_PATTERN.test(text)) {
+		issues.push({ field, message: 'Please enter a valid number.' })
+		return
+	}
 
-	if (parsed <= 0) {
-		issues.push({ field, message: `${label} must be greater than 0` })
+	const parsed = Number(text)
+	if (!Number.isSafeInteger(parsed)) {
+		issues.push({ field, message: 'Please enter a valid number.' })
+		return
+	}
+
+	if (parsed < minimumSats) {
+		issues.push({ field, message: `${label} must be at least ${minimumSats} sats` })
 		return
 	}
 
@@ -233,8 +239,8 @@ const normalizeAuctionPublishInput = (
 		issues.push({ field: 'description', message: 'Auction description is required' })
 	}
 
-	const startingBid = parseNonNegativeInteger(input.startingBid, 'startingBid', 'Starting bid', issues)
-	const bidIncrement = parsePositiveInteger(input.bidIncrement, 'bidIncrement', 'Bid increment', issues)
+	const startingBid = parseIntegerAtLeast(input.startingBid, 'startingBid', 'Starting bid', AUCTION_MIN_BID_SATS, issues)
+	const bidIncrement = parseIntegerAtLeast(input.bidIncrement, 'bidIncrement', 'Bid increment', AUCTION_MIN_BID_LEG_SATS, issues)
 
 	// AUCTIONS.md §4.1: the `reserve` tag is required, with `0` meaning
 	// "no reserve". Default missing/empty input to 0 so the published

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -5,6 +5,7 @@ import {
 	toCompressedAuctionP2pkPubkey,
 } from '@/lib/auctionP2pk'
 import { getDecodedToken, type MintKeyset } from '@cashu/cashu-ts'
+import { AUCTION_MIN_BID_LEG_SATS } from './auction/constants'
 
 export interface AuctionSettlementP2pkPreflightInput {
 	auctionP2pkXpub: string
@@ -165,8 +166,8 @@ export const preflightAuctionSettlementP2pkChain = (
 		if (!mintUrl) {
 			throw new Error(`${label} is missing its mint URL`)
 		}
-		if (!Number.isSafeInteger(leg.expectedAmount) || leg.expectedAmount <= 0) {
-			throw new Error(`${label} has invalid expected leg amount`)
+		if (!Number.isSafeInteger(leg.expectedAmount) || leg.expectedAmount < AUCTION_MIN_BID_LEG_SATS) {
+			throw new Error(`${label} expected leg amount must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
 		}
 
 		try {

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -29,6 +29,29 @@ export interface AuctionSettlementP2pkPreflightResult {
 	derivedChildPubkey: string
 	settlementPlanChildPubkey: string
 	tokenLockPubkey: string
+	tokenAmount: number
+	proofCount: number
+}
+
+export interface AuctionSettlementP2pkChainLegPreflightInput {
+	bidEventId?: string
+	mintUrl?: string
+	token: string
+	derivationPath?: string
+	bidChildPubkey?: string
+	releaseChildPubkey?: string
+	expectedAmount: number
+	mintKeysets?: MintKeyset[]
+}
+
+export interface AuctionSettlementP2pkChainPreflightInput {
+	auctionP2pkXpub: string
+	legs: AuctionSettlementP2pkChainLegPreflightInput[]
+}
+
+export interface AuctionSettlementP2pkChainPreflightResult {
+	legs: Array<AuctionSettlementP2pkPreflightResult & { bidEventId?: string; mintUrl: string; expectedAmount: number }>
+	totalAmount: number
 }
 
 const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/i
@@ -54,6 +77,9 @@ const requireCompressedTokenLockPubkey = (pubkey: string): string => {
 		throw new Error('Winner token P2PK lock pubkey is malformed; cannot settle this bid safely')
 	}
 }
+
+const getChainLegLabel = (leg: AuctionSettlementP2pkChainLegPreflightInput, index: number): string =>
+	leg.bidEventId ? `Chain leg ${leg.bidEventId.slice(0, 8)}…` : `Chain leg ${index + 1}`
 
 export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPreflightInput): AuctionSettlementP2pkPreflightResult => {
 	const derivationPath = input.derivationPath?.trim()
@@ -99,7 +125,12 @@ export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPrefl
 	}
 
 	let tokenLockPubkey = ''
+	let tokenAmount = 0
 	for (const proof of decodedToken.proofs) {
+		if (!Number.isSafeInteger(proof.amount) || proof.amount <= 0) {
+			throw new Error('Winner token proof amount is malformed')
+		}
+		tokenAmount += proof.amount
 		const proofLockPubkey = requireCompressedTokenLockPubkey(extractP2pkLockPubkeyFromSecret(proof.secret))
 		if (proofLockPubkey !== derivedChildPubkey) {
 			throw new Error('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')
@@ -112,5 +143,70 @@ export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPrefl
 		derivedChildPubkey,
 		settlementPlanChildPubkey,
 		tokenLockPubkey,
+		tokenAmount,
+		proofCount: decodedToken.proofs.length,
+	}
+}
+
+export const preflightAuctionSettlementP2pkChain = (
+	input: AuctionSettlementP2pkChainPreflightInput,
+): AuctionSettlementP2pkChainPreflightResult => {
+	if (!input.legs.length) {
+		throw new Error('Settlement chain contains no legs')
+	}
+
+	const preflightedLegs: AuctionSettlementP2pkChainPreflightResult['legs'] = []
+	let totalAmount = 0
+
+	for (let index = 0; index < input.legs.length; index++) {
+		const leg = input.legs[index]
+		const label = getChainLegLabel(leg, index)
+		const mintUrl = leg.mintUrl?.trim()
+		if (!mintUrl) {
+			throw new Error(`${label} is missing its mint URL`)
+		}
+		if (!Number.isSafeInteger(leg.expectedAmount) || leg.expectedAmount <= 0) {
+			throw new Error(`${label} has invalid expected leg amount`)
+		}
+
+		try {
+			if (!leg.bidChildPubkey?.trim()) {
+				throw new Error('bid child pubkey is required')
+			}
+			if (!leg.releaseChildPubkey?.trim()) {
+				throw new Error('release child pubkey is required')
+			}
+			if (!auctionP2pkPubkeysMatch(leg.bidChildPubkey, leg.releaseChildPubkey)) {
+				throw new Error('release child pubkey does not match bid child pubkey')
+			}
+
+			const preflight = preflightAuctionSettlementP2pk({
+				auctionP2pkXpub: input.auctionP2pkXpub,
+				derivationPath: leg.derivationPath,
+				settlementPlanChildPubkey: leg.releaseChildPubkey,
+				token: leg.token,
+				mintKeysets: leg.mintKeysets,
+			})
+
+			if (preflight.tokenAmount !== leg.expectedAmount) {
+				throw new Error(`token proof sum ${preflight.tokenAmount} sats does not equal expected leg amount ${leg.expectedAmount} sats`)
+			}
+
+			preflightedLegs.push({
+				...preflight,
+				bidEventId: leg.bidEventId,
+				mintUrl,
+				expectedAmount: leg.expectedAmount,
+			})
+			totalAmount += leg.expectedAmount
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error)
+			throw new Error(`${label}: ${message}`)
+		}
+	}
+
+	return {
+		legs: preflightedLegs,
+		totalAmount,
 	}
 }

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -82,7 +82,7 @@ const requireCompressedTokenLockPubkey = (pubkey: string): string => {
 }
 
 const getChainLegLabel = (leg: AuctionSettlementP2pkChainLegPreflightInput, index: number): string =>
-	leg.bidEventId ? `Chain leg ${leg.bidEventId.slice(0, 8)}…` : `Chain leg ${index + 1}`
+	leg.bidEventId?.trim() ? `Chain leg ${leg.bidEventId.trim().slice(0, 8)}…` : `Chain leg ${index + 1}`
 
 export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPreflightInput): AuctionSettlementP2pkPreflightResult => {
 	const derivationPath = input.derivationPath?.trim()
@@ -165,11 +165,19 @@ export const preflightAuctionSettlementP2pkChain = (
 	}
 
 	const preflightedLegs: AuctionSettlementP2pkChainPreflightResult['legs'] = []
+	const seenBidEventIds = new Set<string>()
 	let totalAmount = 0
 
 	for (let index = 0; index < input.legs.length; index++) {
 		const leg = input.legs[index]
 		const label = getChainLegLabel(leg, index)
+		const bidEventId = leg.bidEventId?.trim()
+		if (bidEventId) {
+			if (seenBidEventIds.has(bidEventId)) {
+				throw new Error(`${label} reuses bid event ID ${bidEventId}`)
+			}
+			seenBidEventIds.add(bidEventId)
+		}
 		const mintUrl = leg.mintUrl?.trim()
 		if (!mintUrl) {
 			throw new Error(`${label} is missing its mint URL`)

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -4,6 +4,7 @@ import {
 	getAuctionP2pkLockPubkeyFromSecret,
 	toCompressedAuctionP2pkPubkey,
 } from '@/lib/auctionP2pk'
+import { normalizeMintUrl } from '@/lib/wallet'
 import { getDecodedToken, type MintKeyset } from '@cashu/cashu-ts'
 import { AUCTION_MIN_BID_LEG_SATS } from './auction/constants'
 
@@ -196,7 +197,10 @@ export const preflightAuctionSettlementP2pkChain = (
 				mintKeysets: leg.mintKeysets,
 			})
 
-			if (preflight.tokenMintUrl !== mintUrl) {
+			const normalizedTokenMintUrl = normalizeMintUrl(preflight.tokenMintUrl)
+			const normalizedLegMintUrl = normalizeMintUrl(mintUrl)
+
+			if (normalizedTokenMintUrl !== normalizedLegMintUrl) {
 				throw new Error(`token mint URL ${preflight.tokenMintUrl} does not match expected mint URL ${mintUrl}`)
 			}
 

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -84,6 +84,14 @@ const requireCompressedTokenLockPubkey = (pubkey: string): string => {
 const getChainLegLabel = (leg: AuctionSettlementP2pkChainLegPreflightInput, index: number): string =>
 	leg.bidEventId?.trim() ? `Chain leg ${leg.bidEventId.trim().slice(0, 8)}…` : `Chain leg ${index + 1}`
 
+export const addAuctionSettlementProofAmount = (tokenAmount: number, proofAmount: number): number => {
+	const nextAmount = tokenAmount + proofAmount
+	if (!Number.isSafeInteger(nextAmount)) {
+		throw new Error('Winner token proof sum is malformed')
+	}
+	return nextAmount
+}
+
 export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPreflightInput): AuctionSettlementP2pkPreflightResult => {
 	const derivationPath = input.derivationPath?.trim()
 	if (!derivationPath) {
@@ -138,7 +146,7 @@ export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPrefl
 		if (!Number.isSafeInteger(proof.amount) || proof.amount <= 0) {
 			throw new Error('Winner token proof amount is malformed')
 		}
-		tokenAmount += proof.amount
+		tokenAmount = addAuctionSettlementProofAmount(tokenAmount, proof.amount)
 		const proofLockPubkey = requireCompressedTokenLockPubkey(extractP2pkLockPubkeyFromSecret(proof.secret))
 		if (proofLockPubkey !== derivedChildPubkey) {
 			throw new Error('Winner token P2PK lock pubkey does not match auction p2pk_xpub + derivation path')

--- a/src/lib/auctionSettlementP2pk.ts
+++ b/src/lib/auctionSettlementP2pk.ts
@@ -30,6 +30,7 @@ export interface AuctionSettlementP2pkPreflightResult {
 	derivedChildPubkey: string
 	settlementPlanChildPubkey: string
 	tokenLockPubkey: string
+	tokenMintUrl: string
 	tokenAmount: number
 	proofCount: number
 }
@@ -125,6 +126,11 @@ export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPrefl
 		throw new Error('Winner token contains no proofs')
 	}
 
+	const tokenMintUrl = decodedToken.mint?.trim()
+	if (!tokenMintUrl) {
+		throw new Error('Winner token mint URL is missing')
+	}
+
 	let tokenLockPubkey = ''
 	let tokenAmount = 0
 	for (const proof of decodedToken.proofs) {
@@ -144,6 +150,7 @@ export const preflightAuctionSettlementP2pk = (input: AuctionSettlementP2pkPrefl
 		derivedChildPubkey,
 		settlementPlanChildPubkey,
 		tokenLockPubkey,
+		tokenMintUrl,
 		tokenAmount,
 		proofCount: decodedToken.proofs.length,
 	}
@@ -188,6 +195,10 @@ export const preflightAuctionSettlementP2pkChain = (
 				token: leg.token,
 				mintKeysets: leg.mintKeysets,
 			})
+
+			if (preflight.tokenMintUrl !== mintUrl) {
+				throw new Error(`token mint URL ${preflight.tokenMintUrl} does not match expected mint URL ${mintUrl}`)
+			}
 
 			if (preflight.tokenAmount !== leg.expectedAmount) {
 				throw new Error(`token proof sum ${preflight.tokenAmount} sats does not equal expected leg amount ${leg.expectedAmount} sats`)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -14,6 +14,7 @@ import {
 	normalizeAuctionDerivationPath,
 	toCompressedAuctionP2pkPubkey,
 } from '@/lib/auctionP2pk'
+import { AUCTION_MIN_BID_LEG_SATS } from '@/lib/auction/constants'
 import { getAuctionHdAccountFromWalletKeys } from '@/lib/auctionHd'
 import {
 	CashuMint,
@@ -1570,15 +1571,15 @@ export const nip60Actions = {
 	},
 
 	lockAuctionBidFunds: async (params: LockAuctionBidFundsParams): Promise<LockAuctionBidFundsResult> => {
+		const amount = Math.floor(params.amount)
+		if (!Number.isFinite(amount) || amount < AUCTION_MIN_BID_LEG_SATS) {
+			throw new Error(`Bid lock amount must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
+		}
+
 		const wallet = nip60Store.state.wallet
 		const state = nip60Store.state
 		if (!wallet || state.status !== 'ready') {
 			throw new Error('NIP-60 wallet not ready')
-		}
-
-		const amount = Math.floor(params.amount)
-		if (!Number.isFinite(amount) || amount <= 0) {
-			throw new Error('Bid amount must be a positive integer')
 		}
 
 		const keyScheme: AuctionP2pkKeyScheme = 'hd_p2pk'

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -23,8 +23,9 @@ import {
 	upsertBidderRecord,
 	walkBidderRecordChain,
 } from '@/lib/auction/bidderRecords'
-import { AUCTION_PATH_RELEASE_KIND, type PathReleaseReason } from '@/lib/auction/constants'
-import { getEncodedToken, type Proof } from '@cashu/cashu-ts'
+import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS, AUCTION_PATH_RELEASE_KIND, type PathReleaseReason } from '@/lib/auction/constants'
+import { preflightAuctionSettlementP2pkChain } from '@/lib/auctionSettlementP2pk'
+import { getEncodedToken, type MintKeyset, type Proof } from '@cashu/cashu-ts'
 import { getPublicKey } from '@noble/secp256k1'
 import { auctionKeys, orderKeys } from '@/queries/queryKeyFactory'
 import NDK, { NDKEvent, NDKRelaySet, NDKUser, type NDKFilter, type NDKSigner, type NDKTag } from '@nostr-dev-kit/ndk'
@@ -455,7 +456,9 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 	if (!formData.auctionCoordinates) throw new Error('Auction coordinates are required')
 	if (!formData.sellerPubkey) throw new Error('Seller pubkey is required')
 	if (!formData.p2pkXpub) throw new Error('Auction p2pk_xpub is required for path derivation')
-	if (!Number.isFinite(formData.amount) || formData.amount <= 0) throw new Error('Bid amount must be a positive number')
+	if (!Number.isFinite(formData.amount) || formData.amount < AUCTION_MIN_BID_SATS) {
+		throw new Error(`Bid amount must be at least ${AUCTION_MIN_BID_SATS} sats`)
+	}
 	if (!Number.isFinite(formData.auctionStartAt) || formData.auctionStartAt <= 0) {
 		throw new Error('Auction start time is required for bidding')
 	}
@@ -494,8 +497,8 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 		throw new Error(`Rebid (${formData.amount} sats) must exceed your previous bid on this auction (${prevLeg.amount} sats)`)
 	}
 	const legLockAmount = formData.amount - prevLegAmount
-	if (legLockAmount <= 0) {
-		throw new Error(`Computed lock amount must be positive (got ${legLockAmount})`)
+	if (legLockAmount < AUCTION_MIN_BID_LEG_SATS) {
+		throw new Error(`Bid raise must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
 	}
 
 	// Step 2/3 — generate path + derive child pubkey locally. Fresh per
@@ -974,6 +977,8 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 		bid: NDKEvent
 		releaseEventId: string
 		derivationPath: string
+		bidChildPubkey: string
+		releaseChildPubkey: string
 		childPubkey: string
 		mintUrl: string
 		cashuToken: string
@@ -1003,12 +1008,13 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 		}
 		const legChildFromBid = (getTag(legBid, 'child_pubkey') ?? '').toLowerCase()
 		const derivedChild = deriveAuctionChildP2pkPubkeyFromXpub(p2pkXpub, release.derivationPath).toLowerCase()
+		const releaseChildPubkey = release.childPubkey.toLowerCase()
 		if (derivedChild !== legChildFromBid) {
 			throw new Error(
 				`Leg ${legBid.id.slice(0, 8)}… release derives to ${derivedChild} but the bid was locked to ${legChildFromBid}. Fraudulent bid leg.`,
 			)
 		}
-		if (derivedChild !== release.childPubkey.toLowerCase()) {
+		if (derivedChild !== releaseChildPubkey) {
 			throw new Error(`Leg ${legBid.id.slice(0, 8)}… release child_pubkey tag does not match locally-derived child pubkey`)
 		}
 
@@ -1026,6 +1032,8 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 			bid: legBid,
 			releaseEventId: release.id,
 			derivationPath: release.derivationPath,
+			bidChildPubkey: legChildFromBid,
+			releaseChildPubkey,
 			childPubkey: derivedChild,
 			mintUrl: legMint,
 			cashuToken: release.cashuToken,
@@ -1038,6 +1046,25 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 			`Chain sum (${runningCumulative} sats) does not equal winning bid amount (${winningAmount} sats). Chain integrity broken.`,
 		)
 	}
+
+	const mintKeysetsByMint = new Map<string, MintKeyset[]>()
+	for (const legMintUrl of Array.from(new Set(resolvedLegs.map((leg) => leg.mintUrl)))) {
+		mintKeysetsByMint.set(legMintUrl, await nip60Actions.loadAuctionMintKeysets(legMintUrl))
+	}
+
+	preflightAuctionSettlementP2pkChain({
+		auctionP2pkXpub: p2pkXpub,
+		legs: resolvedLegs.map((leg) => ({
+			bidEventId: leg.bid.id,
+			mintUrl: leg.mintUrl,
+			token: leg.cashuToken,
+			derivationPath: leg.derivationPath,
+			bidChildPubkey: leg.bidChildPubkey,
+			releaseChildPubkey: leg.releaseChildPubkey,
+			expectedAmount: leg.legAmount,
+			mintKeysets: mintKeysetsByMint.get(leg.mintUrl),
+		})),
+	})
 
 	// 6. For each leg in the chain (oldest → newest): derive the
 	// seller's child privkey from the auction xpriv + leg's path, then

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -456,8 +456,8 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 	if (!formData.auctionCoordinates) throw new Error('Auction coordinates are required')
 	if (!formData.sellerPubkey) throw new Error('Seller pubkey is required')
 	if (!formData.p2pkXpub) throw new Error('Auction p2pk_xpub is required for path derivation')
-	if (!Number.isFinite(formData.amount) || formData.amount < AUCTION_MIN_BID_SATS) {
-		throw new Error(`Bid amount must be at least ${AUCTION_MIN_BID_SATS} sats`)
+	if (!Number.isSafeInteger(formData.amount) || formData.amount < AUCTION_MIN_BID_SATS) {
+		throw new Error(`Bid amount must be an integer of at least ${AUCTION_MIN_BID_SATS} sats`)
 	}
 	if (!Number.isFinite(formData.auctionStartAt) || formData.auctionStartAt <= 0) {
 		throw new Error('Auction start time is required for bidding')
@@ -497,8 +497,8 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 		throw new Error(`Rebid (${formData.amount} sats) must exceed your previous bid on this auction (${prevLeg.amount} sats)`)
 	}
 	const legLockAmount = formData.amount - prevLegAmount
-	if (legLockAmount < AUCTION_MIN_BID_LEG_SATS) {
-		throw new Error(`Bid raise must be at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
+	if (!Number.isSafeInteger(legLockAmount) || legLockAmount < AUCTION_MIN_BID_LEG_SATS) {
+		throw new Error(`Bid raise must be an integer of at least ${AUCTION_MIN_BID_LEG_SATS} sats`)
 	}
 
 	// Step 2/3 — generate path + derive child pubkey locally. Fresh per

--- a/src/server/auction-validator/lifecycle.ts
+++ b/src/server/auction-validator/lifecycle.ts
@@ -148,12 +148,22 @@ const derivePreCloseVerdict = (auctionState: ValidatorAuctionState, bidState: Va
 		observedAt: bidState.observedAt,
 		nut7State,
 		currentTopBid,
+		bidChainLegAmount: deriveBidChainLegAmount(auctionState, bidState),
 	})
 
 	// validateBid returns a strict union; widen it for the publisher.
 	if (verdict.claim === 'valid_bid_placed') return { claim: 'valid_bid_placed' }
 	if (verdict.claim === 'bid_pending_review') return { claim: 'bid_pending_review', reason: 'nut7_unknown' }
 	return { claim: 'bid_invalid', reason: verdict.reason, detail: verdict.detail }
+}
+
+const deriveBidChainLegAmount = (auctionState: ValidatorAuctionState, bidState: ValidatorBidState): number | undefined => {
+	const prevBidId = bidState.bid.prevBidId?.trim()
+	if (!prevBidId) return undefined
+	const previousBidState = auctionState.bids.get(prevBidId)
+	if (!previousBidState) return undefined
+	if (previousBidState.bid.bidderPubkey.toLowerCase() !== bidState.bid.bidderPubkey.toLowerCase()) return undefined
+	return bidState.bid.amount - previousBidState.bid.amount
 }
 
 // ============================================================================


### PR DESCRIPTION
Addresses #1021 and #1022.

## Summary

- Adds project-level minimum auction bid and bid-leg constants.
- Enforces the minimum in pure validation, bidder UI, compact auction card bid state, publish path, and NIP-60 wallet lock boundary.
- Adds non-mutating structural preflight for every winning settlement-chain leg before any `receiveLockedEcash` call.
- Checks token decoding, non-empty proofs, proof sum, P2PK lock matching, bid/release child-pubkey agreement, and mint URL presence before redemption.
- Does not claim true cross-mint atomic settlement.
- Leaves NUT-7 proof-state preflight as a follow-up because it adds mint/network-state semantics.

## Validation

- `bun test src/lib/__tests__/auctionBidValidation.test.ts`
- `bun test src/lib/__tests__/auctionSettlementP2pk.test.ts`
- `bun run test:unit`
- `bun run format:check`
- `git diff --check upstream/auctions/p2pk-buyer-path-custody-v1...HEAD`
