### PR TITLE
feat(nostr): add NIP-17 DM relay resolver

### DIFF
--- a/src/lib/__tests__/nip17Relays.test.ts
+++ b/src/lib/__tests__/nip17Relays.test.ts
@@ -47,6 +47,7 @@ describe('NIP-17 DM relay resolution', () => {
 			['relay', ' wss://Relay.Example.com/ '],
 			['relay', 'wss://relay.example.com'],
 			['relay', 'ws://localhost:7777/'],
+			['relay', 'wss://relay.example.com/nostr/'],
 			['relay', 'https://not-a-relay.example'],
 			['relay', ''],
 			['relay'],
@@ -54,7 +55,7 @@ describe('NIP-17 DM relay resolution', () => {
 			['relay', 'not a url'],
 		])
 
-		expect(parseNip17DmRelays(event)).toEqual(['wss://relay.example.com', 'ws://localhost:7777'])
+		expect(parseNip17DmRelays(event)).toEqual(['wss://relay.example.com', 'ws://localhost:7777', 'wss://relay.example.com/nostr/'])
 	})
 
 	test('selects the latest kind 10050 event for the requested pubkey', () => {

--- a/src/lib/__tests__/nip17Relays.test.ts
+++ b/src/lib/__tests__/nip17Relays.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	NIP17_DM_RELAY_LIST_KIND,
+	buildNip17DmRelayListFilter,
+	parseNip17DmRelays,
+	resolveNip17DmRelayListFromEvents,
+	resolveNip17RelayTargetsFromEvents,
+} from '../nostr/nip17Relays'
+
+const SENDER_PUBKEY = 'a'.repeat(64)
+const RECIPIENT_PUBKEY = 'b'.repeat(64)
+
+function relayListEvent(
+	pubkey: string,
+	createdAt: number,
+	tags: string[][],
+	id = `${pubkey}-${createdAt}`,
+): {
+	id: string
+	kind: number
+	pubkey: string
+	created_at: number
+	tags: string[][]
+	content: string
+} {
+	return {
+		id,
+		kind: NIP17_DM_RELAY_LIST_KIND,
+		pubkey,
+		created_at: createdAt,
+		tags,
+		content: '',
+	}
+}
+
+describe('NIP-17 DM relay resolution', () => {
+	test('builds a strict kind 10050 relay-list filter', () => {
+		expect(buildNip17DmRelayListFilter(RECIPIENT_PUBKEY)).toEqual({
+			kinds: [NIP17_DM_RELAY_LIST_KIND],
+			authors: [RECIPIENT_PUBKEY],
+			limit: 1,
+		})
+	})
+
+	test('parses, normalizes, and dedupes relay tags from a kind 10050 event', () => {
+		const event = relayListEvent(RECIPIENT_PUBKEY, 100, [
+			['relay', ' wss://Relay.Example.com/ '],
+			['relay', 'wss://relay.example.com'],
+			['relay', 'ws://localhost:7777/'],
+			['relay', 'https://not-a-relay.example'],
+			['relay', ''],
+			['relay'],
+			['r', 'wss://wrong-tag.example'],
+			['relay', 'not a url'],
+		])
+
+		expect(parseNip17DmRelays(event)).toEqual(['wss://relay.example.com', 'ws://localhost:7777'])
+	})
+
+	test('selects the latest kind 10050 event for the requested pubkey', () => {
+		const older = relayListEvent(RECIPIENT_PUBKEY, 100, [['relay', 'wss://older.example']])
+		const newer = relayListEvent(RECIPIENT_PUBKEY, 200, [['relay', 'wss://newer.example']])
+		const wrongAuthor = relayListEvent(SENDER_PUBKEY, 300, [['relay', 'wss://sender.example']])
+		const wrongKind = {
+			...relayListEvent(RECIPIENT_PUBKEY, 400, [['relay', 'wss://kind-10002.example']]),
+			kind: 10002,
+		}
+
+		const result = resolveNip17DmRelayListFromEvents([older, wrongAuthor, newer, wrongKind], RECIPIENT_PUBKEY)
+
+		expect(result.status).toBe('ready')
+		expect(result.pubkey).toBe(RECIPIENT_PUBKEY)
+		expect(result.event).toBe(newer)
+		expect(result.relays).toEqual(['wss://newer.example'])
+	})
+
+	test('fails closed when the user has no usable kind 10050 relay list', () => {
+		expect(resolveNip17DmRelayListFromEvents([], RECIPIENT_PUBKEY)).toEqual({
+			status: 'missing',
+			pubkey: RECIPIENT_PUBKEY,
+			relays: [],
+		})
+
+		const emptyList = relayListEvent(RECIPIENT_PUBKEY, 100, [
+			['relay', 'https://not-a-relay.example'],
+			['r', 'wss://not-a-dm-relay-tag.example'],
+		])
+
+		const result = resolveNip17DmRelayListFromEvents([emptyList], RECIPIENT_PUBKEY)
+
+		expect(result.status).toBe('empty')
+		expect(result.pubkey).toBe(RECIPIENT_PUBKEY)
+		expect(result.event).toBe(emptyList)
+		expect(result.relays).toEqual([])
+	})
+
+	test('resolves recipient and sender relay targets without fallback relays', () => {
+		const recipientList = relayListEvent(RECIPIENT_PUBKEY, 100, [['relay', 'wss://recipient.example']])
+		const senderList = relayListEvent(SENDER_PUBKEY, 100, [['relay', 'wss://sender.example']])
+
+		const readyTargets = resolveNip17RelayTargetsFromEvents({
+			recipientPubkey: RECIPIENT_PUBKEY,
+			senderPubkey: SENDER_PUBKEY,
+			recipientEvents: [recipientList],
+			senderEvents: [senderList],
+		})
+
+		expect(readyTargets.ready).toBe(true)
+		expect(readyTargets.recipient.relays).toEqual(['wss://recipient.example'])
+		expect(readyTargets.sender.relays).toEqual(['wss://sender.example'])
+
+		const missingSenderTargets = resolveNip17RelayTargetsFromEvents({
+			recipientPubkey: RECIPIENT_PUBKEY,
+			senderPubkey: SENDER_PUBKEY,
+			recipientEvents: [recipientList],
+			senderEvents: [],
+		})
+
+		expect(missingSenderTargets.ready).toBe(false)
+		expect(missingSenderTargets.recipient.status).toBe('ready')
+		expect(missingSenderTargets.sender.status).toBe('missing')
+	})
+})

--- a/src/lib/nostr/nip17Relays.ts
+++ b/src/lib/nostr/nip17Relays.ts
@@ -1,0 +1,150 @@
+export const NIP17_DM_RELAY_LIST_KIND = 10050
+
+export type Nip17DmRelayListEvent = {
+	id?: string
+	kind: number
+	pubkey: string
+	created_at: number
+	tags: string[][]
+	content?: string
+}
+
+export type Nip17DmRelayListFilter = {
+	kinds: [typeof NIP17_DM_RELAY_LIST_KIND]
+	authors: [string]
+	limit: 1
+}
+
+export type Nip17DmRelayListReadyResult = {
+	status: 'ready'
+	pubkey: string
+	event: Nip17DmRelayListEvent
+	relays: string[]
+}
+
+export type Nip17DmRelayListMissingResult = {
+	status: 'missing'
+	pubkey: string
+	relays: []
+}
+
+export type Nip17DmRelayListEmptyResult = {
+	status: 'empty'
+	pubkey: string
+	event: Nip17DmRelayListEvent
+	relays: []
+}
+
+export type Nip17DmRelayListResult = Nip17DmRelayListReadyResult | Nip17DmRelayListMissingResult | Nip17DmRelayListEmptyResult
+
+export type ResolveNip17RelayTargetsFromEventsParams = {
+	recipientPubkey: string
+	senderPubkey: string
+	recipientEvents: Nip17DmRelayListEvent[]
+	senderEvents: Nip17DmRelayListEvent[]
+}
+
+export type Nip17RelayTargetsResult = {
+	ready: boolean
+	recipient: Nip17DmRelayListResult
+	sender: Nip17DmRelayListResult
+}
+
+export function buildNip17DmRelayListFilter(pubkey: string): Nip17DmRelayListFilter {
+	return {
+		kinds: [NIP17_DM_RELAY_LIST_KIND],
+		authors: [pubkey],
+		limit: 1,
+	}
+}
+
+export function parseNip17DmRelays(event: Pick<Nip17DmRelayListEvent, 'tags'>): string[] {
+	const relays: string[] = []
+	const seen = new Set<string>()
+
+	for (const tag of event.tags) {
+		if (tag[0] !== 'relay') continue
+
+		const relay = normalizeRelayUrl(tag[1])
+		if (!relay || seen.has(relay)) continue
+
+		seen.add(relay)
+		relays.push(relay)
+	}
+
+	return relays
+}
+
+export function resolveNip17DmRelayListFromEvents(events: Nip17DmRelayListEvent[], pubkey: string): Nip17DmRelayListResult {
+	const event = latestNip17DmRelayListEvent(events, pubkey)
+
+	if (!event) {
+		return {
+			status: 'missing',
+			pubkey,
+			relays: [],
+		}
+	}
+
+	const relays = parseNip17DmRelays(event)
+
+	if (relays.length === 0) {
+		return {
+			status: 'empty',
+			pubkey,
+			event,
+			relays: [],
+		}
+	}
+
+	return {
+		status: 'ready',
+		pubkey,
+		event,
+		relays,
+	}
+}
+
+export function resolveNip17RelayTargetsFromEvents(params: ResolveNip17RelayTargetsFromEventsParams): Nip17RelayTargetsResult {
+	const recipient = resolveNip17DmRelayListFromEvents(params.recipientEvents, params.recipientPubkey)
+	const sender = resolveNip17DmRelayListFromEvents(params.senderEvents, params.senderPubkey)
+
+	return {
+		ready: recipient.status === 'ready' && sender.status === 'ready',
+		recipient,
+		sender,
+	}
+}
+
+function latestNip17DmRelayListEvent(events: Nip17DmRelayListEvent[], pubkey: string): Nip17DmRelayListEvent | undefined {
+	return events
+		.filter((event) => event.kind === NIP17_DM_RELAY_LIST_KIND && event.pubkey === pubkey)
+		.sort(compareRelayListEventsNewestFirst)[0]
+}
+
+function compareRelayListEventsNewestFirst(a: Nip17DmRelayListEvent, b: Nip17DmRelayListEvent): number {
+	if (a.created_at !== b.created_at) return b.created_at - a.created_at
+
+	const aId = a.id ?? ''
+	const bId = b.id ?? ''
+	return bId.localeCompare(aId)
+}
+
+function normalizeRelayUrl(value: string | undefined): string | undefined {
+	if (!value) return undefined
+
+	try {
+		const url = new URL(value.trim())
+		if (url.protocol !== 'ws:' && url.protocol !== 'wss:') return undefined
+		if (!url.hostname) return undefined
+		if (url.username || url.password) return undefined
+
+		url.protocol = url.protocol.toLowerCase()
+		url.hostname = url.hostname.toLowerCase()
+
+		const normalized = url.toString()
+		return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
+	} catch {
+		return undefined
+	}
+}

--- a/src/lib/nostr/nip17Relays.ts
+++ b/src/lib/nostr/nip17Relays.ts
@@ -143,7 +143,11 @@ function normalizeRelayUrl(value: string | undefined): string | undefined {
 		url.hostname = url.hostname.toLowerCase()
 
 		const normalized = url.toString()
-		return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized
+		if (url.pathname === '/' && !url.search && !url.hash) {
+			return normalized.slice(0, -1)
+		}
+
+		return normalized
 	} catch {
 		return undefined
 	}


### PR DESCRIPTION
## Summary

Adds a focused NIP-17 DM relay resolver boundary for issue #1084.

This PR handles kind `10050` DM relay-list parsing and sender/recipient relay target resolution only. It does not wire publishing, checkout/payment/order flows, read-path migration, global NDK relay behavior, or fallback relay behavior.

## What changed

- Added `src/lib/nostr/nip17Relays.ts`
  - Defines `NIP17_DM_RELAY_LIST_KIND = 10050`
  - Builds strict kind `10050` relay-list filters
  - Parses `relay` tags only
  - Normalizes and dedupes `ws://` / `wss://` relay URLs
  - Selects the latest matching kind `10050` event for a pubkey
  - Returns explicit `ready`, `missing`, and `empty` states
  - Resolves recipient and sender relay targets without fallback relays

- Added `src/lib/__tests__/nip17Relays.test.ts`
  - Covers filter shape
  - Covers relay URL normalization/deduping
  - Covers latest-event selection
  - Covers fail-closed missing/empty relay-list behavior
  - Covers sender + recipient target resolution

## Non-goals

- No publish wiring.
- No checkout/payment/order behavior changes.
- No read-path migration.
- No global NDK relay behavior changes.
- No kind `10002` / NIP-65 fallback.
- No app/default relay fallback.
- No gift-wrap creation changes.

## Validation

- `bun test src/lib/__tests__/nip17Relays.test.ts`
- `bun run format:check`
- `bun run test:unit`

Latest local result:

```text
5 pass
0 fail
17 expect() calls

108 pass
0 fail
328 expect() calls
```
