### PR TITLE
perf(auctions): parallelize auction query waterfall (#1046 fix 3)

### DIFF
--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -906,8 +906,15 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 		return event.id
 	}
 
-	// 3. Bids → winning bid.
-	const bids = await fetchAuctionBids(formData.auctionEventId, 1000, auctionCoordinate)
+	// 3. Bids + path releases — fetched concurrently (Fix 3, #1046). Both reads
+	// are keyed off the auction coordinate (resolved above) and neither depends
+	// on the other's result, so they have no data dependency. Running them in a
+	// single Promise.all removes a sequential relay round-trip — and, with a
+	// dead relay in the set, one stacked 8s timeout — from the settlement path.
+	const [bids, allReleases] = await Promise.all([
+		fetchAuctionBids(formData.auctionEventId, 1000, auctionCoordinate),
+		fetchAuctionPathReleases(formData.auctionEventId, 500, auctionCoordinate),
+	])
 	if (!bids.length) {
 		throw new Error('No bids on this auction — nothing to settle. Use reserve_not_met to close it.')
 	}
@@ -955,12 +962,11 @@ export const publishAuctionSettlement = async (formData: AuctionSettlementFormDa
 	}
 	if (chainBids.length === 0) throw new Error('Empty chain — should be impossible')
 
-	// 5. Path releases — collect a kind-1025 for every leg. The bidder
-	// publishes one per leg as part of `publishBidderPathRelease`.
-	// Refuse to settle if any leg is missing its release: a partial
-	// chain can't be redeemed and the seller would only end up with
-	// some of the bid value.
-	const allReleases = await fetchAuctionPathReleases(formData.auctionEventId, 500, auctionCoordinate)
+	// 5. Path releases — collect a kind-1025 for every leg. (Fetched
+	// concurrently with bids in step 3.) The bidder publishes one per leg as
+	// part of `publishBidderPathRelease`. Refuse to settle if any leg is
+	// missing its release: a partial chain can't be redeemed and the seller
+	// would only end up with some of the bid value.
 	const releasesByBidId = new Map<string, NDKEvent[]>()
 	for (const ev of allReleases) {
 		const e = getTag(ev, 'e') ?? ''

--- a/src/queries/__tests__/auctionDetails.test.ts
+++ b/src/queries/__tests__/auctionDetails.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
+
+let fetchedFilters: NDKFilter[] = []
+let relayEvents = new Set<NDKEvent>()
+
+// Deferred gate used to PROVE the per-auction reads run concurrently. While the
+// gate is closed no `fetchEventsWithTimeout` promise resolves. A sequential
+// `await` chain would issue exactly one filter before the gate opens; a
+// `Promise.all` batch issues every one of them up front.
+let openGate: () => void = () => {}
+let gate: Promise<void> = new Promise(() => {})
+
+if (!('localStorage' in globalThis)) {
+	const items = new Map<string, string>()
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: {
+			getItem: (key: string) => items.get(key) ?? null,
+			setItem: (key: string, value: string) => items.set(key, value),
+			removeItem: (key: string) => items.delete(key),
+			clear: () => items.clear(),
+		},
+		configurable: true,
+	})
+}
+
+mock.module('@/lib/stores/blacklist', () => ({
+	blacklistActions: {
+		isBlacklistLoaded: () => false,
+		isPubkeyBlacklisted: () => false,
+		isProductBlacklisted: () => false,
+		isCollectionBlacklisted: () => false,
+	},
+}))
+
+mock.module('@/lib/stores/ndk', () => ({
+	ndkActions: {
+		getNDK: () => ({}),
+		// Record the filter, then park on the gate. The composite's Promise.all
+		// therefore dispatches every call before any can resolve; a sequential
+		// chain would dispatch only the first.
+		fetchEventsWithTimeout: mock((filter: NDKFilter) => {
+			fetchedFilters.push(filter)
+			return gate.then(() => relayEvents)
+		}),
+	},
+}))
+
+const { fetchAuctionDetails } = await import('@/queries/auctions')
+
+const AUCTION_ROOT_EVENT_ID = '1'.repeat(64)
+const SELLER_PUBKEY = 'a'.repeat(64)
+const AUCTION_COORDINATE = `30408:${SELLER_PUBKEY}:auction-1`
+
+describe('fetchAuctionDetails — Fix 3 (#1046) parallel auction reads', () => {
+	beforeEach(() => {
+		fetchedFilters = []
+		relayEvents = new Set()
+		gate = new Promise<void>((resolve) => {
+			openGate = resolve
+		})
+	})
+
+	test('returns an empty structured result and skips the relay when given no root id', async () => {
+		const result = await fetchAuctionDetails('', { auctionCoordinates: AUCTION_COORDINATE })
+
+		expect(result).toEqual({
+			bids: [],
+			settlements: [],
+			pathReleases: [],
+			verdicts: [],
+			claimOrders: [],
+		})
+		expect(fetchedFilters).toHaveLength(0)
+	})
+
+	test('issues every per-auction read concurrently via Promise.all, not a sequential waterfall', async () => {
+		// Kick the composite off WITHOUT awaiting. While the gate is closed a
+		// sequential chain would be parked on the first fetch; a Promise.all
+		// batch dispatches all of them synchronously.
+		const pending = fetchAuctionDetails(AUCTION_ROOT_EVENT_ID, { auctionCoordinates: AUCTION_COORDINATE })
+
+		// Flush microtasks so fetchAuctionDetails's synchronous body (which
+		// constructs the Promise.all and thus invokes every fetcher) runs.
+		await Promise.resolve()
+		await Promise.resolve()
+
+		// bids / settlements / pathReleases / verdicts / claimOrders => 5 reads.
+		// If the reads were sequential this would be 1 (blocked on the gate).
+		expect(fetchedFilters).toHaveLength(5)
+
+		openGate()
+		const result = await pending
+
+		// Structured shape — every channel is an array.
+		expect(Object.keys(result).sort()).toEqual(['bids', 'claimOrders', 'pathReleases', 'settlements', 'verdicts'])
+		for (const value of Object.values(result)) {
+			expect(Array.isArray(value)).toBe(true)
+		}
+	})
+
+	test('omits the coordinate-only reads when no auction coordinate is supplied', async () => {
+		openGate()
+		const result = await fetchAuctionDetails(AUCTION_ROOT_EVENT_ID)
+
+		// Without a coordinate, the two reads that key off `#a` short-circuit:
+		// fetchAuctionClaimOrders (coordinate required) and
+		// fetchAuctionPathReleases (buildAuctionPathReleaseFilter returns null).
+		// The three root-id reads (bids, settlements, verdicts) still fire.
+		expect(fetchedFilters).toHaveLength(3)
+		expect(result.claimOrders).toEqual([])
+		expect(result.pathReleases).toEqual([])
+	})
+})

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -974,3 +974,66 @@ export const usePrivateAuctionClaimForOrder = (publicMarker: NDKEvent | null | u
 	useQuery({
 		...privateAuctionClaimQueryOptions(publicMarker, enabled),
 	})
+
+// ---------------------------------------------------------------------------
+// Composite parallel read — Fix 3, #1046
+//
+// The per-auction reads (bids, settlements, path releases, verdicts, claim
+// orders) are mutually independent: each is keyed off the auction root event
+// id and/or the auction coordinate, and none depends on another's result.
+// Fetching them as a sequential `await` chain stacks their latencies (and,
+// worse, stacks their dead-relay 8s timeouts). Wrapping them in a single
+// `Promise.all` collapses the waterfall into one concurrent batch —
+// ~max(latency) instead of sum(latencies).
+//
+// The React Query detail route already runs these as parallel `useQuery`
+// hooks; this composite is the non-React / server-side-prefetch / migration
+// entry point that codifies the same concurrency in one call.
+// ---------------------------------------------------------------------------
+
+export type AuctionDetails = {
+	bids: NDKEvent[]
+	settlements: NDKEvent[]
+	pathReleases: NDKEvent[]
+	verdicts: NDKEvent[]
+	claimOrders: NDKEvent[]
+}
+
+export type FetchAuctionDetailsOptions = {
+	auctionCoordinates?: string
+	bidsLimit?: number
+	settlementsLimit?: number
+	pathReleasesLimit?: number
+	verdictsLimit?: number
+}
+
+export const fetchAuctionDetails = async (
+	auctionRootEventId: string,
+	options: FetchAuctionDetailsOptions = {},
+): Promise<AuctionDetails> => {
+	if (!auctionRootEventId) {
+		return { bids: [], settlements: [], pathReleases: [], verdicts: [], claimOrders: [] }
+	}
+
+	const { auctionCoordinates, bidsLimit, settlementsLimit, pathReleasesLimit, verdictsLimit } = options
+
+	const [bids, settlements, pathReleases, verdicts, claimOrders] = await Promise.all([
+		fetchAuctionBids(auctionRootEventId, bidsLimit ?? 500, auctionCoordinates),
+		fetchAuctionSettlements(auctionRootEventId, settlementsLimit ?? 100, auctionCoordinates),
+		fetchAuctionPathReleases(auctionRootEventId, pathReleasesLimit ?? 200, auctionCoordinates),
+		fetchAuctionVerdicts(auctionRootEventId, verdictsLimit ?? 500, auctionCoordinates),
+		fetchAuctionClaimOrders(auctionCoordinates ?? ''),
+	])
+
+	return { bids, settlements, pathReleases, verdicts, claimOrders }
+}
+
+export const auctionDetailsQueryOptions = (
+	auctionRootEventId: string,
+	options: FetchAuctionDetailsOptions = {},
+) =>
+	queryOptions({
+		queryKey: [...auctionKeys.all, 'details', auctionRootEventId, options],
+		queryFn: () => fetchAuctionDetails(auctionRootEventId, options),
+		enabled: !!auctionRootEventId,
+	})


### PR DESCRIPTION
Implements **Fix 3 (parallelization of queries)** from #1046, per @Franchovy's decision. Other fixes (aggregator relay, circuit breaker, timeout tiers) are out of scope.

## Problem
`#1046` traced the slow auctions UI to (a) dead relays masked by 8s timeouts and (b) sequential query waterfalls — independent relay reads awaited one-after-another, stacking latencies (and stacking dead-relay 8s timeouts).

## Changes

**1. `src/queries/auctions.tsx` — `fetchAuctionDetails()` composite**
The per-auction reads (bids, settlements, path releases, verdicts, claim orders) are mutually independent — each is keyed off the auction root event id / coordinate, none depends on another's result. The new `fetchAuctionDetails()` runs all five in a single `Promise.all`, collapsing the waterfall into one concurrent batch: **~max(latency) instead of sum(latencies)**. Includes an `auctionDetailsQueryOptions` wrapper.
> The React Query detail route already parallelizes these via `useQuery` hooks; this composite is the non-React / server-prefetch / Applesauce-migration (#1028) entry point that codifies the same concurrency in one call.

**2. `src/publish/auctions.tsx` — concurrent bids + path releases in `publishAuctionSettlement`**
Both `fetchAuctionBids` and `fetchAuctionPathReleases` key off `auctionCoordinate` (known before either fetch) and neither depends on the other's result. Replaced the two sequential `await`s with one `Promise.all` — removes a sequential round-trip (and a potential stacked 8s timeout) from the settlement path.

## Deliberately left sequential (not parallelizable)
- `fetchAuction` — the version-events fetch needs the first fetch's `pubkey`/`dTag` (true data dependency).
- `fetchAuctionByATag` — the `naddr` fetch is a **fallback** gated on `versionEvents.length === 0`; parallelizing it would add a redundant round-trip in the common case.

## Tests
New `src/queries/__tests__/auctionDetails.test.ts`:
- **Concurrency proof**: a gated mock asserts all 5 reads are dispatched *before any resolves* (a sequential chain would dispatch only 1).
- Shape + coordinate-short-circuit behavior.

`bun test` — **20/20 pass** (3 new + 17 existing auction tests; no regressions).

```
src/queries/__tests__/auctionDetails.test.ts ...... 3 pass
src/queries/__tests__/auctionPathReleases.test.ts . 4 pass
src/queries/__tests__/auctionBidStream.test.ts .... 13 pass
```

Closes none yet (follow-up to #1046 discussion). cc @Franchovy @maximotodev