### PR TITLE
feat(orders): add NIP-17 order message boundary

### DIFF
--- a/docs/adr/ADR-013-nip17-order-message-transport.md
+++ b/docs/adr/ADR-013-nip17-order-message-transport.md
@@ -1,0 +1,440 @@
+# ADR-013: NIP-17 Order Message Transport
+
+## Status
+
+Proposed
+
+## Related
+
+- Issue: #1084
+- Broader feature/security scope: #966
+- Read-path overlap to avoid: #1068
+
+## Scope
+
+This ADR defines the transport architecture for moving buyer-seller order communication from raw public order/message events toward NIP-17 encrypted gift-wrapped messages.
+
+This ADR is a foundation plan, not the full production behavior change. The first implementation PR should establish the tested NIP-17/Gamma order-message boundary only. Relay resolution, publish wiring, read/unwrapping integration, and migration behavior should follow in smaller reviewable PRs.
+
+## Context
+
+Current `master` has partial NIP-59 support for private buyer delivery details, but the broader buyer-seller order-processing flow still publishes and reads several raw events.
+
+Verified current repo behavior:
+
+- Conversations still query raw kind `14`, kind `16`, and kind `17` events.
+- Chat sends raw plaintext kind `14`.
+- Order creation, payment request, status, and shipping flows still use raw kind `16` events.
+- Checkout payment receipts still use raw kind `17`.
+- Private buyer delivery details have partial NIP-59 gift-wrap handling.
+- The repo has kind `10002` / NIP-65 relay-list support, but no strict kind `10050` NIP-17 DM relay resolver.
+- Global publish uses `ndkActions.publishEvent`, which routes through current app/default relay behavior.
+
+The PM direction is to move forward with applying gift wrapping to the order-processing flow after the earlier PII/infrastructure fixes.
+
+## External compatibility targets
+
+NIP-17 encrypted direct messages use:
+
+- NIP-44 encryption
+- NIP-59 sealing and gift wrapping
+- unsigned inner rumors
+- kind `13` seal events
+- kind `1059` gift-wrap events
+- one gift wrap per receiver
+- one sender self-wrap
+- randomized timestamps up to two days in the past
+- recipient kind `10050` DM relay lists for strict delivery
+
+Gamma Market compatibility target:
+
+- inner kind `14`: order-related general communication
+- inner kind `16`, type `1`: order creation
+- inner kind `16`, type `2`: payment request
+- inner kind `16`, type `3`: order status update
+- inner kind `16`, type `4`: shipping update
+- inner kind `17`: payment receipt
+
+Gamma is treated as an external compatibility target. It is not proof of current Plebeian behavior.
+
+## Decisions
+
+### Decision 1: Add a dedicated NIP-17/Gamma order-message boundary
+
+Add a focused boundary for order-message transport instead of spreading NIP-17 logic across checkout, order queries, payment publishing, and global NDK state.
+
+Initial production files:
+
+```text
+src/lib/nostr/nip17.ts
+src/lib/orders/orderMessageRumor.ts
+```
+
+Later integration files:
+
+```text
+src/lib/nostr/nip17Relays.ts
+src/publish/orders.tsx
+src/publish/payment.tsx
+src/queries/orderGiftWraps.tsx
+src/queries/messages.tsx
+src/queries/orders.tsx
+```
+
+### Decision 2: Do not mutate global NDK publish behavior
+
+Do not change these global paths for this work:
+
+```text
+ndkActions.publishEvent
+getWriteRelaySet
+getRelayUrls
+global NDK relay initialization
+```
+
+Reason: many unrelated publish paths depend on global NDK behavior. NIP-17 order transport needs per-recipient DM relay routing, which should be explicit and local to the NIP-17/order-message boundary.
+
+### Decision 3: Reuse existing NIP-59 helpers
+
+Reuse existing NIP-59 crypto helpers for sealing and gift wrapping.
+
+The new NIP-17 boundary should sit above the existing NIP-59 helper and add:
+
+- sender self-wrap support
+- timestamp randomization policy
+- recipient/sender wrap grouping
+- validation around unsigned rumors
+- integration with kind `10050` relay resolution
+
+### Decision 4: Add sender self-wrap support
+
+Every NIP-17 order message should produce:
+
+```text
+recipient wrap -> p tag = recipient pubkey
+sender self-wrap -> p tag = sender pubkey
+```
+
+Relay routing target:
+
+```text
+recipient wrap -> recipient DM relays
+sender self-wrap -> sender DM relays
+```
+
+The recipient wrap is for the counterparty. The sender self-wrap allows the sender to recover and display their own sent message from another client/device.
+
+### Decision 5: Preserve Gamma-compatible inner event shapes
+
+The encrypted rumor should preserve the Gamma marketplace message shape.
+
+Inner event targets:
+
+```text
+kind 14: order-related general communication
+kind 16 type 1: order creation
+kind 16 type 2: payment request
+kind 16 type 3: order status update
+kind 16 type 4: shipping update
+kind 17: payment receipt
+```
+
+These fields belong inside the encrypted inner rumor, not on the public gift-wrap event.
+
+### Decision 6: Keep legacy raw reads during migration
+
+Existing raw kind `14`, kind `16`, and kind `17` events must continue to render during migration.
+
+The read path should eventually become:
+
+```text
+legacy raw 14/16/17 reads
++ kind 1059 gift-wrap fetch for current user
++ local unwrap/decrypt
++ filter inner rumors to kind 14/16/17
++ merge/group into existing order and conversation views
+```
+
+Do not remove legacy raw-event support until maintainers explicitly decide the migration is complete.
+
+### Decision 7: Treat kind 10050 relay routing as required for strict NIP-17
+
+Strict NIP-17 delivery requires kind `10050` DM relay lists.
+
+Open decision:
+
+```text
+Should Plebeian use strict kind 10050-only behavior, meaning send fails/skips when the recipient has no DM relay list, or should Plebeian use a documented compatibility fallback to app/default or kind 10002 relays?
+```
+
+Spec-strict behavior is kind `10050` only. A fallback may improve UX, but it must be documented as repo-local compatibility behavior rather than strict NIP-17 behavior.
+
+### Decision 8: Place new tests under src/lib/__tests__
+
+The normal unit script only discovers tests under:
+
+```text
+contextvm
+src/queries/__tests__
+src/lib/__tests__
+```
+
+New boundary tests should live under:
+
+```text
+src/lib/__tests__/nip17.test.ts
+src/lib/__tests__/orderMessageRumor.test.ts
+```
+
+This keeps the first PR covered by `bun run test:unit` without changing test discovery or pulling in adjacent legacy tests.
+
+## Encrypted indexing tradeoff
+
+Once order IDs, payment proofs, amounts, message types, status values, addresses, emails, phone numbers, and notes move inside encrypted rumors, they are no longer relay-queryable as public tags.
+
+Read paths must fetch kind `1059` events addressed to the current user, unwrap locally, then filter/group by inner tags.
+
+Wrapper events must not expose public order-specific or payment-specific tags such as:
+
+```text
+order
+payment
+amount
+status
+shipping
+address
+email
+phone
+name
+```
+
+The wrapper still includes NIP-17 delivery metadata, primarily the recipient `p` tag. Relay hints may be considered only if they do not expose order-specific metadata.
+
+This tradeoff is intentional. It protects order metadata and PII at the cost of local unwrap/filter work.
+
+## Non-goals
+
+PR 1 should not include:
+
+- checkout wiring
+- payment publish wiring
+- full order read-path migration
+- global NDK relay changes
+- removal of legacy raw `14/16/17` reads
+- #1068 orders read-path migration work
+- broad messaging rewrite
+- dependency changes unless strongly justified
+
+## Alternatives considered
+
+### Alternative 1: Mutate global `ndkActions.publishEvent`
+
+Rejected for this work. Global publish is used by many unrelated flows. NIP-17 order-message delivery requires explicit per-recipient DM relay routing and should not change all publishing behavior.
+
+### Alternative 2: Continue wrapping only private delivery details
+
+Rejected as incomplete. It protects one private-order path but leaves order creation, payment requests, status/shipping updates, receipts, and chat on raw public events.
+
+### Alternative 3: Remove raw `14/16/17` reads immediately
+
+Rejected for migration safety. Existing orders and messages must continue to render until maintainers explicitly decide the legacy raw-event migration is complete.
+
+### Alternative 4: Implement all wiring in one PR
+
+Rejected for reviewability. Crypto/message shape, DM relay resolution, publish wiring, and read integration each have separate risks and should be reviewed independently.
+
+## PR plan
+
+### PR 1: NIP-17/Gamma boundary foundation
+
+Files:
+
+```text
+docs/adr/ADR-013-nip17-order-message-transport.md
+src/lib/nostr/nip17.ts
+src/lib/orders/orderMessageRumor.ts
+src/lib/__tests__/nip17.test.ts
+src/lib/__tests__/orderMessageRumor.test.ts
+```
+
+Scope:
+
+- add NIP-17 sender + recipient wrapping boundary
+- reuse existing NIP-59 helpers
+- add Gamma-shaped inner order-message rumor builders
+- prove recipient wrap + sender self-wrap
+- prove no plaintext PII/order/payment details in public gift wraps
+- prove inner rumor validation
+- no checkout/order publish wiring yet
+
+Validation:
+
+```bash
+bun test src/lib/__tests__/nip17.test.ts src/lib/__tests__/orderMessageRumor.test.ts
+bun run test:unit
+```
+
+### PR 2: DM relay resolver
+
+Files:
+
+```text
+src/lib/nostr/nip17Relays.ts
+src/lib/__tests__/nip17Relays.test.ts
+```
+
+Scope:
+
+- fetch latest kind `10050` event for a pubkey
+- parse `relay` tags
+- construct explicit relay targets for recipient and sender wraps
+- implement strict-vs-fallback policy after maintainer decision
+
+Validation:
+
+```bash
+bun test src/lib/__tests__/nip17Relays.test.ts
+bun run test:unit
+```
+
+### PR 3: Publish wiring
+
+Files:
+
+```text
+src/publish/orders.tsx
+src/publish/payment.tsx
+```
+
+Scope:
+
+- wrap order creation
+- wrap payment requests
+- wrap status updates
+- wrap shipping updates
+- wrap checkout payment receipts
+- avoid publishing new private order/payment content as raw public `14/16/17`
+- preserve any explicit compatibility behavior approved by maintainers
+
+Validation:
+
+```bash
+bun test src/lib/__tests__/nip17.test.ts src/lib/__tests__/orderMessageRumor.test.ts
+bun run test:unit
+```
+
+Additional targeted tests may be added under covered test paths. Direct-run tests should be documented if adjacent publish tests remain outside `test:unit`.
+
+### PR 4: Read/unwrapping integration
+
+Files:
+
+```text
+src/queries/orderGiftWraps.tsx
+src/queries/messages.tsx
+src/queries/orders.tsx
+```
+
+Scope:
+
+- fetch kind `1059` events addressed to the current user
+- unwrap/decrypt with signer
+- validate inner author, `p` tag, order id, type/payment/status/shipping tags
+- merge decrypted wrapped messages with legacy raw events
+- avoid stepping on #1068 read-path migration
+
+Validation:
+
+```bash
+bun run test:unit
+```
+
+Add focused query tests under:
+
+```text
+src/queries/__tests__
+```
+
+## Testing strategy
+
+PR 1 tests should prove:
+
+- recipient gift wrap is kind `1059`
+- sender self-wrap is kind `1059`
+- recipient gift wrap has `[['p', recipientPubkey]]`
+- sender self-wrap has `[['p', senderPubkey]]`
+- both unwrap back to the same inner rumor
+- public gift wraps do not expose PII/order/payment details
+- signer without NIP-44 encrypt fails closed
+- inner rumor IDs are canonical
+- inner rumors remain unsigned
+- supplied timestamps are deterministic in tests
+- randomized timestamps are covered separately from deterministic fixtures
+
+Order rumor tests should prove:
+
+- kind `14` order chat shape
+- kind `16` order creation shape
+- kind `16` payment request shape
+- kind `16` status update shape
+- kind `16` shipping update shape
+- kind `17` payment receipt shape
+- required tags are validated
+- public-wrapper unsafe fields remain inside the rumor only
+- direction is validated by author and `p` tag where caller context is available
+
+## Security and privacy notes
+
+- Relay data is untrusted.
+- Public wrapper metadata should be minimized.
+- PII must never appear in public gift-wrap content or tags.
+- Payment proof/reference data should not appear in public wrapper tags.
+- Receipt publication is not the same as payment settlement.
+- Wallet ACK, preimage/proof, receipt publication, merchant confirmation, fulfillment, expiration, failure, refund, and cancellation are separate lifecycle states.
+- Sender self-wraps improve recoverability but double publish volume.
+- Missing kind `10050` relay lists are a UX/product decision, not a crypto detail.
+- Generic NIP-17 clients may render inner kind `14`; marketplace-specific kind `16` and kind `17` may require Plebeian/Gamma-aware clients.
+
+## Open questions
+
+1. Should strict NIP-17 behavior fail/skip when the recipient has no kind `10050` relay list?
+
+2. If not, what exact fallback is approved?
+
+   - app/default relays
+   - kind `10002` / NIP-65 relay list
+   - both
+   - no fallback
+
+3. Should PR 3 stop publishing raw order-processing events immediately, or dual-publish temporarily during migration?
+
+4. Which inner kind `14` order-chat messages are in scope for the first publish-wiring PR?
+
+5. Should payment receipt wrapping include all existing receipt tags inside the encrypted rumor, including payment proof references such as Lightning invoices/preimages, Bitcoin transaction references, eCash proofs, or other supported payment media?
+
+6. Should readable kind `14` companion messages be added for generic NIP-17 client visibility, or should structured kind `16`/`17` remain Plebeian/Gamma-aware only?
+
+## Consequences
+
+Positive:
+
+- Aligns order transport with NIP-17 and Gamma direction.
+- Reduces public leakage of buyer-seller order metadata.
+- Keeps the work reviewable by separating crypto boundary, relay resolution, publish wiring, and reads.
+- Avoids global relay/publish regressions.
+- Preserves legacy raw reads during migration.
+
+Negative / tradeoffs:
+
+- Read paths must unwrap locally before filtering by order id.
+- Publish volume increases because each message needs recipient and sender wraps.
+- Strict kind `10050` behavior may cause sends to fail for users without DM relay lists.
+- Compatibility fallback improves UX but is not strict NIP-17 behavior.
+- Generic NIP-17 clients may display only inner kind `14`; marketplace-specific kind `16` and kind `17` may still require Plebeian/Gamma-aware clients.
+
+## References
+
+- NIP-17: https://github.com/nostr-protocol/nips/blob/master/17.md
+- NIP-59: https://github.com/nostr-protocol/nips/blob/master/59.md
+- NIP-44: https://github.com/nostr-protocol/nips/blob/master/44.md
+- Gamma Market spec: https://github.com/GammaMarkets/market-spec/blob/main/spec.md

