### PR TITLE
fix(cvm): relay failover via applesauce-relay RelayLiveness (#901)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/store": "^0.11.0",
         "@yudiel/react-qr-scanner": "^2.6.0",
+        "applesauce-relay": "^6.2.0",
         "bitcoinjs-lib": "^7.0.1",
         "bs58check": "^4.0.0",
         "bun-plugin-tailwind": "^0.1.2",
@@ -450,9 +451,9 @@
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, ""],
 
-    "applesauce-core": ["applesauce-core@5.2.0", "", { "dependencies": { "debug": "^4.4.0", "fast-deep-equal": "^3.1.3", "hash-sum": "^2.0.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-aSuM6q6/Gs2FGUqytlHDjKZpSst2xKaT0vMXUQFWUctECNIxvwy6/hTDDInukMuI9mrQdjnO781ZJJgghI7RNw=="],
+    "applesauce-core": ["applesauce-core@6.2.0", "", { "dependencies": { "debug": "^4.4.0", "fast-deep-equal": "^3.1.3", "hash-sum": "^2.0.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-O6AlVyzqcuIhTOIuexm6UWmx7mRIa2D98gJP7K7vFGf90YdtvSH78AsKQWZXJ0Pk/K14at+9zkwfCkFr7ghgNw=="],
 
-    "applesauce-relay": ["applesauce-relay@5.2.0", "", { "dependencies": { "@noble/hashes": "^1.7.1", "applesauce-core": "^5.2.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-ty8PzHenocGdTr3x3It8Ql0rMD9rxB6VGCzGRfL5QF6epdstv2YHKuTyr8QdPBvf7yxfc7oZcMi6djSwNxXqkQ=="],
+    "applesauce-relay": ["applesauce-relay@6.2.0", "", { "dependencies": { "@noble/hashes": "^2.2.0", "applesauce-core": "^6.2.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-aalduNw3YcEiOOnyYFTVvSxg683sOPrjFMe2h7tRK0/xFTGPbAslHlFSisY2cw43EEEvQMr2HVHvXT5ahLI3tA=="],
 
     "aria-hidden": ["aria-hidden@1.2.4", "", { "dependencies": { "tslib": "^2.0.0" } }, ""],
 
@@ -1118,6 +1119,8 @@
 
     "@contextvm/sdk/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
+    "@contextvm/sdk/applesauce-relay": ["applesauce-relay@5.2.0", "", { "dependencies": { "@noble/hashes": "^1.7.1", "applesauce-core": "^5.2.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-ty8PzHenocGdTr3x3It8Ql0rMD9rxB6VGCzGRfL5QF6epdstv2YHKuTyr8QdPBvf7yxfc7oZcMi6djSwNxXqkQ=="],
+
     "@contextvm/sdk/nostr-tools": ["nostr-tools@2.18.2", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-lUCJQd9YZG3kEvxV5Zgm7qUkBpaeuvFrtqBz4TJLAxHzUn2pE7nmZZRDQmNzp5neEw20tQS3jR16o7XzzF8ncg=="],
 
     "@contextvm/sdk/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
@@ -1169,8 +1172,6 @@
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, ""],
 
     "applesauce-core/nostr-tools": ["nostr-tools@2.19.4", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg=="],
-
-    "applesauce-relay/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "applesauce-relay/nostr-tools": ["nostr-tools@2.19.4", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg=="],
 
@@ -1227,6 +1228,12 @@
     "@cashu/crypto/@scure/bip32/@scure/base": ["@scure/base@1.2.4", "", {}, ""],
 
     "@cashu/crypto/@scure/bip39/@scure/base": ["@scure/base@1.2.4", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@contextvm/sdk/applesauce-relay/applesauce-core": ["applesauce-core@5.2.0", "", { "dependencies": { "debug": "^4.4.0", "fast-deep-equal": "^3.1.3", "hash-sum": "^2.0.0", "nanoid": "^5.0.9", "nostr-tools": "~2.19", "rxjs": "^7.8.1" } }, "sha512-aSuM6q6/Gs2FGUqytlHDjKZpSst2xKaT0vMXUQFWUctECNIxvwy6/hTDDInukMuI9mrQdjnO781ZJJgghI7RNw=="],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools": ["nostr-tools@2.19.4", "", { "dependencies": { "@noble/ciphers": "^0.5.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.1", "@scure/base": "1.1.1", "@scure/bip32": "1.3.1", "@scure/bip39": "1.2.1", "nostr-wasm": "0.1.0" }, "peerDependencies": { "typescript": ">=5.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg=="],
 
     "@contextvm/sdk/nostr-tools/@noble/ciphers": ["@noble/ciphers@0.5.3", "", {}, ""],
 
@@ -1316,6 +1323,18 @@
 
     "vaul/@radix-ui/react-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, ""],
 
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@noble/ciphers": ["@noble/ciphers@0.5.3", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/base": ["@scure/base@1.1.1", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip32": ["@scure/bip32@1.3.1", "", { "dependencies": { "@noble/curves": "~1.1.0", "@noble/hashes": "~1.3.1", "@scure/base": "~1.1.0" } }, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip39": ["@scure/bip39@1.2.1", "", { "dependencies": { "@noble/hashes": "~1.3.0", "@scure/base": "~1.1.0" } }, ""],
+
     "@contextvm/sdk/nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, ""],
 
     "@contextvm/sdk/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, ""],
@@ -1348,6 +1367,14 @@
 
     "applesauce-relay/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, ""],
 
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip32/@noble/curves": ["@noble/curves@1.1.0", "", { "dependencies": { "@noble/hashes": "1.3.1" } }, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip32/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip39/@noble/hashes": ["@noble/hashes@1.3.2", "", {}, ""],
+
     "@contextvm/sdk/nostr-tools/@scure/bip32/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
 
     "@nostr-dev-kit/sync/nostr-tools/@scure/bip32/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
@@ -1355,5 +1382,7 @@
     "applesauce-core/nostr-tools/@scure/bip32/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
 
     "applesauce-relay/nostr-tools/@scure/bip32/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
+
+    "@contextvm/sdk/applesauce-relay/nostr-tools/@scure/bip32/@noble/curves/@noble/hashes": ["@noble/hashes@1.3.1", "", {}, ""],
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@tanstack/react-table": "^8.21.3",
 		"@tanstack/store": "^0.11.0",
 		"@yudiel/react-qr-scanner": "^2.6.0",
+		"applesauce-relay": "^6.2.0",
 		"bitcoinjs-lib": "^7.0.1",
 		"bs58check": "^4.0.0",
 		"bun-plugin-tailwind": "^0.1.2",

--- a/src/lib/__tests__/contextvm-client.integration.test.ts
+++ b/src/lib/__tests__/contextvm-client.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
 import { getPublicKey } from 'nostr-tools/pure'
+import { RelayLiveness } from 'applesauce-relay'
 import { PlebianCurrencyClient } from '../ctxcn-client'
 import { getCurrencyServerRelays } from '@/lib/constants'
 import { resolveCvmServerPubkey } from '../cvm-identity'
@@ -18,6 +19,10 @@ const DERIVED_SERVER_PUBKEY = (() => {
 	return getPublicKey(new Uint8Array(Buffer.from(key, 'hex')))
 })()
 const RELAYS = Array.from(new Set([RELAY_URL, ...getCurrencyServerRelays()]))
+
+// The three CVM relays configured in src/lib/constants.ts (Issue #901). A single
+// relay outage must not hang currency lookups because the others keep working.
+const CVM_RELAY_URLS = ['wss://relay.contextvm.org', 'wss://relay.primal.net', 'wss://relay.nostr.net']
 
 describe('PlebianCurrencyClient integration', () => {
 	let client: PlebianCurrencyClient | undefined
@@ -46,5 +51,49 @@ describe('PlebianCurrencyClient integration', () => {
 			})
 		}).not.toThrow()
 		expect(client).toBeDefined()
+	})
+
+	test('configures three CVM relays so a single outage can be failed over (Issue #901)', () => {
+		const configured = getCurrencyServerRelays()
+		for (const url of CVM_RELAY_URLS) {
+			expect(configured).toContain(url)
+		}
+	})
+
+	test('exposes failover-aware health: every relay usable on a cold start', () => {
+		const cold = new PlebianCurrencyClient({
+			privateKey: crypto.getRandomValues(new Uint8Array(32)),
+			relays: CVM_RELAY_URLS,
+			serverPubkey: SERVER_PUBKEY,
+		})
+		// Nothing has connected yet, so liveness has observed no failures and
+		// every configured relay is still considered usable.
+		expect(cold.healthyRelays().length).toBe(CVM_RELAY_URLS.length)
+		expect(cold.allRelaysUnhealthy()).toBe(false)
+		cold.close()
+	})
+})
+
+describe('RelayLiveness failover (applesauce-relay)', () => {
+	// Mirrors how PlebianCurrencyClient wires RelayLiveness: maxFailuresBeforeDead: 3.
+	test('auto-blacklists a relay after repeated failures while keeping the rest usable', async () => {
+		const relays = ['wss://relay-a.test', 'wss://relay-b.test', 'wss://relay-c.test']
+		const liveness = new RelayLiveness({ maxFailuresBeforeDead: 3, backoffBaseDelay: 1, backoffMaxDelay: 1 })
+
+		// Cold start: nothing observed yet, every relay is usable.
+		expect(liveness.filter(relays).length).toBe(3)
+
+		// Drive one relay past the failure threshold. Failures that arrive inside
+		// the backoff window are ignored, so we let each 1ms window clear first.
+		for (let i = 0; i < 3; i++) {
+			liveness.recordFailure('wss://relay-a.test')
+			await new Promise((resolve) => setTimeout(resolve, 10))
+		}
+
+		const usable = liveness.filter(relays)
+		expect(usable).not.toContain('wss://relay-a.test')
+		expect(usable).toContain('wss://relay-b.test')
+		expect(usable).toContain('wss://relay-c.test')
+		expect(usable.length).toBe(2)
 	})
 })

--- a/src/lib/__tests__/contextvm-relay-failover.test.ts
+++ b/src/lib/__tests__/contextvm-relay-failover.test.ts
@@ -1,0 +1,209 @@
+import { mock, describe, test, expect, afterEach } from 'bun:test'
+import { getPublicKey } from 'nostr-tools/pure'
+
+/**
+ * Client-level relay failover coverage (Issue #901, PR #1072).
+ *
+ * Sibling files cover the RelayLiveness library directly with mock relays
+ * (no network) — they prove the filtering mechanics:
+ *   - contextvm-client.integration.test.ts: auto-blacklist after 3 failures
+ *   - contextvm-relay-liveness.test.ts:     recovery, all-dead, client contract
+ *
+ * This file closes the last gap in the acceptance criteria: that
+ * {@link PlebianCurrencyClient}'s PUBLISH path only ever hands
+ * `healthyRelays()` to the pool, so a dead primary relay is never asked to
+ * accept the EVENT and therefore cannot block the request. We mock the
+ * `applesauce-relay` module (RelayPool + RelayLiveness) with in-process fakes
+ * that mirror the real `connectToPool` wiring (add$ / open$ / close$), so no
+ * real WebSocket is ever opened.
+ */
+
+const RELAYS = ['wss://relay-a.test', 'wss://relay-b.test', 'wss://relay-c.test']
+
+// --- Minimal rxjs-like Subject (what RelayLiveness.connectToPool consumes) --
+class FakeSubject<T> {
+	private subs = new Set<(v: T) => void>()
+	subscribe(fn: (v: T) => void) {
+		this.subs.add(fn)
+		return { unsubscribe: () => this.subs.delete(fn) }
+	}
+	next(v: T) {
+		for (const s of [...this.subs]) s(v)
+	}
+}
+
+type CloseEvent = { wasClean: boolean }
+
+class FakeRelay {
+	url: string
+	open$ = new FakeSubject<void>()
+	close$ = new FakeSubject<CloseEvent>()
+	constructor(url: string) {
+		this.url = url
+	}
+}
+
+// --- Fakes for the two applesauce-relay exports the client constructs --------
+const POOLS: FakeRelayPool[] = []
+
+class FakeRelayPool {
+	add$ = new FakeSubject<FakeRelay>()
+	remove$ = new FakeSubject<FakeRelay>()
+	// publish() is the boundary we assert on: it must only ever receive the
+	// healthy relay subset. Each call records {from, ok} like the real pool.
+	publish = mock((_relays: string[], _event: unknown) =>
+		Promise.resolve(_relays.map((url) => ({ from: url, ok: true }))),
+	)
+	private relays = new Map<string, FakeRelay>()
+
+	constructor() {
+		POOLS.push(this)
+	}
+
+	/** Register a relay so connectToPool observes it (mirrors lazy pool.add). */
+	register(url: string): FakeRelay {
+		let r = this.relays.get(url)
+		if (!r) {
+			r = new FakeRelay(url)
+			this.relays.set(url, r)
+			this.add$.next(r)
+		}
+		return r
+	}
+
+	/** Simulate the pool detecting a relay socket dropped uncleanly. */
+	dropRelay(url: string, wasClean = false) {
+		this.relays.get(url)?.close$.next({ wasClean })
+	}
+
+	// Methods the client calls on the pool.
+	subscription(_relays: string[], _filter: unknown, _opts?: unknown) {
+		return { subscribe: () => ({ unsubscribe() {} }) }
+	}
+	close() {}
+}
+
+const LIVENESS: FakeRelayLiveness[] = []
+
+class FakeRelayLiveness {
+	private maxFailuresBeforeDead: number
+	private failures = new Map<string, number>()
+	private dead = new Set<string>()
+
+	constructor(options?: { maxFailuresBeforeDead?: number }) {
+		this.maxFailuresBeforeDead = options?.maxFailuresBeforeDead ?? 5
+		LIVENESS.push(this)
+	}
+
+	// Mirrors the real connectToPool: relays surface via add$, and an unclean
+	// close counts as a failure; once failures cross the threshold the relay is
+	// dead and filter() excludes it.
+	connectToPool(pool: FakeRelayPool) {
+		pool.add$.subscribe((relay) => {
+			relay.open$.subscribe(() => this.failures.set(relay.url, 0))
+			relay.close$.subscribe((event) => {
+				if (event.wasClean) return
+				const count = (this.failures.get(relay.url) ?? 0) + 1
+				this.failures.set(relay.url, count)
+				if (count >= this.maxFailuresBeforeDead) this.dead.add(relay.url)
+			})
+		})
+	}
+
+	disconnectFromPool(_pool: FakeRelayPool) {}
+
+	filter(relays: string[]) {
+		return relays.filter((r) => !this.dead.has(r))
+	}
+}
+
+// Register the module mock BEFORE the client is imported. The factory only runs
+// when something first imports 'applesauce-relay' (our dynamic import below), by
+// which point every class above is initialised.
+mock.module('applesauce-relay', () => ({
+	RelayPool: FakeRelayPool,
+	RelayLiveness: FakeRelayLiveness,
+}))
+
+const { PlebianCurrencyClient } = await import('../ctxcn-client')
+
+const SERVER_PUBKEY = getPublicKey(crypto.getRandomValues(new Uint8Array(32)))
+
+function newClient(relays = RELAYS) {
+	return new PlebianCurrencyClient({
+		privateKey: crypto.getRandomValues(new Uint8Array(32)),
+		relays,
+		serverPubkey: SERVER_PUBKEY,
+	})
+}
+
+describe('PlebianCurrencyClient relay failover (mocked pool)', () => {
+	afterEach(() => {
+		POOLS.length = 0
+		LIVENESS.length = 0
+	})
+
+	test('publish targets only healthy relays — a dead primary is never handed to the pool', async () => {
+		const client = newClient()
+		const pool = POOLS[0]!
+
+		// Cold start: every relay usable, nothing published yet.
+		expect(client.healthyRelays()).toEqual(RELAYS)
+
+		// Wire the relays into the pool so liveness can observe them (the real
+		// pool does this lazily as relays connect).
+		for (const url of RELAYS) pool.register(url)
+
+		// Drive the PRIMARY relay past the failure threshold (maxFailuresBeforeDead: 3).
+		for (let i = 0; i < 3; i++) pool.dropRelay(RELAYS[0])
+
+		// Failover contract: RelayLiveness filtered the dead primary, the other
+		// two relays remain healthy, and the caller does not short-circuit yet.
+		expect(client.healthyRelays()).toEqual([RELAYS[1], RELAYS[2]])
+		expect(client.allRelaysUnhealthy()).toBe(false)
+
+		// Trigger the publish path. It must consult healthyRelays() and publish
+		// to exactly the two survivors — the dead primary is absent from the
+		// publish call, so it cannot block the request.
+		const result = await (client as any).sendEncryptedMessage({
+			id: 'req-failover',
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: 'get_price', arguments: {} },
+		})
+
+		expect(pool.publish).toHaveBeenCalledTimes(1)
+		const [publishedRelays] = pool.publish.mock.calls[0]
+		expect(publishedRelays).toEqual([RELAYS[1], RELAYS[2]])
+		expect(publishedRelays).not.toContain(RELAYS[0])
+		expect(result.giftWrapId).toEqual(expect.any(String))
+
+		client.close()
+	})
+
+	test('when every relay is dead, publish short-circuits instead of blocking', async () => {
+		const client = newClient()
+		const pool = POOLS[0]!
+
+		for (const url of RELAYS) pool.register(url)
+		// Kill all three relays.
+		for (const url of RELAYS) for (let i = 0; i < 3; i++) pool.dropRelay(url)
+
+		expect(client.healthyRelays()).toEqual([])
+		expect(client.allRelaysUnhealthy()).toBe(true)
+
+		// No healthy relay -> sendEncryptedMessage returns WITHOUT publishing,
+		// so a fully-dead relay set cannot hang the request (caller falls back).
+		const result = await (client as any).sendEncryptedMessage({
+			id: 'req-all-dead',
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: { name: 'get_price', arguments: {} },
+		})
+
+		expect(pool.publish).not.toHaveBeenCalled()
+		expect(result.giftWrapId).toEqual(expect.any(String))
+
+		client.close()
+	})
+})

--- a/src/lib/__tests__/contextvm-relay-failover.test.ts
+++ b/src/lib/__tests__/contextvm-relay-failover.test.ts
@@ -51,9 +51,7 @@ class FakeRelayPool {
 	remove$ = new FakeSubject<FakeRelay>()
 	// publish() is the boundary we assert on: it must only ever receive the
 	// healthy relay subset. Each call records {from, ok} like the real pool.
-	publish = mock((_relays: string[], _event: unknown) =>
-		Promise.resolve(_relays.map((url) => ({ from: url, ok: true }))),
-	)
+	publish = mock((_relays: string[], _event: unknown) => Promise.resolve(_relays.map((url) => ({ from: url, ok: true }))))
 	private relays = new Map<string, FakeRelay>()
 
 	constructor() {

--- a/src/lib/__tests__/contextvm-relay-liveness.test.ts
+++ b/src/lib/__tests__/contextvm-relay-liveness.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from 'bun:test'
+import { RelayLiveness } from 'applesauce-relay'
+import { getPublicKey } from 'nostr-tools/pure'
+import { PlebianCurrencyClient } from '../ctxcn-client'
+
+/**
+ * Relay failover coverage (Issue #901, PR #1072).
+ *
+ * The integration file (contextvm-client.integration.test.ts) already proves:
+ *   - cold start → every relay usable, allRelaysUnhealthy() false
+ *   - one relay blacklisted after maxFailuresBeforeDead while the rest survive
+ *
+ * This unit file closes the remaining failover gaps that the acceptance
+ * criteria depend on:
+ *   - recovery: a transient outage must NOT permanently evict a relay
+ *   - the all-dead state (the trigger for the Yadio HTTPS fallback)
+ *   - the client boundary contract for allRelaysUnhealthy()
+ *
+ * Runs in the unit suite (no network): RelayLiveness is driven directly via
+ * recordFailure/recordSuccess against synthetic relay URLs.
+ */
+
+const RELAYS = ['wss://relay-a.test', 'wss://relay-b.test', 'wss://relay-c.test']
+const DEAD_AFTER = 3
+
+function freshLiveness() {
+	return new RelayLiveness({
+		maxFailuresBeforeDead: DEAD_AFTER,
+		backoffBaseDelay: 1,
+		backoffMaxDelay: 1,
+	})
+}
+
+/** Push a relay past the failure threshold, clearing each 1ms backoff window. */
+async function killRelay(liveness: RelayLiveness, url: string, failures = DEAD_AFTER) {
+	for (let i = 0; i < failures; i++) {
+		liveness.recordFailure(url)
+		await new Promise((r) => setTimeout(r, 10))
+	}
+}
+
+describe('RelayLiveness failover — recovery', () => {
+	test('a dead relay can be recovered (reset clears its liveness state, relay usable again)', async () => {
+		const liveness = freshLiveness()
+		await killRelay(liveness, RELAYS[0])
+
+		expect(liveness.filter(RELAYS)).not.toContain(RELAYS[0])
+		expect(liveness.getState(RELAYS[0])?.state).toBe('dead')
+
+		// Recovery: clearing the dead state (in production this is driven by the
+		// pool's reconnect events via connectToPool; reset() is the direct way)
+		// brings the relay back into the usable set so a transient outage does
+		// not permanently evict a relay.
+		liveness.reset(RELAYS[0])
+		expect(liveness.filter(RELAYS)).toContain(RELAYS[0])
+		expect(liveness.filter(RELAYS).length).toBe(RELAYS.length)
+	})
+
+	test('recordSuccess keeps a healthy relay healthy and does not throw (idempotent)', () => {
+		const liveness = freshLiveness()
+		liveness.recordSuccess(RELAYS[0])
+		liveness.recordSuccess(RELAYS[0])
+		expect(liveness.filter(RELAYS)).toContain(RELAYS[0])
+	})
+})
+
+describe('RelayLiveness failover — all-dead fallback trigger', () => {
+	test('filter([]) once every relay crosses the failure threshold', async () => {
+		const liveness = freshLiveness()
+		expect(liveness.filter(RELAYS).length).toBe(RELAYS.length)
+
+		// Kill them one by one and watch the usable set shrink each step.
+		await killRelay(liveness, RELAYS[0])
+		expect(liveness.filter(RELAYS).length).toBe(2)
+		await killRelay(liveness, RELAYS[1])
+		expect(liveness.filter(RELAYS).length).toBe(1)
+		await killRelay(liveness, RELAYS[2])
+
+		// This is the exact condition external.tsx checks before short-circuiting
+		// to the Yadio HTTPS fallback instead of waiting out a 20s timeout.
+		expect(liveness.filter(RELAYS)).toEqual([])
+	})
+
+	test('a single healthy relay among three keeps allRelays usable (no premature fallback)', async () => {
+		const liveness = freshLiveness()
+		await killRelay(liveness, RELAYS[0])
+		await killRelay(liveness, RELAYS[1])
+		// RELAYS[2] is still up → we must NOT declare everything unhealthy.
+		expect(liveness.filter(RELAYS).length).toBe(1)
+	})
+})
+
+describe('PlebianCurrencyClient — allRelaysUnhealthy() contract', () => {
+	const SERVER_PUBKEY = getPublicKey(crypto.getRandomValues(new Uint8Array(32)))
+
+	function client(relays: string[]) {
+		return new PlebianCurrencyClient({
+			privateKey: crypto.getRandomValues(new Uint8Array(32)),
+			relays,
+			serverPubkey: SERVER_PUBKEY,
+		})
+	}
+
+	test('returns true for a client with no configured relays', () => {
+		const c = client([])
+		expect(c.allRelaysUnhealthy()).toBe(true)
+		expect(c.healthyRelays()).toEqual([])
+	})
+
+	test('returns false on a cold start with relays (first request is always attempted)', () => {
+		const c = client(RELAYS)
+		expect(c.allRelaysUnhealthy()).toBe(false)
+		expect(c.healthyRelays().length).toBe(RELAYS.length)
+		c.close()
+	})
+})

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -93,7 +93,10 @@ export const CURRENCIES = [
 	'NGN', // Nigerian Naira
 ] as const
 
-const CURRENCY_CVM_RELAYS = ['wss://relay.contextvm.org']
+// Issue #901: connect to multiple CVM relays so a single relay outage no
+// longer hangs currency lookups. applesauce-relay's RelayLiveness will
+// auto-blacklist any of these that go down (see src/lib/ctxcn-client.ts).
+const CURRENCY_CVM_RELAYS = ['wss://relay.contextvm.org', 'wss://relay.primal.net', 'wss://relay.nostr.net']
 
 export function getCurrencyServerRelays(): string[] {
 	const env = process.env.NODE_ENV || 'development'

--- a/src/lib/ctxcn-client.ts
+++ b/src/lib/ctxcn-client.ts
@@ -1,5 +1,6 @@
-import { finalizeEvent, getPublicKey, nip44, SimplePool } from 'nostr-tools'
-import type { Event } from 'nostr-tools'
+import { finalizeEvent, getPublicKey, nip44 } from 'nostr-tools'
+import type { NostrEvent } from 'nostr-tools/pure'
+import { RelayLiveness, RelayPool } from 'applesauce-relay'
 
 const CTXVM_MESSAGES_KIND = 25910
 const GIFT_WRAP_KIND = 1059
@@ -26,18 +27,43 @@ function uuidv4(): string {
 export class PlebianCurrencyClient {
 	private privateKey: Uint8Array
 	private publicKey: string
-	private pool: SimplePool
+	private pool: RelayPool
+	private liveness: RelayLiveness
 	private relays: string[]
 	private serverPubkey: string
 	private pendingRequests: Map<string, PendingRequest> = new Map()
-	private activeSubs: any[] = []
+	private activeSubs: { unsubscribe: () => void }[] = []
 
 	constructor(options: { privateKey: Uint8Array; relays: string[]; serverPubkey: string }) {
 		this.privateKey = options.privateKey
 		this.publicKey = getPublicKey(options.privateKey)
 		this.relays = options.relays
 		this.serverPubkey = options.serverPubkey
-		this.pool = new SimplePool()
+		// applesauce-relay pool: subscriptions auto-reconnect, publishes retry,
+		// and RelayLiveness tracks per-relay health so dead relays are skipped.
+		this.pool = new RelayPool()
+		this.liveness = new RelayLiveness({ maxFailuresBeforeDead: 3 })
+		this.liveness.connectToPool(this.pool)
+	}
+
+	/**
+	 * Relays that are currently usable (not dead, not in backoff).
+	 * On a cold start liveness has not observed any relay yet, so every
+	 * configured relay is returned and the first request still goes out.
+	 */
+	healthyRelays(): string[] {
+		return this.liveness.filter(this.relays)
+	}
+
+	/**
+	 * True when every configured relay is known to liveness and none are
+	 * currently usable. Callers can use this to short-circuit straight to an
+	 * HTTPS fallback instead of waiting out a timeout. Returns false on a cold
+	 * start (relays not yet observed) so the first request is always attempted.
+	 */
+	allRelaysUnhealthy(): boolean {
+		if (this.relays.length === 0) return true
+		return this.liveness.filter(this.relays).length === 0
 	}
 
 	async callTool(params: { name: string; arguments: Record<string, any> }): Promise<any> {
@@ -68,6 +94,7 @@ export class PlebianCurrencyClient {
 				serverPubkey: this.serverPubkey,
 				clientPubkey: this.publicKey,
 				relays: this.relays,
+				healthyRelays: this.healthyRelays(),
 			})
 
 			void (async () => {
@@ -90,16 +117,28 @@ export class PlebianCurrencyClient {
 			relays: this.relays,
 		})
 
-		const sub = this.pool.subscribeMany(this.relays, { kinds: [GIFT_WRAP_KIND], '#p': [this.publicKey], limit: 20 } as any, {
-			onevent: (event: Event) => {
+		// Long-lived REQ across every configured relay. reconnect: Infinity keeps
+		// retrying connection errors forever (survives transient relay drops);
+		// resubscribe: true re-opens the REQ if a relay sends a clean CLOSED.
+		const events$ = this.pool.subscription(
+			this.relays,
+			{ kinds: [GIFT_WRAP_KIND], '#p': [this.publicKey], limit: 20 },
+			{ reconnect: Infinity, resubscribe: true },
+		)
+
+		const sub = events$.subscribe({
+			next: (event: NostrEvent) => {
 				this.handleGiftWrapResponse(event)
+			},
+			error: (error: unknown) => {
+				console.warn('ContextVM response subscription errored:', error)
 			},
 		})
 
 		this.activeSubs.push(sub)
 	}
 
-	private async handleGiftWrapResponse(event: Event): Promise<void> {
+	private async handleGiftWrapResponse(event: NostrEvent): Promise<void> {
 		try {
 			console.info('ContextVM candidate response event', {
 				eventId: event.id,
@@ -109,7 +148,7 @@ export class PlebianCurrencyClient {
 			})
 			const conversationKey = nip44.v2.utils.getConversationKey(this.privateKey, event.pubkey)
 			const decrypted = nip44.v2.decrypt(event.content, conversationKey)
-			const innerEvent = JSON.parse(decrypted) as Event
+			const innerEvent = JSON.parse(decrypted) as NostrEvent
 			const mcpMessage = JSON.parse(innerEvent.content)
 			const responseId = mcpMessage.id || innerEvent.tags?.find((t: string[]) => t[0] === 'e')?.[1]
 			console.info('ContextVM response received', {
@@ -174,15 +213,33 @@ export class PlebianCurrencyClient {
 
 		const signedGiftWrap = finalizeEvent(giftWrap, giftWrapPrivateKey)
 
-		const publishPromises = this.relays.map((relay) => Promise.resolve(this.pool.publish([relay], signedGiftWrap)).catch(() => {}))
+		// Only publish to relays liveness considers usable, so a dead relay no
+		// longer blocks the request. publish() retries each relay (default 3x)
+		// and resolves once the relay accepts the EVENT.
+		const relays = this.healthyRelays()
+		if (relays.length === 0) {
+			console.warn('ContextVM publish skipped — no healthy relays', {
+				requestId: mcpMessage.id,
+				giftWrapId: signedGiftWrap.id,
+			})
+			return { giftWrapId: signedGiftWrap.id, innerEventId: signedInner.id }
+		}
 
-		await Promise.allSettled(publishPromises)
-
-		console.info('ContextVM request published', {
-			requestId: mcpMessage.id,
-			giftWrapId: signedGiftWrap.id,
-			innerEventId: signedInner.id,
-		})
+		try {
+			const responses = await this.pool.publish(relays, signedGiftWrap)
+			const okCount = responses.filter((r) => r.ok).length
+			console.info('ContextVM request published', {
+				requestId: mcpMessage.id,
+				giftWrapId: signedGiftWrap.id,
+				innerEventId: signedInner.id,
+				publishedTo: responses.map((r) => r.from),
+				ok: `${okCount}/${responses.length}`,
+			})
+		} catch (error) {
+			// publish() rejects only when every relay failed to accept the event;
+			// the pending request simply times out and the caller falls back to Yadio.
+			console.warn('ContextVM publish failed on all relays:', error)
+		}
 
 		return { giftWrapId: signedGiftWrap.id, innerEventId: signedInner.id }
 	}
@@ -196,11 +253,14 @@ export class PlebianCurrencyClient {
 
 		for (const sub of this.activeSubs) {
 			try {
-				sub.close()
+				sub.unsubscribe()
 			} catch {}
 		}
 		this.activeSubs = []
 
-		this.pool.close(this.relays)
+		try {
+			this.liveness.disconnectFromPool(this.pool)
+		} catch {}
+		this.pool.close()
 	}
 }

--- a/src/queries/external.tsx
+++ b/src/queries/external.tsx
@@ -63,6 +63,14 @@ async function fetchFromContextVm(): Promise<Record<string, number> | null> {
 		const client = await getCurrencyClient()
 		if (!client) return null
 
+		// Issue #901: if every CVM relay is already known-dead (health tracked by
+		// RelayLiveness inside the client), skip straight to the Yadio HTTPS
+		// fallback instead of making the user wait out the call timeout.
+		if (client.allRelaysUnhealthy()) {
+			console.info('All ContextVM relays unhealthy — skipping to Yadio fallback')
+			return null
+		}
+
 		const startedAt = Date.now()
 		console.info(`ContextVM BTC fetch starting (timeout ${CONTEXTVM_CALL_TIMEOUT}ms)`)
 		const timeout = new Promise<null>((resolve) => setTimeout(() => resolve(null), CONTEXTVM_CALL_TIMEOUT))


### PR DESCRIPTION
## What

Replace the single-relay `nostr-tools` `SimplePool` in `PlebianCurrencyClient` with `applesauce-relay`'s `RelayPool` + `RelayLiveness`, so a single CVM relay outage no longer hangs currency lookups. Adds full failover/liveness test coverage (no real network).

Closes #901.

## Why

The currency client previously connected to exactly one CVM relay (`wss://relay.contextvm.org`). When that relay went down, every currency request blocked until the 20s `TIMEOUT_MS` elapsed before falling back to Yadio over HTTPS — a visible outage for any user doing a currency conversion while the relay was flapping. This was the last open gap in the security-remediation batch for the CVM relay path.

Nostr is a multi-relay protocol by design; applesauce-relay already implements the health tracking we need (`RelayLiveness`: per-relay failure counting, exponential backoff, dead/blacklist + auto-revival). Wiring it in gives us: (1) automatic failover across multiple relays on a primary outage, and (2) a fast path that short-circuits to the HTTPS fallback the instant every relay is known-dead, instead of waiting out the timeout.

## Changes

- **`src/lib/constants.ts`** — Expand `CURRENCY_CVM_RELAYS` from 1 to 3 relays (`relay.contextvm.org`, `relay.primal.net`, `relay.nostr.net`). `getCurrencyServerRelays()` is unchanged for dev/staging/production shapes.
- **`src/lib/ctxcn-client.ts`**
  - `SimplePool` → `applesauce-relay` `RelayPool`. Subscriptions use `pool.subscription(..., { reconnect: Infinity, resubscribe: true })` so a dropped socket auto-reconnects forever and a clean `CLOSED` re-opens the REQ.
  - `RelayLiveness({ maxFailuresBeforeDead: 3 })` is wired to the pool via `connectToPool`; it tracks per-relay health and filters dead / in-backoff relays.
  - New `healthyRelays()` / `allRelaysUnhealthy()` surface lets callers inspect pool health; the publish path (`sendEncryptedMessage`) only hands `healthyRelays()` to `pool.publish(...)`, so a dead relay is never asked to accept the `EVENT` and cannot block the request. When no relay is healthy, publish short-circuits and the caller falls back.
- **`src/lib/external.tsx`** *(see diff)* — When `allRelaysUnhealthy()` is true, skip straight to the Yadio HTTPS fallback instead of waiting out the call timeout.
- **`package.json` / `bun.lock`** — Add `applesauce-relay@^6.2.0`.
- **Tests** *(the test-coverage gap this PR closes)*
  - `src/lib/__tests__/contextvm-client.integration.test.ts` — asserts 3 relays are configured, cold-start health, and that `RelayLiveness` auto-blacklists a relay after repeated failures while keeping the rest usable.
  - `src/lib/__tests__/contextvm-relay-liveness.test.ts` *(new)* — drives the real `RelayLiveness` against synthetic URLs (no network): recovery via `reset()`, the all-dead trigger, a single survivor suppressing fallback, and the `allRelaysUnhealthy()` contract.
  - `src/lib/__tests__/contextvm-relay-failover.test.ts` *(new)* — mocks the `applesauce-relay` module with in-process fakes (mirroring the real `connectToPool` / `add$` / `open$` / `close$` wiring, no WebSocket opened) and asserts the publish path only targets healthy relays and short-circuits when all are dead.

## Test plan

- [x] `bun run test:unit` picks up all three test files (`src/lib/__tests__/*.test.ts`, excluding `*.integration.test.ts`).
- [x] **Liveness mechanics (real library, synthetic URLs, no network):** a relay crossing `maxFailuresBeforeDead: 3` is filtered out while siblings stay usable; `reset()` recovers it; the all-dead set is reached exactly when every relay crosses the threshold; one survivor suppresses the fallback.
- [x] **Client failover (mocked pool, no WebSocket):** publish targets only `healthyRelays()` so a dead primary is absent from the publish call; when every relay is dead, publish is never invoked (request short-circuits).
- [x] **Integration (network):** 3 relays configured; cold start returns every relay usable with `allRelaysUnhealthy() === false`.
- [ ] CI green on push.
- [ ] Manual: with `relay.contextvm.org` firewalled, confirm a currency conversion still resolves via the other two relays (no 20s stall).
