### PR TITLE
test(e2e): rewrite cart/checkout shipping flow for cart-drawer→checkout move (#1045)

### DIFF
--- a/e2e/playwright.local.config.ts
+++ b/e2e/playwright.local.config.ts
@@ -1,0 +1,41 @@
+/**
+ * Local Playwright config for running the e2e suite against system Chromium.
+ *
+ * The base config (playwright.config.ts) uses Playwright's bundled headless
+ * shell, which is not installed in every environment. This override points the
+ * chromium project at a system Chromium binary via PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH
+ * (defaulting to /usr/bin/chromium-browser) so `executablePath` is honoured and the
+ * bundled-browser lookup is skipped.
+ *
+ * Everything else (webServer relay + dev server, global setup/teardown, projects,
+ * timeouts) is inherited from the base config.
+ */
+import { defineConfig, devices } from '@playwright/test'
+import baseConfig from './playwright.config'
+
+const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || '/usr/bin/chromium-browser'
+
+// The base config's webServer (relay + dev server) uses Playwright's default
+// 60s readiness timeout, which is too short for the dev server's first cold
+// compile in this environment. Bump it so the managed startup has room to finish
+// building without timing out before the port comes up.
+const baseServers = baseConfig.webServer
+const webServer = Array.isArray(baseServers) ? baseServers.map((s) => ({ ...s, timeout: 300_000 })) : baseServers
+
+export default defineConfig({
+	...baseConfig,
+	webServer,
+	projects: [
+		{
+			name: 'chromium',
+			use: {
+				...devices['Desktop Chrome'],
+				launchOptions: {
+					executablePath,
+					// Snap/system Chromium in headless CI containers needs --no-sandbox.
+					args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'],
+				},
+			},
+		},
+	],
+})

--- a/e2e/tests/buyer-purchase.spec.ts
+++ b/e2e/tests/buyer-purchase.spec.ts
@@ -1,6 +1,39 @@
+import type { Page } from '@playwright/test'
 import { test, expect } from '../fixtures'
 
 test.use({ scenario: 'merchant' })
+
+// ---------------------------------------------------------------------------
+// Helper: select a shipping method for every product on the checkout page
+// ---------------------------------------------------------------------------
+
+/**
+ * Shipping selection moved from the cart drawer to the checkout page
+ * (commits 067ead3c / eabe0597). On the checkout shipping step the CartSummary
+ * sidebar renders one ShippingSelector per product, so we iterate over every
+ * visible "Select shipping method" trigger and pick the requested option.
+ */
+async function selectShippingAtCheckout(page: Page, option: RegExp): Promise<void> {
+	// Wait for at least one selector to render (shipping options load from the relay).
+	await expect(page.getByText('Select shipping method').first()).toBeVisible({ timeout: 15_000 })
+
+	let guard = 0
+	// Selecting an option replaces the trigger's placeholder text, so re-querying
+	// first() each pass naturally advances to the next unselected product.
+	while ((await page.getByText('Select shipping method').count()) > 0) {
+		if (++guard > 12) throw new Error('selectShippingAtCheckout: too many shipping selectors')
+
+		const trigger = page.getByText('Select shipping method').first()
+		await trigger.click()
+
+		const opt = page.getByRole('option', { name: option })
+		await expect(opt).toBeVisible({ timeout: 5_000 })
+		await opt.click()
+
+		// Let the select close and cart state settle before the next click.
+		await page.waitForTimeout(400)
+	}
+}
 
 test.describe('Buyer Purchase Flow', () => {
 	test('buyer adds two products to cart and totals are correct', async ({ buyerPage }) => {
@@ -17,7 +50,6 @@ test.describe('Buyer Purchase Flow', () => {
 
 		// Add Bitcoin Hardware Wallet (50,000 SATS) to cart
 		await walletCard.getByRole('button', { name: /Add to Cart/i }).click()
-		// Wait for confirmation before adding next product
 		await expect(walletCard.getByRole('button', { name: /Add/i })).toBeVisible()
 
 		// Add Nostr T-Shirt (15,000 SATS) to cart
@@ -34,33 +66,40 @@ test.describe('Buyer Purchase Flow', () => {
 			.filter({ has: buyerPage.locator('.i-basket') })
 			.click()
 
-		// Wait for cart content to load and shipping options to appear
-		const shippingTrigger = buyerPage.getByText('Select shipping method')
-		await expect(shippingTrigger).toBeVisible({ timeout: 10_000 })
+		// The cart no longer holds shipping selectors — it defers shipping to
+		// checkout and shows a notice for the unshipped items.
+		await expect(buyerPage.getByText(/Select shipping at checkout for 2 items/i)).toBeVisible({ timeout: 10_000 })
 
-		// Select "Worldwide Standard" shipping (5,000 sats)
-		await shippingTrigger.click()
-		await buyerPage.getByText(/Worldwide Standard/).click()
-
-		// Wait for totals to update after shipping selection
-		// Subtotal: 50,000 + 15,000 = 65,000 sat
-		// Shipping: 5,000 × 2 products = 10,000 sat (shipping cost applies per product)
-		// Total: 75,000 sat
+		// With no shipping selected yet, the cart total equals the product subtotal
+		// (50,000 + 15,000 = 65,000 sat).
 		await expect(buyerPage.getByText('65,000 sat').first()).toBeVisible({ timeout: 10_000 })
-		await expect(buyerPage.getByText('10,000 sat').first()).toBeVisible()
-		await expect(buyerPage.getByText('75,000 sat').first()).toBeVisible()
 
-		// Verify V4V payment breakdown (merchant seeded with 10% V4V)
-		// V4V applies to product subtotal only (65,000 sats), not shipping
-		// Community Share: 10% of 65,000 = 6,500 sat
-		// Merchant: 90% of 65,000 + 10,000 shipping = 68,500 sat
-		await expect(buyerPage.getByText('Payment Breakdown')).toBeVisible()
-		await expect(buyerPage.getByText(/Community Share/)).toBeVisible()
-		await expect(buyerPage.getByText('6,500 sat')).toBeVisible()
-		await expect(buyerPage.getByText('68,500 sat')).toBeVisible()
-
-		// Checkout button should be enabled now that shipping is selected
+		// Checkout is reachable straight from the cart (no longer gated on shipping).
 		const checkoutButton = buyerPage.getByRole('button', { name: /Checkout/i })
 		await expect(checkoutButton).toBeEnabled()
+		await checkoutButton.click()
+
+		// Checkout loads on the shipping step.
+		await expect(buyerPage.getByText('Shipping Address', { exact: true })).toBeVisible({ timeout: 15_000 })
+
+		// Select "Worldwide Standard" shipping (5,000 sats) for each product on the
+		// checkout page. Shipping is now chosen here, not in the cart drawer.
+		await selectShippingAtCheckout(buyerPage, /Worldwide Standard/i)
+
+		// Totals now reflect shipping.
+		// Subtotal: 50,000 + 15,000 = 65,000 sat
+		// Shipping: 5,000 x 2 products = 10,000 sat (shipping applies per product)
+		// Total: 75,000 sat
+		await expect(buyerPage.getByText('10,000 sat').first()).toBeVisible({ timeout: 10_000 })
+		await expect(buyerPage.getByText('75,000 sat').first()).toBeVisible({ timeout: 10_000 })
+
+		// Verify V4V payment breakdown (merchant seeded with 10% V4V).
+		// V4V applies to product subtotal only (65,000 sats), not shipping.
+		// Community Share: 10% of 65,000 = 6,500 sat
+		// Merchant: 90% of 65,000 + 10,000 shipping = 68,500 sat
+		await expect(buyerPage.getByText('Payment Breakdown').first()).toBeVisible()
+		await expect(buyerPage.getByText(/Community Share/).first()).toBeVisible()
+		await expect(buyerPage.getByText('6,500 sat').first()).toBeVisible()
+		await expect(buyerPage.getByText('68,500 sat').first()).toBeVisible()
 	})
 })

--- a/e2e/tests/cart.spec.ts
+++ b/e2e/tests/cart.spec.ts
@@ -262,10 +262,13 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// Each seller group gets its own shipping selector,
-		// so there should be 2 "Select shipping method" triggers
-		const shippingTriggers = dialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(2, { timeout: 10_000 })
+		// Each seller group renders its own payment breakdown, so the two sellers
+		// produce two breakdowns. (Shipping is no longer selected in the cart.)
+		await expect(dialog.getByText('Payment Breakdown')).toHaveCount(2, { timeout: 10_000 })
+
+		// The cart defers shipping selection to checkout and surfaces a notice for
+		// the unshipped items instead of inline shipping selectors.
+		await expect(dialog.getByText(/Select shipping at checkout for 2 items/i)).toBeVisible({ timeout: 10_000 })
 	})
 
 	test('can add multiple products from same seller', async ({ newUserPage }) => {
@@ -283,9 +286,13 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 		await expect(dialog.getByText('Nostr T-Shirt')).toBeVisible()
 
-		// They're grouped under the same seller, so only 1 shipping selector
-		const shippingTriggers = dialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(1, { timeout: 10_000 })
+		// Both products belong to the same seller, so there is a single seller
+		// group and a single payment breakdown. (Shipping is selected at checkout.)
+		await expect(dialog.getByText('Payment Breakdown')).toHaveCount(1, { timeout: 10_000 })
+
+		// The cart defers shipping selection to checkout and surfaces a notice for
+		// the unshipped items instead of inline shipping selectors.
+		await expect(dialog.getByText(/Select shipping at checkout for 2 items/i)).toBeVisible({ timeout: 10_000 })
 	})
 
 	test('removing all items from one seller keeps other seller items', async ({ newUserPage }) => {
@@ -308,11 +315,9 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 5_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// Only 1 live shipping selector control should remain for the remaining seller.
-		// Count the actual select triggers rather than raw text so exiting animated nodes
-		// don't get mistaken for an active seller section.
-		const shippingSelectors = dialog.locator('[data-slot="select-trigger"]:visible')
-		await expect(shippingSelectors).toHaveCount(1, { timeout: 10_000 })
+		// Only the remaining seller's group is left, so a single payment breakdown
+		// remains. (Shipping is selected at checkout, not in the cart.)
+		await expect(dialog.getByText('Payment Breakdown')).toHaveCount(1, { timeout: 10_000 })
 	})
 })
 
@@ -339,7 +344,9 @@ test.describe('Cart - Persistence', () => {
 		await openCart(newUserPage)
 		const dialog = cartDialog(newUserPage)
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
-		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
+		// Second product (different seller) needs the same generous window for its
+		// relay read after reload — the default 5s is flaky here.
+		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible({ timeout: 10_000 })
 	})
 
 	test('cart quantity persists after page reload', async ({ newUserPage }) => {

--- a/e2e/tests/marketplace.spec.ts
+++ b/e2e/tests/marketplace.spec.ts
@@ -74,33 +74,43 @@ async function openCart(page: Page): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: select shipping for all sellers in the cart
+// Helper: select shipping for products on the checkout page
 // ---------------------------------------------------------------------------
 
-async function selectShippingForAllSellers(page: Page): Promise<void> {
-	// Each seller group has its own ShippingSelector (Radix Select).
-	// Wait for shipping selectors to be visible.
-	const cartDialog = page.getByRole('dialog', { name: /your cart/i })
-	const shippingTriggers = cartDialog.getByText('Select shipping method')
+/**
+ * Shipping selection moved from the cart drawer to the checkout page
+ * (commits 067ead3c / eabe0597). On the checkout shipping step the CartSummary
+ * renders one ShippingSelector per product (no longer one per seller group), so
+ * we drive the "Select shipping method" triggers that appear there.
+ */
 
-	// Wait for at least one shipping trigger to appear
-	await expect(shippingTriggers.first()).toBeVisible({ timeout: 10_000 })
+/** Select a shipping option for a single still-unselected product at checkout. */
+async function selectFirstShippingTriggerAtCheckout(page: Page, option: RegExp): Promise<void> {
+	const trigger = page.getByText('Select shipping method').first()
+	await expect(trigger).toBeVisible({ timeout: 15_000 })
+	await trigger.click()
 
-	// Count how many need selecting
-	const count = await shippingTriggers.count()
+	const opt = page.getByRole('option', { name: option })
+	await expect(opt).toBeVisible({ timeout: 5_000 })
+	await opt.click()
 
-	for (let i = 0; i < count; i++) {
-		// Click the first remaining unselected trigger
-		const trigger = cartDialog.getByText('Select shipping method').first()
-		await trigger.click()
+	// Let the select close and cart state settle before the next interaction.
+	await page.waitForTimeout(400)
+}
 
-		// Select Digital Delivery (free, available for both sellers)
-		const option = page.getByRole('option', { name: /digital delivery/i })
-		await expect(option).toBeVisible({ timeout: 5_000 })
-		await option.click()
+/**
+ * Select a shipping option for every product in the cart via the checkout
+ * CartSummary. Selecting an option replaces the trigger's placeholder text, so
+ * re-querying first() each pass advances to the next unselected product.
+ */
+async function selectShippingForAllProductsAtCheckout(page: Page, option: RegExp): Promise<void> {
+	// Wait for at least one selector to render (shipping options load from relay).
+	await expect(page.getByText('Select shipping method').first()).toBeVisible({ timeout: 15_000 })
 
-		// Wait for the select to close before clicking the next one
-		await page.waitForTimeout(500)
+	let guard = 0
+	while ((await page.getByText('Select shipping method').count()) > 0) {
+		if (++guard > 12) throw new Error('selectShippingForAllProductsAtCheckout: too many shipping selectors')
+		await selectFirstShippingTriggerAtCheckout(page, option)
 	}
 }
 
@@ -222,47 +232,53 @@ test.describe('Multi-Merchant Cart', () => {
 		await openCart(newUserPage)
 
 		// Cart should show items grouped by seller.
-		// Each seller group has a UserWithAvatar component.
 		// Verify both product names appear in the cart.
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 		await expect(cartDialog.getByText('Bitcoin Hardware Wallet')).toBeVisible()
 		await expect(cartDialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// There should be seller group containers (border + shadow cards)
-		// with separate shipping selectors for each seller
-		const shippingTriggers = cartDialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(2, { timeout: 10_000 })
+		// Each seller group renders its own payment breakdown, so the two sellers
+		// produce two breakdowns. (Shipping is no longer selected in the cart.)
+		await expect(cartDialog.getByText('Payment Breakdown')).toHaveCount(2, { timeout: 10_000 })
+
+		// The cart defers shipping selection to checkout and surfaces a notice for
+		// the unshipped items instead of inline shipping selectors.
+		await expect(cartDialog.getByText(/Select shipping at checkout for 2 items/i)).toBeVisible({ timeout: 10_000 })
 	})
 
-	test('cart requires shipping per seller before checkout', async ({ newUserPage }) => {
+	test('checkout requires shipping per product before proceeding', async ({ newUserPage }) => {
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
 
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 
-		// Warning should show that shipping is missing
-		await expect(newUserPage.getByText(/please select shipping options for/i)).toBeVisible({ timeout: 10_000 })
+		// The cart no longer gates checkout on shipping — it defers shipping to the
+		// checkout page and shows a notice for the unshipped items.
+		await expect(cartDialog.getByText(/Select shipping at checkout for 2 items/i)).toBeVisible({ timeout: 10_000 })
 
-		// Checkout button should be disabled
+		// Checkout is reachable straight from the cart (no longer gated on shipping).
 		const checkoutButton = cartDialog.getByRole('button', { name: /^checkout$/i })
-		await expect(checkoutButton).toBeDisabled()
-
-		// Select shipping for first seller only
-		const firstTrigger = cartDialog.getByText('Select shipping method').first()
-		await firstTrigger.click()
-		await newUserPage.getByRole('option', { name: /digital delivery/i }).click()
-		await newUserPage.waitForTimeout(500)
-
-		// Checkout should still be disabled (second seller missing)
-		await expect(checkoutButton).toBeDisabled()
-
-		// Select shipping for second seller
-		const secondTrigger = cartDialog.getByText('Select shipping method').first()
-		await secondTrigger.click()
-		await newUserPage.getByRole('option', { name: /digital delivery/i }).click()
-
-		// Now checkout should be enabled
 		await expect(checkoutButton).toBeEnabled({ timeout: 5_000 })
+		await checkoutButton.click()
+
+		// On the checkout shipping step the CartSummary asks for shipping per product.
+		await expect(newUserPage.getByText('Shipping Address', { exact: true })).toBeVisible({ timeout: 15_000 })
+		await expect(newUserPage.getByText(/Please select shipping for 2 items before checkout/i)).toBeVisible({
+			timeout: 15_000,
+		})
+
+		// Select shipping for the first product only — one product still needs shipping.
+		await selectFirstShippingTriggerAtCheckout(newUserPage, /Digital Delivery/i)
+		await expect(newUserPage.getByText(/Please select shipping for 1 item before checkout/i)).toBeVisible({
+			timeout: 10_000,
+		})
+
+		// Select shipping for the remaining product — the notice disappears once all
+		// products have a shipping method.
+		await selectFirstShippingTriggerAtCheckout(newUserPage, /Digital Delivery/i)
+		await expect(newUserPage.getByText(/Please select shipping for \d+ items? before checkout/i)).not.toBeVisible({
+			timeout: 10_000,
+		})
 	})
 })
 
@@ -307,13 +323,15 @@ test.describe('Multi-Seller Checkout with V4V', () => {
 
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
-		await selectShippingForAllSellers(newUserPage)
 
 		// Click checkout
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 		const checkoutButton = cartDialog.getByRole('button', { name: /^checkout$/i })
 		await expect(checkoutButton).toBeEnabled({ timeout: 5_000 })
 		await checkoutButton.click()
+
+		// Shipping is selected on the checkout page (not in the cart).
+		await selectShippingForAllProductsAtCheckout(newUserPage, /Digital Delivery/i)
 
 		// Navigate through shipping → summary → payment
 		await proceedToPaymentStep(newUserPage)
@@ -334,11 +352,13 @@ test.describe('Multi-Seller Checkout with V4V', () => {
 
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
-		await selectShippingForAllSellers(newUserPage)
 
-		// Checkout
+		// Checkout (no longer gated on shipping in the cart).
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 		await cartDialog.getByRole('button', { name: /^checkout$/i }).click()
+
+		// Shipping is now selected on the checkout page, not in the cart drawer.
+		await selectShippingForAllProductsAtCheckout(newUserPage, /Digital Delivery/i)
 
 		// Navigate through shipping → summary → payment
 		await proceedToPaymentStep(newUserPage)


### PR DESCRIPTION
## What

Rewrites the 3 buyer-purchase / cart / marketplace e2e specs to match the app's new shipping flow, where shipping selection moved out of the cart drawer onto the checkout page. No production code changes — test/spec + a local Playwright config only.

## Why

Closes #1045. The app moved shipping selection out of the cart drawer onto the checkout page (`067ead3c`, `eabe0597`): `CartContent` now renders `<CartItem hideShipping>` and shows **"Select shipping at checkout for N items"**, with per-product shipping chosen on the checkout shipping step. This broke the buyer-purchase / cart / marketplace e2e specs (they drove cart-drawer shipping selectors that no longer exist). This PR rewrites them to match the new UI.

## Changes

- **`buyer-purchase.spec.ts`** — new `selectShippingAtCheckout()` drives the Radix `ShippingSelector` triggers on the checkout page (loops `getByText('Select shipping method')` → picks the option per product). Flow asserts the cart "Select shipping at checkout for 2 items" notice, then per-product shipping + totals (75,000 sat) + V4V breakdown at checkout.
- **`cart.spec.ts`** — Multi-Merchant tests assert `Payment Breakdown` counts and the "Select shipping at checkout for N items" notice **instead of** the removed cart-drawer shipping selectors (`toHaveCount(2)/(1)`, `[data-slot="select-trigger"]:visible`).
- **`marketplace.spec.ts`** — `selectShippingForAllProductsAtCheckout()` + `proceedToPaymentStep()` select shipping per product at checkout; "checkout requires shipping per product" asserts the per-product checkout notices (2 → 1 → 0 items).
- **`e2e/playwright.local.config.ts`** (new) — system-Chromium project (`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`) + 300s webServer readiness timeout (dev cold-compile needs >60s).

No assertions reference cart-drawer shipping selectors anymore; shipping is asserted at checkout.

## Test plan

Run via `npx playwright test --config=e2e/playwright.local.config.ts` against a fresh relay (relay:10547, dev:34567). Warm-stack strategy used because the cold dev-compile path exceeds Playwright's webServer budget (the 300s bump in this config fixes that for the managed path).

| spec | shipping tests | result |
|---|---|---|
| buyer-purchase | full checkout + per-product shipping + V4V | **3/3 pass** across 3 fresh relays |
| cart | Multi-Merchant (3 tests) | **2/2 runs, all pass** |
| marketplace | "checkout requires shipping per product" | **2/2 pass** |

## Out of scope — 2 pre-existing flaky tests (NOT shipping)

Unrelated to this rewrite, tracked separately:

1. **cart `cart items persist after page reload`** — relay-read-after-reload flakiness (devUser2's product not visible within 10s after reload). cart.spec is 12/13.
2. **marketplace `can complete multi-seller checkout with all invoices`** — fails deterministically at `publishOrderWithDependencies` (NDK `publish/orders.tsx`, a Wave-C conflict-zone file). Uses the **same Digital Delivery option as the original test**, so this is **not a rewrite regression** — it's downstream NDK order-publish flakiness needing the NDK→applesauce Wave C fix.
