### PR TITLE
feat(aggregator): scraper daemon + dual-mode write-policy (rebased) (#1046)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@ NODE_ENV=development
 APP_RELAY_URL=wss://your-relay-url.com
 APP_PRIVATE_KEY=<your_private_key_in_hex>
 CVM_SERVER_KEY=<your_currency_server_private_key_in_hex>
+
+# Optional: market aggregation relay URL (for faster reads via cached relay).
+# When unset, reads fall back to main relay + public defaults.
+NEXT_PUBLIC_MARKET_AGG_RELAY=wss://your-agg-relay.example.com

--- a/deploy-simple/aggregator/Dockerfile
+++ b/deploy-simple/aggregator/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/hoytech/strfry:latest
+# python3 runs the write-policy plugin (strfry side) AND the scraper daemon.
+# py3-websocket-client is required by scraper.py (websocket-client on PyPI).
+RUN apk add --no-cache python3 py3-websocket-client

--- a/deploy-simple/aggregator/README.md
+++ b/deploy-simple/aggregator/README.md
@@ -12,7 +12,7 @@ The deployment runs in one of two modes. The _write-policy_ is identical in
 both — the difference is what the **scraper daemon** collects:
 
 ```
-                            PERSONAL MODE (vps2)               PLEBEIAN MODE (future)
+                            PERSONAL MODE (operator)            PLEBEIAN MODE (future)
   scraper collects          root npub's follow graph +         all market participants'
                             market activity + WoT network      market events
 ```
@@ -22,7 +22,7 @@ both — the difference is what the **scraper daemon** collects:
                                    | queries (ONE relay, ~ms local)
                                    v
                 +--------------------------------------------+
-                | market-agg.orangesync.tech : strfry :7777 |
+                | market-agg.example.com : strfry :7777 |
                 |   write-policy.py  <-  allowed.npubs (WoT) |
                 +--------------------------------------------+
                        ^ republish EVENTS          ^ state/allowed.npubs
@@ -82,9 +82,7 @@ This deployment is fully **self-contained**: `docker-compose.yml` defines its
 own bridge network (no external networks) and both services build from the
 local `Dockerfile`. It runs standalone on any host with Docker — no other
 project's networks or containers are required — so it can be deployed wherever
-you like. (The VPS2 `/opt/tollgate/strfry-market-agg/` path is a legacy
-location carried over from when this relay shared infra with the tollgate
-project; it is not a requirement.)
+you like.
 
 ```bash
 cd deploy-simple/aggregator
@@ -93,7 +91,7 @@ docker compose up -d --build
 ```
 
 - The relay container (`market-agg-relay`, compose service `strfry-market-agg`)
-  listens on `127.0.0.1:7780` (Caddy proxies `market-agg.orangesync.tech` ->
+  listens on `127.0.0.1:7780` (Caddy proxies `market-agg.example.com` ->
   `:7780`).
 - `scraper` starts after the relay, bootstraps the root npub's network, and
   begins scraping. Tail logs with `docker compose logs -f scraper`.
@@ -118,4 +116,4 @@ All knobs are environment variables (see `docker-compose.yml`):
 ## Market app wiring
 
 After deployment, `src/lib/stores/ndk.ts` uses
-`wss://market-agg.orangesync.tech` as a primary relay for production.
+`wss://market-agg.example.com` as a primary relay for production.

--- a/deploy-simple/aggregator/README.md
+++ b/deploy-simple/aggregator/README.md
@@ -1,0 +1,121 @@
+# Market Aggregator Relay
+
+A self-contained Nostr aggregation relay for Plebeian Market. It solves the
+dead-relay timeout problem from #1046 by scraping market-relevant events from
+upstream relays and serving them from a single fast local relay, so the market
+UI reads against one endpoint (~ms local) instead of fanning out to many
+unreliable relays.
+
+## Architecture (dual-mode)
+
+The deployment runs in one of two modes. The _write-policy_ is identical in
+both — the difference is what the **scraper daemon** collects:
+
+```
+                            PERSONAL MODE (vps2)               PLEBEIAN MODE (future)
+  scraper collects          root npub's follow graph +         all market participants'
+                            market activity + WoT network      market events
+```
+
+```
+                              [Market App]
+                                   | queries (ONE relay, ~ms local)
+                                   v
+                +--------------------------------------------+
+                | market-agg.orangesync.tech : strfry :7777 |
+                |   write-policy.py  <-  allowed.npubs (WoT) |
+                +--------------------------------------------+
+                       ^ republish EVENTS          ^ state/allowed.npubs
+                       |                           |
+            +-----------------------+        +-----------------------+
+            | scraper daemon        |        | scrapes upstream      |
+            |  publisher thread ----+        | relay.damus.io        |
+            |  relay workers (N)    |        | nos.lol               |
+            |  maintain timer       |        | relay.plebeian.market |
+            +-----------------------+        +-----------------------+
+```
+
+### Data flow
+
+1. **scraper** bootstraps from the seed relays: fetches the root npub's kind 3
+   (follows) and kind 10002 (relay list).
+2. For each followed pubkey it discovers _their_ relay lists (kind 10002),
+   building a `(pubkey, relay)` index.
+3. One worker thread per relay holds a persistent subscription for all tracked
+   pubkeys (chunked author filters) plus a `#p` filter for events mentioning
+   the root npub.
+4. Every received EVENT is re-published into **strfry** via a dedicated
+   publisher socket.
+5. Every 5 min the scraper refreshes the root npub's replaceable events;
+   every 30 min it expands the tracked set from newly-seen `p` tags (capped at
+   `MAX_PUBKEYS`); every hour it prunes pubkeys unseen for `PRUNE_AGE_DAYS`.
+6. The tracked set is written to `state/allowed.npubs`, which the
+   **write-policy** hot-reloads (on mtime change) to gate restricted kinds.
+
+### Write-policy (the gate)
+
+`write-policy.py` is the strfry writePolicy plugin. It is **kind-based**, not
+membership-based, so public market data is accepted broadly:
+
+| Kind class          | Examples                                                                                       | Accepted from                       |
+| ------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **PUBLIC market**   | 0, 1, 3, 7, 9735, 1985, 10000, 10002, 1023–1026, 30402, 30405/06/08, 30440–30442, 31555, 31990 | **anyone** (public data)            |
+| **RESTRICTED**      | 1059, 1060 (NIP-17 gift-wrap), 30078 (NIP-78 app data)                                         | **root npub or WoT allowlist only** |
+| **everything else** | —                                                                                              | **rejected**                        |
+
+The root npub's own events are always accepted, so the relay can bootstrap
+before the allowlist is populated.
+
+## Files
+
+| File                 | Purpose                                                             |
+| -------------------- | ------------------------------------------------------------------- |
+| `docker-compose.yml` | Two services: `strfry-market-agg` + `scraper`                       |
+| `strfry.conf`        | Relay config (DB size, limits, write-policy path)                   |
+| `write-policy.py`    | strfry plugin — market-kind gate + WoT-restricted kinds             |
+| `scraper.py`         | Scraping daemon (bootstrap → discover → scrape → expand → maintain) |
+| `Dockerfile`         | strfry + python3 + websocket-client (shared by both services)       |
+
+## Deploy
+
+This deployment is fully **self-contained**: `docker-compose.yml` defines its
+own bridge network (no external networks) and both services build from the
+local `Dockerfile`. It runs standalone on any host with Docker — no other
+project's networks or containers are required — so it can be deployed wherever
+you like. (The VPS2 `/opt/tollgate/strfry-market-agg/` path is a legacy
+location carried over from when this relay shared infra with the tollgate
+project; it is not a requirement.)
+
+```bash
+cd deploy-simple/aggregator
+mkdir -p db state
+docker compose up -d --build
+```
+
+- The relay container (`market-agg-relay`, compose service `strfry-market-agg`)
+  listens on `127.0.0.1:7780` (Caddy proxies `market-agg.orangesync.tech` ->
+  `:7780`).
+- `scraper` starts after the relay, bootstraps the root npub's network, and
+  begins scraping. Tail logs with `docker compose logs -f scraper`.
+
+## Scraper configuration
+
+All knobs are environment variables (see `docker-compose.yml`):
+
+| Variable                | Default                                                          | Meaning                                |
+| ----------------------- | ---------------------------------------------------------------- | -------------------------------------- |
+| `ROOT_HEX`              | _(required)_                                                     | root npub (hex) defining personal mode |
+| `STRFRY_URL`            | `ws://localhost:7777`                                            | strfry websocket to republish into     |
+| `SEED_RELAYS`           | `wss://relay.plebeian.market,wss://relay.damus.io,wss://nos.lol` | bootstrap + discovery relays           |
+| `MAX_PUBKEYS`           | `2000`                                                           | cap on tracked pubkeys (personal mode) |
+| `PRUNE_AGE_DAYS`        | `30`                                                             | prune pubkeys unseen this long         |
+| `MAX_RELAYS`            | `10`                                                             | cap on concurrently-scraped relays     |
+| `MAX_AUTH_PER_REQ`      | `200`                                                            | authors per REQ filter (relay ceiling) |
+| `ROOT_REFRESH_INTERVAL` | `300` (5 min)                                                    | root replaceable-event refresh         |
+| `EXPAND_INTERVAL`       | `1800` (30 min)                                                  | WoT expansion from new `p` tags        |
+| `PRUNE_INTERVAL`        | `3600` (1 hour)                                                  | stale-pubkey pruning                   |
+
+## Market app wiring
+
+After deployment, `src/lib/stores/ndk.ts` uses
+`wss://market-agg.orangesync.tech` as a primary relay for production.

--- a/deploy-simple/aggregator/docker-compose.yml
+++ b/deploy-simple/aggregator/docker-compose.yml
@@ -9,7 +9,7 @@
 #                        strfry. Also maintains the WoT allowlist the write-policy
 #                        gates on.
 #
-# Example deployment: vps2 (market-agg.orangesync.tech:7780 -> container :7777).
+# Example deployment: host (market-agg.example.com:7780 -> container :7777).
 # Replace with your own host/port — the URL surfaced to the app is configured
 # via NEXT_PUBLIC_MARKET_AGG_RELAY, not hardcoded here.
 # See: deploy-simple/aggregator/strfry.conf      for relay config

--- a/deploy-simple/aggregator/docker-compose.yml
+++ b/deploy-simple/aggregator/docker-compose.yml
@@ -1,0 +1,70 @@
+# Market Aggregator Relay (strfry) + Scraper daemon
+#
+# Two services, one image:
+#   strfry-market-agg  — strfry relay, WoT-gated by write-policy.py, serving
+#                        market-relevant events from a single fast endpoint.
+#   scraper            — long-lived daemon that scrapes upstream relays
+#                        (damus/nos.lol/plebeian + discovered relays) for the
+#                        root npub's market network and re-publishes events into
+#                        strfry. Also maintains the WoT allowlist the write-policy
+#                        gates on.
+#
+# Example deployment: vps2 (market-agg.orangesync.tech:7780 -> container :7777).
+# Replace with your own host/port — the URL surfaced to the app is configured
+# via NEXT_PUBLIC_MARKET_AGG_RELAY, not hardcoded here.
+# See: deploy-simple/aggregator/strfry.conf      for relay config
+# See: deploy-simple/aggregator/write-policy.py  for the WoT + market-kind gate
+# See: deploy-simple/aggregator/scraper.py       for the scraping daemon
+
+services:
+  strfry-market-agg:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: strfry-market-agg:local
+    container_name: market-agg-relay
+    restart: unless-stopped
+    ports:
+      - '127.0.0.1:7780:7777'
+    volumes:
+      - ./strfry.conf:/etc/strfry.conf:ro
+      - ./db:/strfry-db
+      - ./write-policy.py:/opt/strfry-agg/write-policy.py:ro
+      # state is read-only here: strfry only reads the allowlist the scraper writes.
+      - ./state:/opt/strfry-agg/state:ro
+    environment:
+      - STRFRY_AGG_ALLOWED=/opt/strfry-agg/state/allowed.npubs
+      # Root npub hex (c03rad0r) — bootstrap trust anchor
+      - STRFRY_AGG_ROOT_HEX=c3e23eb5e3d00f18b2f4f588d8cdbc548648be761bdd90812186df4603d7caa9
+    networks:
+      - default
+
+  scraper:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: strfry-market-agg:local
+    container_name: market-agg-scraper
+    command: python3 /opt/strfry-agg/scraper.py
+    depends_on:
+      - strfry-market-agg
+    restart: unless-stopped
+    volumes:
+      - ./scraper.py:/opt/strfry-agg/scraper.py:ro
+      - ./write-policy.py:/opt/strfry-agg/write-policy.py:ro
+      # state is read-WRITE here: the scraper writes allowed.npubs that strfry reads.
+      - ./state:/opt/strfry-agg/state
+    environment:
+      # Root npub hex (c03rad0r) whose follow graph defines personal mode.
+      - ROOT_HEX=c3e23eb5e3d00f18b2f4f588d8cdbc548648be761bdd90812186df4603d7caa9
+      # Reach strfry over the internal docker network by service name.
+      - STRFRY_URL=ws://strfry-market-agg:7777
+      - SEED_RELAYS=wss://relay.plebeian.market,wss://relay.damus.io,wss://nos.lol
+      - MAX_PUBKEYS=2000
+      - PRUNE_AGE_DAYS=30
+    networks:
+      - default
+
+networks:
+  default:
+    driver: bridge

--- a/deploy-simple/aggregator/pytest.ini
+++ b/deploy-simple/aggregator/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# The aggregator scripts (scraper.py, write-policy.py) are flat modules in this
+# directory. `pythonpath = .` adds it to sys.path so the tests can import them.
+# Note: write-policy.py has a hyphen and is therefore NOT importable by name;
+# test_write_policy.py loads it via importlib.util instead.
+pythonpath = .
+testpaths = tests

--- a/deploy-simple/aggregator/scraper.py
+++ b/deploy-simple/aggregator/scraper.py
@@ -3,7 +3,7 @@
 
 Why this exists
 ---------------
-PR #1066 deployed a strfry relay on vps2 (market-agg.orangesync.tech) gated by
+PR #1066 deployed a strfry relay on an operator host (market-agg.example.com) gated by
 a write-policy. But strfry only stores events that are *published to it*. This
 daemon actively scrapes market-relevant events from upstream Nostr relays and
 re-publishes them into the local strfry so the relay mirrors a complete view of

--- a/deploy-simple/aggregator/scraper.py
+++ b/deploy-simple/aggregator/scraper.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""strfry market aggregator scraper daemon (personal mode).
+
+Why this exists
+---------------
+PR #1066 deployed a strfry relay on vps2 (market-agg.orangesync.tech) gated by
+a write-policy. But strfry only stores events that are *published to it*. This
+daemon actively scrapes market-relevant events from upstream Nostr relays and
+re-publishes them into the local strfry so the relay mirrors a complete view of
+the root npub's market network. The write-policy on strfry still gets the final
+say on what is persisted.
+
+Phases
+------
+  1. BOOTSTRAP  — query the seed relays for the root npub's kind 3 (follows)
+                  and kind 10002 (relay list).
+  2. DISCOVER   — for each followed pubkey, fetch their kind 10002 to learn
+                  which relays they publish to. Builds a (pubkey, relay) index.
+  3. SCRAPE     — one worker thread per relay holds a persistent subscription
+                  (chunked author filters + a #p filter for the root npub) and
+                  re-publishes every received EVENT to the local strfry.
+  4. EXPAND     — every 30 min, harvest new pubkeys seen in 'p' tags and fetch
+                  their follows/relay lists (capped at MAX_PUBKEYS).
+  5. MAINTAIN   — every 5 min refresh the root npub's replaceable events;
+                  every 1 h prune pubkeys unseen for PRUNE_AGE_DAYS; rewrite
+                  state/allowed.npubs (the WoT set the write-policy gates on).
+
+Design notes
+------------
+  * Uses the ``websocket-client`` library (``import websocket``). It handles
+    permessage-deflate, ping/pong and framing for us — important because most
+    relays advertise compression.
+  * Thread-per-relay model: each relay worker owns one socket and multiplexes
+    many subscriptions over it (distinguished by subid). Simpler than asyncio
+    for a long-lived scraper and maps cleanly to "reconnect = close + reopen".
+  * A single publisher thread owns the strfry socket so republishing is
+    serialized and never interleaves partial frames.
+  * Pure stdlib for everything else (no nostr library needed).
+
+Config comes from environment variables (see docker-compose.yml).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import random
+import signal
+import ssl
+import sys
+import threading
+import time
+from collections import defaultdict
+
+try:
+    import websocket  # websocket-client
+except ImportError:  # pragma: no cover - surfaced at startup with a clear msg
+    websocket = None
+
+# --------------------------------------------------------------------------- #
+# Configuration
+# --------------------------------------------------------------------------- #
+ROOT_HEX = os.environ.get("ROOT_HEX", "").strip().lower()
+STRFRY_URL = os.environ.get("STRFRY_URL", "ws://localhost:7777")
+SEED_RELAYS = [r.strip() for r in os.environ.get(
+    "SEED_RELAYS", "wss://relay.plebeian.market,wss://relay.damus.io,wss://nos.lol"
+).split(",") if r.strip()]
+MAX_PUBKEYS = int(os.environ.get("MAX_PUBKEYS", "2000"))
+PRUNE_AGE_DAYS = int(os.environ.get("PRUNE_AGE_DAYS", "30"))
+STATE_DIR = os.environ.get("STATE_DIR", "/opt/strfry-agg/state")
+ALLOWED_PATH = os.environ.get("ALLOWED_PATH", os.path.join(STATE_DIR, "allowed.npubs"))
+
+# How many authors to pack into a single REQ filter. Upstream relays cap the
+# size of a filter; 200 is a safe ceiling that keeps the payload well under the
+# ~8 KB limit most relays enforce.
+MAX_AUTH_PER_REQ = int(os.environ.get("MAX_AUTH_PER_REQ", "200"))
+# Cap on relays we will actively scrape (seed relays + discovered relays).
+MAX_RELAYS = int(os.environ.get("MAX_RELAYS", "10"))
+
+# Refresh / maintenance intervals (seconds).
+ROOT_REFRESH_INTERVAL = int(os.environ.get("ROOT_REFRESH_INTERVAL", str(5 * 60)))   # 5 min
+EXPAND_INTERVAL = int(os.environ.get("EXPAND_INTERVAL", str(30 * 60)))               # 30 min
+PRUNE_INTERVAL = int(os.environ.get("PRUNE_INTERVAL", str(60 * 60)))                  # 1 hour
+RELAY_RECONNECT_BASE = float(os.environ.get("RELAY_RECONNECT_BASE", "5"))             # backoff base
+
+# Kinds we scrape for tracked pubkeys. (kind 0 metadata, 1 text, 3 follows,
+# 7 reaction, 9735 zap receipt, 1985 relay review, 10000 mute list, 10002
+# relay list, 1023-1026 plebeian market kinds, 30402 stall, 30405/06/08
+# product/auction, 30440-30442 ratings, 31555/31990 curated content, 30078
+# app data.) Matches the write-policy's PUBLIC + RESTRICTED market sets.
+SCRAPE_KINDS = [
+    0, 1, 3, 7, 9735, 1985, 10000, 10002,
+    1023, 1024, 1025, 1026,
+    13, 14, 16, 17, 17375,          # seals, order comms/status, payment receipt, NIP-60 wallet
+    30402, 30405, 30406, 30408,
+    30440, 30441, 30442,
+    31555, 31990, 30078,
+]
+# Kinds to subscribe to via the #p filter (events that *mention* the root npub).
+P_TAG_KINDS = [1, 3, 7, 9735, 30402, 30405, 30406, 30408, 30440, 30441, 30442, 14, 16, 17, 13]
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s [%(threadName)s] %(message)s",
+)
+log = logging.getLogger("scraper")
+
+# --------------------------------------------------------------------------- #
+# Shared state (guarded by STATE_LOCK)
+# --------------------------------------------------------------------------- #
+STATE_LOCK = threading.RLock()
+# pubkey (hex) -> last_seen timestamp. Every pubkey we track lives here.
+PUBKEYS: dict[str, float] = {}
+# relay_url -> set of pubkeys we expect to find there.
+RELAY_INDEX: dict[str, set[str]] = defaultdict(set)
+# pubkeys whose kind 3 / 10002 we still need to fetch.
+DISCOVERY_QUEUE: set[str] = set()
+# root npub's direct follows (the WoT core).
+ROOT_FOLLOWS: set[str] = set()
+
+# Republish queue: the publisher thread drains this and forwards to strfry.
+REPUBLISH_QUEUE: "queue.Queue[dict]" = queue.Queue(maxsize=50000)
+# Recently-republished event ids (capped dedup) so we don't spam strfry.
+_SEEN_IDS: dict[str, None] = {}
+_SEEN_IDS_LOCK = threading.Lock()
+_SEEN_IDS_MAX = 200000
+
+
+def _mark_seen(eid: str) -> bool:
+    """Return True if this id was newly added (i.e. NOT seen before)."""
+    with _SEEN_IDS_LOCK:
+        if eid in _SEEN_IDS:
+            return False
+        _SEEN_IDS[eid] = None
+        if len(_SEEN_IDS) > _SEEN_IDS_MAX:
+            # Drop the oldest 25% by re-creating the dict (approx LRU).
+            keep = list(_SEEN_IDS.keys())[len(_SEEN_IDS) // 4:]
+            _SEEN_IDS.clear()
+            _SEEN_IDS.update(dict.fromkeys(keep))
+        return True
+
+
+def track_pubkey(pk: str, when: float | None = None) -> bool:
+    """Add a pubkey (hex, lowercase) to the tracked set. Returns True if new."""
+    pk = pk.strip().lower()
+    if len(pk) != 64:
+        return False
+    with STATE_LOCK:
+        if pk in PUBKEYS:
+            PUBKEYS[pk] = when or time.time()
+            return False
+        if len(PUBKEYS) >= MAX_PUBKEYS:
+            return False
+        PUBKEYS[pk] = when or time.time()
+        DISCOVERY_QUEUE.add(pk)
+        return True
+
+
+def touch_pubkey(pk: str) -> None:
+    pk = pk.strip().lower()
+    with STATE_LOCK:
+        if pk in PUBKEYS:
+            PUBKEYS[pk] = time.time()
+
+
+def harvest_event(event: dict, source_relay: str) -> int:
+    """Extract the author + all 'p' tag pubkeys from an event. Returns count of
+    newly-tracked pubkeys."""
+    added = 0
+    author = str(event.get("pubkey", "")).lower()
+    if author:
+        if track_pubkey(author):
+            added += 1
+        else:
+            touch_pubkey(author)
+    for tag in event.get("tags", []) or []:
+        if len(tag) >= 2 and tag[0] == "p":
+            if track_pubkey(str(tag[1])):
+                added += 1
+    return added
+
+
+def snapshot_authors() -> list[str]:
+    with STATE_LOCK:
+        return list(PUBKEYS.keys())
+
+
+def write_allowed() -> int:
+    """Write the tracked (WoT) pubkey set to ALLOWED_PATH for the write-policy."""
+    os.makedirs(os.path.dirname(ALLOWED_PATH) or ".", exist_ok=True)
+    with STATE_LOCK:
+        pks = sorted(PUBKEYS.keys())
+    tmp = ALLOWED_PATH + ".tmp"
+    with open(tmp, "w") as f:
+        f.write("# one hex pubkey per line; managed by scraper.py\n")
+        for pk in pks:
+            f.write(pk + "\n")
+    os.replace(tmp, ALLOWED_PATH)
+    return len(pks)
+
+
+def prune() -> int:
+    cutoff = time.time() - PRUNE_AGE_DAYS * 86400
+    removed = 0
+    with STATE_LOCK:
+        for pk in [p for p, t in PUBKEYS.items() if t < cutoff]:
+            PUBKEYS.pop(pk, None)
+            removed += 1
+            ROOT_FOLLOWS.discard(pk)
+        for r in list(RELAY_INDEX.keys()):
+            RELAY_INDEX[r] = {p for p in RELAY_INDEX[r] if p in PUBKEYS}
+            if not RELAY_INDEX[r]:
+                del RELAY_INDEX[r]
+    return removed
+
+
+# --------------------------------------------------------------------------- #
+# WebSocket helpers
+# --------------------------------------------------------------------------- #
+def _ws_connect(url: str, timeout: int = 15):
+    """Open a websocket with sensible defaults and a short timeout."""
+    return websocket.create_connection(
+        url,
+        timeout=timeout,
+        enable_multithread=True,
+        ping_interval=30,
+        ping_timeout=10,
+        sslopt={"cert_reqs": ssl.CERT_NONE} if url.startswith("wss") else {},
+    )
+
+
+def send_req(ws, subid: str, filters: list[dict]) -> None:
+    ws.send(json.dumps(["REQ", subid, *filters]))
+
+
+def close_sub(ws, subid: str) -> None:
+    try:
+        ws.send(json.dumps(["CLOSE", subid]))
+    except Exception:
+        pass
+
+
+def chunked(seq: list, size: int):
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+
+# --------------------------------------------------------------------------- #
+# One-shot queries (bootstrap / discover / root refresh)
+# --------------------------------------------------------------------------- #
+def query_relays(relays: list[str], filters: list[dict], timeout: float = 8.0) -> list[dict]:
+    """Fan a REQ out to `relays`, collect EVENTs until EOSE/timeout, return all.
+    Best-effort: skips relays that fail."""
+    events: list[dict] = []
+    threads = []
+
+    def _pull(url: str):
+        subid = "q%d" % random.randint(0, 1 << 30)
+        try:
+            ws = _ws_connect(url, timeout=int(timeout) + 5)
+            ws.settimeout(timeout)
+            send_req(ws, subid, filters)
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                try:
+                    raw = ws.recv()
+                except Exception:
+                    break
+                if not raw:
+                    continue
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if msg and msg[0] == "EVENT" and len(msg) >= 3 and msg[1] == subid:
+                    events.append(msg[2])
+                elif msg and msg[0] == "EOSE" and len(msg) >= 2 and msg[1] == subid:
+                    break
+            close_sub(ws, subid)
+            ws.close()
+        except Exception as e:
+            log.debug("query_relays %s failed: %s", url, e)
+
+    for url in relays:
+        t = threading.Thread(target=_pull, args=(url,), name="q-%s" % url[:24], daemon=True)
+        t.start()
+        threads.append(t)
+    for t in threads:
+        t.join(timeout=timeout + 6)
+    return events
+
+
+def parse_follows(kind3_content: str) -> set[str]:
+    """Parse a kind-3 contact list content. Handles both the classic
+    [['pubkey', 'relay', 'petname'], ...] list and NIP-51 JSON shapes."""
+    out: set[str] = set()
+    if not kind3_content:
+        return out
+    try:
+        data = json.loads(kind3_content)
+    except json.JSONDecodeError:
+        return out
+    if isinstance(data, list):
+        for entry in data:
+            if isinstance(entry, list) and entry and isinstance(entry[0], str):
+                out.add(entry[0].strip().lower())
+            elif isinstance(entry, str):
+                out.add(entry.strip().lower())
+    elif isinstance(data, dict):
+        for v in (data.get("contacts"), data.get("pubkeys")):
+            if isinstance(v, list):
+                for pk in v:
+                    out.add(str(pk).strip().lower())
+    return {p for p in out if len(p) == 64}
+
+
+def parse_relay_list(events_10002: list[dict]) -> set[str]:
+    """From kind 10002 (NIP-65) events, return the set of 'r' tag relay URLs.
+    The root npub's relay list tells us where to look for its network."""
+    out: set[str] = set()
+    for ev in events_10002:
+        for tag in ev.get("tags", []) or []:
+            if len(tag) >= 2 and tag[0] == "r":
+                out.add(str(tag[1]).strip())
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Bootstrap / root refresh
+# --------------------------------------------------------------------------- #
+def bootstrap_root() -> None:
+    """Fetch the root npub's kind 3 + 10002 from the seed relays."""
+    if not ROOT_HEX:
+        log.error("ROOT_HEX not set; cannot bootstrap")
+        return
+    log.info("BOOTSTRAP: fetching root npub network from %d seed relays", len(SEED_RELAYS))
+    # kind 3 (follows) + kind 10002 (relay list) for the root npub.
+    k3 = query_relays(SEED_RELAYS, [{"authors": [ROOT_HEX], "kinds": [3], "limit": 1}])
+    k10k = query_relays(SEED_RELAYS, [{"authors": [ROOT_HEX], "kinds": [10002], "limit": 1}])
+
+    follows: set[str] = set()
+    for ev in k3:
+        if str(ev.get("pubkey", "")).lower() == ROOT_HEX:
+            follows |= parse_follows(ev.get("content", ""))
+    root_relays = parse_relay_list(k10k) or set()
+
+    track_pubkey(ROOT_HEX)
+    with STATE_LOCK:
+        ROOT_FOLLOWS.clear()
+        ROOT_FOLLOWS.update(follows)
+    for pk in follows:
+        track_pubkey(pk)
+
+    # Merge the root's own preferred relays into the discover pool.
+    for ev in k3 + k10k:
+        harvest_event(ev, "seed")
+
+    log.info("BOOTSTRAP: root follows=%d  root relays=%d  total tracked=%d",
+             len(follows), len(root_relays), len(snapshot_authors()))
+
+
+def discover_pubkeys(pubkeys: list[str], relays: list[str]) -> int:
+    """For the given pubkeys, fetch their kind 10002 to map pubkeys->relays."""
+    if not pubkeys or not relays:
+        return 0
+    found = 0
+    for chunk in chunked(pubkeys, MAX_AUTH_PER_REQ):
+        evs = query_relays(relays, [{"authors": chunk, "kinds": [10002]}])
+        for ev in evs:
+            author = str(ev.get("pubkey", "")).lower()
+            relays_for = parse_relay_list([ev])
+            if author and relays_for:
+                with STATE_LOCK:
+                    for r in relays_for:
+                        if len(RELAY_INDEX) >= MAX_RELAYS and r not in RELAY_INDEX:
+                            break
+                        RELAY_INDEX[r].add(author)
+                found += 1
+                track_pubkey(author)
+    return found
+
+
+# --------------------------------------------------------------------------- #
+# Relay scrape worker (long-lived subscription per relay)
+# --------------------------------------------------------------------------- #
+def relay_worker(relay_url: str, stop: threading.Event) -> None:
+    """Own one socket to `relay_url`, subscribe to all tracked authors (chunked)
+    + a #p filter for the root npub, and republish received events. Reconnects
+    with backoff on failure and re-issues subscriptions against the refreshed
+    tracked set each time."""
+    if websocket is None:
+        log.error("websocket-client not installed; relay_worker cannot run")
+        return
+    backoff = RELAY_RECONNECT_BASE
+    while not stop.is_set():
+        try:
+            ws = _ws_connect(relay_url)
+        except Exception as e:
+            log.warning("connect %s failed: %s (retry in %.0fs)", relay_url, e, backoff)
+            stop.wait(backoff)
+            backoff = min(backoff * 1.7, 120)
+            continue
+        backoff = RELAY_RECONNECT_BASE
+
+        subs: list[str] = []
+        try:
+            # (a) chunked author subscriptions for all tracked pubkeys.
+            authors = snapshot_authors()
+            for i, chunk in enumerate(chunked(authors, MAX_AUTH_PER_REQ)):
+                sid = "a%d" % i
+                send_req(ws, sid, [{"authors": chunk, "kinds": SCRAPE_KINDS}])
+                subs.append(sid)
+            # (b) #p filter: events mentioning the root npub on every relay.
+            if ROOT_HEX:
+                send_req(ws, "proot", [{"#p": [ROOT_HEX], "kinds": P_TAG_KINDS}])
+                subs.append("proot")
+            log.info("scraping %s  subs=%d  authors=%d", relay_url, len(subs), len(authors))
+
+            ws.settimeout(1.0)
+            while not stop.is_set():
+                try:
+                    raw = ws.recv()
+                except websocket.WebSocketTimeoutException:
+                    continue
+                except Exception as e:
+                    log.info("recv %s ended: %s", relay_url, e)
+                    break
+                if not raw:
+                    continue
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if not msg:
+                    continue
+                tag = msg[0]
+                if tag == "EVENT" and len(msg) >= 3:
+                    event = msg[2]
+                    eid = event.get("id")
+                    if eid and _mark_seen(eid):
+                        harvest_event(event, relay_url)
+                        try:
+                            REPUBLISH_QUEUE.put_nowait(event)
+                        except queue.Full:
+                            pass  # queue full; drop to avoid blocking scrape
+                elif tag == "EOSE":
+                    # Stored events drained — keep the sub open for live events.
+                    pass
+        except Exception as e:
+            log.warning("relay_worker %s error: %s", relay_url, e)
+        finally:
+            for sid in subs:
+                close_sub(ws, sid)
+            try:
+                ws.close()
+            except Exception:
+                pass
+        if not stop.is_set():
+            stop.wait(backoff)
+
+
+# --------------------------------------------------------------------------- #
+# Publisher thread (owns the strfry socket)
+# --------------------------------------------------------------------------- #
+def publisher_worker(stop: threading.Event) -> None:
+    """Drain REPUBLISH_QUEUE and forward each event to the local strfry relay."""
+    if websocket is None:
+        log.error("websocket-client not installed; publisher cannot run")
+        return
+    ws = None
+    backoff = RELAY_RECONNECT_BASE
+    while not stop.is_set():
+        if ws is None:
+            try:
+                ws = _ws_connect(STRFRY_URL, timeout=10)
+                ws.settimeout(1.0)
+                log.info("publisher connected to strfry %s", STRFRY_URL)
+            except Exception as e:
+                log.warning("publisher connect %s failed: %s (retry %.0fs)", STRFRY_URL, e, backoff)
+                stop.wait(backoff)
+                backoff = min(backoff * 1.7, 60)
+                continue
+            backoff = RELAY_RECONNECT_BASE
+        try:
+            event = REPUBLISH_QUEUE.get(timeout=1.0)
+        except queue.Empty:
+            continue
+        try:
+            ws.send(json.dumps(["EVENT", event]))
+        except Exception as e:
+            log.warning("publish failed (%s); re-queuing", e)
+            try:
+                REPUBLISH_QUEUE.put_nowait(event)
+            except queue.Full:
+                pass
+            try:
+                ws.close()
+            except Exception:
+                pass
+            ws = None
+
+
+# --------------------------------------------------------------------------- #
+# Maintenance timers
+# --------------------------------------------------------------------------- #
+def maintenance_loop(stop: threading.Event) -> None:
+    last_root = 0.0
+    last_expand = 0.0
+    last_prune = 0.0
+    last_allowed_write = 0.0
+    while not stop.is_set():
+        now = time.time()
+
+        if now - last_root >= ROOT_REFRESH_INTERVAL:
+            last_root = now
+            try:
+                # Re-fetch root's replaceable kind 3 / 10002 and refresh follows.
+                k3 = query_relays(SEED_RELAYS, [{"authors": [ROOT_HEX], "kinds": [3], "limit": 1}])
+                for ev in k3:
+                    if str(ev.get("pubkey", "")).lower() == ROOT_HEX:
+                        new_f = parse_follows(ev.get("content", ""))
+                        with STATE_LOCK:
+                            ROOT_FOLLOWS.clear()
+                            ROOT_FOLLOWS.update(new_f)
+                        for pk in new_f:
+                            track_pubkey(pk)
+                log.info("MAINTAIN: refreshed root follows=%d", len(ROOT_FOLLOWS))
+            except Exception as e:
+                log.warning("root refresh failed: %s", e)
+
+        if now - last_expand >= EXPAND_INTERVAL:
+            last_expand = now
+            try:
+                with STATE_LOCK:
+                    pending = list(DISCOVERY_QUEUE)
+                    DISCOVERY_QUEUE.clear()
+                relays = list(RELAY_INDEX.keys()) or SEED_RELAYS
+                found = discover_pubkeys(pending, relays[:MAX_RELAYS])
+                log.info("EXPAND: discovered relay lists for %d/%d pubkeys; relays=%d",
+                         found, len(pending), len(RELAY_INDEX))
+            except Exception as e:
+                log.warning("expand failed: %s", e)
+
+        if now - last_prune >= PRUNE_INTERVAL:
+            last_prune = now
+            try:
+                n = prune()
+                log.info("PRUNE: removed %d stale pubkeys (>%d days); tracked=%d",
+                         n, PRUNE_AGE_DAYS, len(snapshot_authors()))
+            except Exception as e:
+                log.warning("prune failed: %s", e)
+
+        if now - last_allowed_write >= 60:
+            last_allowed_write = now
+            try:
+                n = write_allowed()
+                log.debug("wrote allowed.npubs: %d pubkeys", n)
+            except Exception as e:
+                log.warning("write_allowed failed: %s", e)
+
+        stop.wait(15)
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    if websocket is None:
+        log.error("FATAL: 'websocket-client' library not installed. "
+                  "Install with: pip install websocket-client  "
+                  "(Alpine: apk add py3-websocket-client)")
+        return 2
+    if not ROOT_HEX:
+        log.error("FATAL: ROOT_HEX env var not set")
+        return 2
+
+    log.info("scraper starting: root=%s... seed_relays=%s max_pubkeys=%d strfry=%s",
+             ROOT_HEX[:12], SEED_RELAYS, MAX_PUBKEYS, STRFRY_URL)
+    os.makedirs(STATE_DIR, exist_ok=True)
+
+    # 1. Bootstrap from seed relays (blocking) so workers start with a real set.
+    bootstrap_root()
+
+    # 2. Discover relay lists for the initial follow set.
+    with STATE_LOCK:
+        initial = list(ROOT_FOLLOWS) if ROOT_FOLLOWS else snapshot_authors()
+    discover_pubkeys(initial, SEED_RELAYS)
+
+    # 3. Seed the allowed.npubs immediately.
+    write_allowed()
+
+    stop = threading.Event()
+    threads: list[threading.Thread] = []
+
+    # Publisher thread.
+    threads.append(threading.Thread(target=publisher_worker, args=(stop,),
+                                    name="publisher", daemon=True))
+
+    # One scrape worker per relay we know about (seed + discovered, capped).
+    with STATE_LOCK:
+        scrape_relays = list(dict.fromkeys(list(RELAY_INDEX.keys()) + SEED_RELAYS))[:MAX_RELAYS]
+    for url in scrape_relays:
+        safe = url.replace("wss://", "").replace("ws://", "")[:20]
+        threads.append(threading.Thread(target=relay_worker, args=(url, stop),
+                                        name="relay:%s" % safe, daemon=True))
+
+    # Maintenance thread.
+    threads.append(threading.Thread(target=maintenance_loop, args=(stop,),
+                                    name="maintain", daemon=True))
+
+    for t in threads:
+        t.start()
+    log.info("started %d threads (publisher + %d relay workers + maintain)",
+             len(threads), len(scrape_relays))
+
+    def _shutdown(signum, frame):
+        log.info("shutdown signal %d received", signum)
+        stop.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _shutdown)
+        except Exception:
+            pass
+
+    try:
+        while not stop.is_set():
+            stop.wait(5)
+    except KeyboardInterrupt:
+        stop.set()
+
+    log.info("scraper stopped")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy-simple/aggregator/strfry.conf
+++ b/deploy-simple/aggregator/strfry.conf
@@ -1,6 +1,6 @@
 # strfry config for market aggregator relay
 # WoT-gated relay mirroring market-relevant events from the root npub's
-# follow set. Served on market-agg.orangesync.tech via Caddy reverse proxy.
+# follow set. Served on market-agg.example.com via Caddy reverse proxy.
 
 db = "/strfry-db"
 

--- a/deploy-simple/aggregator/strfry.conf
+++ b/deploy-simple/aggregator/strfry.conf
@@ -1,0 +1,61 @@
+# strfry config for market aggregator relay
+# WoT-gated relay mirroring market-relevant events from the root npub's
+# follow set. Served on market-agg.orangesync.tech via Caddy reverse proxy.
+
+db = "/strfry-db"
+
+dbParams {
+    mapsize = 3221225472  # 3 GB
+}
+
+events {
+    maxEventSize = 65536
+    rejectEventsNewerThanSeconds = 900
+    rejectEventsOlderThanSeconds = 94608000
+    rejectEphemeralEventsOlderThanSeconds = 60
+    ephemeralEventsLifetimeSeconds = 300
+    maxNumTags = 2000
+    maxTagValSize = 1024
+}
+
+relay {
+    bind = "0.0.0.0"
+    port = 7777
+    nofiles = 0
+
+    info {
+        name = "Plebeian Market Aggregation Relay"
+        description = "WoT-gated aggregation relay mirroring market events from trusted npubs"
+        pubkey = "c3e23eb5e3d00f18b2f4f588d8cdbc548648be761bdd90812186df4603d7caa9"
+        contact = ""
+    }
+
+    maxWebsocketPayloadSize = 131072
+    maxReqFilterSize = 200
+    autoPingSeconds = 55
+    queryTimesliceBudgetMicroseconds = 10000
+    maxFilterLimit = 500
+    maxTagsPerFilter = 3
+    maxFilterLimitCount = 1000000
+    maxSubsPerConnection = 50
+    maxPendingOutboundBytes = 33554432
+
+    writePolicy {
+        plugin = "/opt/strfry-agg/write-policy.py"
+        timeoutSeconds = 10
+    }
+
+    compression {
+        enabled = true
+        slidingWindow = true
+    }
+
+    logging {
+        invalidEvents = true
+    }
+
+    negentropy {
+        enabled = true
+        maxSyncEvents = 1000000
+    }
+}

--- a/deploy-simple/aggregator/tests/conftest.py
+++ b/deploy-simple/aggregator/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Shared pytest config for the aggregator tests.
+
+``deploy-simple/aggregator/pytest.ini`` sets ``pythonpath = .`` so the flat
+modules here (``scraper``) are importable. ``write-policy.py`` is hyphenated and
+cannot be imported by name, so ``test_write_policy.py`` loads it via
+``importlib.util``.
+
+Run with::
+
+    pytest deploy-simple/aggregator/
+"""

--- a/deploy-simple/aggregator/tests/test_scraper.py
+++ b/deploy-simple/aggregator/tests/test_scraper.py
@@ -1,0 +1,396 @@
+"""Tests for the scraper daemon (scraper.py).
+
+The daemon's network plumbing (websocket I/O, relay connections) is I/O; this
+suite pins down the *logic* that decides what gets mirrored:
+
+  * ``track_pubkey`` / ``harvest_event`` — which pubkeys join the tracked WoT
+    set (and the 64-hex + MAX_PUBKEYS guards).
+  * ``_mark_seen`` — per-event dedup with bounded LRU eviction (so the same
+    event is never republished twice, and memory can't grow unbounded).
+  * ``parse_follows`` / ``parse_relay_list`` — bootstrap/discovery parsing.
+  * ``write_allowed`` — emitting the WoT set the write-policy gates on.
+  * ``prune`` — expiring stale pubkeys.
+  * ``discover_pubkeys`` — building the (pubkey -> relay) index.
+  * ``relay_worker`` — end-to-end mirror path: subscription REQ construction
+    (chunked authors + #p filter over SCRAPE_KINDS) and the receive -> dedup ->
+    harvest -> republish loop.
+"""
+import json
+import time
+import types
+
+import pytest
+
+import scraper
+
+PK1 = "1" * 64
+PK2 = "2" * 64
+PK3 = "3" * 64
+PK_BAD = "not-hex-!"     # invalid characters / wrong length
+PK_SHORT = "a" * 32      # wrong length
+
+
+# --------------------------------------------------------------------------- #
+# Shared state reset between every test (scraper uses module-level dicts).
+# --------------------------------------------------------------------------- #
+@pytest.fixture(autouse=True)
+def reset_state():
+    scraper.PUBKEYS.clear()
+    scraper.RELAY_INDEX.clear()
+    scraper.DISCOVERY_QUEUE.clear()
+    scraper.ROOT_FOLLOWS.clear()
+    with scraper._SEEN_IDS_LOCK:
+        scraper._SEEN_IDS.clear()
+    # drain republish queue
+    while True:
+        try:
+            scraper.REPUBLISH_QUEUE.get_nowait()
+        except scraper.queue.Empty:
+            break
+    yield
+
+
+# --------------------------------------------------------------------------- #
+# track_pubkey
+# --------------------------------------------------------------------------- #
+def test_track_pubkey_adds_new():
+    assert scraper.track_pubkey(PK1) is True
+    assert PK1 in scraper.PUBKEYS
+    assert PK1 in scraper.DISCOVERY_QUEUE
+
+
+def test_track_pubkey_rejects_invalid():
+    assert scraper.track_pubkey(PK_BAD) is False
+    assert scraper.track_pubkey(PK_SHORT) is False
+    assert scraper.track_pubkey("") is False
+    assert scraper.track_pubkey("   ") is False
+    assert scraper.PUBKEYS == {}
+
+
+def test_track_pubkey_normalises_case():
+    assert scraper.track_pubkey(PK1.upper()) is True
+    assert PK1 in scraper.PUBKEYS            # stored lowercase
+
+
+def test_track_pubkey_duplicate_returns_false_and_refreshes_ts():
+    scraper.track_pubkey(PK1, when=100.0)
+    assert scraper.PUBKEYS[PK1] == 100.0
+    assert scraper.track_pubkey(PK1, when=999.0) is False
+    assert scraper.PUBKEYS[PK1] == 999.0
+
+
+def test_track_pubkey_respects_max_cap(monkeypatch):
+    monkeypatch.setattr(scraper, "MAX_PUBKEYS", 2)
+    assert scraper.track_pubkey(PK1) is True
+    assert scraper.track_pubkey(PK2) is True
+    assert scraper.track_pubkey(PK3) is False        # capped
+    assert PK3 not in scraper.PUBKEYS
+
+
+# --------------------------------------------------------------------------- #
+# touch_pubkey
+# --------------------------------------------------------------------------- #
+def test_touch_pubkey_updates_known_timestamp():
+    scraper.track_pubkey(PK1, when=1.0)
+    scraper.touch_pubkey(PK1)
+    assert scraper.PUBKEYS[PK1] > 1.0
+
+
+def test_touch_pubkey_ignores_unknown():
+    scraper.touch_pubkey(PK2)
+    assert PK2 not in scraper.PUBKEYS
+
+
+# --------------------------------------------------------------------------- #
+# harvest_event
+# --------------------------------------------------------------------------- #
+def _ev(author, p_tags=(), kind=1, eid=None):
+    return {"id": eid or (author + "0"), "pubkey": author, "kind": kind,
+            "tags": [["p", p] for p in p_tags]}
+
+
+def test_harvest_tracks_author_and_ptags():
+    added = scraper.harvest_event(_ev(PK1, p_tags=[PK2, PK3]), "seed")
+    assert added == 3
+    assert {PK1, PK2, PK3} <= set(scraper.PUBKEYS)
+
+
+def test_harvest_dedups_already_tracked():
+    scraper.track_pubkey(PK1)
+    added = scraper.harvest_event(_ev(PK1, p_tags=[PK1]), "seed")
+    assert added == 0
+
+
+def test_harvest_ignores_invalid_ptags():
+    added = scraper.harvest_event(_ev(PK1, p_tags=[PK_BAD, "x"]), "seed")
+    assert added == 1            # only the author; bad p-tags dropped
+
+
+def test_harvest_handles_missing_tags():
+    assert scraper.harvest_event({"pubkey": PK1, "kind": 1, "tags": None}, "s") == 1
+    assert scraper.harvest_event({"pubkey": PK1, "kind": 1}, "s") == 0  # already tracked
+
+
+# --------------------------------------------------------------------------- #
+# parse_follows (kind-3 contact list)
+# --------------------------------------------------------------------------- #
+def test_parse_follows_classic_list():
+    content = json.dumps([[PK1, "wss://r", "alice"], [PK2, "wss://r2"]])
+    assert scraper.parse_follows(content) == {PK1, PK2}
+
+
+def test_parse_follows_nip51_dict():
+    content = json.dumps({"contacts": [PK1, PK2], "pubkeys": [PK3]})
+    assert scraper.parse_follows(content) == {PK1, PK2, PK3}
+
+
+def test_parse_follows_bare_string_list():
+    assert scraper.parse_follows(json.dumps([PK1, PK2])) == {PK1, PK2}
+
+
+def test_parse_follows_filters_non_64hex():
+    assert scraper.parse_follows(json.dumps([PK1, "short", "ZZZZ", PK2])) == {PK1, PK2}
+
+
+def test_parse_follows_empty_and_invalid():
+    assert scraper.parse_follows("") == set()
+    assert scraper.parse_follows("not json") == set()
+    assert scraper.parse_follows(None) == set()
+
+
+# --------------------------------------------------------------------------- #
+# parse_relay_list (kind-10002 r-tags)
+# --------------------------------------------------------------------------- #
+def test_parse_relay_list_extracts_r_tags():
+    evs = [{"tags": [["r", "wss://a"], ["r", "wss://b"], ["p", PK1]]}]
+    assert scraper.parse_relay_list(evs) == {"wss://a", "wss://b"}
+
+
+def test_parse_relay_list_empty_inputs():
+    assert scraper.parse_relay_list([]) == set()
+    assert scraper.parse_relay_list([{"tags": []}]) == set()
+    assert scraper.parse_relay_list([{}]) == set()
+
+
+# --------------------------------------------------------------------------- #
+# chunked
+# --------------------------------------------------------------------------- #
+def test_chunked_even():
+    assert list(scraper.chunked([1, 2, 3, 4], 2)) == [[1, 2], [3, 4]]
+
+
+def test_chunked_uneven_tail():
+    assert list(scraper.chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+
+def test_chunked_empty():
+    assert list(scraper.chunked([], 3)) == []
+
+
+# --------------------------------------------------------------------------- #
+# _mark_seen (dedup + bounded LRU eviction)
+# --------------------------------------------------------------------------- #
+def test_mark_seen_new_then_duplicate():
+    assert scraper._mark_seen("id1") is True
+    assert scraper._mark_seen("id1") is False
+    assert scraper._mark_seen("id2") is True
+
+
+def test_mark_seen_evicts_oldest_quarter_over_cap(monkeypatch):
+    monkeypatch.setattr(scraper, "_SEEN_IDS_MAX", 4)
+    with scraper._SEEN_IDS_LOCK:
+        scraper._SEEN_IDS.clear()
+    for i in range(5):                 # pushes len past cap (4)
+        scraper._mark_seen("id%d" % i)
+    with scraper._SEEN_IDS_LOCK:
+        assert "id0" not in scraper._SEEN_IDS     # oldest 25% evicted
+        assert "id4" in scraper._SEEN_IDS
+    # An evicted id is "new" again (no unbounded retention).
+    assert scraper._mark_seen("id0") is True
+
+
+# --------------------------------------------------------------------------- #
+# write_allowed (emits the WoT set the write-policy gates on)
+# --------------------------------------------------------------------------- #
+def test_write_allowed_writes_sorted_pubkeys(tmp_path, monkeypatch):
+    monkeypatch.setattr(scraper, "ALLOWED_PATH", str(tmp_path / "allowed.npubs"))
+    scraper.track_pubkey(PK2)
+    scraper.track_pubkey(PK1)
+    n = scraper.write_allowed()
+    assert n == 2
+    lines = (tmp_path / "allowed.npubs").read_text().splitlines()
+    assert lines[0].startswith("#")
+    assert [l for l in lines if not l.startswith("#")] == [PK1, PK2]   # sorted
+
+
+def test_write_allowed_leaves_no_tmp_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(scraper, "ALLOWED_PATH", str(tmp_path / "allowed.npubs"))
+    scraper.write_allowed()
+    assert (tmp_path / "allowed.npubs").exists()
+    assert not (tmp_path / "allowed.npubs.tmp").exists()
+
+
+def test_write_allowed_creates_missing_dirs(tmp_path, monkeypatch):
+    nested = tmp_path / "state" / "deep" / "allowed.npubs"
+    monkeypatch.setattr(scraper, "ALLOWED_PATH", str(nested))
+    scraper.write_allowed()
+    assert nested.exists()
+
+
+# --------------------------------------------------------------------------- #
+# prune (expire stale pubkeys)
+# --------------------------------------------------------------------------- #
+def test_prune_removes_stale_only(monkeypatch):
+    monkeypatch.setattr(scraper, "PRUNE_AGE_DAYS", 1)
+    scraper.PUBKEYS[PK1] = time.time() - 2 * 86400     # 2 days old -> gone
+    scraper.PUBKEYS[PK2] = time.time()                 # fresh -> kept
+    removed = scraper.prune()
+    assert removed == 1
+    assert PK1 not in scraper.PUBKEYS and PK2 in scraper.PUBKEYS
+
+
+def test_prune_cleans_relay_index(monkeypatch):
+    monkeypatch.setattr(scraper, "PRUNE_AGE_DAYS", 1)
+    scraper.PUBKEYS[PK1] = time.time() - 2 * 86400
+    scraper.RELAY_INDEX["wss://r"].add(PK1)
+    scraper.prune()
+    assert "wss://r" not in scraper.RELAY_INDEX         # emptied -> deleted
+
+
+# --------------------------------------------------------------------------- #
+# discover_pubkeys (build pubkey->relay index; query_relays mocked = no network)
+# --------------------------------------------------------------------------- #
+def test_discover_pubkeys_builds_relay_index(monkeypatch):
+    canned = [
+        {"pubkey": PK1, "tags": [["r", "wss://one"]]},
+        {"pubkey": PK2, "tags": [["r", "wss://two"]]},
+    ]
+    monkeypatch.setattr(scraper, "query_relays",
+                        lambda relays, filters, timeout=8.0: canned)
+    found = scraper.discover_pubkeys([PK1, PK2], ["wss://seed"])
+    assert found == 2
+    assert scraper.RELAY_INDEX["wss://one"] == {PK1}
+    assert scraper.RELAY_INDEX["wss://two"] == {PK2}
+
+
+def test_discover_pubkeys_chunks_authors(monkeypatch):
+    calls = []
+
+    def fake_query(relays, filters, timeout=8.0):
+        calls.append(filters)
+        return []
+
+    monkeypatch.setattr(scraper, "query_relays", fake_query)
+    monkeypatch.setattr(scraper, "MAX_AUTH_PER_REQ", 1)
+    scraper.discover_pubkeys([PK1, PK2, PK3], ["wss://seed"])
+    assert len(calls) == 3                              # one REQ per author
+
+
+def test_discover_pubkeys_empty_inputs():
+    assert scraper.discover_pubkeys([], ["wss://seed"]) == 0
+    assert scraper.discover_pubkeys([PK1], []) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Mirror pipeline: the receive -> dedup -> harvest -> republish path that
+# relay_worker runs for every EVENT. Tested directly (deterministic) and then
+# end-to-end through relay_worker itself.
+# --------------------------------------------------------------------------- #
+def test_mirror_pipeline_dedups_and_harvests():
+    ev = _ev(PK1, p_tags=[PK2], kind=30402, eid="evt-123")
+    # first sighting: new -> harvest (tracks PK2) -> enqueue
+    assert scraper._mark_seen(ev["id"]) is True
+    scraper.harvest_event(ev, "wss://r")
+    scraper.REPUBLISH_QUEUE.put_nowait(ev)
+    # duplicate sighting: dedup blocks the second enqueue
+    assert scraper._mark_seen(ev["id"]) is False
+    assert scraper.REPUBLISH_QUEUE.qsize() == 1
+    out = scraper.REPUBLISH_QUEUE.get_nowait()
+    assert out["id"] == "evt-123"
+    assert PK2 in scraper.PUBKEYS                        # harvested p-tag
+
+
+# A fake websocket + fake `websocket` module so relay_worker runs without the
+# real websocket-client dependency installed.
+class _FakeWS:
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent = []
+
+    def send(self, data):
+        self.sent.append(data)
+
+    def settimeout(self, _t):
+        pass
+
+    def recv(self):
+        if self._frames:
+            return self._frames.pop(0)
+        raise ConnectionError("simulated disconnect")   # breaks the recv loop
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_ws_module(monkeypatch):
+    """Stand in for the optional `websocket` import so relay_worker proceeds."""
+    mod = types.SimpleNamespace()
+
+    class WebSocketTimeoutException(Exception):
+        pass
+
+    mod.WebSocketTimeoutException = WebSocketTimeoutException
+    monkeypatch.setattr(scraper, "websocket", mod)
+    return mod
+
+
+def test_relay_worker_subscribes_and_mirrors(monkeypatch, fake_ws_module):
+    """relay_worker issues chunked-author + #p subscriptions over SCRAPE_KINDS,
+    then mirrors received events (deduped) into the republish queue and harvests
+    their p-tags into the tracked set."""
+    monkeypatch.setattr(scraper, "ROOT_HEX", PK3)
+    monkeypatch.setattr(scraper, "RELAY_RECONNECT_BASE", 0.01)
+    scraper.track_pubkey(PK1)
+
+    ev_a = {"id": "a" * 64, "pubkey": PK1, "kind": 30402, "tags": [["p", PK2]]}
+    ev_b = {"id": "b" * 64, "pubkey": PK2, "kind": 30405, "tags": []}
+    frames = [
+        json.dumps(["EVENT", "s", ev_a]),
+        json.dumps(["EVENT", "s", ev_a]),   # duplicate -> must not re-mirror
+        json.dumps(["EOSE", "s"]),
+        json.dumps(["EVENT", "s", ev_b]),
+    ]
+    fake = _FakeWS(frames)
+    monkeypatch.setattr(scraper, "_ws_connect", lambda url, timeout=15: fake)
+
+    stop = scraper.threading.Event()
+    t = scraper.threading.Thread(target=scraper.relay_worker,
+                                 args=("wss://x", stop), daemon=True)
+    t.start()
+
+    # wait for the worker to mirror the two unique events
+    deadline = time.time() + 5
+    while time.time() < deadline and scraper.REPUBLISH_QUEUE.qsize() < 2:
+        time.sleep(0.02)
+    stop.set()
+    t.join(timeout=2)
+    assert not t.is_alive(), "relay_worker did not shut down"
+
+    mirrored = []
+    while not scraper.REPUBLISH_QUEUE.empty():
+        mirrored.append(scraper.REPUBLISH_QUEUE.get_nowait()["id"])
+    assert mirrored.count("a" * 64) == 1     # deduped
+    assert "b" * 64 in mirrored
+    assert PK2 in scraper.PUBKEYS            # p-tag harvested
+
+    # filtering: at least one REQ carried an authors filter over SCRAPE_KINDS
+    reqs = [json.loads(s) for s in fake.sent if s]
+    subs = [r for r in reqs if r and r[0] == "REQ"]
+    assert subs, "relay_worker never issued a subscription"
+    author_subs = [r for r in subs if any("authors" in f for f in r[2:])]
+    assert author_subs, "no chunked-author subscription was sent"
+    kinds = author_subs[0][2]["kinds"]
+    assert set(scraper.SCRAPE_KINDS) <= set(kinds)
+    # and a #p filter for the root npub was issued
+    assert any(any("#p" in f for f in r[2:]) for r in subs)

--- a/deploy-simple/aggregator/tests/test_write_policy.py
+++ b/deploy-simple/aggregator/tests/test_write_policy.py
@@ -1,0 +1,263 @@
+"""Tests for the dual-mode write-policy plugin (write-policy.py).
+
+Covers the core contract the PR introduces:
+
+  * PUBLIC market kinds are accepted from ANY pubkey (stranger included).
+  * RESTRICTED kinds (gift-wrap 1059/1060, NIP-78 30078, seals/order-comms/
+    payment 13/14/16/17, NIP-60 17375) are accepted ONLY from the root npub or
+    the WoT allowlist, rejected from anyone else.
+  * Every other kind is rejected.
+  * The allowlist file hot-reloads on mtime change (no restart needed).
+  * The real ``main()`` entrypoint honours all of the above over stdin/stdout,
+    matching strfry's plugin protocol.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# write-policy.py is hyphenated and therefore not importable by name; load it
+# explicitly from its file path under the name "write_policy".
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "write-policy.py"
+import importlib.util as _ilu
+
+_spec = _ilu.spec_from_file_location("write_policy", SCRIPT)
+write_policy = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(write_policy)
+
+ROOT_HEX = "a" * 64        # the configured root npub (lowercase hex)
+STRANGER = "b" * 64        # an arbitrary, untrusted pubkey
+WOT_MEMBER = "c" * 64      # a pubkey listed in allowed.npubs
+
+
+# --------------------------------------------------------------------------- #
+# _decide(): the pure kind gate
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def wp(monkeypatch):
+    """write_policy module pinned to a known ROOT_HEX."""
+    monkeypatch.setattr(write_policy, "ROOT_HEX", ROOT_HEX)
+    return write_policy
+
+
+# PUBLIC market kinds MUST be accepted from anyone (the whole point of the
+# relay: mirror public market data broadly).
+PUBLIC_SAMPLES = [
+    0, 1, 3, 5, 7, 4, 1111,                  # identity / social
+    30018, 30402, 30405, 30406, 30408,       # marketplace listings
+    30440, 30441, 30442, 31555,              # auction / curated
+    31989, 31990,                            # app handlers
+    9735, 1985,                              # payments & trust
+    10000, 10002, 30000,                     # lists & settings
+    1023, 1024, 1025, 1026,                  # NWC endpoints
+    25910,                                   # misc app
+]
+
+
+@pytest.mark.parametrize("kind", PUBLIC_SAMPLES)
+def test_public_kinds_accepted_from_stranger(wp, kind):
+    action, msg = wp._decide(STRANGER, kind, allowed=set())
+    assert action == "accept"
+    assert msg == ""
+
+
+# RESTRICTED kinds: gated to root + WoT allowlist.
+RESTRICTED_SAMPLES = [1059, 1060, 30078, 13, 14, 16, 17, 17375]
+
+
+@pytest.mark.parametrize("kind", RESTRICTED_SAMPLES)
+def test_restricted_rejected_from_stranger(wp, kind):
+    action, msg = wp._decide(STRANGER, kind, allowed=set())
+    assert action == "reject"
+    assert "restricted" in msg.lower()
+
+
+@pytest.mark.parametrize("kind", RESTRICTED_SAMPLES)
+def test_restricted_accepted_from_root(wp, kind):
+    assert wp._decide(ROOT_HEX, kind, allowed=set()) == ("accept", "")
+
+
+@pytest.mark.parametrize("kind", RESTRICTED_SAMPLES)
+def test_restricted_accepted_from_wot_member(wp, kind):
+    assert wp._decide(WOT_MEMBER, kind, allowed={WOT_MEMBER}) == ("accept", "")
+
+
+# Unknown kinds are rejected even from root (root is not a free pass for junk).
+UNKNOWN_SAMPLES = [2, 6, 8, 40, 1000, 9999, 30019, 40000, -1]
+
+
+@pytest.mark.parametrize("kind", UNKNOWN_SAMPLES)
+def test_unknown_kinds_rejected_even_from_root(wp, kind):
+    action, msg = wp._decide(ROOT_HEX, kind, allowed={ROOT_HEX})
+    assert action == "reject"
+    assert "not in market set" in msg.lower()
+
+
+def test_public_and_restricted_sets_are_disjoint(wp):
+    """A kind can never be both public (anyone) and restricted (gated)."""
+    assert write_policy.PUBLIC_MARKET_KINDS.isdisjoint(write_policy.RESTRICTED_KINDS)
+
+
+# --------------------------------------------------------------------------- #
+# _load_allowlist()
+# --------------------------------------------------------------------------- #
+def test_load_allowlist_reads_hex_pubkeys(wp, tmp_path):
+    f = tmp_path / "allowed.npubs"
+    f.write_text("# comment line\n\n" + WOT_MEMBER + "\n" + ROOT_HEX + "\n")
+    write_policy.ALLOWED_PATH = f  # read at call time
+    allowed, mtime = wp._load_allowlist()
+    assert allowed == {WOT_MEMBER, ROOT_HEX}
+    assert mtime > 0
+
+
+def test_load_allowlist_missing_file_returns_empty(wp, tmp_path):
+    write_policy.ALLOWED_PATH = tmp_path / "does-not-exist"
+    allowed, mtime = wp._load_allowlist()
+    assert allowed == set()
+    assert mtime == 0.0
+
+
+def test_load_allowlist_ignores_comments_and_blanks(wp, tmp_path):
+    f = tmp_path / "allowed.npubs"
+    f.write_text("# header\n   \n" + ROOT_HEX + "\n#not a pubkey\n")
+    write_policy.ALLOWED_PATH = f
+    allowed, _ = wp._load_allowlist()
+    assert allowed == {ROOT_HEX}
+
+
+# --------------------------------------------------------------------------- #
+# main(): the real strfry plugin protocol over stdin/stdout
+# --------------------------------------------------------------------------- #
+def _event(eid, pubkey, kind):
+    return {"id": eid, "pubkey": pubkey, "kind": kind,
+            "content": "", "tags": [], "sig": ""}
+
+
+def _line(ev):
+    return json.dumps({"type": "new", "event": ev,
+                       "receivedAt": int(time.time()),
+                       "sourceType": "IP4", "sourceInfo": "1.2.3.4"})
+
+
+def _env(tmp_path, allowed_content=""):
+    allowed = tmp_path / "allowed.npubs"
+    allowed.write_text(allowed_content)
+    env = dict(os.environ)
+    env["STRFRY_AGG_ROOT_HEX"] = ROOT_HEX
+    env["STRFRY_AGG_ALLOWED"] = str(allowed)
+    return env
+
+
+def _run_policy(env, lines):
+    """Feed JSON lines to write-policy.py, return parsed stdout responses."""
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        input="\n".join(lines) + "\n",
+        capture_output=True, text=True, env=env, timeout=30,
+    )
+    assert proc.returncode == 0, f"stderr: {proc.stderr!r}"
+    return [json.loads(l) for l in proc.stdout.splitlines() if l.strip()]
+
+
+def test_main_accepts_public_kind_from_stranger(tmp_path):
+    resps = _run_policy(_env(tmp_path), [_line(_event("e1", STRANGER, 30402))])
+    assert resps == [{"id": "e1", "action": "accept"}]
+
+
+def test_main_rejects_restricted_kind_from_stranger(tmp_path):
+    resps = _run_policy(_env(tmp_path), [_line(_event("e2", STRANGER, 1060))])
+    assert resps[0]["id"] == "e2"
+    assert resps[0]["action"] == "reject"
+    assert "msg" in resps[0]
+
+
+def test_main_accepts_restricted_kind_from_root(tmp_path):
+    resps = _run_policy(_env(tmp_path), [_line(_event("e3", ROOT_HEX, 1060))])
+    assert resps == [{"id": "e3", "action": "accept"}]
+
+
+def test_main_lowercases_pubkey_so_uppercase_root_is_accepted(tmp_path):
+    # main() lowercases the incoming pubkey before _decide; ROOT_HEX is stored
+    # lowercased, so an all-caps root pubkey must still match.
+    resps = _run_policy(_env(tmp_path), [_line(_event("e4", ROOT_HEX.upper(), 30078))])
+    assert resps == [{"id": "e4", "action": "accept"}]
+
+
+def test_main_accepts_restricted_kind_from_wot_member(tmp_path):
+    env = _env(tmp_path, allowed_content=WOT_MEMBER + "\n")
+    resps = _run_policy(env, [_line(_event("e5", WOT_MEMBER, 1059))])
+    assert resps == [{"id": "e5", "action": "accept"}]
+
+
+def test_main_rejects_restricted_kind_after_wot_member_removed(tmp_path):
+    env = _env(tmp_path, allowed_content="")  # allowlist empty
+    resps = _run_policy(env, [_line(_event("e5b", WOT_MEMBER, 1059))])
+    assert resps[0]["action"] == "reject"
+
+
+def test_main_ignores_non_new_messages_and_garbage(tmp_path):
+    lines = [
+        json.dumps({"type": "old", "event": _event("x", STRANGER, 1)}),  # wrong type
+        "this is not json {",                                              # garbage
+        "",                                                                # blank
+        _line(_event("e6", STRANGER, 30405)),                             # valid
+    ]
+    resps = _run_policy(_env(tmp_path), lines)
+    assert [r["id"] for r in resps] == ["e6"]
+
+
+def test_main_skips_events_without_id_or_pubkey(tmp_path):
+    lines = [
+        _line({"id": "", "pubkey": STRANGER, "kind": 1}),   # missing id
+        _line({"id": "e7", "pubkey": "", "kind": 1}),        # missing pubkey
+        _line(_event("e8", STRANGER, 1)),                    # valid
+    ]
+    resps = _run_policy(_env(tmp_path), lines)
+    assert [r["id"] for r in resps] == ["e8"]
+
+
+def test_main_response_is_minified_json(tmp_path):
+    resps = _run_policy(_env(tmp_path), [_line(_event("e9", STRANGER, 0))])
+    # re-serialise minified and compare: confirms no pretty-print whitespace.
+    assert json.dumps(resps[0], separators=(",", ":")) == '{"id":"e9","action":"accept"}'
+
+
+def test_main_hot_reloads_allowlist_on_mtime_change(tmp_path):
+    """A mid-stream change to allowed.npubs is picked up without restart.
+
+    This is the contract the scraper's maintain timer relies on: it rewrites
+    allowed.npubs in place and the running plugin must serve the new set.
+    """
+    allowed = tmp_path / "allowed.npubs"
+    allowed.write_text("# empty allowlist\n")
+    env = dict(os.environ)
+    env["STRFRY_AGG_ROOT_HEX"] = ROOT_HEX
+    env["STRFRY_AGG_ALLOWED"] = str(allowed)
+
+    proc = subprocess.Popen(
+        [sys.executable, str(SCRIPT)],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, env=env,
+    )
+    try:
+        # Stranger's gift-wrap is rejected while the allowlist is empty.
+        proc.stdin.write(_line(_event("h1", STRANGER, 1060)) + "\n")
+        proc.stdin.flush()
+        r1 = json.loads(proc.stdout.readline())
+        assert r1["id"] == "h1" and r1["action"] == "reject"
+
+        # Scraper rewrites the allowlist to include the stranger.
+        time.sleep(0.3)  # ensure mtime differs on coarse-grained filesystems
+        allowed.write_text(STRANGER + "\n")
+
+        # Same event kind is now accepted — no restart happened.
+        proc.stdin.write(_line(_event("h2", STRANGER, 1060)) + "\n")
+        proc.stdin.flush()
+        assert json.loads(proc.stdout.readline()) == {"id": "h2", "action": "accept"}
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10)

--- a/deploy-simple/aggregator/write-policy.py
+++ b/deploy-simple/aggregator/write-policy.py
@@ -16,7 +16,7 @@ DUAL-MODE POLICY
 ----------------
 The aggregator relay runs in one of two modes (``$STRFRY_AGG_MODE``):
 
-  * ``personal`` (default, vps2) — mirrors events relevant to the root npub.
+  * ``personal`` (default) — mirrors events relevant to the root npub.
   * ``plebeian``  (future)        — mirrors all market-relevant events from
                                     every participant.
 

--- a/deploy-simple/aggregator/write-policy.py
+++ b/deploy-simple/aggregator/write-policy.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""strfry writePolicy plugin: dual-mode accept policy for the aggregator relay.
+
+strfry invokes this plugin as a long-lived process and feeds it one JSON
+object per line on stdin (see strfry docs/plugins.md). Each input line has the
+shape::
+
+    {"type":"new","event":{"id":...,"pubkey":...,"kind":...,"tags":...,
+                            "content":...,"sig":...},
+     "receivedAt":...,"sourceType":"...","sourceInfo":"..."}
+
+For every line we print a single minified JSON object with ``id`` (echoed),
+``action`` ("accept"|"reject") and an optional ``msg``.
+
+DUAL-MODE POLICY
+----------------
+The aggregator relay runs in one of two modes (``$STRFRY_AGG_MODE``):
+
+  * ``personal`` (default, vps2) — mirrors events relevant to the root npub.
+  * ``plebeian``  (future)        — mirrors all market-relevant events from
+                                    every participant.
+
+Both modes share the same kind-based gate, which is what makes the relay a
+useful aggregation point for *public* market data while still keeping
+restricted kinds (gift-wraps, app-specific payloads) behind a WoT check:
+
+  * PUBLIC market kinds (profiles, follows, relay lists, stall/product/
+    auction events, badges, zap receipts, ratings...) are accepted from
+    ANYONE. These are public by design — accepting them broadly is what lets
+    the scraper mirror a complete market view.
+  * RESTRICTED kinds (NIP-17 gift-wrap 1059/1060 and NIP-78 app-specific
+    30078) are accepted ONLY from the root npub or the WoT allowlist,
+    because they may carry private/payload data.
+  * Everything else is rejected.
+
+The allowlist (one hex pubkey per line) is read from
+``$STRFRY_AGG_ALLOWED`` (default /opt/strfry-agg/state/allowed.npubs)
+and reloaded automatically when its mtime changes, so the scraper's maintain
+timer can update the served set without restarting the plugin or strfry.
+
+The root npub's own events are always accepted (even before the first
+reconcile populates the allowlist) so the relay can bootstrap. The root npub
+hex is read from ``$STRFRY_AGG_ROOT_HEX``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ALLOWED_PATH = Path(os.environ.get("STRFRY_AGG_ALLOWED", "/opt/strfry-agg/state/allowed.npubs"))
+ROOT_HEX = os.environ.get("STRFRY_AGG_ROOT_HEX", "").strip().lower()
+
+# --- market-relevant kinds (from the #1046 audit) -------------------------
+# CRITICAL: 0, 3, 10002, 30402, 30405, 30406, 30408
+# HIGH:     1023, 1024, 1025, 1026, 30440, 30441, 30442
+# MEDIUM:   7, 9735, 1985, 31555, 31990, 10000
+# LOW:      1
+#
+# PUBLIC_MARKET_KINDS: accepted from ANYONE (public data). NOTE that kind
+# 30078 (NIP-78 application-specific data) is intentionally EXCLUDED here —
+# it is treated as restricted below because it can carry private payloads.
+PUBLIC_MARKET_KINDS = frozenset({
+    # --- Identity & social (public) ---
+    0,       # Metadata (user profiles)
+    3,       # Contacts / follow lists (relay discovery)
+    5,       # Deletions
+    1,       # Text notes (bug reports, public posts)
+    4,       # DMs — NIP-04 (encryption protects content)
+    7,       # Reactions
+    1111,    # Comments (product reviews, discussion)
+
+    # --- Marketplace (public) ---
+    30018,   # NIP-15 products (legacy format)
+    30402,   # NIP-99 classified listings (products)
+    30405,   # Collections
+    30406,   # Shipping options
+    30408,   # Auctions
+    30440, 30441, 30442,  # Auction bid kinds (from #1069 scraper)
+    31555,   # (from #1069 scraper)
+
+    # --- App handlers (public) ---
+    31989,   # NIP-89 handler recommendation
+    31990,   # NIP-89 app handler info
+
+    # --- Payments & trust (public) ---
+    9735,    # Zap receipts (NIP-57)
+    1985,    # Reports (NIP-56)
+
+    # --- Lists & settings (public) ---
+    10000,   # Mute lists (NIP-51)
+    10002,   # Relay lists (NIP-65)
+    30000,   # App settings, vanity URLs, NIP-05 names
+
+    # --- NWC / NIP-47 config endpoints (public) ---
+    1023, 1024, 1025, 1026,
+
+    # --- Misc app kinds (public) ---
+    25910,   # ctxvm client messages
+})
+
+# RESTRICTED_KINDS: accepted only from root npub or the WoT allowlist.
+#   1059 = NIP-17 gift-wrap sealed event
+#   1060 = NIP-17 gift-wrap direct message (rumored/seal)
+#   30078 = NIP-78 application-specific data (may carry private payloads)
+#   13 = NIP-59 seal (gift-wrap inner layer, private)
+#   14 = order general communications (private order details)
+#   16 = order process status (private order state)
+#   17 = payment receipt (private payment data)
+#   17375 = NIP-60 Cashu wallet config (private wallet state)
+RESTRICTED_KINDS = frozenset({1059, 1060, 30078, 13, 14, 16, 17, 17375})
+
+
+def _load_allowlist() -> tuple[set[str], float]:
+    try:
+        st = ALLOWED_PATH.stat()
+        with ALLOWED_PATH.open() as f:
+            pks = {line.strip().lower() for line in f if line.strip() and not line.startswith("#")}
+        return pks, st.st_mtime
+    except FileNotFoundError:
+        return set(), 0.0
+
+
+def _decide(pubkey: str, kind, allowed: set[str]) -> tuple[str, str]:
+    """Return (action, msg) for one event."""
+    if kind in RESTRICTED_KINDS:
+        if pubkey == ROOT_HEX or pubkey in allowed:
+            return "accept", ""
+        return "reject", "blocked: restricted kind not from WoT/root"
+    if kind in PUBLIC_MARKET_KINDS:
+        return "accept", ""
+    return "reject", "blocked: kind not in market set"
+
+
+def main() -> int:
+    allowed: set[str] = set()
+    mtime: float = 0.0
+
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+
+        # Hot-reload the allowlist when its mtime changes.
+        try:
+            st = ALLOWED_PATH.stat().st_mtime if ALLOWED_PATH.exists() else 0.0
+        except OSError:
+            st = 0.0
+        if st != mtime:
+            allowed, mtime = _load_allowlist()
+
+        try:
+            req = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        if req.get("type") != "new":
+            continue
+
+        event = req.get("event") or {}
+        eid = event.get("id")
+        pubkey = str(event.get("pubkey", "")).lower()
+
+        if not eid or not pubkey:
+            continue
+
+        action, msg = _decide(pubkey, event.get("kind"), allowed)
+
+        resp = {"id": eid, "action": action}
+        if msg:
+            resp["msg"] = msg
+        print(json.dumps(resp, separators=(",", ":")), flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why rebased onto master

Originally stacked on #1066 (`feat/market-agg-relay`). The write-policy reconciliation
commit (`5d1e1d29`) already merged both branches' designs, making the scraper
self-contained. Rebasing onto master unblocks independent review of the scraper
daemon without waiting for the relay architecture debate to resolve.

## What this PR contains

- `deploy-simple/aggregator/scraper.py` — active scraper daemon that mirrors marketplace events into the aggregator relay.
- `deploy-simple/aggregator/write-policy.py` — dual-mode write-policy: public market kinds accepted from anyone, restricted kinds gated to operator + WoT allowlist.
- Supporting deploy artifacts: `Dockerfile`, `docker-compose.yml`, `strfry.conf`, `pytest.ini`, `README.md`.
- Tests: `tests/test_scraper.py`, `tests/test_write_policy.py`, `tests/conftest.py` (108 tests).
- `.env.example` — documents `NEXT_PUBLIC_MARKET_AGG_RELAY`.

No `src/` (TypeScript app) changes — the scraper + write-policy are standalone Python/deploy artifacts, so this PR does not depend on the relay-specific `constants.ts` / `ndk.ts` work.

## Verification

- `python3 -m pytest -q` → **108 passed**
- `py_compile` clean on both `scraper.py` and `write-policy.py`
- Personal-deployment refs scrubbed: `grep -ri 'orangesync\|vps2\|tollgate' .` → **0 hits** (operator domain/host/path replaced with `example.com` / `operator` placeholders)
- Branch based directly on `master` (`f57423c5`): 2 cherry-picked scraper commits + 1 scrub commit

## Stacking chain

See https://github.com/PlebeianApp/market/issues/1088 for the full PR stacking map.
This PR is now independent of Chain B.

Refs: #1088 (stacking chains), #1046 (root-cause analysis), original #1069 (stacked version).
