### PR TITLE
test(e2e): fix shipping-selector drift from cart UI redesign (#1045, #1057)

### DIFF
--- a/e2e/tests/buyer-purchase.spec.ts
+++ b/e2e/tests/buyer-purchase.spec.ts
@@ -4,7 +4,7 @@ test.use({ scenario: 'merchant' })
 
 test.describe('Buyer Purchase Flow', () => {
 	test('buyer adds two products to cart and totals are correct', async ({ buyerPage }) => {
-		test.setTimeout(60_000)
+		test.setTimeout(90_000)
 
 		await buyerPage.goto('/products')
 
@@ -34,33 +34,53 @@ test.describe('Buyer Purchase Flow', () => {
 			.filter({ has: buyerPage.locator('.i-basket') })
 			.click()
 
-		// Wait for cart content to load and shipping options to appear
-		const shippingTrigger = buyerPage.getByText('Select shipping method')
-		await expect(shippingTrigger).toBeVisible({ timeout: 10_000 })
+		// Post-redesign (#1045): shipping is no longer chosen in the cart. The cart
+		// defers shipping to checkout, so each product shows
+		// "Select shipping at checkout". The Checkout button is always enabled.
+		const cartDialog = buyerPage.getByRole('dialog', { name: /your cart/i })
+		await expect(cartDialog.getByText('Select shipping at checkout').first()).toBeVisible({ timeout: 10_000 })
 
-		// Select "Worldwide Standard" shipping (5,000 sats)
-		await shippingTrigger.click()
-		await buyerPage.getByText(/Worldwide Standard/).click()
+		// Proceed to checkout
+		const checkoutButton = cartDialog.getByRole('button', { name: /Checkout/i })
+		await expect(checkoutButton).toBeEnabled()
+		await checkoutButton.click()
 
-		// Wait for totals to update after shipping selection
+		// --- Checkout page: Shipping step ---
+		// Wait for the checkout shipping step to render.
+		await expect(buyerPage.getByText('Shipping Address', { exact: true })).toBeVisible({ timeout: 30_000 })
+
+		// Select "Worldwide Standard" shipping (5,000 sats) for each product.
+		// The sidebar renders one "Select shipping method" trigger per product.
+		const shippingTriggers = buyerPage.getByText('Select shipping method')
+		await expect(shippingTriggers.first()).toBeVisible({ timeout: 15_000 })
+		const triggerCount = await shippingTriggers.count()
+		for (let i = 0; i < triggerCount; i++) {
+			await buyerPage.getByText('Select shipping method').first().click()
+			const option = buyerPage.getByRole('option', { name: /Worldwide Standard/ })
+			await expect(option).toBeVisible({ timeout: 10_000 })
+			await option.click()
+			await buyerPage.waitForTimeout(500)
+		}
+
+		// Wait for totals to update after shipping selection.
 		// Subtotal: 50,000 + 15,000 = 65,000 sat
 		// Shipping: 5,000 × 2 products = 10,000 sat (shipping cost applies per product)
 		// Total: 75,000 sat
-		await expect(buyerPage.getByText('65,000 sat').first()).toBeVisible({ timeout: 10_000 })
+		await expect(buyerPage.getByText('65,000 sat').first()).toBeVisible({ timeout: 15_000 })
 		await expect(buyerPage.getByText('10,000 sat').first()).toBeVisible()
 		await expect(buyerPage.getByText('75,000 sat').first()).toBeVisible()
 
-		// Verify V4V payment breakdown (merchant seeded with 10% V4V)
-		// V4V applies to product subtotal only (65,000 sats), not shipping
+		// Verify V4V payment breakdown (merchant seeded with 10% V4V).
+		// V4V applies to product subtotal only (65,000 sats), not shipping.
 		// Community Share: 10% of 65,000 = 6,500 sat
 		// Merchant: 90% of 65,000 + 10,000 shipping = 68,500 sat
-		await expect(buyerPage.getByText('Payment Breakdown')).toBeVisible()
-		await expect(buyerPage.getByText(/Community Share/)).toBeVisible()
-		await expect(buyerPage.getByText('6,500 sat')).toBeVisible()
-		await expect(buyerPage.getByText('68,500 sat')).toBeVisible()
+		await expect(buyerPage.getByText('Payment Breakdown').first()).toBeVisible()
+		await expect(buyerPage.getByText(/Community Share/).first()).toBeVisible()
+		await expect(buyerPage.getByText('6,500 sat').first()).toBeVisible()
+		await expect(buyerPage.getByText('68,500 sat').first()).toBeVisible()
 
-		// Checkout button should be enabled now that shipping is selected
-		const checkoutButton = buyerPage.getByRole('button', { name: /Checkout/i })
-		await expect(checkoutButton).toBeEnabled()
+		// "Continue to Review" is enabled once every product has a shipping method.
+		const continueButton = buyerPage.locator('button[form="shipping-form"]')
+		await expect(continueButton).toBeEnabled({ timeout: 10_000 })
 	})
 })

--- a/e2e/tests/cart.spec.ts
+++ b/e2e/tests/cart.spec.ts
@@ -262,10 +262,11 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// Each seller group gets its own shipping selector,
-		// so there should be 2 "Select shipping method" triggers
-		const shippingTriggers = dialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(2, { timeout: 10_000 })
+		// Post-redesign (#1045): shipping selection moved from the cart dialog to the
+		// checkout sidebar. The cart now defers shipping — each product renders a
+		// "Select shipping at checkout" notice (exact), one per product.
+		const shippingNotices = dialog.getByText('Select shipping at checkout', { exact: true })
+		await expect(shippingNotices).toHaveCount(2, { timeout: 10_000 })
 	})
 
 	test('can add multiple products from same seller', async ({ newUserPage }) => {
@@ -283,9 +284,11 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).toBeVisible({ timeout: 10_000 })
 		await expect(dialog.getByText('Nostr T-Shirt')).toBeVisible()
 
-		// They're grouped under the same seller, so only 1 shipping selector
-		const shippingTriggers = dialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(1, { timeout: 10_000 })
+		// Post-redesign (#1045): shipping is deferred to checkout, so each product
+		// (not each seller group) carries its own "Select shipping at checkout"
+		// notice. Two products => two notices regardless of seller grouping.
+		const shippingNotices = dialog.getByText('Select shipping at checkout', { exact: true })
+		await expect(shippingNotices).toHaveCount(2, { timeout: 10_000 })
 	})
 
 	test('removing all items from one seller keeps other seller items', async ({ newUserPage }) => {
@@ -308,11 +311,11 @@ test.describe('Cart - Multiple Merchants', () => {
 		await expect(dialog.getByText('Bitcoin Hardware Wallet')).not.toBeVisible({ timeout: 5_000 })
 		await expect(dialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// Only 1 live shipping selector control should remain for the remaining seller.
-		// Count the actual select triggers rather than raw text so exiting animated nodes
-		// don't get mistaken for an active seller section.
-		const shippingSelectors = dialog.locator('[data-slot="select-trigger"]:visible')
-		await expect(shippingSelectors).toHaveCount(1, { timeout: 10_000 })
+		// Only the remaining product should still show its "Select shipping at
+		// checkout" notice. The removed item's assertion above already waited for
+		// its node to leave the DOM, so exactly one notice should remain.
+		const shippingNotices = dialog.getByText('Select shipping at checkout', { exact: true })
+		await expect(shippingNotices).toHaveCount(1, { timeout: 10_000 })
 	})
 })
 

--- a/e2e/tests/marketplace.spec.ts
+++ b/e2e/tests/marketplace.spec.ts
@@ -74,50 +74,20 @@ async function openCart(page: Page): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: select shipping for all sellers in the cart
-// ---------------------------------------------------------------------------
-
-async function selectShippingForAllSellers(page: Page): Promise<void> {
-	// Each seller group has its own ShippingSelector (Radix Select).
-	// Wait for shipping selectors to be visible.
-	const cartDialog = page.getByRole('dialog', { name: /your cart/i })
-	const shippingTriggers = cartDialog.getByText('Select shipping method')
-
-	// Wait for at least one shipping trigger to appear
-	await expect(shippingTriggers.first()).toBeVisible({ timeout: 10_000 })
-
-	// Count how many need selecting
-	const count = await shippingTriggers.count()
-
-	for (let i = 0; i < count; i++) {
-		// Click the first remaining unselected trigger
-		const trigger = cartDialog.getByText('Select shipping method').first()
-		await trigger.click()
-
-		// Select Digital Delivery (free, available for both sellers)
-		const option = page.getByRole('option', { name: /digital delivery/i })
-		await expect(option).toBeVisible({ timeout: 5_000 })
-		await option.click()
-
-		// Wait for the select to close before clicking the next one
-		await page.waitForTimeout(500)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // Helper: navigate through checkout steps to the payment step
 // ---------------------------------------------------------------------------
 
 /**
  * After clicking Checkout in the cart, the checkout flow goes through:
- * 1. Shipping Address step (even for digital delivery)
+ * 1. Shipping Address step — select a shipping method per product (sidebar),
+ *    then fill the (digital-delivery) contact and submit "Continue to Review".
  * 2. Order Summary step
  * 3. Payment step (invoices)
  *
- * This helper navigates through shipping and summary to reach payment.
- * For digital delivery, the shipping form requires no address fields but
- * we must wait for the async shipping-type detection to complete before
- * the form's submit button becomes enabled.
+ * Post-redesign (#1045): shipping methods are no longer chosen in the cart.
+ * They are selected on the checkout sidebar, one "Select shipping method"
+ * trigger per product. This helper selects Digital Delivery (free) for every
+ * product before submitting the shipping form.
  */
 async function proceedToPaymentStep(page: Page): Promise<void> {
 	// Wait for checkout page to load (shipping step appears first)
@@ -132,7 +102,20 @@ async function proceedToPaymentStep(page: Page): Promise<void> {
 			.isVisible()
 			.catch(() => false)
 	) {
-		// Wait for the async shipping-type check to complete.
+		// 1a. Select a shipping method for each product on the checkout sidebar.
+		// The redesign renders one "Select shipping method" trigger per product.
+		const methodTriggers = page.getByText('Select shipping method')
+		await expect(methodTriggers.first()).toBeVisible({ timeout: 15_000 })
+		const methodCount = await methodTriggers.count()
+		for (let i = 0; i < methodCount; i++) {
+			await page.getByText('Select shipping method').first().click()
+			const option = page.getByRole('option', { name: /digital delivery/i })
+			await expect(option).toBeVisible({ timeout: 5_000 })
+			await option.click()
+			await page.waitForTimeout(500)
+		}
+
+		// 1b. Wait for the async shipping-type check to complete.
 		// For digital delivery, the "Digital Delivery" notice appears once
 		// the form detects all items use digital shipping (noAddressRequired = true).
 		// This also enables the submit button by removing required field validators.
@@ -228,41 +211,47 @@ test.describe('Multi-Merchant Cart', () => {
 		await expect(cartDialog.getByText('Bitcoin Hardware Wallet')).toBeVisible()
 		await expect(cartDialog.getByText('Lightning Node Setup Guide')).toBeVisible()
 
-		// There should be seller group containers (border + shadow cards)
-		// with separate shipping selectors for each seller
-		const shippingTriggers = cartDialog.getByText('Select shipping method')
-		await expect(shippingTriggers).toHaveCount(2, { timeout: 10_000 })
+		// Post-redesign (#1045): shipping selection moved from the cart to the
+		// checkout sidebar. The cart defers shipping — each product renders a
+		// "Select shipping at checkout" notice (exact), one per product.
+		const shippingNotices = cartDialog.getByText('Select shipping at checkout', { exact: true })
+		await expect(shippingNotices).toHaveCount(2, { timeout: 10_000 })
 	})
 
-	test('cart requires shipping per seller before checkout', async ({ newUserPage }) => {
+	test('checkout requires a shipping method for every product before review', async ({ newUserPage }) => {
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
 
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 
-		// Warning should show that shipping is missing
-		await expect(newUserPage.getByText(/please select shipping options for/i)).toBeVisible({ timeout: 10_000 })
-
-		// Checkout button should be disabled
+		// Post-redesign (#1045): the cart defers shipping to checkout. The cart
+		// shows a banner prompting the buyer, and the Checkout button is always
+		// enabled (the shipping gate now lives on the checkout page).
+		await expect(cartDialog.getByText(/Select shipping at checkout for 2 items\./)).toBeVisible({ timeout: 10_000 })
 		const checkoutButton = cartDialog.getByRole('button', { name: /^checkout$/i })
-		await expect(checkoutButton).toBeDisabled()
+		await expect(checkoutButton).toBeEnabled()
+		await checkoutButton.click()
 
-		// Select shipping for first seller only
-		const firstTrigger = cartDialog.getByText('Select shipping method').first()
-		await firstTrigger.click()
+		// On the checkout shipping step, "Continue to Review" stays disabled until
+		// every product has a shipping method selected.
+		await expect(newUserPage.getByText('Shipping Address', { exact: true })).toBeVisible({ timeout: 30_000 })
+		const continueButton = newUserPage.locator('button[form="shipping-form"]')
+		await expect(continueButton).toBeDisabled()
+
+		// Select a method for the first product only.
+		await newUserPage.getByText('Select shipping method').first().click()
 		await newUserPage.getByRole('option', { name: /digital delivery/i }).click()
 		await newUserPage.waitForTimeout(500)
 
-		// Checkout should still be disabled (second seller missing)
-		await expect(checkoutButton).toBeDisabled()
+		// Still disabled — the second product has no method yet.
+		await expect(continueButton).toBeDisabled()
 
-		// Select shipping for second seller
-		const secondTrigger = cartDialog.getByText('Select shipping method').first()
-		await secondTrigger.click()
+		// Select a method for the second product.
+		await newUserPage.getByText('Select shipping method').first().click()
 		await newUserPage.getByRole('option', { name: /digital delivery/i }).click()
 
-		// Now checkout should be enabled
-		await expect(checkoutButton).toBeEnabled({ timeout: 5_000 })
+		// Now "Continue to Review" is enabled.
+		await expect(continueButton).toBeEnabled({ timeout: 5_000 })
 	})
 })
 
@@ -307,7 +296,6 @@ test.describe('Multi-Seller Checkout with V4V', () => {
 
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
-		await selectShippingForAllSellers(newUserPage)
 
 		// Click checkout
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
@@ -316,6 +304,8 @@ test.describe('Multi-Seller Checkout with V4V', () => {
 		await checkoutButton.click()
 
 		// Navigate through shipping → summary → payment
+		// (proceedToPaymentStep selects a shipping method per product on the
+		// checkout sidebar — post-redesign, #1045.)
 		await proceedToPaymentStep(newUserPage)
 
 		// With 2 sellers × (1 merchant + 1 V4V) = 4 invoices.
@@ -334,13 +324,14 @@ test.describe('Multi-Seller Checkout with V4V', () => {
 
 		await addProductsFromBothSellers(newUserPage)
 		await openCart(newUserPage)
-		await selectShippingForAllSellers(newUserPage)
 
 		// Checkout
 		const cartDialog = newUserPage.getByRole('dialog', { name: /your cart/i })
 		await cartDialog.getByRole('button', { name: /^checkout$/i }).click()
 
 		// Navigate through shipping → summary → payment
+		// (proceedToPaymentStep selects a shipping method per product on the
+		// checkout sidebar — post-redesign, #1045.)
 		await proceedToPaymentStep(newUserPage)
 
 		// Pay all 4 invoices using WebLN


### PR DESCRIPTION
## What

Updates the stale Playwright selectors in the cart, buyer-purchase, and marketplace e2e specs that broke when the cart UI redesign **moved shipping selection from the cart dialog to the checkout page sidebar**. This is the selector drift tracked in #1045 and #1057 (Fix 2) — **not** an NDK/relay issue (products load fine; only the shipping-selector step fails).

Baseline on `master`: cart, buyer-purchase, marketplace all at **0% pass** (#1045, #1057).

## Why

The cart redesign:
- **Removed** shipping selectors from the cart dialog (`hideShipping=true`).
- Each cart product now shows *"Select shipping at checkout"*; the cart banner reads *"Select shipping at checkout for N items."*
- The cart **Checkout** button is **always enabled** (the shipping gate moved off the cart).
- Shipping methods are now chosen on the **checkout sidebar**: one *"Select shipping method"* trigger per product (Radix combobox, `role=option`). The submit is `button[form="shipping-form"]` (*"Continue to Review"*), disabled until every product has a method.

DOM ground truth was captured in diagnostic commit `ac92231b` (real flow: add products → cart → checkout → select shipping).

## Changes

**`e2e/tests/cart.spec.ts`** — *Cart - Multiple Merchants* (3 tests)
- Replace the in-cart `'Select shipping method'` trigger / `[data-slot="select-trigger"]` assertions with the new per-product `'Select shipping at checkout'` notice (exact). The product-visibility / removal assertions are unchanged.

**`e2e/tests/buyer-purchase.spec.ts`** — *Buyer Purchase Flow* (1 test)
- Move shipping selection out of the cart onto the checkout sidebar (one trigger per product); assert subtotal / shipping / total sats and the V4V breakdown on checkout; verify `button[form="shipping-form"]` (*"Continue to Review"*) enables once every product has a method.

**`e2e/tests/marketplace.spec.ts`**
- Drop the obsolete in-cart `selectShippingForAllSellers` helper; fold per-product method selection into `proceedToPaymentStep` (checkout sidebar).
- Rewrite *"cart requires shipping per seller before checkout"* → **"checkout requires a shipping method for every product before review"**: the gate now lives on the checkout page (`Continue to Review` disabled until all methods chosen; enabled after).
- Update the multi-seller checkout flow to select methods on checkout.

## Verification

| Check | Result |
|------|--------|
| `tsc --noEmit -p tsconfig.json` (edited specs) | ✅ 0 errors |
| Local e2e | ⛔ **Blocked** — Playwright does not ship chromium for `ubuntu26.04-x64` on the dev host (`bunx playwright install chromium` → *"Playwright does not support chromium on ubuntu26.04-x64"*). Same class as #1057 Fix 1; contributors on current Ubuntu cannot run e2e locally. |
| e2e full suite | 🔄 `e2e-full` workflow_dispatch on the fork, run **[#28303985565](https://github.com/c03rad0r/market/actions/runs/28303985565)** (`--grep-invert 'Product Page - View Only\|Collection Management'` covers cart/buyer-purchase/marketplace). Upstream PR CI (`e2e-pricing`) only runs *Product Page - View Only*, and `e2e-full` is dispatch/schedule-only, so verification is via the fork run. Status updated below when it lands. |

RED baseline is the documented 0% pass for these specs on `master` (#1045, #1057).

Refs #1045 · Refs #1057.