### PR TITLE
docs(agents): add 4-class bot governance taxonomy to AGENTS.md framework

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,5 +1,10 @@
 # .github Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** human-only
+- **Sensitive Surface:** CI/CD supply chain; SSH deploy secrets (#996 H5: unpinned bun, H7: password SSH); workflows control production deployment
+
 ## CI/CD Pipeline Architecture
 
 ### Core Workflow Structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,32 @@ PR.
 
 ---
 
+## Bot Governance Taxonomy
+
+Every directory in this repository has a **governance class** that determines
+what level of automation is appropriate and what approval is required before
+merging changes. Each subdirectory `AGENTS.md` must declare its class.
+
+| Class                              | Typical Scope                                                                 | Approval Model                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------ |
+| **bot-safe**                       | Docs, formatting, dead code removal, low-risk dep bumps, test fixture cleanup | Bot prepares, auto-merges after CI passes        |
+| **bot-reviewed-human-approve**     | UI work, moderate refactors, non-critical feature changes                     | Bot proposes, human approves                     |
+| **human-only**                     | Secrets, key handling, signing, payment settlement, trust boundaries          | Human review required, no automated PRs          |
+| **architecture-decision-required** | Cross-package dependency changes, major restructures, root config             | Explicit architectural approval from maintainers |
+
+### Class Inheritance
+
+A child directory's governance class must be **at least as restrictive** as its
+parent's. The restriction ordering is:
+
+`human-only` > `bot-reviewed-human-approve` > `bot-safe`
+
+The `architecture-decision-required` class is orthogonal — it is triggered by
+_scope_ (cross-cutting changes such as root config or cross-package deps) and
+always takes precedence regardless of the directory's base class.
+
+_(Taxonomy adapted from @ChiefmonkeyArt's audit report.)_
+
 ## Instructions
 
 ### AGENTS.md Protocol — Read This First
@@ -156,6 +182,9 @@ These apply across **all** projects in this monorepo unless a subdirectory
 
 #### Architecture Boundaries
 
+- **Governance class inheritance.** A child directory's governance class must be
+  at least as restrictive as its parent's (`human-only` > `bot-reviewed-human-approve`
+  > `bot-safe`; `architecture-decision-required` is orthogonal and always wins).
 - No direct cross-project imports. The client (`src/`) must not import from
   `contextvm/` or `e2e/`. Shared types and utilities should be extracted
   explicitly, not imported sideways.
@@ -275,6 +304,10 @@ These apply across **all** projects in this monorepo unless a subdirectory
 - **Reject PRs that bypass the protocol.** A PR that changes code behavior
   without touching `AGENTS.md`, or changes `AGENTS.md` without touching code, is
   incomplete.
+- **Enforce governance class.** If a PR touches a `human-only` directory and was
+  prepared by automation, require explicit human review and block auto-merge. If
+  it touches an `architecture-decision-required` path, require maintainer
+  architectural sign-off before approval.
 
 #### For Auditors
 
@@ -308,6 +341,11 @@ When creating a new `AGENTS.md` in a subdirectory, follow this structure:
 # AGENTS.md — [Directory Name]
 
 > Brief one-line purpose of what this directory contains and achieves.
+
+## Governance
+
+- **Class:** [bot-safe | bot-reviewed-human-approve | human-only | architecture-decision-required]
+- **Sensitive Surface:** [What makes this directory this class — specific files, trust boundaries, security findings]
 
 ## Context
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,5 +1,10 @@
 # docs/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-safe
+- **Sensitive Surface:** Specifications and reference docs only; pure prose, no executable code
+
 ## Documentation Architecture
 
 ### Core Documentation Types

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,5 +1,10 @@
 # e2e/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** Test infrastructure; global-setup.ts and seed-relay.ts touch relay state and auth flow
+
 ## End-to-End Testing Architecture
 
 ### Core Purpose

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,5 +1,10 @@
 # scripts/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** human-only
+- **Sensitive Surface:** Deploy, seed, key, wallet tooling; deploy-staging.sh, encrypt_test_wallet.ts, gen_wallets.ts — high blast radius
+
 ## Scripting Architecture
 
 ### Core Purpose

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,5 +1,10 @@
 # src/ Development Guidelines
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** UI + client logic mixed; contains unextracted server code per inconsistency #4
+
 ## Routing
 
 Routes are file-based using TanStack Router. Place route files in `src/routes/` using `createFileRoute`. The dashboard uses a `_dashboard-layout` layout route pattern.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -1,5 +1,10 @@
 # src/components/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** UI components using shadcn/ui + Tailwind; XSS surface in content rendering
+
 ## Component Architecture
 
 ### Core Purpose

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -1,5 +1,10 @@
 # src/hooks/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** UI behavior hooks; no signing or custody logic
+
 ## Hook Architecture
 
 ### Core Purpose

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -1,5 +1,10 @@
 # src/lib/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** human-only
+- **Sensitive Surface:** Parent of nostr/, stores/, wallet/, payments/, schemas/ — signing, custody, trust boundaries (#996 H8: unencrypted localStorage)
+
 ## Library Architecture
 
 ### Core Purpose

--- a/src/publish/AGENTS.md
+++ b/src/publish/AGENTS.md
@@ -1,5 +1,10 @@
 # src/publish/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** human-only
+- **Sensitive Surface:** Write-side event construction + signing for all marketplace entities; bypasses NDK validation per inconsistency #8
+
 ## Publishing Architecture
 
 ### Core Purpose

--- a/src/queries/AGENTS.md
+++ b/src/queries/AGENTS.md
@@ -1,5 +1,10 @@
 # src/queries/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** Read-side relay parsing; parse bugs surface forged data but no write capability
+
 ## Query Architecture
 
 ### Core Purpose

--- a/src/routes/AGENTS.md
+++ b/src/routes/AGENTS.md
@@ -1,5 +1,10 @@
 # src/routes/ Directory Design Decisions Overview
 
+## Governance
+
+- **Class:** bot-reviewed-human-approve
+- **Sensitive Surface:** UI routing layer; no protocol or payment logic
+
 ## Routing Architecture
 
 ### Core Purpose


### PR DESCRIPTION
## What

Adds the 4-class bot governance taxonomy to the AGENTS.md framework introduced in #1063.

## Why

@ChiefmonkeyArt recently shared an audit report on the repo's AI-maintainability. One key recommendation was a clean classification system for what kinds of work are appropriate for automated agents vs. humans in each directory. This PR implements that recommendation.

## Changes

**Root AGENTS.md:**
- New Bot Governance Taxonomy section with the 4-class table
- Class inheritance rule added to Universal Constraints
- Updated Subdirectory AGENTS.md Template with mandatory Governance section
- Reviewer enforcement guidance added to role-specific instructions

**All 11 subdirectory AGENTS.md files:**
- Each gets a Governance section declaring its class and sensitive surface

| Directory | Class |
|---|---|
| src/lib/ | human-only |
| src/publish/ | human-only |
| .github/ | human-only |
| scripts/ | human-only |
| src/ | bot-reviewed-human-approve |
| src/components/ | bot-reviewed-human-approve |
| src/hooks/ | bot-reviewed-human-approve |
| src/queries/ | bot-reviewed-human-approve |
| src/routes/ | bot-reviewed-human-approve |
| e2e/ | bot-reviewed-human-approve |
| docs/ | bot-safe |

## Relationship to other work

- Stacks on #1063 (base branch: docs/agents-adr)
- Supersedes the governance portions of closed #1003
- Related: #1064, #1094

_(Taxonomy adapted from @ChiefmonkeyArt's audit report.)_

## Checks

- [x] All changed files pass `prettier --check` (12 AGENTS.md files verified clean)
- [x] Docs-only — no runtime code changes
- Note: 4 pre-existing files unrelated to this PR fail `prettier --check` on the base branch `docs/agents-adr` (`.claude/skills/...`, `src/lib/tests/communityQueryFixtures.ts`, `src/queries/bugReports.tsx`); none are modified here.
