### PR TITLE
security: fix HIGH severity findings — auth gaps, supply chain, deployment hardening (#996)

### DIFF
--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '>=1.22'
 

--- a/.github/workflows/ci-unit.yml
+++ b/.github/workflows/ci-unit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check for hardcoded Nostr keys and secrets
         run: bash scripts/git-hooks/pre-commit --full-repo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUN_VERSION: 'latest'
+  BUN_VERSION: '1.3.10'
 
 concurrency:
   group: deploy-staging
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
@@ -55,7 +55,7 @@ jobs:
           cp package.json bun.lock tsconfig.json deploy-package/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: deploy-package
           path: deploy-package/
@@ -70,12 +70,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: deploy-package
           path: deploy-package/
@@ -144,51 +144,51 @@ jobs:
           EOF
 
       - name: Prepare server directories
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
             mkdir -p ~/releases ~/logs
             chmod 755 ~
             rm -rf /tmp/deploy-package
 
       - name: Upload files to tmp
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           source: 'deploy-package/*'
           target: '/tmp/deploy-package'
           strip_components: 1
 
       - name: Upload Caddyfile
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           source: 'deploy-simple/caddyfiles/Caddyfile.staging'
           target: '/tmp'
           strip_components: 2
 
       - name: Move files to release directory
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
             mv /tmp/deploy-package ~/releases/${{ needs.build.outputs.release_name }}
 
       - name: Activate release
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
           script: |
             set -euo pipefail
             RELEASE_DIR="/home/deployer/releases/${{ needs.build.outputs.release_name }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -33,7 +33,7 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '>=1.22'
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -118,7 +118,7 @@ jobs:
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
 
       - name: Upload pricing test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: test-results-pricing
@@ -135,15 +135,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.10
 
       - name: Cache bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -151,7 +151,7 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '>=1.22'
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -236,7 +236,7 @@ jobs:
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
 
       - name: Upload full test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: test-results-full

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -12,12 +12,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # v1
         with:
-          bun-version: latest
+          bun-version: 1.3.10
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout master
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: master
           fetch-depth: 0

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
 	"mcpServers": {
 		"nostrbook": {
 			"command": "npx",
-			"args": ["-y", "@nostrbook/mcp@latest"]
+			"args": ["-y", "@nostrBook/mcp@0.5.3"]
 		},
 		"nak": {
 			"command": "nak",

--- a/deploy-simple/control.sh
+++ b/deploy-simple/control.sh
@@ -73,15 +73,17 @@ if [[ -z "$SSH_HOST" && ! "$COMMAND" =~ ^(help|--help|-h)$ ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# SSH setup
+# SSH setup (key-based auth only — H3/H4 security hardening, mirrors deploy.sh)
 # -----------------------------------------------------------------------------
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+# H4: accept-new trusts the first-seen host key and FAILS on key changes (MITM
+# detection), recording keys to a real known_hosts file instead of /dev/null.
+KNOWN_HOSTS_FILE="${KNOWN_HOSTS_FILE:-$HOME/.ssh/known_hosts}"
+SSH_OPTS="-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$KNOWN_HOSTS_FILE -o LogLevel=ERROR"
+# H3: key-based auth only. SSH_PASSWORD/sshpass support removed.
 if [[ -n "$SSH_KEY" ]]; then
-    SSH_CMD="ssh $SSH_OPTS -i $SSH_KEY -p $SSH_PORT $SSH_USER@$SSH_HOST"
-elif [[ -n "$SSH_PASSWORD" ]]; then
-    SSH_CMD="sshpass -p $SSH_PASSWORD ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
+	SSH_CMD="ssh $SSH_OPTS -i $SSH_KEY -p $SSH_PORT $SSH_USER@$SSH_HOST"
 else
-    SSH_CMD="ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
+	SSH_CMD="ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
 fi
 
 run_ssh() { $SSH_CMD "$@"; }

--- a/deploy-simple/deploy.sh
+++ b/deploy-simple/deploy.sh
@@ -116,24 +116,30 @@ if [[ ! -f "$ENV_FILE" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# SSH setup
+# SSH setup (key-based auth only — H3/H4 security hardening)
 # -----------------------------------------------------------------------------
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+# H4: do NOT disable host-key checking. accept-new trusts the first-seen host
+# key (recording it to a real known_hosts file) and FAILS on subsequent key
+# changes (MITM detection). To pre-seed the key non-interactively for a host:
+#   ssh-keyscan -H -p <port> <host> >> ~/.ssh/known_hosts
+KNOWN_HOSTS_FILE="${KNOWN_HOSTS_FILE:-$HOME/.ssh/known_hosts}"
+SSH_OPTS="-o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$KNOWN_HOSTS_FILE -o LogLevel=ERROR"
+
+# H3: key-based authentication only. SSH_PASSWORD support removed — writing the
+# password to plaintext .env.deploy files is a security risk. Use SSH_KEY=<path>
+# or a key loaded into ssh-agent.
 if [[ -n "$SSH_KEY" ]]; then
-    SSH_CMD="ssh $SSH_OPTS -i $SSH_KEY -p $SSH_PORT $SSH_USER@$SSH_HOST"
-    SCP_CMD="scp $SSH_OPTS -i $SSH_KEY -P $SSH_PORT"
+	SSH_CMD="ssh $SSH_OPTS -i $SSH_KEY -p $SSH_PORT $SSH_USER@$SSH_HOST"
+	SCP_CMD="scp $SSH_OPTS -i $SSH_KEY -P $SSH_PORT"
 else
-    if [[ -n "$SSH_PASSWORD" ]]; then
-        if ! command -v sshpass &> /dev/null; then
-            echo "❌ sshpass not installed. Install it or use SSH_KEY for key-based auth."
-            exit 1
-        fi
-        SSH_CMD="sshpass -p $SSH_PASSWORD ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
-        SCP_CMD="sshpass -p $SSH_PASSWORD scp $SSH_OPTS -P $SSH_PORT"
-    else
-        SSH_CMD="ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
-        SCP_CMD="scp $SSH_OPTS -P $SSH_PORT"
-    fi
+	# Fall back to ssh-agent / default keys. Verify something is available.
+	if ! ssh-add -l &>/dev/null && [[ ! -f "$HOME/.ssh/id_rsa" && ! -f "$HOME/.ssh/id_ed25519" ]]; then
+		echo "❌ No SSH key available. Set SSH_KEY=<path> or load an ssh-agent."
+		echo "   Password-based SSH is no longer supported (H3 security hardening)."
+		exit 1
+	fi
+	SSH_CMD="ssh $SSH_OPTS -p $SSH_PORT $SSH_USER@$SSH_HOST"
+	SCP_CMD="scp $SSH_OPTS -P $SSH_PORT"
 fi
 
 run_ssh() { $SSH_CMD "$@"; }
@@ -383,7 +389,6 @@ SSH_HOST=$SSH_HOST
 SSH_PORT=$SSH_PORT
 SSH_USER=$SSH_USER
 ${SSH_KEY:+SSH_KEY=$SSH_KEY}
-${SSH_PASSWORD:+SSH_PASSWORD=$SSH_PASSWORD}
 APP_PORT=$APP_PORT
 PM2_APP_NAME=$PM2_APP_NAME
 REMOTE_APP_DIR=$REMOTE_APP_DIR

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
 		"test:e2e:ui": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --config=e2e/playwright.config.ts --ui",
 		"test:e2e:debug": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --config=e2e/playwright.config.ts --debug",
 		"dev:contextvm-server": "bun run contextvm/server.ts",
-		"test:unit": "bun test $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
-		"test:unit:watch": "bun test --watch $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
+		"test:unit": "bun test $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ src/lib/security/__tests__ src/server/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
+		"test:unit:watch": "bun test --watch $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ src/lib/security/__tests__ src/server/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
 		"test:integration": "bun test $(find src/lib/__tests__ -type f -name '*.integration.test.ts' | sort)",
 		"prepare": "ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit 2>/dev/null; chmod +x scripts/git-hooks/pre-commit 2>/dev/null; true"
 	},

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
 		"test:e2e:ui": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --config=e2e/playwright.config.ts --ui",
 		"test:e2e:debug": "NODE_OPTIONS='--dns-result-order=ipv4first' playwright test --config=e2e/playwright.config.ts --debug",
 		"dev:contextvm-server": "bun run contextvm/server.ts",
-		"test:unit": "bun test $(find contextvm src/queries/__tests__ src/lib/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
-		"test:unit:watch": "bun test --watch $(find contextvm src/queries/__tests__ src/lib/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
+		"test:unit": "bun test $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
+		"test:unit:watch": "bun test --watch $(find contextvm src/queries/__tests__ src/lib/__tests__ src/lib/wallet/__tests__ -type f -name '*.test.ts' ! -name '*.integration.test.ts' | sort)",
 		"test:integration": "bun test $(find src/lib/__tests__ -type f -name '*.integration.test.ts' | sort)",
 		"prepare": "ln -sf ../../scripts/git-hooks/pre-commit .git/hooks/pre-commit 2>/dev/null; chmod +x scripts/git-hooks/pre-commit 2>/dev/null; true"
 	},

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,53 @@ function getCvmServerPublicKey(): string {
 	return CVM_SERVER_PUBKEY
 }
 
+/**
+ * Resolve the explicit allowlist of WebSocket origins (H1: cross-site WS hijacking).
+ * Set via the `ALLOWED_ORIGINS` env var as a comma-separated list
+ * (e.g. "https://plebeian.market,https://staging.plebeian.market").
+ * Production SHOULD set this explicitly; an empty list falls back to same-origin
+ * matching in isWebSocketOriginAllowed() so default/dev deployments keep working.
+ */
+function getAllowedOrigins(): string[] {
+	const raw = process.env.ALLOWED_ORIGINS
+	if (raw && raw.trim()) {
+		return raw
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean)
+	}
+	return []
+}
+
+/**
+ * H1: Validate the WebSocket Origin header to prevent cross-site WebSocket hijacking.
+ *
+ * Browser WebSocket clients always send an `Origin` header; programmatic clients
+ * (relay software, tests, server-to-server) typically do not. Absent Origin is
+ * therefore allowed. When Origin is present:
+ *   - if `ALLOWED_ORIGINS` is configured, it must contain the origin verbatim;
+ *   - otherwise the origin's host must match the request's `Host` header
+ *     (same-origin), which is the common SPA case and still blocks genuine
+ *     cross-origin abuse.
+ */
+function isWebSocketOriginAllowed(req: Request): boolean {
+	const origin = req.headers.get('origin')
+	if (!origin) return true // non-browser client (no Origin header)
+
+	const allowlist = getAllowedOrigins()
+	if (allowlist.length > 0) {
+		return allowlist.includes(origin)
+	}
+	// No explicit allowlist: accept same-origin only.
+	try {
+		const originHost = new URL(origin).host
+		const requestHost = req.headers.get('host')
+		return !!requestHost && originHost === requestHost
+	} catch {
+		return false
+	}
+}
+
 function decodeLnurlBech32(lnurl: string): string | null {
 	try {
 		const decoded = bech32.decode(lnurl.toLowerCase(), 1500)
@@ -324,6 +371,13 @@ export const server = serve({
 	},
 	development: process.env.NODE_ENV !== 'production',
 	fetch(req, server) {
+		// H1: Validate Origin on WebSocket upgrade requests to prevent cross-site
+		// WebSocket hijacking. Non-upgrade requests fall through to the 500 below
+		// (unchanged behaviour); this only gates the actual WS handshake.
+		const isUpgrade = req.headers.get('upgrade')?.toLowerCase() === 'websocket'
+		if (isUpgrade && !isWebSocketOriginAllowed(req)) {
+			return new Response('Forbidden: WebSocket origin not allowed', { status: 403 })
+		}
 		if (server.upgrade(req)) {
 			return new Response()
 		}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import { resolveCvmServerPubkey } from './lib/cvm-identity'
 import { getEventHandler } from './server'
 import { ZapInvoiceError } from './server/ZapPurchaseManager'
 import type { ZapPurchaseInvoiceRequestBody } from './server/ZapPurchaseManager'
+import { isWebSocketOriginAllowed } from './lib/security/webSocketOrigin'
 import { join } from 'path'
 import { file } from 'bun'
 
@@ -44,53 +45,6 @@ function getCvmServerPublicKey(): string {
 	if (CVM_SERVER_PUBKEY) return CVM_SERVER_PUBKEY
 	CVM_SERVER_PUBKEY = resolveCvmServerPubkey()
 	return CVM_SERVER_PUBKEY
-}
-
-/**
- * Resolve the explicit allowlist of WebSocket origins (H1: cross-site WS hijacking).
- * Set via the `ALLOWED_ORIGINS` env var as a comma-separated list
- * (e.g. "https://plebeian.market,https://staging.plebeian.market").
- * Production SHOULD set this explicitly; an empty list falls back to same-origin
- * matching in isWebSocketOriginAllowed() so default/dev deployments keep working.
- */
-function getAllowedOrigins(): string[] {
-	const raw = process.env.ALLOWED_ORIGINS
-	if (raw && raw.trim()) {
-		return raw
-			.split(',')
-			.map((s) => s.trim())
-			.filter(Boolean)
-	}
-	return []
-}
-
-/**
- * H1: Validate the WebSocket Origin header to prevent cross-site WebSocket hijacking.
- *
- * Browser WebSocket clients always send an `Origin` header; programmatic clients
- * (relay software, tests, server-to-server) typically do not. Absent Origin is
- * therefore allowed. When Origin is present:
- *   - if `ALLOWED_ORIGINS` is configured, it must contain the origin verbatim;
- *   - otherwise the origin's host must match the request's `Host` header
- *     (same-origin), which is the common SPA case and still blocks genuine
- *     cross-origin abuse.
- */
-function isWebSocketOriginAllowed(req: Request): boolean {
-	const origin = req.headers.get('origin')
-	if (!origin) return true // non-browser client (no Origin header)
-
-	const allowlist = getAllowedOrigins()
-	if (allowlist.length > 0) {
-		return allowlist.includes(origin)
-	}
-	// No explicit allowlist: accept same-origin only.
-	try {
-		const originHost = new URL(origin).host
-		const requestHost = req.headers.get('host')
-		return !!requestHost && originHost === requestHost
-	} catch {
-		return false
-	}
 }
 
 function decodeLnurlBech32(lnurl: string): string | null {

--- a/src/lib/security/__tests__/deployScripts.test.ts
+++ b/src/lib/security/__tests__/deployScripts.test.ts
@@ -1,0 +1,59 @@
+import { expect, test, describe } from 'bun:test'
+import { join, resolve } from 'node:path'
+
+/**
+ * Deploy-script hardening guards (H3 / H4 from PR #1074).
+ *
+ * Static guards over deploy-simple/deploy.sh and deploy-simple/control.sh so
+ * that a future commit re-introducing SSH password auth (sshpass /
+ * SSH_PASSWORD) or weakening host-key verification (StrictHostKeyChecking=no,
+ * UserKnownHostsFile=/dev/null) fails CI immediately.
+ *
+ * Comment-stripping rationale: both scripts contain explanatory *comments*
+ * mentioning the forbidden tokens (e.g. "SSH_PASSWORD support removed" /
+ * "sshpass support removed"). Those are documentation, not executable code, so
+ * we strip full-line shell comments before asserting. The guard then fires
+ * only when a forbidden token reappears in actual code — a genuine regression.
+ */
+
+const REPO_ROOT = resolve(import.meta.dir, '../../../..')
+const DEPLOY_DIR = join(REPO_ROOT, 'deploy-simple')
+const SCRIPTS = ['deploy.sh', 'control.sh'] as const
+
+async function read(p: string): Promise<string> {
+	return await Bun.file(p).text()
+}
+
+// Drop full-line shell comments (lines whose first non-whitespace char is '#').
+// Inline comments after code are intentionally left in.
+function stripComments(src: string): string {
+	return src
+		.split('\n')
+		.filter((line) => !/^\s*#/.test(line))
+		.join('\n')
+}
+
+describe('H3 — deploy scripts use key-based SSH auth (no password auth)', () => {
+	for (const script of SCRIPTS) {
+		test(`${script}: contains no sshpass and no SSH_PASSWORD in executable code`, async () => {
+			const code = stripComments(await read(join(DEPLOY_DIR, script)))
+			// Password-based SSH was removed in favor of SSH keys / ssh-agent.
+			expect(code).not.toMatch(/sshpass/)
+			expect(code).not.toMatch(/SSH_PASSWORD/)
+		})
+	}
+})
+
+describe('H4 — deploy scripts enforce StrictHostKeyChecking=accept-new', () => {
+	for (const script of SCRIPTS) {
+		test(`${script}: uses accept-new and never disables host-key verification`, async () => {
+			const code = stripComments(await read(join(DEPLOY_DIR, script)))
+			// accept-new trusts the first-seen host key and FAILS on a later key
+			// change (MITM detection), recording keys to a real known_hosts file.
+			expect(code).toMatch(/StrictHostKeyChecking=accept-new/)
+			// Must NOT neutralize host-key checking or discard the known_hosts DB.
+			expect(code).not.toMatch(/StrictHostKeyChecking=no/)
+			expect(code).not.toMatch(/UserKnownHostsFile=\/dev\/null/)
+		})
+	}
+})

--- a/src/lib/security/__tests__/supplyChainDeployment.test.ts
+++ b/src/lib/security/__tests__/supplyChainDeployment.test.ts
@@ -1,0 +1,89 @@
+import { expect, test, describe } from 'bun:test'
+import { join, resolve } from 'node:path'
+
+/**
+ * Supply-chain & deployment hardening guards (H5 / H6 / H7 from PR #1074).
+ *
+ * These are not behavioral tests — they guard the static config that the
+ * security fixes rely on, so a future commit that reverts a pinned SHA, re-adds
+ * `-y @latest`, or switches deploy back to password auth fails CI immediately.
+ *
+ * Scope note: the PR pins FIVE workflows (ci-unit, e2e, prettier, deploy,
+ * promote-production). Other workflow files (deploy-auctionsdev, deploy-relay,
+ * release) are out of scope and intentionally not asserted here.
+ */
+
+const REPO_ROOT = resolve(import.meta.dir, '../../../..')
+const WORKFLOWS = join(REPO_ROOT, '.github/workflows')
+const PINNED_WORKFLOWS = ['ci-unit.yml', 'e2e.yml', 'prettier.yml', 'deploy.yml', 'promote-production.yml']
+
+async function read(p: string): Promise<string> {
+	return await Bun.file(p).text()
+}
+
+// A SHA-pinned action use looks like:  uses: owner/repo@<40-hex> # vN
+const PINNED_USE_RE = /uses:\s+([a-z0-9-]+\/[a-z0-9-]+)@([0-9a-f]{40})\b/i
+// A tag/major-version ref looks like:  uses: owner/repo@v4  /  @v1.0.3
+const UNPINNED_USE_RE = /uses:\s+[a-z0-9-]+\/[a-z0-9-]+@(?!0x)[a-z0-9._-]*v?[0-9]/i
+
+describe('H5 — GitHub Actions pinned to commit SHAs', () => {
+	for (const wf of PINNED_WORKFLOWS) {
+		test(`${wf}: every third-party action is SHA-pinned (no floating @vN tags)`, async () => {
+			const content = await read(join(WORKFLOWS, wf))
+			const usesLines = content
+				.split('\n')
+				.map((l) => l.trim())
+				.filter((l) => l.startsWith('uses:'))
+
+			expect(usesLines.length, `${wf} should reference at least one action`).toBeGreaterThan(0)
+
+			const unpinned = usesLines.filter((line) => !PINNED_USE_RE.test(line))
+			expect(unpinned, `${wf} has floating (non-SHA-pinned) action refs:\n${unpinned.join('\n')}`).toEqual([])
+		})
+	}
+})
+
+describe('H6 — MCP package pinned to an explicit version (no @latest)', () => {
+	test('.mcp.json pins @nostrBook/mcp to a concrete version', async () => {
+		const raw = await read(join(REPO_ROOT, '.mcp.json'))
+		const mcp = JSON.parse(raw)
+
+		const nostrBook = mcp.mcpServers?.nostrbook
+		expect(nostrBook, 'nostrbook MCP server entry should exist').toBeTruthy()
+
+		const args: unknown[] = nostrBook.args
+		expect(Array.isArray(args), 'nostrbook.args should be an array').toBe(true)
+
+		const versionArg = args.find((a) => typeof a === 'string' && a.includes('@nostrBook/mcp@'))
+		expect(versionArg, 'an @nostrBook/mcp@<version> arg should be present').toBeTruthy()
+
+		// Must be a concrete version, not the floating "@latest".
+		expect(String(versionArg)).not.toMatch(/@latest$/)
+		expect(String(versionArg)).toMatch(/@nostrBook\/mcp@\d+\.\d+\.\d+/)
+	})
+})
+
+describe('H7 — deploy workflow uses SSH key auth (never password)', () => {
+	test('deploy.yml never references password-based SSH secrets', async () => {
+		const content = await read(join(WORKFLOWS, 'deploy.yml'))
+
+		// The remediation removed sshpass / *_PASSWORD secret usage in favor of SSH keys.
+		expect(content).not.toMatch(/password\s*:/i)
+		expect(content).not.toMatch(/(STAGING|PROD)_PASSWORD/)
+		expect(content).not.toMatch(/sshpass/)
+	})
+
+	test('deploy.yml references the SSH key secrets for every appleboy step', async () => {
+		const content = await read(join(WORKFLOWS, 'deploy.yml'))
+		const appleboySteps = content.split('uses:').filter((s) => /appleboy\/(ssh|scp)-action/.test(s))
+
+		expect(appleboySteps.length, 'deploy.yml should use appleboy ssh/scp actions').toBeGreaterThan(0)
+
+		// Every appleboy step block must carry an SSH `key:` input, and none may
+		// fall back to `password:`.
+		for (const block of appleboySteps) {
+			expect(block).toMatch(/key:\s*\$\{\{\s*secrets\.(STAGING|PROD)_SSH_KEY\s*\}\}/)
+			expect(block).not.toMatch(/password\s*:/i)
+		}
+	})
+})

--- a/src/lib/security/__tests__/webSocketOrigin.test.ts
+++ b/src/lib/security/__tests__/webSocketOrigin.test.ts
@@ -1,8 +1,5 @@
 import { expect, test, describe, beforeEach, afterEach } from 'bun:test'
-import {
-	isWebSocketOriginAllowed,
-	getAllowedOrigins,
-} from '../webSocketOrigin'
+import { isWebSocketOriginAllowed, getAllowedOrigins } from '../webSocketOrigin'
 
 /**
  * H1 — WebSocket Origin validation (cross-site WebSocket hijacking).
@@ -24,8 +21,7 @@ describe('H1 — isWebSocketOriginAllowed', () => {
 		else process.env.ALLOWED_ORIGINS = PREV_ORIGINS
 	})
 
-	const req = (headers: Record<string, string> = {}) =>
-		new Request('https://example.invalid/', { headers })
+	const req = (headers: Record<string, string> = {}) => new Request('https://example.invalid/', { headers })
 
 	test('allows requests with no Origin header (non-browser / server-to-server)', () => {
 		expect(isWebSocketOriginAllowed(req({ host: 'plebeian.market' }))).toBe(true)
@@ -34,31 +30,20 @@ describe('H1 — isWebSocketOriginAllowed', () => {
 
 	test('blocks a cross-origin browser request when no allowlist is set (same-origin fallback)', () => {
 		// attacker.com opening a WS against plebeian.market must be refused
-		expect(
-			isWebSocketOriginAllowed(req({ origin: 'https://attacker.com', host: 'plebeian.market' })),
-		).toBe(false)
+		expect(isWebSocketOriginAllowed(req({ origin: 'https://attacker.com', host: 'plebeian.market' }))).toBe(false)
 	})
 
 	test('allows a same-origin browser request when no allowlist is set', () => {
-		expect(
-			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'plebeian.market' })),
-		).toBe(true)
+		expect(isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'plebeian.market' }))).toBe(true)
 	})
 
 	test('respects an explicit ALLOWED_ORIGINS allowlist (positive + negative)', () => {
-		process.env.ALLOWED_ORIGINS =
-			'https://plebeian.market, https://staging.plebeian.market '
+		process.env.ALLOWED_ORIGINS = 'https://plebeian.market, https://staging.plebeian.market '
 		// listed origin → allowed (even if host header differs, allowlist wins)
-		expect(
-			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'cdn.example' })),
-		).toBe(true)
-		expect(
-			isWebSocketOriginAllowed(req({ origin: 'https://staging.plebeian.market', host: 'x' })),
-		).toBe(true)
+		expect(isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'cdn.example' }))).toBe(true)
+		expect(isWebSocketOriginAllowed(req({ origin: 'https://staging.plebeian.market', host: 'x' }))).toBe(true)
 		// unlisted origin → blocked, even if it would otherwise be same-origin
-		expect(
-			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market.evil', host: 'plebeian.market.evil' })),
-		).toBe(false)
+		expect(isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market.evil', host: 'plebeian.market.evil' }))).toBe(false)
 	})
 
 	test('rejects a malformed Origin header', () => {

--- a/src/lib/security/__tests__/webSocketOrigin.test.ts
+++ b/src/lib/security/__tests__/webSocketOrigin.test.ts
@@ -1,0 +1,94 @@
+import { expect, test, describe, beforeEach, afterEach } from 'bun:test'
+import {
+	isWebSocketOriginAllowed,
+	getAllowedOrigins,
+} from '../webSocketOrigin'
+
+/**
+ * H1 — WebSocket Origin validation (cross-site WebSocket hijacking).
+ *
+ * Regression coverage for the origin check added in PR #1074. Without this
+ * check a malicious page could open a WebSocket to the app server and act on
+ * behalf of the authenticated user (the browser sends credentials on WS
+ * upgrades the same way it does for XHR).
+ */
+describe('H1 — isWebSocketOriginAllowed', () => {
+	const PREV_ORIGINS = process.env.ALLOWED_ORIGINS
+
+	beforeEach(() => {
+		delete process.env.ALLOWED_ORIGINS
+	})
+
+	afterEach(() => {
+		if (PREV_ORIGINS === undefined) delete process.env.ALLOWED_ORIGINS
+		else process.env.ALLOWED_ORIGINS = PREV_ORIGINS
+	})
+
+	const req = (headers: Record<string, string> = {}) =>
+		new Request('https://example.invalid/', { headers })
+
+	test('allows requests with no Origin header (non-browser / server-to-server)', () => {
+		expect(isWebSocketOriginAllowed(req({ host: 'plebeian.market' }))).toBe(true)
+		expect(isWebSocketOriginAllowed(req({}))).toBe(true)
+	})
+
+	test('blocks a cross-origin browser request when no allowlist is set (same-origin fallback)', () => {
+		// attacker.com opening a WS against plebeian.market must be refused
+		expect(
+			isWebSocketOriginAllowed(req({ origin: 'https://attacker.com', host: 'plebeian.market' })),
+		).toBe(false)
+	})
+
+	test('allows a same-origin browser request when no allowlist is set', () => {
+		expect(
+			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'plebeian.market' })),
+		).toBe(true)
+	})
+
+	test('respects an explicit ALLOWED_ORIGINS allowlist (positive + negative)', () => {
+		process.env.ALLOWED_ORIGINS =
+			'https://plebeian.market, https://staging.plebeian.market '
+		// listed origin → allowed (even if host header differs, allowlist wins)
+		expect(
+			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market', host: 'cdn.example' })),
+		).toBe(true)
+		expect(
+			isWebSocketOriginAllowed(req({ origin: 'https://staging.plebeian.market', host: 'x' })),
+		).toBe(true)
+		// unlisted origin → blocked, even if it would otherwise be same-origin
+		expect(
+			isWebSocketOriginAllowed(req({ origin: 'https://plebeian.market.evil', host: 'plebeian.market.evil' })),
+		).toBe(false)
+	})
+
+	test('rejects a malformed Origin header', () => {
+		// not a valid URL → new URL() throws → fail closed
+		expect(isWebSocketOriginAllowed(req({ origin: 'not-a-url', host: 'plebeian.market' }))).toBe(false)
+	})
+})
+
+describe('H1 — getAllowedOrigins parsing', () => {
+	const PREV_ORIGINS = process.env.ALLOWED_ORIGINS
+
+	beforeEach(() => {
+		delete process.env.ALLOWED_ORIGINS
+	})
+
+	afterEach(() => {
+		if (PREV_ORIGINS === undefined) delete process.env.ALLOWED_ORIGINS
+		else process.env.ALLOWED_ORIGINS = PREV_ORIGINS
+	})
+
+	test('returns [] when ALLOWED_ORIGINS is unset / empty / whitespace', () => {
+		expect(getAllowedOrigins()).toEqual([])
+		process.env.ALLOWED_ORIGINS = ''
+		expect(getAllowedOrigins()).toEqual([])
+		process.env.ALLOWED_ORIGINS = '   '
+		expect(getAllowedOrigins()).toEqual([])
+	})
+
+	test('trims and splits entries, dropping blanks', () => {
+		process.env.ALLOWED_ORIGINS = ' https://a.com ,https://b.com, ,https://c.com '
+		expect(getAllowedOrigins()).toEqual(['https://a.com', 'https://b.com', 'https://c.com'])
+	})
+})

--- a/src/lib/security/webSocketOrigin.ts
+++ b/src/lib/security/webSocketOrigin.ts
@@ -1,0 +1,54 @@
+/**
+ * WebSocket Origin validation (H1: cross-site WebSocket hijacking).
+ *
+ * Extracted from src/index.tsx into a pure module so the security-critical
+ * allowlist/same-origin logic can be unit-tested without booting the Bun
+ * server. Behavior is unchanged.
+ */
+
+/**
+ * Resolve the explicit allowlist of WebSocket origins (H1: cross-site WS hijacking).
+ * Set via the `ALLOWED_ORIGINS` env var as a comma-separated list
+ * (e.g. "https://plebeian.market,https://staging.plebeian.market").
+ * Production SHOULD set this explicitly; an empty list falls back to same-origin
+ * matching in isWebSocketOriginAllowed() so default/dev deployments keep working.
+ */
+export function getAllowedOrigins(): string[] {
+	const raw = process.env.ALLOWED_ORIGINS
+	if (raw && raw.trim()) {
+		return raw
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean)
+	}
+	return []
+}
+
+/**
+ * H1: Validate the WebSocket Origin header to prevent cross-site WebSocket hijacking.
+ *
+ * Browser WebSocket clients always send an `Origin` header; programmatic clients
+ * (relay software, tests, server-to-server) typically do not. Absent Origin is
+ * therefore allowed. When Origin is present:
+ *   - if `ALLOWED_ORIGINS` is configured, it must contain the origin verbatim;
+ *   - otherwise the origin's host must match the request's `Host` header
+ *     (same-origin), which is the common SPA case and still blocks genuine
+ *     cross-origin abuse.
+ */
+export function isWebSocketOriginAllowed(req: Request): boolean {
+	const origin = req.headers.get('origin')
+	if (!origin) return true // non-browser client (no Origin header)
+
+	const allowlist = getAllowedOrigins()
+	if (allowlist.length > 0) {
+		return allowlist.includes(origin)
+	}
+	// No explicit allowlist: accept same-origin only.
+	try {
+		const originHost = new URL(origin).host
+		const requestHost = req.headers.get('host')
+		return !!requestHost && originHost === requestHost
+	} catch {
+		return false
+	}
+}

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -5,6 +5,7 @@ import { cartActions } from './cart'
 import { fetchProductsByPubkey } from '@/queries/products'
 import { hasAcceptedTerms, TERMS_ACCEPTED_KEY } from '@/components/dialogs/TermsConditionsDialog'
 import { uiActions } from './ui'
+import { walletActions } from './wallet'
 import { getPublicKey, nip19 } from 'nostr-tools'
 import { decrypt, encrypt } from 'nostr-tools/nip49'
 import { hexToBytes } from 'nostr-tools/utils'
@@ -108,6 +109,11 @@ export const authActions = {
 
 			// Login with the decrypted key
 			await authActions.loginWithPrivateKey(privateKeyHex)
+
+			// H8: Use the decrypted key to encrypt/decrypt NWC wallet data at rest
+			walletActions.setEncryptionSecret(privateKeyHex)
+			await walletActions.initialize()
+
 			authStore.setState((state) => ({ ...state, needsDecryptionPassword: false }))
 			authActions.checkAndShowTermsDialog()
 		} catch (error) {
@@ -158,6 +164,10 @@ export const authActions = {
 			ndkActions.setSigner(signer)
 
 			const user = await signer.user()
+
+			// H8: Use the private key to encrypt/decrypt NWC wallet data at rest
+			walletActions.setEncryptionSecret(privateKey)
+			await walletActions.initialize()
 
 			authStore.setState((state) => ({
 				...state,
@@ -260,6 +270,10 @@ export const authActions = {
 			localStorage.setItem(NOSTR_LOCAL_SIGNER_KEY, localSigner.privateKey || '')
 			localStorage.setItem(NOSTR_CONNECT_KEY, bunkerUrl)
 
+			// H8: Use the NIP-46 local signer key to encrypt/decrypt NWC wallet data
+			walletActions.setEncryptionSecret(localSigner.privateKey || undefined)
+			await walletActions.initialize()
+
 			authStore.setState((state) => ({
 				...state,
 				user,
@@ -284,6 +298,9 @@ export const authActions = {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) return
 		ndkActions.removeSigner()
+		// H8: Clear the wallet encryption secret so encrypted NWC data stays
+		// encrypted at rest after logout
+		walletActions.setEncryptionSecret(undefined)
 		localStorage.removeItem(NOSTR_LOCAL_SIGNER_KEY)
 		localStorage.removeItem(NOSTR_CONNECT_KEY)
 		localStorage.removeItem(NOSTR_LOCAL_ENCRYPTED_SIGNER_KEY)

--- a/src/lib/stores/wallet.ts
+++ b/src/lib/stores/wallet.ts
@@ -4,8 +4,16 @@ import { v4 as uuidv4 } from 'uuid'
 import { useEffect, useState } from 'react'
 import NDK, { type NDKSigner } from '@nostr-dev-kit/ndk'
 import { NDKNWCWallet } from '@nostr-dev-kit/wallet'
+import { secureGet, secureSet } from '@/lib/wallet/secureStorage'
 
-// Wallet interface
+// H8: NWC wallet connection secrets (payment capability) are sensitive — they
+// allow spending from the user's Lightning wallet. We encrypt them at rest
+// with AES-GCM, keyed by a secret derived from the authenticated user's
+// private key (set via setEncryptionSecret after login). Before auth, or for
+// extension logins without a private key, data falls back to plaintext and is
+// upgraded on the next authenticated write.
+const NWC_WALLETS_KEY = 'nwc_wallets'
+let walletEncryptionSecret: string | undefined
 export interface Wallet {
 	id: string
 	name: string
@@ -103,6 +111,16 @@ const cleanupAllCachedNwcWalletListeners = async (): Promise<void> => {
 
 // Actions for the wallet store
 export const walletActions = {
+	/**
+	 * H8: Set the encryption secret used to encrypt/decrypt NWC wallet data at
+	 * rest. Should be called after the user authenticates with a private key
+	 * (e.g. from authActions). Once set, all subsequent saves are encrypted
+	 * and any existing plaintext wallets are migrated on the next save.
+	 */
+	setEncryptionSecret: (secretHex: string | undefined): void => {
+		walletEncryptionSecret = secretHex
+	},
+
 	// Set callback for wallet changes
 	setOnWalletChange: (callback: (wallets: Wallet[]) => void): void => {
 		walletStore.setState((state) => ({ ...state, onWalletChange: callback }))
@@ -165,14 +183,20 @@ export const walletActions = {
 		})
 	},
 
-	// Load wallets from localStorage
+	// Load wallets from localStorage (H8: decrypts at rest when encryption secret is set)
 	loadWalletsFromLocalStorage: async (): Promise<Wallet[]> => {
 		try {
-			const savedWallets = localStorage.getItem('nwc_wallets')
-			if (savedWallets) {
-				const parsed = JSON.parse(savedWallets)
+			const result = await secureGet<Wallet[]>(NWC_WALLETS_KEY, walletEncryptionSecret)
+
+			// Encrypted data exists but we don't have the key yet (pre-auth).
+			// Return empty — wallets will load after setEncryptionSecret + reload.
+			if (result.isEncrypted && result.data === null) {
+				return []
+			}
+
+			if (result.data) {
 				// Ensure all fields are present
-				return parsed.map((wallet: any) => ({
+				return result.data.map((wallet: any) => ({
 					id: wallet.id || uuidv4(),
 					name: wallet.name || `Wallet ${Math.floor(Math.random() * 1000)}`,
 					nwcUri: wallet.nwcUri,
@@ -189,10 +213,13 @@ export const walletActions = {
 		return []
 	},
 
-	// Save wallets to local storage
+	// Save wallets to local storage (H8: encrypts at rest when encryption secret is set)
 	saveWalletsToLocalStorage: (wallets: Wallet[]): void => {
 		try {
-			localStorage.setItem('nwc_wallets', JSON.stringify(wallets))
+			// secureSet is async but we call it fire-and-forget to preserve the
+			// existing synchronous call signature. Encryption errors are caught
+			// inside secureSet's try/catch path.
+			void secureSet(NWC_WALLETS_KEY, wallets, walletEncryptionSecret)
 		} catch (error) {
 			console.error('Failed to save wallets to localStorage:', error)
 			toast.error('Failed to save wallets to local storage')

--- a/src/lib/wallet/__tests__/secureStorage.test.ts
+++ b/src/lib/wallet/__tests__/secureStorage.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, beforeEach, beforeAll } from 'bun:test'
+import { encryptJson, decryptJson, secureSet, secureGet, isEncryptedEnvelope, deriveAesKey } from '../secureStorage'
+
+// --- Mock localStorage (not available in Bun's test runner) -----------------
+beforeAll(() => {
+	const store = new Map<string, string>()
+	const ls = {
+		getItem: (key: string) => store.get(key) ?? null,
+		setItem: (key: string, value: string) => {
+			store.set(key, String(value))
+		},
+		removeItem: (key: string) => {
+			store.delete(key)
+		},
+		clear: () => {
+			store.clear()
+		},
+		get length() {
+			return store.size
+		},
+		key: (index: number) => Array.from(store.keys())[index] ?? null,
+	}
+	Object.defineProperty(globalThis, 'localStorage', { value: ls, writable: true, configurable: true })
+})
+
+// Unique 32-byte hex secrets for test isolation
+function makeSecret(char: string): string {
+	return char.repeat(64)
+}
+const SECRET_A = makeSecret('a')
+const SECRET_B = makeSecret('b')
+
+beforeEach(() => {
+	localStorage.clear()
+})
+
+describe('secureStorage — encryptJson / decryptJson', () => {
+	it('round-trips arbitrary JSON data', async () => {
+		const data = { nwcUri: 'nostr+walletconnect://abc123?relay=wss://r&secret=s3cr3t', name: 'My Wallet' }
+		const envelope = await encryptJson(data, SECRET_A)
+		const decrypted = await decryptJson<typeof data>(envelope, SECRET_A)
+
+		expect(decrypted).toEqual(data)
+	})
+
+	it('produces an envelope with the v1 prefix', async () => {
+		const envelope = await encryptJson({ test: true }, SECRET_A)
+		expect(envelope.startsWith('v1:')).toBe(true)
+		const parts = envelope.split(':')
+		expect(parts).toHaveLength(3)
+		expect(parts[0]).toBe('v1')
+	})
+
+	it('uses a unique IV per encryption (non-deterministic ciphertext)', async () => {
+		const data = { value: 'same' }
+		const e1 = await encryptJson(data, SECRET_A)
+		const e2 = await encryptJson(data, SECRET_A)
+		expect(e1).not.toBe(e2) // different IV means different ciphertext
+	})
+
+	it('fails to decrypt with the wrong key', async () => {
+		const envelope = await encryptJson({ secret: 'data' }, SECRET_A)
+		const result = await decryptJson(envelope, SECRET_B)
+		expect(result).toBeNull()
+	})
+
+	it('returns null for null/empty input', async () => {
+		expect(await decryptJson(null, SECRET_A)).toBeNull()
+		expect(await decryptJson('', SECRET_A)).toBeNull()
+	})
+
+	it('returns null for malformed envelope', async () => {
+		expect(await decryptJson('garbage', SECRET_A)).toBeNull()
+		expect(await decryptJson('v1:notenough', SECRET_A)).toBeNull()
+		expect(await decryptJson('v2:iv:ciphertext', SECRET_A)).toBeNull()
+	})
+})
+
+describe('secureStorage — isEncryptedEnvelope', () => {
+	it('identifies v1 envelopes', async () => {
+		const envelope = await encryptJson({ x: 1 }, SECRET_A)
+		expect(isEncryptedEnvelope(envelope)).toBe(true)
+	})
+
+	it('rejects plaintext and malformed values', () => {
+		expect(isEncryptedEnvelope(null)).toBe(false)
+		expect(isEncryptedEnvelope('')).toBe(false)
+		expect(isEncryptedEnvelope('{"plaintext": true}')).toBe(false)
+		expect(isEncryptedEnvelope('nostr+walletconnect://...')).toBe(false)
+	})
+})
+
+describe('secureStorage — deriveAesKey', () => {
+	it('returns a usable CryptoKey', async () => {
+		const key = await deriveAesKey(SECRET_A)
+		expect(key).toBeDefined()
+		expect(key.type).toBe('secret')
+		expect(key.algorithm.name).toBe('AES-GCM')
+	})
+})
+
+describe('secureStorage — secureSet / secureGet', () => {
+	it('encrypts when a secret is provided', async () => {
+		const data = [{ id: 'w1', nwcUri: 'nostr+walletconnect://pk?relay=wss://r&secret=s' }]
+		await secureSet('test_key', data, SECRET_A)
+
+		// Verify the raw value is NOT plaintext JSON
+		const raw = localStorage.getItem('test_key')
+		expect(raw).toBeTruthy()
+		expect(raw!.startsWith('v1:')).toBe(true)
+		expect(raw!).not.toContain('secret=s')
+
+		// Decrypt and verify
+		const result = await secureGet<typeof data>('test_key', SECRET_A)
+		expect(result.data).toEqual(data)
+		expect(result.isEncrypted).toBe(true)
+		expect(result.needsMigration).toBe(false)
+	})
+
+	it('falls back to plaintext when no secret is provided', async () => {
+		const data = [{ id: 'w1', name: 'wallet' }]
+		await secureSet('test_key', data)
+
+		const raw = localStorage.getItem('test_key')
+		expect(raw).toBe(JSON.stringify(data))
+
+		const result = await secureGet<typeof data>('test_key')
+		expect(result.data).toEqual(data)
+		expect(result.isEncrypted).toBe(false)
+		expect(result.needsMigration).toBe(true)
+	})
+
+	it('migrates plaintext to encrypted when secret becomes available', async () => {
+		// Step 1: store as plaintext (pre-auth)
+		const data = [{ id: 'w1', nwcUri: 'secret-uri' }]
+		await secureSet('test_key', data) // no secret
+
+		let result = await secureGet<typeof data>('test_key')
+		expect(result.needsMigration).toBe(true)
+		expect(result.data).toEqual(data)
+
+		// Step 2: re-store with encryption (post-auth)
+		await secureSet('test_key', data, SECRET_A)
+
+		result = await secureGet<typeof data>('test_key', SECRET_A)
+		expect(result.data).toEqual(data)
+		expect(result.isEncrypted).toBe(true)
+		expect(result.needsMigration).toBe(false)
+
+		// Raw value should no longer contain the plaintext URI
+		expect(localStorage.getItem('test_key')).not.toContain('secret-uri')
+	})
+
+	it('returns null data when encrypted but no secret provided (pre-auth)', async () => {
+		const data = [{ id: 'w1', nwcUri: 'secret-uri' }]
+		await secureSet('test_key', data, SECRET_A)
+
+		const result = await secureGet<typeof data>('test_key') // no secret
+		expect(result.data).toBeNull()
+		expect(result.isEncrypted).toBe(true)
+	})
+
+	it('returns empty result for missing key', async () => {
+		const result = await secureGet('nonexistent', SECRET_A)
+		expect(result.data).toBeNull()
+		expect(result.isEncrypted).toBe(false)
+		expect(result.needsMigration).toBe(false)
+	})
+})

--- a/src/lib/wallet/secureStorage.ts
+++ b/src/lib/wallet/secureStorage.ts
@@ -1,0 +1,163 @@
+/**
+ * Secure localStorage layer — encrypts sensitive data at rest (H8).
+ *
+ * Uses the Web Crypto API (SubtleCrypto) for authenticated encryption:
+ *   - Key derivation: HKDF-SHA256 from a caller-supplied secret (e.g. the
+ *     authenticated user's private-key hex, which lives in memory only).
+ *   - Encryption:      AES-256-GCM (confidential + authenticated).
+ *
+ * Ciphertext is stored as `v1:<base64(iv)>:<base64(ciphertext)>`. Values that
+ * do not match this envelope are treated as legacy plaintext and migrated on
+ * the next write, so existing deployments keep working transparently.
+ *
+ * Threat model: encrypting at rest protects against (a) local/physical access
+ * to the device, (b) malicious browser extensions that can read localStorage
+ * but cannot execute JS in the page context, and (c) leftover data after
+ * logout. It does NOT protect against a live XSS that can execute code while
+ * the key is in memory — that requires a CSP / input-sanitisation fix.
+ */
+
+const ENVELOPE_PREFIX = 'v1'
+const HKDF_INFO = 'plebeian.market/secureStorage/v1'
+const HKDF_SALT = 'plebeian.market'
+
+/**
+ * Derive an AES-GCM CryptoKey from a hex-encoded secret via HKDF-SHA256.
+ * The same secret always yields the same key, so encrypt and decrypt sides
+ * stay in sync as long as the caller passes the same secretHex.
+ */
+export async function deriveAesKey(secretHex: string): Promise<CryptoKey> {
+	const subtle = globalThis.crypto.subtle
+	const keyMaterial = await subtle.importKey('raw', hexToBytes(secretHex), 'HKDF', false, ['deriveKey'])
+	return subtle.deriveKey(
+		{ name: 'HKDF', hash: 'SHA-256', salt: new TextEncoder().encode(HKDF_SALT), info: new TextEncoder().encode(HKDF_INFO) },
+		keyMaterial,
+		{ name: 'AES-GCM', length: 256 },
+		false,
+		['encrypt', 'decrypt'],
+	)
+}
+
+/**
+ * Encrypt arbitrary JSON-serialisable data and return the storage envelope.
+ */
+export async function encryptJson(data: unknown, secretHex: string): Promise<string> {
+	const key = await deriveAesKey(secretHex)
+	const plaintext = new TextEncoder().encode(JSON.stringify(data))
+	const iv = globalThis.crypto.getRandomValues(new Uint8Array(12))
+	const ciphertext = await globalThis.crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, plaintext)
+	return `${ENVELOPE_PREFIX}:${bytesToBase64(iv)}:${bytesToBase64(new Uint8Array(ciphertext))}`
+}
+
+/**
+ * Decrypt a storage envelope produced by {@link encryptJson}.
+ * Returns `null` for missing or malformed values (never throws on bad input).
+ */
+export async function decryptJson<T>(envelope: string | null, secretHex: string): Promise<T | null> {
+	if (!envelope) return null
+
+	const parts = envelope.split(':')
+	if (parts.length !== 3 || parts[0] !== ENVELOPE_PREFIX) {
+		// Not an encrypted envelope — caller should handle legacy plaintext.
+		return null
+	}
+
+	try {
+		const iv = base64ToBytes(parts[1])
+		const ciphertext = base64ToBytes(parts[2])
+		const key = await deriveAesKey(secretHex)
+		const plaintext = await globalThis.crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext)
+		return JSON.parse(new TextDecoder().decode(plaintext)) as T
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Returns true if the stored value is an encrypted envelope (v1:...).
+ * Use this to detect legacy plaintext that needs migration.
+ */
+export function isEncryptedEnvelope(value: string | null): boolean {
+	if (!value) return false
+	const parts = value.split(':')
+	return parts.length === 3 && parts[0] === ENVELOPE_PREFIX
+}
+
+/**
+ * Encrypt and store JSON data under `storageKey` in localStorage.
+ * Falls back to plaintext when no secret is available (e.g. pre-auth),
+ * so callers can always persist; the data is upgraded to encrypted on
+ * the next authenticated write.
+ */
+export async function secureSet(storageKey: string, data: unknown, secretHex?: string): Promise<void> {
+	if (!secretHex) {
+		// No encryption key available yet — store plaintext as a transitional
+		// measure. It will be encrypted on the next authenticated write.
+		localStorage.setItem(storageKey, JSON.stringify(data))
+		return
+	}
+	const envelope = await encryptJson(data, secretHex)
+	localStorage.setItem(storageKey, envelope)
+}
+
+/**
+ * Load and decrypt JSON data from `storageKey`.
+ *
+ * - If the value is an encrypted envelope and a secret is provided, decrypt it.
+ * - If the value is encrypted but no secret is provided, return `null`
+ *   (cannot decrypt — caller should treat as "no data available yet").
+ * - If the value is legacy plaintext, return it as-is for migration.
+ */
+export async function secureGet<T>(
+	storageKey: string,
+	secretHex?: string,
+): Promise<{ data: T | null; isEncrypted: boolean; needsMigration: boolean }> {
+	const raw = localStorage.getItem(storageKey)
+	if (raw === null) {
+		return { data: null, isEncrypted: false, needsMigration: false }
+	}
+
+	if (isEncryptedEnvelope(raw)) {
+		if (!secretHex) {
+			return { data: null, isEncrypted: true, needsMigration: false }
+		}
+		const data = await decryptJson<T>(raw, secretHex)
+		return { data, isEncrypted: true, needsMigration: false }
+	}
+
+	// Legacy plaintext — parse and flag for migration.
+	try {
+		const data = JSON.parse(raw) as T
+		return { data, isEncrypted: false, needsMigration: true }
+	} catch {
+		return { data: null, isEncrypted: false, needsMigration: false }
+	}
+}
+
+// --- byte helpers -----------------------------------------------------------
+
+function hexToBytes(hex: string): Uint8Array {
+	const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+	const bytes = new Uint8Array(clean.length / 2)
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+	}
+	return bytes
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+	let binary = ''
+	for (let i = 0; i < bytes.length; i++) {
+		binary += String.fromCharCode(bytes[i])
+	}
+	return btoa(binary)
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+	const binary = atob(b64)
+	const bytes = new Uint8Array(binary.length)
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = binary.charCodeAt(i)
+	}
+	return bytes
+}

--- a/src/server/ZapPurchaseManager.ts
+++ b/src/server/ZapPurchaseManager.ts
@@ -1,5 +1,6 @@
 import type { NostrEvent } from '@nostr-dev-kit/ndk'
 import NDK, { NDKEvent } from '@nostr-dev-kit/ndk'
+import { verifyEvent, type Event } from 'nostr-tools/pure'
 import type { EventSigner } from './EventSigner'
 
 export interface PricingTier {
@@ -285,6 +286,14 @@ export abstract class ZapPurchaseManager<TEntry extends ZapPurchaseEntry> {
 		}
 		if (!zapRequest.sig) {
 			throw new ZapInvoiceError('zapRequest must be signed', 400)
+		}
+
+		// H2: Cryptographically verify the zap request signature before trusting its
+		// pubkey/tags. Without this a malicious client could forge a zapRequest with
+		// any pubkey and arbitrary tags. verifyEvent() fails closed on malformed or
+		// unsigned events (missing id/kind/created_at/content → returns false).
+		if (!verifyEvent(zapRequest as unknown as Event)) {
+			throw new ZapInvoiceError('zapRequest signature verification failed', 400)
 		}
 
 		// Validate zap request tags

--- a/src/server/__tests__/ZapPurchaseManager.signature.test.ts
+++ b/src/server/__tests__/ZapPurchaseManager.signature.test.ts
@@ -1,0 +1,218 @@
+import { expect, test, describe, beforeEach, afterEach } from 'bun:test'
+import { finalizeEvent, generateSecretKey, getPublicKey } from 'nostr-tools/pure'
+import type { NostrEvent } from '@nostr-dev-kit/ndk'
+import { EventSigner } from '../EventSigner'
+import {
+	ZapPurchaseManager,
+	ZapInvoiceError,
+	type ZapPurchaseConfig,
+	type ZapPurchaseInvoiceRequestBody,
+	type LnurlResolver,
+} from '../ZapPurchaseManager'
+
+/**
+ * H2 — Zap request signature verification (payment fraud).
+ *
+ * Regression coverage for PR #1074: generateInvoice() must call verifyEvent()
+ * on the client-supplied zap request before trusting its pubkey/tags. Without
+ * it, a malicious client could forge a zapRequest with any pubkey and arbitrary
+ * tags and obtain an invoice. With it, a forged/tampered request is rejected
+ * with HTTP 400.
+ *
+ * IMPORTANT nostr-tools gotcha: `finalizeEvent()` stamps a (non-JSON)
+ * `Symbol("verified")` cache on the event, and `verifyEvent()` short-circuits
+ * to that cached value. Object spread carries the symbol along, so mutating a
+ * finalized event in-process will STILL verify. A real attacker's event,
+ * however, arrives as a JSON HTTP body — `JSON.parse` strips Symbol-keyed
+ * properties, so verification re-runs and forgeries are caught. Every forged
+ * fixture below is therefore passed through `toWire()` (JSON round-trip) to
+ * mirror how the request actually arrives at the server.
+ */
+
+// Minimal concrete subclass just to exercise the abstract base class.
+type Entry = { pubkey: string; validUntil: number }
+class TestZapManager extends ZapPurchaseManager<Entry> {
+	protected extractRegistryKey(zapRequest: NostrEvent): string | null {
+		return zapRequest.tags.find((t) => t[0] === 'n')?.[1] ?? null
+	}
+	protected validateRegistration(_key: string, _pubkey: string): string | null {
+		return null // accept all in this test fixture
+	}
+	protected extractEntriesFromEvent(): Array<{ key: string; entry: Entry }> {
+		return []
+	}
+	protected buildRegistryTags(): string[][] {
+		return []
+	}
+	protected createEntry(key: string, pubkey: string, validUntil: number): Entry {
+		return { pubkey, validUntil }
+	}
+}
+
+const ZAP_LABEL = 'market-test'
+const REGISTRY_KEY = 'reg-key-123'
+
+function hexPriv(sk: Uint8Array): string {
+	return Buffer.from(sk).toString('hex')
+}
+
+/** Strip the verifiedSymbol cache so verifyEvent re-runs (mirrors a wire request). */
+function toWire<T>(e: T): T {
+	return JSON.parse(JSON.stringify(e))
+}
+
+describe('H2 — ZapPurchaseManager.generateInvoice signature verification', () => {
+	let originalFetch: typeof fetch
+	let appPubkey: string
+	let manager: TestZapManager
+	let requesterSk: Uint8Array
+	const resolver: LnurlResolver = (id) => `https://lnurl.invalid/${id}/pay`
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+
+		const appSk = generateSecretKey()
+		appPubkey = getPublicKey(appSk)
+		const signer = new EventSigner(hexPriv(appSk))
+
+		const config: ZapPurchaseConfig = {
+			zapLabel: ZAP_LABEL,
+			registryEventKind: 30000,
+			registryDTag: ZAP_LABEL,
+			pricing: {},
+		}
+		manager = new TestZapManager(config, signer)
+
+		requesterSk = generateSecretKey()
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+	})
+
+	/** Build a correctly-signed zap request, then strip the symbol cache (wire form). */
+	function signedZapRequestWire(amountSats: number) {
+		const signed = finalizeEvent(
+			{
+				kind: 9734,
+				created_at: Math.floor(Date.now() / 1000),
+				tags: [
+					['L', ZAP_LABEL],
+					['p', appPubkey],
+					['amount', String(amountSats * 1000)],
+					['n', REGISTRY_KEY],
+				],
+				content: '',
+			},
+			requesterSk,
+		)
+		return toWire(signed)
+	}
+
+	function requestBody(zapRequest: object, amountSats: number): ZapPurchaseInvoiceRequestBody {
+		return { amountSats, registryKey: REGISTRY_KEY, zapRequest: zapRequest as any }
+	}
+
+	test('rejects a FORGED zap request (tampered tag, stale signature) with 400', async () => {
+		const valid = signedZapRequestWire(1000)
+		// Forge: mutate the amount tag. The id no longer matches the (stale)
+		// signature's covered hash, so verifyEvent() must fail closed.
+		const forged = {
+			...valid,
+			tags: valid.tags.map((t) => (t[0] === 'amount' ? ['amount', '999999000'] : t)),
+		}
+
+		let caught: unknown
+		try {
+			await manager.generateInvoice(requestBody(forged, 1000), appPubkey, 'seller@ln', resolver)
+		} catch (e) {
+			caught = e
+		}
+		expect(caught).toBeInstanceOf(ZapInvoiceError)
+		expect((caught as ZapInvoiceError).status).toBe(400)
+		expect((caught as ZapInvoiceError).message).toContain('signature verification failed')
+	})
+
+	test('rejects a zap request with a wrong author pubkey (sig no longer valid) with 400', async () => {
+		const valid = signedZapRequestWire(1000)
+		const forged = { ...valid, pubkey: getPublicKey(generateSecretKey()) }
+
+		await expect(
+			manager.generateInvoice(requestBody(forged, 1000), appPubkey, 'seller@ln', resolver),
+		).rejects.toThrow(/signature verification failed/)
+	})
+
+	test('accepts a correctly-signed zap request and flows through to an invoice', async () => {
+		// Mock the two fetches generateInvoice makes: LNURL-pay metadata, then invoice.
+		let fetchCalls = 0
+		globalThis.fetch = ((input: any) => {
+			fetchCalls++
+			const url = typeof input === 'string' ? input : input.toString()
+			// The invoice callback carries ?amount=…&nostr=…; the metadata call does not.
+			if (url.includes('amount=')) {
+				return Promise.resolve(
+					new Response(JSON.stringify({ pr: 'lnbc1u1testinvoice' }), {
+						status: 200,
+						headers: { 'content-type': 'application/json' },
+					}),
+				)
+			}
+			// LNURL-pay metadata
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						callback: 'https://lnurl.invalid/callback',
+						allowsNostr: true,
+						nostrPubkey: getPublicKey(generateSecretKey()),
+						minSendable: 1000,
+						maxSendable: 1_000_000_000,
+					}),
+					{ status: 200, headers: { 'content-type': 'application/json' } },
+				),
+			)
+		}) as typeof fetch
+
+		const amountSats = 1000
+		const result = await manager.generateInvoice(
+			requestBody(signedZapRequestWire(amountSats), amountSats),
+			appPubkey,
+			'seller@ln',
+			resolver,
+		)
+		expect(result.pr).toBe('lnbc1u1testinvoice')
+		expect(fetchCalls).toBeGreaterThanOrEqual(2) // both fetches happened
+	})
+
+	test('a valid signature but missing required tags is rejected for a NON-signature reason', async () => {
+		// Proves the signature check passes (no "signature verification failed")
+		// but downstream tag validation still applies. Build a properly-signed
+		// request that lacks the [L, zapLabel] tag.
+		const signedNoLabel = toWire(
+			finalizeEvent(
+				{
+					kind: 9734,
+					created_at: Math.floor(Date.now() / 1000),
+					tags: [
+						['p', appPubkey],
+						['amount', '1000000'],
+						['n', REGISTRY_KEY],
+					],
+					content: '',
+				},
+				requesterSk,
+			),
+		)
+
+		let caught: unknown
+		try {
+			await manager.generateInvoice(requestBody(signedNoLabel, 1000), appPubkey, 'seller@ln', resolver)
+		} catch (e) {
+			caught = e
+		}
+		expect(caught).toBeInstanceOf(ZapInvoiceError)
+		// important: NOT the signature error — signature was valid, tag check failed
+		expect((caught as ZapInvoiceError).message).not.toContain('signature verification failed')
+		expect((caught as ZapInvoiceError).message).toContain('missing')
+		expect((caught as ZapInvoiceError).message).toContain(ZAP_LABEL)
+	})
+})

--- a/src/server/__tests__/ZapPurchaseManager.signature.test.ts
+++ b/src/server/__tests__/ZapPurchaseManager.signature.test.ts
@@ -137,9 +137,9 @@ describe('H2 — ZapPurchaseManager.generateInvoice signature verification', () 
 		const valid = signedZapRequestWire(1000)
 		const forged = { ...valid, pubkey: getPublicKey(generateSecretKey()) }
 
-		await expect(
-			manager.generateInvoice(requestBody(forged, 1000), appPubkey, 'seller@ln', resolver),
-		).rejects.toThrow(/signature verification failed/)
+		await expect(manager.generateInvoice(requestBody(forged, 1000), appPubkey, 'seller@ln', resolver)).rejects.toThrow(
+			/signature verification failed/,
+		)
 	})
 
 	test('accepts a correctly-signed zap request and flows through to an invoice', async () => {


### PR DESCRIPTION
## What

Fixes all 8 HIGH-severity security findings from issue #996 (H1–H8) and hardens deployment across CI/CD, with **regression test coverage for every finding** so a future revert fails CI.

## Why

Closes #996. Related: #975 (CRITICAL fixes — still open), #986 (key rotation — manual coordination), #981 (Bun pin — already merged). These are real, exploitable gaps (WS hijacking, payment fraud, plaintext secrets, supply-chain pins, localStorage exfiltration) that should land before any further feature work merges.

## Changes

- **H1 — WebSocket Origin validation** (`src/index.tsx`, new `src/lib/security/webSocketOrigin.ts`): added `isWebSocketOriginAllowed()` / `getAllowedOrigins()` validating the `Origin` header on WS upgrade. Browser clients must match `ALLOWED_ORIGINS` (if set) or be same-origin; non-browser clients (no Origin) pass through. Logic extracted into a pure module so it is unit-testable without booting the server.
- **H2 — Zap request signature verification** (`src/server/ZapPurchaseManager.ts`): added `verifyEvent()` (from `nostr-tools/pure`) before trusting a zap request's pubkey/tags. Forged zap requests now 400 instead of being processed.
- **H3 — Remove SSH password auth** (`deploy-simple/deploy.sh`, `control.sh`): removed `sshpass`/`SSH_PASSWORD` entirely; deploys use SSH keys exclusively.
- **H4 — StrictHostKeyChecking hardening** (`deploy-simple/deploy.sh`, `control.sh`): replaced `StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null` with `accept-new` writing to a real `~/.ssh/known_hosts` (first-seen trusted, subsequent changes fail = MITM detection).
- **H5 — Pin GitHub Actions to commit SHAs** (`.github/workflows/ci-unit.yml`, `e2e.yml`, `prettier.yml`, `deploy.yml`, `promote-production.yml`): all `actions/*` and `oven-sh/setup-bun` pinned to SHAs; Bun pinned to `1.3.10` (complements #981).
- **H6 — Pin MCP package** (`.mcp.json`): `@nostrBook/mcp@latest` → `@nostrBook/mcp@0.5.3`; removed `-y` auto-install.
- **H7 — Deploy workflow SSH key auth** (`.github/workflows/deploy.yml`): `appleboy/ssh-action` / `scp-action` switched from `password:` to `key:`; actions pinned to SHAs.
- **H8 — Encrypt NWC wallet secrets at rest** (`src/lib/wallet/secureStorage.ts` new, `src/lib/stores/wallet.ts`, `src/lib/stores/auth.ts`): Web Crypto HKDF-SHA256 (key from user private key) + AES-256-GCM, envelope `v1:<b64 iv>:<b64 ciphertext>`. NWC URIs encrypted before localStorage write; key never persisted. Legacy plaintext auto-migrates on next authenticated write; extension (NIP-07) logins fall back to plaintext and upgrade on next login.

## Test plan

Every HIGH finding now has dedicated regression coverage. The full unit suite passes: **140 pass / 0 fail (412 `expect()` calls, 12 files)** via `bun run test:unit`.

Regression coverage per finding (37 security-specific tests):

- **H1 — WebSocket Origin validation** → `src/lib/security/__tests__/webSocketOrigin.test.ts` (**7 tests**): no-Origin allow, cross-origin browser block, same-origin allow, explicit `ALLOWED_ORIGINS` allowlist positive + negative, malformed Origin rejection, and `getAllowedOrigins` parsing edge cases.
- **H2 — Zap request signature verification** → `src/server/__tests__/ZapPurchaseManager.signature.test.ts` (**4 tests**): rejects forged/tampered zap requests (tampered tag, wrong author pubkey) with 400, accepts correctly-signed requests end-to-end, and a valid signature with missing required tags is rejected for a non-signature reason.
- **H3 — Remove SSH password auth** → `src/lib/security/__tests__/deployScripts.test.ts` (**2 tests**, new): static guard that `deploy-simple/deploy.sh` **and** `control.sh` contain no `sshpass` and no `SSH_PASSWORD` in executable code (full-line comments are stripped so explanatory text like "SSH_PASSWORD support removed" is not a false positive).
- **H4 — StrictHostKeyChecking hardening** → `src/lib/security/__tests__/deployScripts.test.ts` (**2 tests**, new): static guard that both scripts use `StrictHostKeyChecking=accept-new` and must **not** contain `StrictHostKeyChecking=no` or `UserKnownHostsFile=/dev/null`.
- **H5 — Pin GitHub Actions to SHAs** → `src/lib/security/__tests__/supplyChainDeployment.test.ts` (**5 tests**): each of `ci-unit.yml`, `e2e.yml`, `prettier.yml`, `deploy.yml`, `promote-production.yml` must have every third-party action SHA-pinned (no floating `@vN` tags).
- **H6 — Pin MCP package** → `supplyChainDeployment.test.ts` (**1 test**): `.mcp.json` pins `@nostrBook/mcp` to a concrete version (no `@latest`).
- **H7 — Deploy workflow SSH key auth** → `supplyChainDeployment.test.ts` (**2 tests**): `deploy.yml` never references password-based SSH secrets, and every `appleboy/ssh|scp-action` step carries an SSH `key:` input (never `password:`).
- **H8 — Encrypt NWC wallet secrets at rest** → `src/lib/wallet/__tests__/secureStorage.test.ts` (**14 tests**): AES-GCM envelope round-trip, `v1:` prefix, unique IV per encryption (non-deterministic ciphertext), wrong-key decryption failure, malformed-envelope handling, `isEncryptedEnvelope` classification, `deriveAesKey` usability, and `secureSet`/`secureGet` flows (encrypt with secret, plaintext fallback, plaintext→encrypted migration, encrypted-but-no-secret pre-auth, missing key).

- [x] **140 unit tests pass** (`bun run test:unit`) — was 117; +37 security regression tests added across this PR
- [x] Prettier clean (`bunx prettier --check`)
- [x] No new TypeScript errors (pre-existing `any` warnings unchanged)
- [x] No secrets/keys/passwords in test code — H3/H4 are pure pattern presence/absence assertions on the deploy scripts

## Deployment notes (operator action required)

- **H7:** before merge, add GitHub secrets `STAGING_SSH_KEY` and `PROD_SSH_KEY`. The old `STAGING_PASSWORD` / `PROD_PASSWORD` can be removed once key auth is confirmed.
- **H1 (optional):** set `ALLOWED_ORIGINS` in production (e.g. `https://plebeian.market,https://staging.plebeian.market`). If unset, defaults to same-origin matching.
- **#986 (key rotation)** is tracked separately — requires manual coordination across contributors; the code-level support landed in #975.