--- a/docs/adr/ADR-013-nip17-order-message-transport.md
+++ b/docs/adr/ADR-013-nip17-order-message-transport.md
@@ -169,7 +169,7 @@ Should Plebeian use strict kind 10050-only behavior, meaning send fails/skips wh
 
 Spec-strict behavior is kind `10050` only. A fallback may improve UX, but it must be documented as repo-local compatibility behavior rather than strict NIP-17 behavior.
 
-### Decision 8: Place new tests under src/lib/__tests__
+### Decision 8: Place new tests under `src/lib/__tests__`
 
 The normal unit script only discovers tests under:
 
@@ -400,7 +400,6 @@ Order rumor tests should prove:
 1. Should strict NIP-17 behavior fail/skip when the recipient has no kind `10050` relay list?
 
 2. If not, what exact fallback is approved?
-
    - app/default relays
    - kind `10002` / NIP-65 relay list
    - both

--- a/src/lib/__tests__/nip17.test.ts
+++ b/src/lib/__tests__/nip17.test.ts
@@ -1,199 +1,193 @@
 import { NDKUser, type NDKEncryptionScheme, type NDKSigner } from '@nostr-dev-kit/ndk'
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
-import {
-        NIP59_GIFT_WRAP_KIND,
-        NIP59_SEAL_KIND,
-        unwrapNip59GiftWrapWithSigner,
-        type UnsignedRumor,
-} from '../nostr/nip59'
+import { NIP59_GIFT_WRAP_KIND, NIP59_SEAL_KIND, unwrapNip59GiftWrapWithSigner, type UnsignedRumor } from '../nostr/nip59'
 import { createNip17GiftWrapsWithSigner, randomizeNip17CreatedAt } from '../nostr/nip17'
 
 const CREATED_AT = 1_700_000_000
 const PUBLIC_DATA_SENTINELS = [
-        'buyer@example.com',
-        '123 Main Street',
-        'Satoshi Nakamoto',
-        '+15551234567',
-        'order-123',
-        'lnbc-secret-invoice',
-        'preimage-secret',
+	'buyer@example.com',
+	'123 Main Street',
+	'Satoshi Nakamoto',
+	'+15551234567',
+	'order-123',
+	'lnbc-secret-invoice',
+	'preimage-secret',
 ]
 
 type KeyPair = {
-        privateKey: Uint8Array
-        pubkey: string
+	privateKey: Uint8Array
+	pubkey: string
 }
 
 type MockSignerOptions = {
-        supportsNip44?: boolean
-        canEncrypt?: boolean
-        canDecrypt?: boolean
+	supportsNip44?: boolean
+	canEncrypt?: boolean
+	canDecrypt?: boolean
 }
 
 function keyPair(): KeyPair {
-        const privateKey = crypto.getRandomValues(new Uint8Array(32))
-        return { privateKey, pubkey: getPublicKey(privateKey) }
+	const privateKey = crypto.getRandomValues(new Uint8Array(32))
+	return { privateKey, pubkey: getPublicKey(privateKey) }
 }
 
 function signerFor(privateKey: Uint8Array, options: MockSignerOptions = {}): NDKSigner {
-        const pubkey = getPublicKey(privateKey)
-        const user = new NDKUser({ pubkey })
+	const pubkey = getPublicKey(privateKey)
+	const user = new NDKUser({ pubkey })
 
-        return {
-                get pubkey() {
-                        return pubkey
-                },
-                blockUntilReady: async () => user,
-                user: async () => user,
-                get userSync() {
-                        return user
-                },
-                encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
-                        if (options.supportsNip44 === false) return []
-                        if (!scheme || scheme === 'nip44') return ['nip44']
-                        return []
-                },
-                encrypt: async (recipient, value, scheme) => {
-                        if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') {
-                                throw new Error('NIP-44 unavailable')
-                        }
-                        const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
-                        return nip44.v2.encrypt(value, conversationKey)
-                },
-                decrypt: async (sender, value, scheme) => {
-                        if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') {
-                                throw new Error('NIP-44 unavailable')
-                        }
-                        const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
-                        return nip44.v2.decrypt(value, conversationKey)
-                },
-                sign: async (event) => finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig,
-                toPayload: () => JSON.stringify({ type: 'mock' }),
-        }
+	return {
+		get pubkey() {
+			return pubkey
+		},
+		blockUntilReady: async () => user,
+		user: async () => user,
+		get userSync() {
+			return user
+		},
+		encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
+			if (options.supportsNip44 === false) return []
+			if (!scheme || scheme === 'nip44') return ['nip44']
+			return []
+		},
+		encrypt: async (recipient, value, scheme) => {
+			if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') {
+				throw new Error('NIP-44 unavailable')
+			}
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(value, conversationKey)
+		},
+		decrypt: async (sender, value, scheme) => {
+			if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') {
+				throw new Error('NIP-44 unavailable')
+			}
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(value, conversationKey)
+		},
+		sign: async (event) => finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig,
+		toPayload: () => JSON.stringify({ type: 'mock' }),
+	}
 }
 
 function rumorFor(buyerPubkey: string, sellerPubkey: string): UnsignedRumor {
-        return {
-                kind: 16,
-                pubkey: buyerPubkey,
-                created_at: CREATED_AT,
-                tags: [
-                        ['p', sellerPubkey],
-                        ['subject', 'order-info'],
-                        ['type', '1'],
-                        ['order', 'order-123'],
-                        ['amount', '2100'],
-                        ['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret'],
-                ],
-                content: 'Satoshi Nakamoto buyer@example.com +15551234567 123 Main Street',
-        }
+	return {
+		kind: 16,
+		pubkey: buyerPubkey,
+		created_at: CREATED_AT,
+		tags: [
+			['p', sellerPubkey],
+			['subject', 'order-info'],
+			['type', '1'],
+			['order', 'order-123'],
+			['amount', '2100'],
+			['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret'],
+		],
+		content: 'Satoshi Nakamoto buyer@example.com +15551234567 123 Main Street',
+	}
 }
 
 function canonicalRumorId(rumor: UnsignedRumor): string {
-        return getEventHash({
-                pubkey: rumor.pubkey,
-                created_at: rumor.created_at,
-                kind: rumor.kind,
-                tags: rumor.tags,
-                content: rumor.content,
-        })
+	return getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
 }
 
 function expectNoPublicOrderData(value: unknown): void {
-        const serialized = JSON.stringify(value)
-        for (const sentinel of PUBLIC_DATA_SENTINELS) {
-                expect(serialized).not.toContain(sentinel)
-        }
+	const serialized = JSON.stringify(value)
+	for (const sentinel of PUBLIC_DATA_SENTINELS) {
+		expect(serialized).not.toContain(sentinel)
+	}
 }
 
 describe('NIP-17 gift wrapping boundary', () => {
-        test('creates recipient and sender self-wraps for the same unsigned rumor', async () => {
-                const buyer = keyPair()
-                const seller = keyPair()
-                const recipientWrapper = keyPair()
-                const senderWrapper = keyPair()
-                const rumor = rumorFor(buyer.pubkey, seller.pubkey)
+	test('creates recipient and sender self-wraps for the same unsigned rumor', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
+		const recipientWrapper = keyPair()
+		const senderWrapper = keyPair()
+		const rumor = rumorFor(buyer.pubkey, seller.pubkey)
 
-                const result = await createNip17GiftWrapsWithSigner({
-                        rumor,
-                        signer: signerFor(buyer.privateKey),
-                        recipientPubkey: seller.pubkey,
-                        recipientWrapperPrivateKey: recipientWrapper.privateKey,
-                        senderWrapperPrivateKey: senderWrapper.privateKey,
-                        createdAt: CREATED_AT,
-                })
+		const result = await createNip17GiftWrapsWithSigner({
+			rumor,
+			signer: signerFor(buyer.privateKey),
+			recipientPubkey: seller.pubkey,
+			recipientWrapperPrivateKey: recipientWrapper.privateKey,
+			senderWrapperPrivateKey: senderWrapper.privateKey,
+			createdAt: CREATED_AT,
+		})
 
-                expect(result.rumor.id).toBe(canonicalRumorId(rumor))
-                expect(result.rumor.created_at).toBe(CREATED_AT)
-                expect('sig' in result.rumor).toBe(false)
+		expect(result.rumor.id).toBe(canonicalRumorId(rumor))
+		expect(result.rumor.created_at).toBe(CREATED_AT)
+		expect('sig' in result.rumor).toBe(false)
 
-                expect(result.recipient.seal.kind).toBe(NIP59_SEAL_KIND)
-                expect(result.recipient.seal.created_at).toBe(CREATED_AT)
-                expect(result.recipient.seal.tags).toEqual([])
-                expect(result.recipient.seal.pubkey).toBe(buyer.pubkey)
-                expect(verifyEvent(result.recipient.seal)).toBe(true)
+		expect(result.recipient.seal.kind).toBe(NIP59_SEAL_KIND)
+		expect(result.recipient.seal.created_at).toBe(CREATED_AT)
+		expect(result.recipient.seal.tags).toEqual([])
+		expect(result.recipient.seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(result.recipient.seal)).toBe(true)
 
-                expect(result.recipient.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
-                expect(result.recipient.giftWrap.created_at).toBe(CREATED_AT)
-                expect(result.recipient.giftWrap.pubkey).toBe(recipientWrapper.pubkey)
-                expect(result.recipient.giftWrap.tags).toEqual([['p', seller.pubkey]])
-                expect(verifyEvent(result.recipient.giftWrap)).toBe(true)
-                expectNoPublicOrderData(result.recipient.giftWrap)
+		expect(result.recipient.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(result.recipient.giftWrap.created_at).toBe(CREATED_AT)
+		expect(result.recipient.giftWrap.pubkey).toBe(recipientWrapper.pubkey)
+		expect(result.recipient.giftWrap.tags).toEqual([['p', seller.pubkey]])
+		expect(verifyEvent(result.recipient.giftWrap)).toBe(true)
+		expectNoPublicOrderData(result.recipient.giftWrap)
 
-                expect(result.sender.seal.kind).toBe(NIP59_SEAL_KIND)
-                expect(result.sender.seal.created_at).toBe(CREATED_AT)
-                expect(result.sender.seal.tags).toEqual([])
-                expect(result.sender.seal.pubkey).toBe(buyer.pubkey)
-                expect(verifyEvent(result.sender.seal)).toBe(true)
+		expect(result.sender.seal.kind).toBe(NIP59_SEAL_KIND)
+		expect(result.sender.seal.created_at).toBe(CREATED_AT)
+		expect(result.sender.seal.tags).toEqual([])
+		expect(result.sender.seal.pubkey).toBe(buyer.pubkey)
+		expect(verifyEvent(result.sender.seal)).toBe(true)
 
-                expect(result.sender.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
-                expect(result.sender.giftWrap.created_at).toBe(CREATED_AT)
-                expect(result.sender.giftWrap.pubkey).toBe(senderWrapper.pubkey)
-                expect(result.sender.giftWrap.tags).toEqual([['p', buyer.pubkey]])
-                expect(verifyEvent(result.sender.giftWrap)).toBe(true)
-                expectNoPublicOrderData(result.sender.giftWrap)
+		expect(result.sender.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(result.sender.giftWrap.created_at).toBe(CREATED_AT)
+		expect(result.sender.giftWrap.pubkey).toBe(senderWrapper.pubkey)
+		expect(result.sender.giftWrap.tags).toEqual([['p', buyer.pubkey]])
+		expect(verifyEvent(result.sender.giftWrap)).toBe(true)
+		expectNoPublicOrderData(result.sender.giftWrap)
 
-                const recipientUnwrapped = await unwrapNip59GiftWrapWithSigner({
-                        giftWrap: result.recipient.giftWrap,
-                        signer: signerFor(seller.privateKey),
-                        expectedRecipientPubkey: seller.pubkey,
-                        expectedSenderPubkey: buyer.pubkey,
-                })
+		const recipientUnwrapped = await unwrapNip59GiftWrapWithSigner({
+			giftWrap: result.recipient.giftWrap,
+			signer: signerFor(seller.privateKey),
+			expectedRecipientPubkey: seller.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
 
-                const senderUnwrapped = await unwrapNip59GiftWrapWithSigner({
-                        giftWrap: result.sender.giftWrap,
-                        signer: signerFor(buyer.privateKey),
-                        expectedRecipientPubkey: buyer.pubkey,
-                        expectedSenderPubkey: buyer.pubkey,
-                })
+		const senderUnwrapped = await unwrapNip59GiftWrapWithSigner({
+			giftWrap: result.sender.giftWrap,
+			signer: signerFor(buyer.privateKey),
+			expectedRecipientPubkey: buyer.pubkey,
+			expectedSenderPubkey: buyer.pubkey,
+		})
 
-                expect(recipientUnwrapped.seal.id).toBe(result.recipient.seal.id)
-                expect(senderUnwrapped.seal.id).toBe(result.sender.seal.id)
-                expect(recipientUnwrapped.rumor).toEqual(result.rumor)
-                expect(senderUnwrapped.rumor).toEqual(result.rumor)
-        })
+		expect(recipientUnwrapped.seal.id).toBe(result.recipient.seal.id)
+		expect(senderUnwrapped.seal.id).toBe(result.sender.seal.id)
+		expect(recipientUnwrapped.rumor).toEqual(result.rumor)
+		expect(senderUnwrapped.rumor).toEqual(result.rumor)
+	})
 
+	test('randomizes created_at up to two days in the past', () => {
+		const now = 1_700_200_000
 
-        test('randomizes created_at up to two days in the past', () => {
-                const now = 1_700_200_000
+		expect(randomizeNip17CreatedAt(now, () => 0)).toBe(now)
+		expect(randomizeNip17CreatedAt(now, () => 0.5)).toBe(now - 86_400)
+		expect(randomizeNip17CreatedAt(now, () => 0.999999)).toBe(now - 172_800)
+	})
 
-                expect(randomizeNip17CreatedAt(now, () => 0)).toBe(now)
-                expect(randomizeNip17CreatedAt(now, () => 0.5)).toBe(now - 86_400)
-                expect(randomizeNip17CreatedAt(now, () => 0.999999)).toBe(now - 172_800)
-        })
+	test('fails closed when signer does not support NIP-44 encrypt', async () => {
+		const buyer = keyPair()
+		const seller = keyPair()
 
-        test('fails closed when signer does not support NIP-44 encrypt', async () => {
-                const buyer = keyPair()
-                const seller = keyPair()
-
-                await expect(
-                        createNip17GiftWrapsWithSigner({
-                                rumor: rumorFor(buyer.pubkey, seller.pubkey),
-                                signer: signerFor(buyer.privateKey, { supportsNip44: false }),
-                                recipientPubkey: seller.pubkey,
-                                createdAt: CREATED_AT,
-                        }),
-                ).rejects.toThrow('Signer does not support NIP-44 encrypt')
-        })
+		await expect(
+			createNip17GiftWrapsWithSigner({
+				rumor: rumorFor(buyer.pubkey, seller.pubkey),
+				signer: signerFor(buyer.privateKey, { supportsNip44: false }),
+				recipientPubkey: seller.pubkey,
+				createdAt: CREATED_AT,
+			}),
+		).rejects.toThrow('Signer does not support NIP-44 encrypt')
+	})
 })

--- a/src/lib/__tests__/nip17.test.ts
+++ b/src/lib/__tests__/nip17.test.ts
@@ -1,0 +1,199 @@
+import { NDKUser, type NDKEncryptionScheme, type NDKSigner } from '@nostr-dev-kit/ndk'
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, getEventHash, getPublicKey, nip44, verifyEvent } from 'nostr-tools'
+import {
+        NIP59_GIFT_WRAP_KIND,
+        NIP59_SEAL_KIND,
+        unwrapNip59GiftWrapWithSigner,
+        type UnsignedRumor,
+} from '../nostr/nip59'
+import { createNip17GiftWrapsWithSigner, randomizeNip17CreatedAt } from '../nostr/nip17'
+
+const CREATED_AT = 1_700_000_000
+const PUBLIC_DATA_SENTINELS = [
+        'buyer@example.com',
+        '123 Main Street',
+        'Satoshi Nakamoto',
+        '+15551234567',
+        'order-123',
+        'lnbc-secret-invoice',
+        'preimage-secret',
+]
+
+type KeyPair = {
+        privateKey: Uint8Array
+        pubkey: string
+}
+
+type MockSignerOptions = {
+        supportsNip44?: boolean
+        canEncrypt?: boolean
+        canDecrypt?: boolean
+}
+
+function keyPair(): KeyPair {
+        const privateKey = crypto.getRandomValues(new Uint8Array(32))
+        return { privateKey, pubkey: getPublicKey(privateKey) }
+}
+
+function signerFor(privateKey: Uint8Array, options: MockSignerOptions = {}): NDKSigner {
+        const pubkey = getPublicKey(privateKey)
+        const user = new NDKUser({ pubkey })
+
+        return {
+                get pubkey() {
+                        return pubkey
+                },
+                blockUntilReady: async () => user,
+                user: async () => user,
+                get userSync() {
+                        return user
+                },
+                encryptionEnabled: async (scheme?: NDKEncryptionScheme) => {
+                        if (options.supportsNip44 === false) return []
+                        if (!scheme || scheme === 'nip44') return ['nip44']
+                        return []
+                },
+                encrypt: async (recipient, value, scheme) => {
+                        if (options.supportsNip44 === false || options.canEncrypt === false || scheme !== 'nip44') {
+                                throw new Error('NIP-44 unavailable')
+                        }
+                        const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+                        return nip44.v2.encrypt(value, conversationKey)
+                },
+                decrypt: async (sender, value, scheme) => {
+                        if (options.supportsNip44 === false || options.canDecrypt === false || scheme !== 'nip44') {
+                                throw new Error('NIP-44 unavailable')
+                        }
+                        const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+                        return nip44.v2.decrypt(value, conversationKey)
+                },
+                sign: async (event) => finalizeEvent(event as unknown as Parameters<typeof finalizeEvent>[0], privateKey).sig,
+                toPayload: () => JSON.stringify({ type: 'mock' }),
+        }
+}
+
+function rumorFor(buyerPubkey: string, sellerPubkey: string): UnsignedRumor {
+        return {
+                kind: 16,
+                pubkey: buyerPubkey,
+                created_at: CREATED_AT,
+                tags: [
+                        ['p', sellerPubkey],
+                        ['subject', 'order-info'],
+                        ['type', '1'],
+                        ['order', 'order-123'],
+                        ['amount', '2100'],
+                        ['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret'],
+                ],
+                content: 'Satoshi Nakamoto buyer@example.com +15551234567 123 Main Street',
+        }
+}
+
+function canonicalRumorId(rumor: UnsignedRumor): string {
+        return getEventHash({
+                pubkey: rumor.pubkey,
+                created_at: rumor.created_at,
+                kind: rumor.kind,
+                tags: rumor.tags,
+                content: rumor.content,
+        })
+}
+
+function expectNoPublicOrderData(value: unknown): void {
+        const serialized = JSON.stringify(value)
+        for (const sentinel of PUBLIC_DATA_SENTINELS) {
+                expect(serialized).not.toContain(sentinel)
+        }
+}
+
+describe('NIP-17 gift wrapping boundary', () => {
+        test('creates recipient and sender self-wraps for the same unsigned rumor', async () => {
+                const buyer = keyPair()
+                const seller = keyPair()
+                const recipientWrapper = keyPair()
+                const senderWrapper = keyPair()
+                const rumor = rumorFor(buyer.pubkey, seller.pubkey)
+
+                const result = await createNip17GiftWrapsWithSigner({
+                        rumor,
+                        signer: signerFor(buyer.privateKey),
+                        recipientPubkey: seller.pubkey,
+                        recipientWrapperPrivateKey: recipientWrapper.privateKey,
+                        senderWrapperPrivateKey: senderWrapper.privateKey,
+                        createdAt: CREATED_AT,
+                })
+
+                expect(result.rumor.id).toBe(canonicalRumorId(rumor))
+                expect(result.rumor.created_at).toBe(CREATED_AT)
+                expect('sig' in result.rumor).toBe(false)
+
+                expect(result.recipient.seal.kind).toBe(NIP59_SEAL_KIND)
+                expect(result.recipient.seal.created_at).toBe(CREATED_AT)
+                expect(result.recipient.seal.tags).toEqual([])
+                expect(result.recipient.seal.pubkey).toBe(buyer.pubkey)
+                expect(verifyEvent(result.recipient.seal)).toBe(true)
+
+                expect(result.recipient.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+                expect(result.recipient.giftWrap.created_at).toBe(CREATED_AT)
+                expect(result.recipient.giftWrap.pubkey).toBe(recipientWrapper.pubkey)
+                expect(result.recipient.giftWrap.tags).toEqual([['p', seller.pubkey]])
+                expect(verifyEvent(result.recipient.giftWrap)).toBe(true)
+                expectNoPublicOrderData(result.recipient.giftWrap)
+
+                expect(result.sender.seal.kind).toBe(NIP59_SEAL_KIND)
+                expect(result.sender.seal.created_at).toBe(CREATED_AT)
+                expect(result.sender.seal.tags).toEqual([])
+                expect(result.sender.seal.pubkey).toBe(buyer.pubkey)
+                expect(verifyEvent(result.sender.seal)).toBe(true)
+
+                expect(result.sender.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+                expect(result.sender.giftWrap.created_at).toBe(CREATED_AT)
+                expect(result.sender.giftWrap.pubkey).toBe(senderWrapper.pubkey)
+                expect(result.sender.giftWrap.tags).toEqual([['p', buyer.pubkey]])
+                expect(verifyEvent(result.sender.giftWrap)).toBe(true)
+                expectNoPublicOrderData(result.sender.giftWrap)
+
+                const recipientUnwrapped = await unwrapNip59GiftWrapWithSigner({
+                        giftWrap: result.recipient.giftWrap,
+                        signer: signerFor(seller.privateKey),
+                        expectedRecipientPubkey: seller.pubkey,
+                        expectedSenderPubkey: buyer.pubkey,
+                })
+
+                const senderUnwrapped = await unwrapNip59GiftWrapWithSigner({
+                        giftWrap: result.sender.giftWrap,
+                        signer: signerFor(buyer.privateKey),
+                        expectedRecipientPubkey: buyer.pubkey,
+                        expectedSenderPubkey: buyer.pubkey,
+                })
+
+                expect(recipientUnwrapped.seal.id).toBe(result.recipient.seal.id)
+                expect(senderUnwrapped.seal.id).toBe(result.sender.seal.id)
+                expect(recipientUnwrapped.rumor).toEqual(result.rumor)
+                expect(senderUnwrapped.rumor).toEqual(result.rumor)
+        })
+
+
+        test('randomizes created_at up to two days in the past', () => {
+                const now = 1_700_200_000
+
+                expect(randomizeNip17CreatedAt(now, () => 0)).toBe(now)
+                expect(randomizeNip17CreatedAt(now, () => 0.5)).toBe(now - 86_400)
+                expect(randomizeNip17CreatedAt(now, () => 0.999999)).toBe(now - 172_800)
+        })
+
+        test('fails closed when signer does not support NIP-44 encrypt', async () => {
+                const buyer = keyPair()
+                const seller = keyPair()
+
+                await expect(
+                        createNip17GiftWrapsWithSigner({
+                                rumor: rumorFor(buyer.pubkey, seller.pubkey),
+                                signer: signerFor(buyer.privateKey, { supportsNip44: false }),
+                                recipientPubkey: seller.pubkey,
+                                createdAt: CREATED_AT,
+                        }),
+                ).rejects.toThrow('Signer does not support NIP-44 encrypt')
+        })
+})

--- a/src/lib/__tests__/orderMessageRumor.test.ts
+++ b/src/lib/__tests__/orderMessageRumor.test.ts
@@ -186,6 +186,20 @@ describe('order message rumors', () => {
 		expect(() => assertOrderMessageRumor(chat)).not.toThrow()
 	})
 
+	test('rejects payment request rumors without payment methods', () => {
+		expect(() =>
+			createPaymentRequestRumor({
+				merchantPubkey: SELLER_PUBKEY,
+				buyerPubkey: BUYER_PUBKEY,
+				orderId: 'order-123',
+				amountSats: 2100,
+				paymentMethods: [] as never,
+				content: 'Payment details pending',
+				createdAt: CREATED_AT,
+			}),
+		).toThrow('Payment request rumors require at least one payment method')
+	})
+
 	test('rejects invalid order message rumors', () => {
 		const valid = createOrderCreationRumor({
 			buyerPubkey: BUYER_PUBKEY,

--- a/src/lib/__tests__/orderMessageRumor.test.ts
+++ b/src/lib/__tests__/orderMessageRumor.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from 'bun:test'
+import { getEventHash } from 'nostr-tools'
+import {
+        ORDER_GENERAL_KIND,
+        ORDER_MESSAGE_TYPE,
+        ORDER_PROCESS_KIND,
+        ORDER_STATUS,
+        PAYMENT_RECEIPT_KIND,
+        SHIPPING_STATUS,
+} from '../schemas/order'
+import {
+        assertOrderMessageRumor,
+        createOrderChatRumor,
+        createOrderCreationRumor,
+        createPaymentReceiptRumor,
+        createPaymentRequestRumor,
+        createShippingUpdateRumor,
+        createStatusUpdateRumor,
+        type OrderMessageRumor,
+} from '../orders/orderMessageRumor'
+
+const CREATED_AT = 1_700_000_000
+const BUYER_PUBKEY = 'a'.repeat(64)
+const SELLER_PUBKEY = 'b'.repeat(64)
+const PRODUCT_REF = `30402:${SELLER_PUBKEY}:product-1`
+const SHIPPING_REF = `30406:${SELLER_PUBKEY}:standard`
+
+function canonicalRumorId(rumor: OrderMessageRumor): string {
+        return getEventHash({
+                pubkey: rumor.pubkey,
+                created_at: rumor.created_at,
+                kind: rumor.kind,
+                tags: rumor.tags,
+                content: rumor.content,
+        })
+}
+
+function tagValue(tags: string[][], name: string): string | undefined {
+        return tags.find((tag) => tag[0] === name)?.[1]
+}
+
+function tagValues(tags: string[][], name: string): string[][] {
+        return tags.filter((tag) => tag[0] === name)
+}
+
+function expectUnsignedCanonicalRumor(rumor: OrderMessageRumor): void {
+        expect(rumor.id).toBe(canonicalRumorId(rumor))
+        expect('sig' in rumor).toBe(false)
+}
+
+describe('order message rumors', () => {
+        test('creates a Gamma-shaped kind 16 order creation rumor', () => {
+                const rumor = createOrderCreationRumor({
+                        buyerPubkey: BUYER_PUBKEY,
+                        merchantPubkey: SELLER_PUBKEY,
+                        orderId: 'order-123',
+                        amountSats: 2100,
+                        items: [{ productRef: PRODUCT_REF, quantity: 2 }],
+                        shippingRef: SHIPPING_REF,
+                        content: 'Order created',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(rumor.kind).toBe(ORDER_PROCESS_KIND)
+                expect(rumor.pubkey).toBe(BUYER_PUBKEY)
+                expect(rumor.created_at).toBe(CREATED_AT)
+                expect(rumor.content).toBe('Order created')
+                expect(tagValue(rumor.tags, 'p')).toBe(SELLER_PUBKEY)
+                expect(tagValue(rumor.tags, 'subject')).toBe('order-info')
+                expect(tagValue(rumor.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.ORDER_CREATION)
+                expect(tagValue(rumor.tags, 'order')).toBe('order-123')
+                expect(tagValue(rumor.tags, 'amount')).toBe('2100')
+                expect(tagValue(rumor.tags, 'shipping')).toBe(SHIPPING_REF)
+                expect(tagValues(rumor.tags, 'item')).toEqual([['item', PRODUCT_REF, '2']])
+                expectUnsignedCanonicalRumor(rumor)
+                expect(() => assertOrderMessageRumor(rumor)).not.toThrow()
+        })
+
+        test('creates Gamma-shaped payment request, status update, shipping update, receipt, and chat rumors', () => {
+                const paymentRequest = createPaymentRequestRumor({
+                        merchantPubkey: SELLER_PUBKEY,
+                        buyerPubkey: BUYER_PUBKEY,
+                        orderId: 'order-123',
+                        amountSats: 2100,
+                        paymentMethods: [{ type: 'lightning', details: 'lnbc-secret-invoice' }],
+                        expirationTime: CREATED_AT + 3600,
+                        content: 'Payment request for your order',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(paymentRequest.kind).toBe(ORDER_PROCESS_KIND)
+                expect(paymentRequest.pubkey).toBe(SELLER_PUBKEY)
+                expect(tagValue(paymentRequest.tags, 'p')).toBe(BUYER_PUBKEY)
+                expect(tagValue(paymentRequest.tags, 'subject')).toBe('order-payment')
+                expect(tagValue(paymentRequest.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.PAYMENT_REQUEST)
+                expect(tagValue(paymentRequest.tags, 'order')).toBe('order-123')
+                expect(tagValue(paymentRequest.tags, 'amount')).toBe('2100')
+                expect(tagValues(paymentRequest.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice']])
+                expect(tagValue(paymentRequest.tags, 'expiration')).toBe(String(CREATED_AT + 3600))
+                expect(tagValue(paymentRequest.tags, 'recipient')).toBeUndefined()
+                expectUnsignedCanonicalRumor(paymentRequest)
+                expect(() => assertOrderMessageRumor(paymentRequest)).not.toThrow()
+
+                const statusUpdate = createStatusUpdateRumor({
+                        senderPubkey: SELLER_PUBKEY,
+                        recipientPubkey: BUYER_PUBKEY,
+                        orderId: 'order-123',
+                        status: ORDER_STATUS.CONFIRMED,
+                        content: 'Order status updated to confirmed',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(statusUpdate.kind).toBe(ORDER_PROCESS_KIND)
+                expect(statusUpdate.pubkey).toBe(SELLER_PUBKEY)
+                expect(tagValue(statusUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
+                expect(tagValue(statusUpdate.tags, 'subject')).toBe('order-info')
+                expect(tagValue(statusUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.STATUS_UPDATE)
+                expect(tagValue(statusUpdate.tags, 'order')).toBe('order-123')
+                expect(tagValue(statusUpdate.tags, 'status')).toBe(ORDER_STATUS.CONFIRMED)
+                expectUnsignedCanonicalRumor(statusUpdate)
+                expect(() => assertOrderMessageRumor(statusUpdate)).not.toThrow()
+
+                const shippingUpdate = createShippingUpdateRumor({
+                        senderPubkey: SELLER_PUBKEY,
+                        recipientPubkey: BUYER_PUBKEY,
+                        orderId: 'order-123',
+                        status: SHIPPING_STATUS.SHIPPED,
+                        tracking: 'tracking-123',
+                        carrier: 'UPS',
+                        eta: '2026-07-01',
+                        content: 'Order shipped',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(shippingUpdate.kind).toBe(ORDER_PROCESS_KIND)
+                expect(shippingUpdate.pubkey).toBe(SELLER_PUBKEY)
+                expect(tagValue(shippingUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
+                expect(tagValue(shippingUpdate.tags, 'subject')).toBe('shipping-info')
+                expect(tagValue(shippingUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.SHIPPING_UPDATE)
+                expect(tagValue(shippingUpdate.tags, 'order')).toBe('order-123')
+                expect(tagValue(shippingUpdate.tags, 'status')).toBe(SHIPPING_STATUS.SHIPPED)
+                expect(tagValue(shippingUpdate.tags, 'tracking')).toBe('tracking-123')
+                expect(tagValue(shippingUpdate.tags, 'carrier')).toBe('UPS')
+                expect(tagValue(shippingUpdate.tags, 'eta')).toBe('2026-07-01')
+                expectUnsignedCanonicalRumor(shippingUpdate)
+                expect(() => assertOrderMessageRumor(shippingUpdate)).not.toThrow()
+
+                const receipt = createPaymentReceiptRumor({
+                        buyerPubkey: BUYER_PUBKEY,
+                        merchantPubkey: SELLER_PUBKEY,
+                        orderId: 'order-123',
+                        payment: {
+                                medium: 'lightning',
+                                reference: 'lnbc-secret-invoice',
+                                proof: 'preimage-secret',
+                        },
+                        amountSats: 2100,
+                        content: 'Payment confirmation',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(receipt.kind).toBe(PAYMENT_RECEIPT_KIND)
+                expect(receipt.pubkey).toBe(BUYER_PUBKEY)
+                expect(tagValue(receipt.tags, 'p')).toBe(SELLER_PUBKEY)
+                expect(tagValue(receipt.tags, 'subject')).toBe('order-receipt')
+                expect(tagValue(receipt.tags, 'order')).toBe('order-123')
+                expect(tagValues(receipt.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret']])
+                expect(tagValue(receipt.tags, 'amount')).toBe('2100')
+                expectUnsignedCanonicalRumor(receipt)
+                expect(() => assertOrderMessageRumor(receipt)).not.toThrow()
+
+                const chat = createOrderChatRumor({
+                        senderPubkey: BUYER_PUBKEY,
+                        recipientPubkey: SELLER_PUBKEY,
+                        subject: 'order-123',
+                        content: 'Question about my order',
+                        createdAt: CREATED_AT,
+                })
+
+                expect(chat.kind).toBe(ORDER_GENERAL_KIND)
+                expect(chat.pubkey).toBe(BUYER_PUBKEY)
+                expect(tagValue(chat.tags, 'p')).toBe(SELLER_PUBKEY)
+                expect(tagValue(chat.tags, 'subject')).toBe('order-123')
+                expect(chat.content).toBe('Question about my order')
+                expectUnsignedCanonicalRumor(chat)
+                expect(() => assertOrderMessageRumor(chat)).not.toThrow()
+        })
+
+        test('rejects invalid order message rumors', () => {
+                const valid = createOrderCreationRumor({
+                        buyerPubkey: BUYER_PUBKEY,
+                        merchantPubkey: SELLER_PUBKEY,
+                        orderId: 'order-123',
+                        amountSats: 2100,
+                        items: [{ productRef: PRODUCT_REF, quantity: 2 }],
+                        content: 'Order created',
+                        createdAt: CREATED_AT,
+                })
+
+                const missingRecipient = {
+                        ...valid,
+                        tags: valid.tags.filter((tag) => tag[0] !== 'p'),
+                }
+
+                expect(() => assertOrderMessageRumor(missingRecipient)).toThrow('Invalid order message rumor')
+        })
+})

--- a/src/lib/__tests__/orderMessageRumor.test.ts
+++ b/src/lib/__tests__/orderMessageRumor.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, test } from 'bun:test'
 import { getEventHash } from 'nostr-tools'
 import {
-        ORDER_GENERAL_KIND,
-        ORDER_MESSAGE_TYPE,
-        ORDER_PROCESS_KIND,
-        ORDER_STATUS,
-        PAYMENT_RECEIPT_KIND,
-        SHIPPING_STATUS,
+	ORDER_GENERAL_KIND,
+	ORDER_MESSAGE_TYPE,
+	ORDER_PROCESS_KIND,
+	ORDER_STATUS,
+	PAYMENT_RECEIPT_KIND,
+	SHIPPING_STATUS,
 } from '../schemas/order'
 import {
-        assertOrderMessageRumor,
-        createOrderChatRumor,
-        createOrderCreationRumor,
-        createPaymentReceiptRumor,
-        createPaymentRequestRumor,
-        createShippingUpdateRumor,
-        createStatusUpdateRumor,
-        type OrderMessageRumor,
+	assertOrderMessageRumor,
+	createOrderChatRumor,
+	createOrderCreationRumor,
+	createPaymentReceiptRumor,
+	createPaymentRequestRumor,
+	createShippingUpdateRumor,
+	createStatusUpdateRumor,
+	type OrderMessageRumor,
 } from '../orders/orderMessageRumor'
 
 const CREATED_AT = 1_700_000_000
@@ -26,182 +26,182 @@ const PRODUCT_REF = `30402:${SELLER_PUBKEY}:product-1`
 const SHIPPING_REF = `30406:${SELLER_PUBKEY}:standard`
 
 function canonicalRumorId(rumor: OrderMessageRumor): string {
-        return getEventHash({
-                pubkey: rumor.pubkey,
-                created_at: rumor.created_at,
-                kind: rumor.kind,
-                tags: rumor.tags,
-                content: rumor.content,
-        })
+	return getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
 }
 
 function tagValue(tags: string[][], name: string): string | undefined {
-        return tags.find((tag) => tag[0] === name)?.[1]
+	return tags.find((tag) => tag[0] === name)?.[1]
 }
 
 function tagValues(tags: string[][], name: string): string[][] {
-        return tags.filter((tag) => tag[0] === name)
+	return tags.filter((tag) => tag[0] === name)
 }
 
 function expectUnsignedCanonicalRumor(rumor: OrderMessageRumor): void {
-        expect(rumor.id).toBe(canonicalRumorId(rumor))
-        expect('sig' in rumor).toBe(false)
+	expect(rumor.id).toBe(canonicalRumorId(rumor))
+	expect('sig' in rumor).toBe(false)
 }
 
 describe('order message rumors', () => {
-        test('creates a Gamma-shaped kind 16 order creation rumor', () => {
-                const rumor = createOrderCreationRumor({
-                        buyerPubkey: BUYER_PUBKEY,
-                        merchantPubkey: SELLER_PUBKEY,
-                        orderId: 'order-123',
-                        amountSats: 2100,
-                        items: [{ productRef: PRODUCT_REF, quantity: 2 }],
-                        shippingRef: SHIPPING_REF,
-                        content: 'Order created',
-                        createdAt: CREATED_AT,
-                })
+	test('creates a Gamma-shaped kind 16 order creation rumor', () => {
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: BUYER_PUBKEY,
+			merchantPubkey: SELLER_PUBKEY,
+			orderId: 'order-123',
+			amountSats: 2100,
+			items: [{ productRef: PRODUCT_REF, quantity: 2 }],
+			shippingRef: SHIPPING_REF,
+			content: 'Order created',
+			createdAt: CREATED_AT,
+		})
 
-                expect(rumor.kind).toBe(ORDER_PROCESS_KIND)
-                expect(rumor.pubkey).toBe(BUYER_PUBKEY)
-                expect(rumor.created_at).toBe(CREATED_AT)
-                expect(rumor.content).toBe('Order created')
-                expect(tagValue(rumor.tags, 'p')).toBe(SELLER_PUBKEY)
-                expect(tagValue(rumor.tags, 'subject')).toBe('order-info')
-                expect(tagValue(rumor.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.ORDER_CREATION)
-                expect(tagValue(rumor.tags, 'order')).toBe('order-123')
-                expect(tagValue(rumor.tags, 'amount')).toBe('2100')
-                expect(tagValue(rumor.tags, 'shipping')).toBe(SHIPPING_REF)
-                expect(tagValues(rumor.tags, 'item')).toEqual([['item', PRODUCT_REF, '2']])
-                expectUnsignedCanonicalRumor(rumor)
-                expect(() => assertOrderMessageRumor(rumor)).not.toThrow()
-        })
+		expect(rumor.kind).toBe(ORDER_PROCESS_KIND)
+		expect(rumor.pubkey).toBe(BUYER_PUBKEY)
+		expect(rumor.created_at).toBe(CREATED_AT)
+		expect(rumor.content).toBe('Order created')
+		expect(tagValue(rumor.tags, 'p')).toBe(SELLER_PUBKEY)
+		expect(tagValue(rumor.tags, 'subject')).toBe('order-info')
+		expect(tagValue(rumor.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.ORDER_CREATION)
+		expect(tagValue(rumor.tags, 'order')).toBe('order-123')
+		expect(tagValue(rumor.tags, 'amount')).toBe('2100')
+		expect(tagValue(rumor.tags, 'shipping')).toBe(SHIPPING_REF)
+		expect(tagValues(rumor.tags, 'item')).toEqual([['item', PRODUCT_REF, '2']])
+		expectUnsignedCanonicalRumor(rumor)
+		expect(() => assertOrderMessageRumor(rumor)).not.toThrow()
+	})
 
-        test('creates Gamma-shaped payment request, status update, shipping update, receipt, and chat rumors', () => {
-                const paymentRequest = createPaymentRequestRumor({
-                        merchantPubkey: SELLER_PUBKEY,
-                        buyerPubkey: BUYER_PUBKEY,
-                        orderId: 'order-123',
-                        amountSats: 2100,
-                        paymentMethods: [{ type: 'lightning', details: 'lnbc-secret-invoice' }],
-                        expirationTime: CREATED_AT + 3600,
-                        content: 'Payment request for your order',
-                        createdAt: CREATED_AT,
-                })
+	test('creates Gamma-shaped payment request, status update, shipping update, receipt, and chat rumors', () => {
+		const paymentRequest = createPaymentRequestRumor({
+			merchantPubkey: SELLER_PUBKEY,
+			buyerPubkey: BUYER_PUBKEY,
+			orderId: 'order-123',
+			amountSats: 2100,
+			paymentMethods: [{ type: 'lightning', details: 'lnbc-secret-invoice' }],
+			expirationTime: CREATED_AT + 3600,
+			content: 'Payment request for your order',
+			createdAt: CREATED_AT,
+		})
 
-                expect(paymentRequest.kind).toBe(ORDER_PROCESS_KIND)
-                expect(paymentRequest.pubkey).toBe(SELLER_PUBKEY)
-                expect(tagValue(paymentRequest.tags, 'p')).toBe(BUYER_PUBKEY)
-                expect(tagValue(paymentRequest.tags, 'subject')).toBe('order-payment')
-                expect(tagValue(paymentRequest.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.PAYMENT_REQUEST)
-                expect(tagValue(paymentRequest.tags, 'order')).toBe('order-123')
-                expect(tagValue(paymentRequest.tags, 'amount')).toBe('2100')
-                expect(tagValues(paymentRequest.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice']])
-                expect(tagValue(paymentRequest.tags, 'expiration')).toBe(String(CREATED_AT + 3600))
-                expect(tagValue(paymentRequest.tags, 'recipient')).toBeUndefined()
-                expectUnsignedCanonicalRumor(paymentRequest)
-                expect(() => assertOrderMessageRumor(paymentRequest)).not.toThrow()
+		expect(paymentRequest.kind).toBe(ORDER_PROCESS_KIND)
+		expect(paymentRequest.pubkey).toBe(SELLER_PUBKEY)
+		expect(tagValue(paymentRequest.tags, 'p')).toBe(BUYER_PUBKEY)
+		expect(tagValue(paymentRequest.tags, 'subject')).toBe('order-payment')
+		expect(tagValue(paymentRequest.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.PAYMENT_REQUEST)
+		expect(tagValue(paymentRequest.tags, 'order')).toBe('order-123')
+		expect(tagValue(paymentRequest.tags, 'amount')).toBe('2100')
+		expect(tagValues(paymentRequest.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice']])
+		expect(tagValue(paymentRequest.tags, 'expiration')).toBe(String(CREATED_AT + 3600))
+		expect(tagValue(paymentRequest.tags, 'recipient')).toBeUndefined()
+		expectUnsignedCanonicalRumor(paymentRequest)
+		expect(() => assertOrderMessageRumor(paymentRequest)).not.toThrow()
 
-                const statusUpdate = createStatusUpdateRumor({
-                        senderPubkey: SELLER_PUBKEY,
-                        recipientPubkey: BUYER_PUBKEY,
-                        orderId: 'order-123',
-                        status: ORDER_STATUS.CONFIRMED,
-                        content: 'Order status updated to confirmed',
-                        createdAt: CREATED_AT,
-                })
+		const statusUpdate = createStatusUpdateRumor({
+			senderPubkey: SELLER_PUBKEY,
+			recipientPubkey: BUYER_PUBKEY,
+			orderId: 'order-123',
+			status: ORDER_STATUS.CONFIRMED,
+			content: 'Order status updated to confirmed',
+			createdAt: CREATED_AT,
+		})
 
-                expect(statusUpdate.kind).toBe(ORDER_PROCESS_KIND)
-                expect(statusUpdate.pubkey).toBe(SELLER_PUBKEY)
-                expect(tagValue(statusUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
-                expect(tagValue(statusUpdate.tags, 'subject')).toBe('order-info')
-                expect(tagValue(statusUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.STATUS_UPDATE)
-                expect(tagValue(statusUpdate.tags, 'order')).toBe('order-123')
-                expect(tagValue(statusUpdate.tags, 'status')).toBe(ORDER_STATUS.CONFIRMED)
-                expectUnsignedCanonicalRumor(statusUpdate)
-                expect(() => assertOrderMessageRumor(statusUpdate)).not.toThrow()
+		expect(statusUpdate.kind).toBe(ORDER_PROCESS_KIND)
+		expect(statusUpdate.pubkey).toBe(SELLER_PUBKEY)
+		expect(tagValue(statusUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
+		expect(tagValue(statusUpdate.tags, 'subject')).toBe('order-info')
+		expect(tagValue(statusUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.STATUS_UPDATE)
+		expect(tagValue(statusUpdate.tags, 'order')).toBe('order-123')
+		expect(tagValue(statusUpdate.tags, 'status')).toBe(ORDER_STATUS.CONFIRMED)
+		expectUnsignedCanonicalRumor(statusUpdate)
+		expect(() => assertOrderMessageRumor(statusUpdate)).not.toThrow()
 
-                const shippingUpdate = createShippingUpdateRumor({
-                        senderPubkey: SELLER_PUBKEY,
-                        recipientPubkey: BUYER_PUBKEY,
-                        orderId: 'order-123',
-                        status: SHIPPING_STATUS.SHIPPED,
-                        tracking: 'tracking-123',
-                        carrier: 'UPS',
-                        eta: '2026-07-01',
-                        content: 'Order shipped',
-                        createdAt: CREATED_AT,
-                })
+		const shippingUpdate = createShippingUpdateRumor({
+			senderPubkey: SELLER_PUBKEY,
+			recipientPubkey: BUYER_PUBKEY,
+			orderId: 'order-123',
+			status: SHIPPING_STATUS.SHIPPED,
+			tracking: 'tracking-123',
+			carrier: 'UPS',
+			eta: '2026-07-01',
+			content: 'Order shipped',
+			createdAt: CREATED_AT,
+		})
 
-                expect(shippingUpdate.kind).toBe(ORDER_PROCESS_KIND)
-                expect(shippingUpdate.pubkey).toBe(SELLER_PUBKEY)
-                expect(tagValue(shippingUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
-                expect(tagValue(shippingUpdate.tags, 'subject')).toBe('shipping-info')
-                expect(tagValue(shippingUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.SHIPPING_UPDATE)
-                expect(tagValue(shippingUpdate.tags, 'order')).toBe('order-123')
-                expect(tagValue(shippingUpdate.tags, 'status')).toBe(SHIPPING_STATUS.SHIPPED)
-                expect(tagValue(shippingUpdate.tags, 'tracking')).toBe('tracking-123')
-                expect(tagValue(shippingUpdate.tags, 'carrier')).toBe('UPS')
-                expect(tagValue(shippingUpdate.tags, 'eta')).toBe('2026-07-01')
-                expectUnsignedCanonicalRumor(shippingUpdate)
-                expect(() => assertOrderMessageRumor(shippingUpdate)).not.toThrow()
+		expect(shippingUpdate.kind).toBe(ORDER_PROCESS_KIND)
+		expect(shippingUpdate.pubkey).toBe(SELLER_PUBKEY)
+		expect(tagValue(shippingUpdate.tags, 'p')).toBe(BUYER_PUBKEY)
+		expect(tagValue(shippingUpdate.tags, 'subject')).toBe('shipping-info')
+		expect(tagValue(shippingUpdate.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.SHIPPING_UPDATE)
+		expect(tagValue(shippingUpdate.tags, 'order')).toBe('order-123')
+		expect(tagValue(shippingUpdate.tags, 'status')).toBe(SHIPPING_STATUS.SHIPPED)
+		expect(tagValue(shippingUpdate.tags, 'tracking')).toBe('tracking-123')
+		expect(tagValue(shippingUpdate.tags, 'carrier')).toBe('UPS')
+		expect(tagValue(shippingUpdate.tags, 'eta')).toBe('2026-07-01')
+		expectUnsignedCanonicalRumor(shippingUpdate)
+		expect(() => assertOrderMessageRumor(shippingUpdate)).not.toThrow()
 
-                const receipt = createPaymentReceiptRumor({
-                        buyerPubkey: BUYER_PUBKEY,
-                        merchantPubkey: SELLER_PUBKEY,
-                        orderId: 'order-123',
-                        payment: {
-                                medium: 'lightning',
-                                reference: 'lnbc-secret-invoice',
-                                proof: 'preimage-secret',
-                        },
-                        amountSats: 2100,
-                        content: 'Payment confirmation',
-                        createdAt: CREATED_AT,
-                })
+		const receipt = createPaymentReceiptRumor({
+			buyerPubkey: BUYER_PUBKEY,
+			merchantPubkey: SELLER_PUBKEY,
+			orderId: 'order-123',
+			payment: {
+				medium: 'lightning',
+				reference: 'lnbc-secret-invoice',
+				proof: 'preimage-secret',
+			},
+			amountSats: 2100,
+			content: 'Payment confirmation',
+			createdAt: CREATED_AT,
+		})
 
-                expect(receipt.kind).toBe(PAYMENT_RECEIPT_KIND)
-                expect(receipt.pubkey).toBe(BUYER_PUBKEY)
-                expect(tagValue(receipt.tags, 'p')).toBe(SELLER_PUBKEY)
-                expect(tagValue(receipt.tags, 'subject')).toBe('order-receipt')
-                expect(tagValue(receipt.tags, 'order')).toBe('order-123')
-                expect(tagValues(receipt.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret']])
-                expect(tagValue(receipt.tags, 'amount')).toBe('2100')
-                expectUnsignedCanonicalRumor(receipt)
-                expect(() => assertOrderMessageRumor(receipt)).not.toThrow()
+		expect(receipt.kind).toBe(PAYMENT_RECEIPT_KIND)
+		expect(receipt.pubkey).toBe(BUYER_PUBKEY)
+		expect(tagValue(receipt.tags, 'p')).toBe(SELLER_PUBKEY)
+		expect(tagValue(receipt.tags, 'subject')).toBe('order-receipt')
+		expect(tagValue(receipt.tags, 'order')).toBe('order-123')
+		expect(tagValues(receipt.tags, 'payment')).toEqual([['payment', 'lightning', 'lnbc-secret-invoice', 'preimage-secret']])
+		expect(tagValue(receipt.tags, 'amount')).toBe('2100')
+		expectUnsignedCanonicalRumor(receipt)
+		expect(() => assertOrderMessageRumor(receipt)).not.toThrow()
 
-                const chat = createOrderChatRumor({
-                        senderPubkey: BUYER_PUBKEY,
-                        recipientPubkey: SELLER_PUBKEY,
-                        subject: 'order-123',
-                        content: 'Question about my order',
-                        createdAt: CREATED_AT,
-                })
+		const chat = createOrderChatRumor({
+			senderPubkey: BUYER_PUBKEY,
+			recipientPubkey: SELLER_PUBKEY,
+			subject: 'order-123',
+			content: 'Question about my order',
+			createdAt: CREATED_AT,
+		})
 
-                expect(chat.kind).toBe(ORDER_GENERAL_KIND)
-                expect(chat.pubkey).toBe(BUYER_PUBKEY)
-                expect(tagValue(chat.tags, 'p')).toBe(SELLER_PUBKEY)
-                expect(tagValue(chat.tags, 'subject')).toBe('order-123')
-                expect(chat.content).toBe('Question about my order')
-                expectUnsignedCanonicalRumor(chat)
-                expect(() => assertOrderMessageRumor(chat)).not.toThrow()
-        })
+		expect(chat.kind).toBe(ORDER_GENERAL_KIND)
+		expect(chat.pubkey).toBe(BUYER_PUBKEY)
+		expect(tagValue(chat.tags, 'p')).toBe(SELLER_PUBKEY)
+		expect(tagValue(chat.tags, 'subject')).toBe('order-123')
+		expect(chat.content).toBe('Question about my order')
+		expectUnsignedCanonicalRumor(chat)
+		expect(() => assertOrderMessageRumor(chat)).not.toThrow()
+	})
 
-        test('rejects invalid order message rumors', () => {
-                const valid = createOrderCreationRumor({
-                        buyerPubkey: BUYER_PUBKEY,
-                        merchantPubkey: SELLER_PUBKEY,
-                        orderId: 'order-123',
-                        amountSats: 2100,
-                        items: [{ productRef: PRODUCT_REF, quantity: 2 }],
-                        content: 'Order created',
-                        createdAt: CREATED_AT,
-                })
+	test('rejects invalid order message rumors', () => {
+		const valid = createOrderCreationRumor({
+			buyerPubkey: BUYER_PUBKEY,
+			merchantPubkey: SELLER_PUBKEY,
+			orderId: 'order-123',
+			amountSats: 2100,
+			items: [{ productRef: PRODUCT_REF, quantity: 2 }],
+			content: 'Order created',
+			createdAt: CREATED_AT,
+		})
 
-                const missingRecipient = {
-                        ...valid,
-                        tags: valid.tags.filter((tag) => tag[0] !== 'p'),
-                }
+		const missingRecipient = {
+			...valid,
+			tags: valid.tags.filter((tag) => tag[0] !== 'p'),
+		}
 
-                expect(() => assertOrderMessageRumor(missingRecipient)).toThrow('Invalid order message rumor')
-        })
+		expect(() => assertOrderMessageRumor(missingRecipient)).toThrow('Invalid order message rumor')
+	})
 })

--- a/src/lib/__tests__/orderMessageRumor.test.ts
+++ b/src/lib/__tests__/orderMessageRumor.test.ts
@@ -186,18 +186,29 @@ describe('order message rumors', () => {
 		expect(() => assertOrderMessageRumor(chat)).not.toThrow()
 	})
 
-	test('rejects payment request rumors without payment methods', () => {
-		expect(() =>
-			createPaymentRequestRumor({
-				merchantPubkey: SELLER_PUBKEY,
-				buyerPubkey: BUYER_PUBKEY,
-				orderId: 'order-123',
-				amountSats: 2100,
-				paymentMethods: [] as never,
-				content: 'Payment details pending',
-				createdAt: CREATED_AT,
-			}),
-		).toThrow('Payment request rumors require at least one payment method')
+	test('creates a pending payment request rumor without payment methods', () => {
+		const rumor = createPaymentRequestRumor({
+			merchantPubkey: SELLER_PUBKEY,
+			buyerPubkey: BUYER_PUBKEY,
+			orderId: 'order-123',
+			amountSats: 2100,
+			paymentMethods: [],
+			content: 'Payment details pending',
+			createdAt: CREATED_AT,
+		})
+
+		expectUnsignedCanonicalRumor(rumor)
+		assertOrderMessageRumor(rumor)
+
+		expect(rumor.kind).toBe(ORDER_PROCESS_KIND)
+		expect(rumor.pubkey).toBe(SELLER_PUBKEY)
+		expect(tagValue(rumor.tags, 'p')).toBe(BUYER_PUBKEY)
+		expect(tagValue(rumor.tags, 'subject')).toBe('order-payment')
+		expect(tagValue(rumor.tags, 'type')).toBe(ORDER_MESSAGE_TYPE.PAYMENT_REQUEST)
+		expect(tagValue(rumor.tags, 'order')).toBe('order-123')
+		expect(tagValue(rumor.tags, 'amount')).toBe('2100')
+		expect(tagValues(rumor.tags, 'payment')).toEqual([])
+		expect(rumor.content).toBe('Payment details pending')
 	})
 
 	test('rejects invalid order message rumors', () => {

--- a/src/lib/nostr/nip17.ts
+++ b/src/lib/nostr/nip17.ts
@@ -6,60 +6,60 @@ const NIP17_MAX_TIMESTAMP_RANDOMIZATION_SECONDS = 2 * 24 * 60 * 60
 type Nip59SignerWrapResult = Awaited<ReturnType<typeof createNip59GiftWrapWithSigner>>
 
 export type CreateNip17GiftWrapsWithSignerParams = {
-        rumor: UnsignedRumor
-        signer: NDKSigner
-        recipientPubkey: string
-        recipientWrapperPrivateKey?: Uint8Array
-        senderWrapperPrivateKey?: Uint8Array
-        createdAt?: number
+	rumor: UnsignedRumor
+	signer: NDKSigner
+	recipientPubkey: string
+	recipientWrapperPrivateKey?: Uint8Array
+	senderWrapperPrivateKey?: Uint8Array
+	createdAt?: number
 }
 
 export type Nip17GiftWrapsWithSignerResult = {
-        rumor: Nip59SignerWrapResult['rumor']
-        recipient: Nip59SignerWrapResult
-        sender: Nip59SignerWrapResult
+	rumor: Nip59SignerWrapResult['rumor']
+	recipient: Nip59SignerWrapResult
+	sender: Nip59SignerWrapResult
 }
 
 export function randomizeNip17CreatedAt(now = Math.floor(Date.now() / 1000), random = Math.random): number {
-        const offset = Math.floor(random() * (NIP17_MAX_TIMESTAMP_RANDOMIZATION_SECONDS + 1))
-        return now - offset
+	const offset = Math.floor(random() * (NIP17_MAX_TIMESTAMP_RANDOMIZATION_SECONDS + 1))
+	return now - offset
 }
 
 async function signerPubkey(signer: NDKSigner): Promise<string> {
-        const user = await signer.user()
-        if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
-        return user.pubkey
+	const user = await signer.user()
+	if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
+	return user.pubkey
 }
 
 export async function createNip17GiftWrapsWithSigner(
-        params: CreateNip17GiftWrapsWithSignerParams,
+	params: CreateNip17GiftWrapsWithSignerParams,
 ): Promise<Nip17GiftWrapsWithSignerResult> {
-        const senderPubkey = await signerPubkey(params.signer)
-        const createdAt = params.createdAt ?? randomizeNip17CreatedAt()
+	const senderPubkey = await signerPubkey(params.signer)
+	const createdAt = params.createdAt ?? randomizeNip17CreatedAt()
 
-        const recipient = await createNip59GiftWrapWithSigner({
-                rumor: params.rumor,
-                signer: params.signer,
-                recipientPubkey: params.recipientPubkey,
-                wrapperPrivateKey: params.recipientWrapperPrivateKey,
-                createdAt,
-        })
+	const recipient = await createNip59GiftWrapWithSigner({
+		rumor: params.rumor,
+		signer: params.signer,
+		recipientPubkey: params.recipientPubkey,
+		wrapperPrivateKey: params.recipientWrapperPrivateKey,
+		createdAt,
+	})
 
-        const sender = await createNip59GiftWrapWithSigner({
-                rumor: recipient.rumor,
-                signer: params.signer,
-                recipientPubkey: senderPubkey,
-                wrapperPrivateKey: params.senderWrapperPrivateKey,
-                createdAt,
-        })
+	const sender = await createNip59GiftWrapWithSigner({
+		rumor: recipient.rumor,
+		signer: params.signer,
+		recipientPubkey: senderPubkey,
+		wrapperPrivateKey: params.senderWrapperPrivateKey,
+		createdAt,
+	})
 
-        if (recipient.rumor.id !== sender.rumor.id) {
-                throw new Error('NIP-17 gift wraps produced different rumor ids')
-        }
+	if (recipient.rumor.id !== sender.rumor.id) {
+		throw new Error('NIP-17 gift wraps produced different rumor ids')
+	}
 
-        return {
-                rumor: recipient.rumor,
-                recipient,
-                sender,
-        }
+	return {
+		rumor: recipient.rumor,
+		recipient,
+		sender,
+	}
 }

--- a/src/lib/nostr/nip17.ts
+++ b/src/lib/nostr/nip17.ts
@@ -1,0 +1,65 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
+import { createNip59GiftWrapWithSigner, type UnsignedRumor } from './nip59'
+
+const NIP17_MAX_TIMESTAMP_RANDOMIZATION_SECONDS = 2 * 24 * 60 * 60
+
+type Nip59SignerWrapResult = Awaited<ReturnType<typeof createNip59GiftWrapWithSigner>>
+
+export type CreateNip17GiftWrapsWithSignerParams = {
+        rumor: UnsignedRumor
+        signer: NDKSigner
+        recipientPubkey: string
+        recipientWrapperPrivateKey?: Uint8Array
+        senderWrapperPrivateKey?: Uint8Array
+        createdAt?: number
+}
+
+export type Nip17GiftWrapsWithSignerResult = {
+        rumor: Nip59SignerWrapResult['rumor']
+        recipient: Nip59SignerWrapResult
+        sender: Nip59SignerWrapResult
+}
+
+export function randomizeNip17CreatedAt(now = Math.floor(Date.now() / 1000), random = Math.random): number {
+        const offset = Math.floor(random() * (NIP17_MAX_TIMESTAMP_RANDOMIZATION_SECONDS + 1))
+        return now - offset
+}
+
+async function signerPubkey(signer: NDKSigner): Promise<string> {
+        const user = await signer.user()
+        if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
+        return user.pubkey
+}
+
+export async function createNip17GiftWrapsWithSigner(
+        params: CreateNip17GiftWrapsWithSignerParams,
+): Promise<Nip17GiftWrapsWithSignerResult> {
+        const senderPubkey = await signerPubkey(params.signer)
+        const createdAt = params.createdAt ?? randomizeNip17CreatedAt()
+
+        const recipient = await createNip59GiftWrapWithSigner({
+                rumor: params.rumor,
+                signer: params.signer,
+                recipientPubkey: params.recipientPubkey,
+                wrapperPrivateKey: params.recipientWrapperPrivateKey,
+                createdAt,
+        })
+
+        const sender = await createNip59GiftWrapWithSigner({
+                rumor: recipient.rumor,
+                signer: params.signer,
+                recipientPubkey: senderPubkey,
+                wrapperPrivateKey: params.senderWrapperPrivateKey,
+                createdAt,
+        })
+
+        if (recipient.rumor.id !== sender.rumor.id) {
+                throw new Error('NIP-17 gift wraps produced different rumor ids')
+        }
+
+        return {
+                rumor: recipient.rumor,
+                recipient,
+                sender,
+        }
+}

--- a/src/lib/orders/orderMessageRumor.ts
+++ b/src/lib/orders/orderMessageRumor.ts
@@ -1,0 +1,303 @@
+import { getEventHash } from 'nostr-tools'
+import {
+        GeneralCommunicationSchema,
+        ORDER_GENERAL_KIND,
+        ORDER_MESSAGE_TYPE,
+        ORDER_PROCESS_KIND,
+        ORDER_STATUS,
+        OrderCreationSchema,
+        PAYMENT_RECEIPT_KIND,
+        PaymentReceiptSchema,
+        PaymentRequestSchema,
+        SHIPPING_STATUS,
+        ShippingUpdateSchema,
+        StatusUpdateSchema,
+} from '../schemas/order'
+
+type PaymentMedium = 'lightning' | 'bitcoin' | 'fiat' | 'other'
+
+export type OrderMessageRumor = {
+        id: string
+        pubkey: string
+        created_at: number
+        kind: number
+        tags: string[][]
+        content: string
+}
+
+export type OrderItemInput = {
+        productRef: string
+        quantity: number
+}
+
+export type PaymentMethodInput = {
+        type: PaymentMedium
+        details: string
+        proof?: string
+}
+
+export type PaymentReceiptInput = {
+        medium: PaymentMedium
+        reference: string
+        proof: string
+}
+
+export type CreateOrderCreationRumorParams = {
+        buyerPubkey: string
+        merchantPubkey: string
+        orderId: string
+        amountSats: number
+        items: OrderItemInput[]
+        shippingRef?: string
+        content?: string
+        createdAt?: number
+}
+
+export type CreatePaymentRequestRumorParams = {
+        merchantPubkey: string
+        buyerPubkey: string
+        orderId: string
+        amountSats: number
+        paymentMethods: PaymentMethodInput[]
+        expirationTime?: number
+        content?: string
+        createdAt?: number
+}
+
+export type CreateStatusUpdateRumorParams = {
+        senderPubkey: string
+        recipientPubkey: string
+        orderId: string
+        status: (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS]
+        content?: string
+        createdAt?: number
+}
+
+export type CreateShippingUpdateRumorParams = {
+        senderPubkey: string
+        recipientPubkey: string
+        orderId: string
+        status: (typeof SHIPPING_STATUS)[keyof typeof SHIPPING_STATUS]
+        tracking?: string
+        carrier?: string
+        eta?: string
+        content?: string
+        createdAt?: number
+}
+
+export type CreatePaymentReceiptRumorParams = {
+        buyerPubkey: string
+        merchantPubkey: string
+        orderId: string
+        payment: PaymentReceiptInput
+        amountSats: number
+        content?: string
+        createdAt?: number
+}
+
+export type CreateOrderChatRumorParams = {
+        senderPubkey: string
+        recipientPubkey: string
+        subject?: string
+        content: string
+        createdAt?: number
+}
+
+export function createOrderCreationRumor(params: CreateOrderCreationRumorParams): OrderMessageRumor {
+        const tags: string[][] = [
+                ['p', params.merchantPubkey],
+                ['subject', 'order-info'],
+                ['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
+                ['order', params.orderId],
+                ['amount', params.amountSats.toString()],
+        ]
+
+        for (const item of params.items) {
+                tags.push(['item', item.productRef, item.quantity.toString()])
+        }
+
+        if (params.shippingRef) {
+                tags.push(['shipping', params.shippingRef])
+        }
+
+        return createCanonicalRumor({
+                kind: ORDER_PROCESS_KIND,
+                pubkey: params.buyerPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content ?? 'Order created',
+                tags,
+        })
+}
+
+export function createPaymentRequestRumor(params: CreatePaymentRequestRumorParams): OrderMessageRumor {
+        const tags: string[][] = [
+                ['p', params.buyerPubkey],
+                ['subject', 'order-payment'],
+                ['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
+                ['order', params.orderId],
+                ['amount', params.amountSats.toString()],
+        ]
+
+        for (const method of params.paymentMethods) {
+                const tag = ['payment', method.type, method.details]
+                if (method.proof !== undefined) tag.push(method.proof)
+                tags.push(tag)
+        }
+
+        if (params.expirationTime !== undefined) {
+                tags.push(['expiration', params.expirationTime.toString()])
+        }
+
+        return createCanonicalRumor({
+                kind: ORDER_PROCESS_KIND,
+                pubkey: params.merchantPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content ?? 'Payment request for your order',
+                tags,
+        })
+}
+
+export function createStatusUpdateRumor(params: CreateStatusUpdateRumorParams): OrderMessageRumor {
+        return createCanonicalRumor({
+                kind: ORDER_PROCESS_KIND,
+                pubkey: params.senderPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content ?? `Order status updated to ${params.status}`,
+                tags: [
+                        ['p', params.recipientPubkey],
+                        ['subject', 'order-info'],
+                        ['type', ORDER_MESSAGE_TYPE.STATUS_UPDATE],
+                        ['order', params.orderId],
+                        ['status', params.status],
+                ],
+        })
+}
+
+export function createShippingUpdateRumor(params: CreateShippingUpdateRumorParams): OrderMessageRumor {
+        const tags: string[][] = [
+                ['p', params.recipientPubkey],
+                ['subject', 'shipping-info'],
+                ['type', ORDER_MESSAGE_TYPE.SHIPPING_UPDATE],
+                ['order', params.orderId],
+                ['status', params.status],
+        ]
+
+        if (params.tracking) tags.push(['tracking', params.tracking])
+        if (params.carrier) tags.push(['carrier', params.carrier])
+        if (params.eta) tags.push(['eta', params.eta])
+
+        return createCanonicalRumor({
+                kind: ORDER_PROCESS_KIND,
+                pubkey: params.senderPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content ?? 'Shipping update',
+                tags,
+        })
+}
+
+export function createPaymentReceiptRumor(params: CreatePaymentReceiptRumorParams): OrderMessageRumor {
+        return createCanonicalRumor({
+                kind: PAYMENT_RECEIPT_KIND,
+                pubkey: params.buyerPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content ?? 'Payment confirmation',
+                tags: [
+                        ['p', params.merchantPubkey],
+                        ['subject', 'order-receipt'],
+                        ['order', params.orderId],
+                        ['payment', params.payment.medium, params.payment.reference, params.payment.proof],
+                        ['amount', params.amountSats.toString()],
+                ],
+        })
+}
+
+export function createOrderChatRumor(params: CreateOrderChatRumorParams): OrderMessageRumor {
+        const tags: string[][] = [['p', params.recipientPubkey]]
+
+        if (params.subject) {
+                tags.push(['subject', params.subject])
+        }
+
+        return createCanonicalRumor({
+                kind: ORDER_GENERAL_KIND,
+                pubkey: params.senderPubkey,
+                created_at: params.createdAt ?? unixNow(),
+                content: params.content,
+                tags,
+        })
+}
+
+export function assertOrderMessageRumor(value: unknown): asserts value is OrderMessageRumor {
+        try {
+                if (!isRecord(value)) throw new Error('not an object')
+                if (typeof value.id !== 'string') throw new Error('missing id')
+                if (typeof value.pubkey !== 'string') throw new Error('missing pubkey')
+                if (typeof value.created_at !== 'number') throw new Error('missing created_at')
+                if (typeof value.kind !== 'number') throw new Error('missing kind')
+                if (typeof value.content !== 'string') throw new Error('missing content')
+                if (!Array.isArray(value.tags)) throw new Error('missing tags')
+                if ('sig' in value) throw new Error('rumor must be unsigned')
+
+                const schemaInput = {
+                        kind: value.kind,
+                        created_at: value.created_at,
+                        content: value.content,
+                        tags: value.tags,
+                }
+
+                if (value.kind === ORDER_GENERAL_KIND) {
+                        GeneralCommunicationSchema.parse(schemaInput)
+                } else if (value.kind === ORDER_PROCESS_KIND) {
+                        const messageType = value.tags.find((tag) => tag[0] === 'type')?.[1]
+                        if (messageType === ORDER_MESSAGE_TYPE.ORDER_CREATION) {
+                                OrderCreationSchema.parse(schemaInput)
+                        } else if (messageType === ORDER_MESSAGE_TYPE.PAYMENT_REQUEST) {
+                                PaymentRequestSchema.parse(schemaInput)
+                        } else if (messageType === ORDER_MESSAGE_TYPE.STATUS_UPDATE) {
+                                StatusUpdateSchema.parse(schemaInput)
+                        } else if (messageType === ORDER_MESSAGE_TYPE.SHIPPING_UPDATE) {
+                                ShippingUpdateSchema.parse(schemaInput)
+                        } else {
+                                throw new Error('unknown order process message type')
+                        }
+                } else if (value.kind === PAYMENT_RECEIPT_KIND) {
+                        PaymentReceiptSchema.parse(schemaInput)
+                } else {
+                        throw new Error('unsupported order message kind')
+                }
+
+                if (value.id !== canonicalRumorId(value as OrderMessageRumor)) {
+                        throw new Error('non-canonical rumor id')
+                }
+        } catch {
+                throw new Error('Invalid order message rumor')
+        }
+}
+
+function createCanonicalRumor(rumor: Omit<OrderMessageRumor, 'id'>): OrderMessageRumor {
+        const withId = {
+                ...rumor,
+                id: canonicalRumorId(rumor),
+        }
+
+        assertOrderMessageRumor(withId)
+        return withId
+}
+
+function canonicalRumorId(rumor: Omit<OrderMessageRumor, 'id'>): string {
+        return getEventHash({
+                pubkey: rumor.pubkey,
+                created_at: rumor.created_at,
+                kind: rumor.kind,
+                tags: rumor.tags,
+                content: rumor.content,
+        })
+}
+
+function unixNow(): number {
+        return Math.floor(Date.now() / 1000)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+        return typeof value === 'object' && value !== null
+}

--- a/src/lib/orders/orderMessageRumor.ts
+++ b/src/lib/orders/orderMessageRumor.ts
@@ -1,303 +1,303 @@
 import { getEventHash } from 'nostr-tools'
 import {
-        GeneralCommunicationSchema,
-        ORDER_GENERAL_KIND,
-        ORDER_MESSAGE_TYPE,
-        ORDER_PROCESS_KIND,
-        ORDER_STATUS,
-        OrderCreationSchema,
-        PAYMENT_RECEIPT_KIND,
-        PaymentReceiptSchema,
-        PaymentRequestSchema,
-        SHIPPING_STATUS,
-        ShippingUpdateSchema,
-        StatusUpdateSchema,
+	GeneralCommunicationSchema,
+	ORDER_GENERAL_KIND,
+	ORDER_MESSAGE_TYPE,
+	ORDER_PROCESS_KIND,
+	ORDER_STATUS,
+	OrderCreationSchema,
+	PAYMENT_RECEIPT_KIND,
+	PaymentReceiptSchema,
+	PaymentRequestSchema,
+	SHIPPING_STATUS,
+	ShippingUpdateSchema,
+	StatusUpdateSchema,
 } from '../schemas/order'
 
 type PaymentMedium = 'lightning' | 'bitcoin' | 'fiat' | 'other'
 
 export type OrderMessageRumor = {
-        id: string
-        pubkey: string
-        created_at: number
-        kind: number
-        tags: string[][]
-        content: string
+	id: string
+	pubkey: string
+	created_at: number
+	kind: number
+	tags: string[][]
+	content: string
 }
 
 export type OrderItemInput = {
-        productRef: string
-        quantity: number
+	productRef: string
+	quantity: number
 }
 
 export type PaymentMethodInput = {
-        type: PaymentMedium
-        details: string
-        proof?: string
+	type: PaymentMedium
+	details: string
+	proof?: string
 }
 
 export type PaymentReceiptInput = {
-        medium: PaymentMedium
-        reference: string
-        proof: string
+	medium: PaymentMedium
+	reference: string
+	proof: string
 }
 
 export type CreateOrderCreationRumorParams = {
-        buyerPubkey: string
-        merchantPubkey: string
-        orderId: string
-        amountSats: number
-        items: OrderItemInput[]
-        shippingRef?: string
-        content?: string
-        createdAt?: number
+	buyerPubkey: string
+	merchantPubkey: string
+	orderId: string
+	amountSats: number
+	items: OrderItemInput[]
+	shippingRef?: string
+	content?: string
+	createdAt?: number
 }
 
 export type CreatePaymentRequestRumorParams = {
-        merchantPubkey: string
-        buyerPubkey: string
-        orderId: string
-        amountSats: number
-        paymentMethods: PaymentMethodInput[]
-        expirationTime?: number
-        content?: string
-        createdAt?: number
+	merchantPubkey: string
+	buyerPubkey: string
+	orderId: string
+	amountSats: number
+	paymentMethods: PaymentMethodInput[]
+	expirationTime?: number
+	content?: string
+	createdAt?: number
 }
 
 export type CreateStatusUpdateRumorParams = {
-        senderPubkey: string
-        recipientPubkey: string
-        orderId: string
-        status: (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS]
-        content?: string
-        createdAt?: number
+	senderPubkey: string
+	recipientPubkey: string
+	orderId: string
+	status: (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS]
+	content?: string
+	createdAt?: number
 }
 
 export type CreateShippingUpdateRumorParams = {
-        senderPubkey: string
-        recipientPubkey: string
-        orderId: string
-        status: (typeof SHIPPING_STATUS)[keyof typeof SHIPPING_STATUS]
-        tracking?: string
-        carrier?: string
-        eta?: string
-        content?: string
-        createdAt?: number
+	senderPubkey: string
+	recipientPubkey: string
+	orderId: string
+	status: (typeof SHIPPING_STATUS)[keyof typeof SHIPPING_STATUS]
+	tracking?: string
+	carrier?: string
+	eta?: string
+	content?: string
+	createdAt?: number
 }
 
 export type CreatePaymentReceiptRumorParams = {
-        buyerPubkey: string
-        merchantPubkey: string
-        orderId: string
-        payment: PaymentReceiptInput
-        amountSats: number
-        content?: string
-        createdAt?: number
+	buyerPubkey: string
+	merchantPubkey: string
+	orderId: string
+	payment: PaymentReceiptInput
+	amountSats: number
+	content?: string
+	createdAt?: number
 }
 
 export type CreateOrderChatRumorParams = {
-        senderPubkey: string
-        recipientPubkey: string
-        subject?: string
-        content: string
-        createdAt?: number
+	senderPubkey: string
+	recipientPubkey: string
+	subject?: string
+	content: string
+	createdAt?: number
 }
 
 export function createOrderCreationRumor(params: CreateOrderCreationRumorParams): OrderMessageRumor {
-        const tags: string[][] = [
-                ['p', params.merchantPubkey],
-                ['subject', 'order-info'],
-                ['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
-                ['order', params.orderId],
-                ['amount', params.amountSats.toString()],
-        ]
+	const tags: string[][] = [
+		['p', params.merchantPubkey],
+		['subject', 'order-info'],
+		['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
+		['order', params.orderId],
+		['amount', params.amountSats.toString()],
+	]
 
-        for (const item of params.items) {
-                tags.push(['item', item.productRef, item.quantity.toString()])
-        }
+	for (const item of params.items) {
+		tags.push(['item', item.productRef, item.quantity.toString()])
+	}
 
-        if (params.shippingRef) {
-                tags.push(['shipping', params.shippingRef])
-        }
+	if (params.shippingRef) {
+		tags.push(['shipping', params.shippingRef])
+	}
 
-        return createCanonicalRumor({
-                kind: ORDER_PROCESS_KIND,
-                pubkey: params.buyerPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content ?? 'Order created',
-                tags,
-        })
+	return createCanonicalRumor({
+		kind: ORDER_PROCESS_KIND,
+		pubkey: params.buyerPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content ?? 'Order created',
+		tags,
+	})
 }
 
 export function createPaymentRequestRumor(params: CreatePaymentRequestRumorParams): OrderMessageRumor {
-        const tags: string[][] = [
-                ['p', params.buyerPubkey],
-                ['subject', 'order-payment'],
-                ['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
-                ['order', params.orderId],
-                ['amount', params.amountSats.toString()],
-        ]
+	const tags: string[][] = [
+		['p', params.buyerPubkey],
+		['subject', 'order-payment'],
+		['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
+		['order', params.orderId],
+		['amount', params.amountSats.toString()],
+	]
 
-        for (const method of params.paymentMethods) {
-                const tag = ['payment', method.type, method.details]
-                if (method.proof !== undefined) tag.push(method.proof)
-                tags.push(tag)
-        }
+	for (const method of params.paymentMethods) {
+		const tag = ['payment', method.type, method.details]
+		if (method.proof !== undefined) tag.push(method.proof)
+		tags.push(tag)
+	}
 
-        if (params.expirationTime !== undefined) {
-                tags.push(['expiration', params.expirationTime.toString()])
-        }
+	if (params.expirationTime !== undefined) {
+		tags.push(['expiration', params.expirationTime.toString()])
+	}
 
-        return createCanonicalRumor({
-                kind: ORDER_PROCESS_KIND,
-                pubkey: params.merchantPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content ?? 'Payment request for your order',
-                tags,
-        })
+	return createCanonicalRumor({
+		kind: ORDER_PROCESS_KIND,
+		pubkey: params.merchantPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content ?? 'Payment request for your order',
+		tags,
+	})
 }
 
 export function createStatusUpdateRumor(params: CreateStatusUpdateRumorParams): OrderMessageRumor {
-        return createCanonicalRumor({
-                kind: ORDER_PROCESS_KIND,
-                pubkey: params.senderPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content ?? `Order status updated to ${params.status}`,
-                tags: [
-                        ['p', params.recipientPubkey],
-                        ['subject', 'order-info'],
-                        ['type', ORDER_MESSAGE_TYPE.STATUS_UPDATE],
-                        ['order', params.orderId],
-                        ['status', params.status],
-                ],
-        })
+	return createCanonicalRumor({
+		kind: ORDER_PROCESS_KIND,
+		pubkey: params.senderPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content ?? `Order status updated to ${params.status}`,
+		tags: [
+			['p', params.recipientPubkey],
+			['subject', 'order-info'],
+			['type', ORDER_MESSAGE_TYPE.STATUS_UPDATE],
+			['order', params.orderId],
+			['status', params.status],
+		],
+	})
 }
 
 export function createShippingUpdateRumor(params: CreateShippingUpdateRumorParams): OrderMessageRumor {
-        const tags: string[][] = [
-                ['p', params.recipientPubkey],
-                ['subject', 'shipping-info'],
-                ['type', ORDER_MESSAGE_TYPE.SHIPPING_UPDATE],
-                ['order', params.orderId],
-                ['status', params.status],
-        ]
+	const tags: string[][] = [
+		['p', params.recipientPubkey],
+		['subject', 'shipping-info'],
+		['type', ORDER_MESSAGE_TYPE.SHIPPING_UPDATE],
+		['order', params.orderId],
+		['status', params.status],
+	]
 
-        if (params.tracking) tags.push(['tracking', params.tracking])
-        if (params.carrier) tags.push(['carrier', params.carrier])
-        if (params.eta) tags.push(['eta', params.eta])
+	if (params.tracking) tags.push(['tracking', params.tracking])
+	if (params.carrier) tags.push(['carrier', params.carrier])
+	if (params.eta) tags.push(['eta', params.eta])
 
-        return createCanonicalRumor({
-                kind: ORDER_PROCESS_KIND,
-                pubkey: params.senderPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content ?? 'Shipping update',
-                tags,
-        })
+	return createCanonicalRumor({
+		kind: ORDER_PROCESS_KIND,
+		pubkey: params.senderPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content ?? 'Shipping update',
+		tags,
+	})
 }
 
 export function createPaymentReceiptRumor(params: CreatePaymentReceiptRumorParams): OrderMessageRumor {
-        return createCanonicalRumor({
-                kind: PAYMENT_RECEIPT_KIND,
-                pubkey: params.buyerPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content ?? 'Payment confirmation',
-                tags: [
-                        ['p', params.merchantPubkey],
-                        ['subject', 'order-receipt'],
-                        ['order', params.orderId],
-                        ['payment', params.payment.medium, params.payment.reference, params.payment.proof],
-                        ['amount', params.amountSats.toString()],
-                ],
-        })
+	return createCanonicalRumor({
+		kind: PAYMENT_RECEIPT_KIND,
+		pubkey: params.buyerPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content ?? 'Payment confirmation',
+		tags: [
+			['p', params.merchantPubkey],
+			['subject', 'order-receipt'],
+			['order', params.orderId],
+			['payment', params.payment.medium, params.payment.reference, params.payment.proof],
+			['amount', params.amountSats.toString()],
+		],
+	})
 }
 
 export function createOrderChatRumor(params: CreateOrderChatRumorParams): OrderMessageRumor {
-        const tags: string[][] = [['p', params.recipientPubkey]]
+	const tags: string[][] = [['p', params.recipientPubkey]]
 
-        if (params.subject) {
-                tags.push(['subject', params.subject])
-        }
+	if (params.subject) {
+		tags.push(['subject', params.subject])
+	}
 
-        return createCanonicalRumor({
-                kind: ORDER_GENERAL_KIND,
-                pubkey: params.senderPubkey,
-                created_at: params.createdAt ?? unixNow(),
-                content: params.content,
-                tags,
-        })
+	return createCanonicalRumor({
+		kind: ORDER_GENERAL_KIND,
+		pubkey: params.senderPubkey,
+		created_at: params.createdAt ?? unixNow(),
+		content: params.content,
+		tags,
+	})
 }
 
 export function assertOrderMessageRumor(value: unknown): asserts value is OrderMessageRumor {
-        try {
-                if (!isRecord(value)) throw new Error('not an object')
-                if (typeof value.id !== 'string') throw new Error('missing id')
-                if (typeof value.pubkey !== 'string') throw new Error('missing pubkey')
-                if (typeof value.created_at !== 'number') throw new Error('missing created_at')
-                if (typeof value.kind !== 'number') throw new Error('missing kind')
-                if (typeof value.content !== 'string') throw new Error('missing content')
-                if (!Array.isArray(value.tags)) throw new Error('missing tags')
-                if ('sig' in value) throw new Error('rumor must be unsigned')
+	try {
+		if (!isRecord(value)) throw new Error('not an object')
+		if (typeof value.id !== 'string') throw new Error('missing id')
+		if (typeof value.pubkey !== 'string') throw new Error('missing pubkey')
+		if (typeof value.created_at !== 'number') throw new Error('missing created_at')
+		if (typeof value.kind !== 'number') throw new Error('missing kind')
+		if (typeof value.content !== 'string') throw new Error('missing content')
+		if (!Array.isArray(value.tags)) throw new Error('missing tags')
+		if ('sig' in value) throw new Error('rumor must be unsigned')
 
-                const schemaInput = {
-                        kind: value.kind,
-                        created_at: value.created_at,
-                        content: value.content,
-                        tags: value.tags,
-                }
+		const schemaInput = {
+			kind: value.kind,
+			created_at: value.created_at,
+			content: value.content,
+			tags: value.tags,
+		}
 
-                if (value.kind === ORDER_GENERAL_KIND) {
-                        GeneralCommunicationSchema.parse(schemaInput)
-                } else if (value.kind === ORDER_PROCESS_KIND) {
-                        const messageType = value.tags.find((tag) => tag[0] === 'type')?.[1]
-                        if (messageType === ORDER_MESSAGE_TYPE.ORDER_CREATION) {
-                                OrderCreationSchema.parse(schemaInput)
-                        } else if (messageType === ORDER_MESSAGE_TYPE.PAYMENT_REQUEST) {
-                                PaymentRequestSchema.parse(schemaInput)
-                        } else if (messageType === ORDER_MESSAGE_TYPE.STATUS_UPDATE) {
-                                StatusUpdateSchema.parse(schemaInput)
-                        } else if (messageType === ORDER_MESSAGE_TYPE.SHIPPING_UPDATE) {
-                                ShippingUpdateSchema.parse(schemaInput)
-                        } else {
-                                throw new Error('unknown order process message type')
-                        }
-                } else if (value.kind === PAYMENT_RECEIPT_KIND) {
-                        PaymentReceiptSchema.parse(schemaInput)
-                } else {
-                        throw new Error('unsupported order message kind')
-                }
+		if (value.kind === ORDER_GENERAL_KIND) {
+			GeneralCommunicationSchema.parse(schemaInput)
+		} else if (value.kind === ORDER_PROCESS_KIND) {
+			const messageType = value.tags.find((tag) => tag[0] === 'type')?.[1]
+			if (messageType === ORDER_MESSAGE_TYPE.ORDER_CREATION) {
+				OrderCreationSchema.parse(schemaInput)
+			} else if (messageType === ORDER_MESSAGE_TYPE.PAYMENT_REQUEST) {
+				PaymentRequestSchema.parse(schemaInput)
+			} else if (messageType === ORDER_MESSAGE_TYPE.STATUS_UPDATE) {
+				StatusUpdateSchema.parse(schemaInput)
+			} else if (messageType === ORDER_MESSAGE_TYPE.SHIPPING_UPDATE) {
+				ShippingUpdateSchema.parse(schemaInput)
+			} else {
+				throw new Error('unknown order process message type')
+			}
+		} else if (value.kind === PAYMENT_RECEIPT_KIND) {
+			PaymentReceiptSchema.parse(schemaInput)
+		} else {
+			throw new Error('unsupported order message kind')
+		}
 
-                if (value.id !== canonicalRumorId(value as OrderMessageRumor)) {
-                        throw new Error('non-canonical rumor id')
-                }
-        } catch {
-                throw new Error('Invalid order message rumor')
-        }
+		if (value.id !== canonicalRumorId(value as OrderMessageRumor)) {
+			throw new Error('non-canonical rumor id')
+		}
+	} catch {
+		throw new Error('Invalid order message rumor')
+	}
 }
 
 function createCanonicalRumor(rumor: Omit<OrderMessageRumor, 'id'>): OrderMessageRumor {
-        const withId = {
-                ...rumor,
-                id: canonicalRumorId(rumor),
-        }
+	const withId = {
+		...rumor,
+		id: canonicalRumorId(rumor),
+	}
 
-        assertOrderMessageRumor(withId)
-        return withId
+	assertOrderMessageRumor(withId)
+	return withId
 }
 
 function canonicalRumorId(rumor: Omit<OrderMessageRumor, 'id'>): string {
-        return getEventHash({
-                pubkey: rumor.pubkey,
-                created_at: rumor.created_at,
-                kind: rumor.kind,
-                tags: rumor.tags,
-                content: rumor.content,
-        })
+	return getEventHash({
+		pubkey: rumor.pubkey,
+		created_at: rumor.created_at,
+		kind: rumor.kind,
+		tags: rumor.tags,
+		content: rumor.content,
+	})
 }
 
 function unixNow(): number {
-        return Math.floor(Date.now() / 1000)
+	return Math.floor(Date.now() / 1000)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-        return typeof value === 'object' && value !== null
+	return typeof value === 'object' && value !== null
 }

--- a/src/lib/orders/orderMessageRumor.ts
+++ b/src/lib/orders/orderMessageRumor.ts
@@ -15,7 +15,6 @@ import {
 } from '../schemas/order'
 
 type PaymentMedium = 'lightning' | 'bitcoin' | 'fiat' | 'other'
-type NonEmptyArray<T> = [T, ...T[]]
 
 export type OrderMessageRumor = {
 	id: string
@@ -59,7 +58,7 @@ export type CreatePaymentRequestRumorParams = {
 	buyerPubkey: string
 	orderId: string
 	amountSats: number
-	paymentMethods: NonEmptyArray<PaymentMethodInput>
+	paymentMethods: PaymentMethodInput[]
 	expirationTime?: number
 	content?: string
 	createdAt?: number
@@ -131,10 +130,6 @@ export function createOrderCreationRumor(params: CreateOrderCreationRumorParams)
 }
 
 export function createPaymentRequestRumor(params: CreatePaymentRequestRumorParams): OrderMessageRumor {
-	if (params.paymentMethods.length === 0) {
-		throw new Error('Payment request rumors require at least one payment method')
-	}
-
 	const tags: string[][] = [
 		['p', params.buyerPubkey],
 		['subject', 'order-payment'],

--- a/src/lib/orders/orderMessageRumor.ts
+++ b/src/lib/orders/orderMessageRumor.ts
@@ -15,6 +15,7 @@ import {
 } from '../schemas/order'
 
 type PaymentMedium = 'lightning' | 'bitcoin' | 'fiat' | 'other'
+type NonEmptyArray<T> = [T, ...T[]]
 
 export type OrderMessageRumor = {
 	id: string
@@ -58,7 +59,7 @@ export type CreatePaymentRequestRumorParams = {
 	buyerPubkey: string
 	orderId: string
 	amountSats: number
-	paymentMethods: PaymentMethodInput[]
+	paymentMethods: NonEmptyArray<PaymentMethodInput>
 	expirationTime?: number
 	content?: string
 	createdAt?: number
@@ -130,6 +131,10 @@ export function createOrderCreationRumor(params: CreateOrderCreationRumorParams)
 }
 
 export function createPaymentRequestRumor(params: CreatePaymentRequestRumorParams): OrderMessageRumor {
+	if (params.paymentMethods.length === 0) {
+		throw new Error('Payment request rumors require at least one payment method')
+	}
+
 	const tags: string[][] = [
 		['p', params.buyerPubkey],
 		['subject', 'order-payment'],

--- a/src/lib/schemas/order.ts
+++ b/src/lib/schemas/order.ts
@@ -141,18 +141,19 @@ export const PaymentRequestSchema = z.object({
 		)
 		.refine(
 			(tags) => {
-				// Verify required tags are present
+				// Verify required tags are present. Payment method tags are optional for
+				// pending/manual payment setup where a seller or V4V recipient has not
+				// configured payment details yet.
 				return (
 					tags.some((tag) => tag[0] === 'p') &&
 					tags.some((tag) => tag[0] === 'subject') &&
 					tags.some((tag) => tag[0] === 'type' && tag[1] === ORDER_MESSAGE_TYPE.PAYMENT_REQUEST) &&
 					tags.some((tag) => tag[0] === 'order') &&
-					tags.some((tag) => tag[0] === 'amount') &&
-					tags.some((tag) => tag[0] === 'payment')
+					tags.some((tag) => tag[0] === 'amount')
 				)
 			},
 			{
-				message: 'Missing required tags: p, subject, type, order, amount, payment',
+				message: 'Missing required tags: p, subject, type, order, amount',
 			},
 		),
 })


### PR DESCRIPTION
## Summary

Adds a PR-1 foundation for #1084 by introducing a tested NIP-17/Gamma order-message boundary without wiring it into checkout, payment publishing, reads, relay resolution, or global NDK publish behavior.

## What changed

- Added ADR-013 for NIP-17 order message transport.
- Added `src/lib/nostr/nip17.ts` for recipient gift wrap + sender self-wrap creation.
- Added `src/lib/orders/orderMessageRumor.ts` for pure Gamma-shaped order-message rumor builders and schema-backed validation.
- Added covered unit tests for:
  - recipient and sender self-wraps
  - canonical unsigned inner rumors
  - no public gift-wrap leakage of order/payment/PII sentinels
  - NIP-44 failure behavior
  - NIP-17 timestamp randomization bounds
  - kind 14, kind 16 type 1–4, and kind 17 inner rumor shapes

## Non-goals

- No checkout/order publish wiring.
- No payment publish wiring.
- No read-path migration.
- No relay resolver or kind 10050 routing implementation.
- No global NDK publish or relay behavior changes.
- No removal of legacy raw kind 14/16/17 reads.

## Validation

- `bun test src/lib/__tests__/nip17.test.ts`
- `bun test src/lib/__tests__/orderMessageRumor.test.ts`
- `bun run test:unit`

Latest local result:

```text
109 pass
0 fail
425 expect() calls
```
