### PR TITLE
feat(orders): add NIP-17 order publish boundary

### DIFF
--- a/src/lib/__tests__/nip17OrderPublish.test.ts
+++ b/src/lib/__tests__/nip17OrderPublish.test.ts
@@ -92,6 +92,8 @@ describe('NIP-17 order publish boundary', () => {
 		expect(result.rumorId).toBe(rumor.id)
 		expect(result.relayTargets.ready).toBe(true)
 		expect(calls).toHaveLength(2)
+		expect(calls[0]?.target).toBe('sender')
+		expect(calls[1]?.target).toBe('recipient')
 
 		const recipientCall = calls.find((call) => call.target === 'recipient')
 		const senderCall = calls.find((call) => call.target === 'sender')
@@ -173,7 +175,7 @@ describe('NIP-17 order publish boundary', () => {
 
 		expect(calls).toHaveLength(0)
 	})
-	test('fails when a gift wrap publish returns no relay success', async () => {
+	test('fails before recipient delivery when sender self-wrap publish returns no relay success', async () => {
 		const senderPrivateKey = generateSecretKey()
 		const senderPubkey = getPublicKey(senderPrivateKey)
 		const recipientPubkey = getPublicKey(generateSecretKey())
@@ -200,10 +202,10 @@ describe('NIP-17 order publish boundary', () => {
 					return new Set()
 				},
 			}),
-		).rejects.toThrow('NIP-17 recipient gift wrap could not be published')
+		).rejects.toThrow('NIP-17 sender gift wrap could not be published')
 
 		expect(calls).toHaveLength(1)
-		expect(calls[0]?.target).toBe('recipient')
+		expect(calls[0]?.target).toBe('sender')
 	})
 	test('fails closed without publishing when the rumor recipient does not match recipientPubkey', async () => {
 		const senderPrivateKey = generateSecretKey()

--- a/src/lib/__tests__/nip17OrderPublish.test.ts
+++ b/src/lib/__tests__/nip17OrderPublish.test.ts
@@ -205,4 +205,71 @@ describe('NIP-17 order publish boundary', () => {
 		expect(calls).toHaveLength(1)
 		expect(calls[0]?.target).toBe('recipient')
 	})
+	test('fails closed without publishing when the rumor recipient does not match recipientPubkey', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const intendedRecipientPubkey = getPublicKey(generateSecretKey())
+		const wrongRecipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: intendedRecipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${intendedRecipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		await expect(
+			publishNip17OrderMessage({
+				rumor,
+				signer: createSigner(senderPrivateKey),
+				recipientPubkey: wrongRecipientPubkey,
+				recipientRelayEvents: [relayListEvent(wrongRecipientPubkey, ['wss://wrong-recipient.example'])],
+				senderRelayEvents: [relayListEvent(senderPubkey, ['wss://sender.example'])],
+				publishGiftWrap: async ({ target, relays, giftWrap }) => {
+					calls.push({ target, relays, giftWrap })
+					return new Set(relays)
+				},
+			}),
+		).rejects.toThrow('NIP-17 order rumor recipient does not match recipientPubkey')
+
+		expect(calls).toHaveLength(0)
+	})
+
+	test('fails closed without publishing when the rumor has a malformed extra recipient p tag', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		await expect(
+			publishNip17OrderMessage({
+				rumor: {
+					...rumor,
+					tags: [...rumor.tags, ['p', '']],
+				},
+				signer: createSigner(senderPrivateKey),
+				recipientPubkey,
+				recipientRelayEvents: [relayListEvent(recipientPubkey, ['wss://recipient.example'])],
+				senderRelayEvents: [relayListEvent(senderPubkey, ['wss://sender.example'])],
+				publishGiftWrap: async ({ target, relays, giftWrap }) => {
+					calls.push({ target, relays, giftWrap })
+					return new Set(relays)
+				},
+			}),
+		).rejects.toThrow('Invalid order message rumor')
+
+		expect(calls).toHaveLength(0)
+	})
 })

--- a/src/lib/__tests__/nip17OrderPublish.test.ts
+++ b/src/lib/__tests__/nip17OrderPublish.test.ts
@@ -1,0 +1,208 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, generateSecretKey, getPublicKey, nip44, type Event } from 'nostr-tools'
+import { NIP59_GIFT_WRAP_KIND } from '../nostr/nip59'
+import { NIP17_DM_RELAY_LIST_KIND, type Nip17DmRelayListEvent } from '../nostr/nip17Relays'
+import { publishNip17OrderMessage } from '../orders/nip17OrderPublish'
+import { createOrderCreationRumor } from '../orders/orderMessageRumor'
+
+type PublishCall = {
+	target: 'recipient' | 'sender'
+	relays: string[]
+	giftWrap: Event
+}
+
+const ORDER_SENTINEL = 'order-secret-123'
+const PRODUCT_SENTINEL = 'secret-coffee-dtag'
+
+function relayListEvent(pubkey: string, relays: string[], createdAt = 100): Nip17DmRelayListEvent {
+	return {
+		id: `${pubkey}-${createdAt}`,
+		kind: NIP17_DM_RELAY_LIST_KIND,
+		pubkey,
+		created_at: createdAt,
+		tags: relays.map((relay) => ['relay', relay]),
+		content: '',
+	}
+}
+
+function createSigner(privateKey: Uint8Array): NDKSigner {
+	const pubkey = getPublicKey(privateKey)
+
+	return {
+		user: async () => ({ pubkey }),
+		encryptionEnabled: async () => ['nip44'],
+		encrypt: async (recipient: { pubkey: string }, plaintext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(plaintext, conversationKey)
+		},
+		decrypt: async (sender: { pubkey: string }, ciphertext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(ciphertext, conversationKey)
+		},
+		sign: async (event: { kind: number; created_at: number; tags: string[][]; content: string }) => {
+			return finalizeEvent(
+				{
+					kind: event.kind,
+					created_at: event.created_at,
+					tags: event.tags,
+					content: event.content,
+				},
+				privateKey,
+			).sig
+		},
+	} as unknown as NDKSigner
+}
+
+function expectNoPublicOrderSentinels(value: unknown): void {
+	const serialized = JSON.stringify(value)
+	for (const sentinel of [ORDER_SENTINEL, PRODUCT_SENTINEL]) {
+		expect(serialized).not.toContain(sentinel)
+	}
+}
+
+describe('NIP-17 order publish boundary', () => {
+	test('publishes recipient and sender gift wraps only to their kind 10050 relays', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 2 }],
+			createdAt: 123456,
+		})
+
+		const result = await publishNip17OrderMessage({
+			rumor,
+			signer: createSigner(senderPrivateKey),
+			recipientPubkey,
+			recipientRelayEvents: [relayListEvent(recipientPubkey, ['wss://recipient.example'])],
+			senderRelayEvents: [relayListEvent(senderPubkey, ['wss://sender.example'])],
+			publishGiftWrap: async ({ target, relays, giftWrap }) => {
+				calls.push({ target, relays, giftWrap })
+				return new Set(relays)
+			},
+		})
+
+		expect(result.rumorId).toBe(rumor.id)
+		expect(result.relayTargets.ready).toBe(true)
+		expect(calls).toHaveLength(2)
+
+		const recipientCall = calls.find((call) => call.target === 'recipient')
+		const senderCall = calls.find((call) => call.target === 'sender')
+
+		expect(recipientCall?.relays).toEqual(['wss://recipient.example'])
+		expect(senderCall?.relays).toEqual(['wss://sender.example'])
+
+		expect(recipientCall?.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(senderCall?.giftWrap.kind).toBe(NIP59_GIFT_WRAP_KIND)
+		expect(recipientCall?.giftWrap.tags).toContainEqual(['p', recipientPubkey])
+		expect(senderCall?.giftWrap.tags).toContainEqual(['p', senderPubkey])
+
+		expect(calls.some((call) => call.giftWrap.kind === rumor.kind)).toBe(false)
+		expectNoPublicOrderSentinels(calls.map((call) => call.giftWrap))
+	})
+
+	test('fails closed without publishing when recipient or sender kind 10050 relays are missing', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		await expect(
+			publishNip17OrderMessage({
+				rumor,
+				signer: createSigner(senderPrivateKey),
+				recipientPubkey,
+				recipientRelayEvents: [],
+				senderRelayEvents: [relayListEvent(senderPubkey, ['wss://sender.example'])],
+				publishGiftWrap: async ({ target, relays, giftWrap }) => {
+					calls.push({ target, relays, giftWrap })
+					return new Set(relays)
+				},
+			}),
+		).rejects.toThrow('NIP-17 relay targets are not ready')
+
+		expect(calls).toHaveLength(0)
+	})
+
+	test('fails closed without publishing when the signer does not match the rumor author', async () => {
+		const rumorAuthorPrivateKey = generateSecretKey()
+		const signerPrivateKey = generateSecretKey()
+		const rumorAuthorPubkey = getPublicKey(rumorAuthorPrivateKey)
+		const signerPubkey = getPublicKey(signerPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: rumorAuthorPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		await expect(
+			publishNip17OrderMessage({
+				rumor,
+				signer: createSigner(signerPrivateKey),
+				recipientPubkey,
+				recipientRelayEvents: [relayListEvent(recipientPubkey, ['wss://recipient.example'])],
+				senderRelayEvents: [relayListEvent(signerPubkey, ['wss://sender.example'])],
+				publishGiftWrap: async ({ target, relays, giftWrap }) => {
+					calls.push({ target, relays, giftWrap })
+					return new Set(relays)
+				},
+			}),
+		).rejects.toThrow('NIP-17 order rumor pubkey does not match signer pubkey')
+
+		expect(calls).toHaveLength(0)
+	})
+	test('fails when a gift wrap publish returns no relay success', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: ORDER_SENTINEL,
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:${PRODUCT_SENTINEL}`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		await expect(
+			publishNip17OrderMessage({
+				rumor,
+				signer: createSigner(senderPrivateKey),
+				recipientPubkey,
+				recipientRelayEvents: [relayListEvent(recipientPubkey, ['wss://recipient.example'])],
+				senderRelayEvents: [relayListEvent(senderPubkey, ['wss://sender.example'])],
+				publishGiftWrap: async ({ target, relays, giftWrap }) => {
+					calls.push({ target, relays, giftWrap })
+					return new Set()
+				},
+			}),
+		).rejects.toThrow('NIP-17 recipient gift wrap could not be published')
+
+		expect(calls).toHaveLength(1)
+		expect(calls[0]?.target).toBe('recipient')
+	})
+})

--- a/src/lib/orders/nip17OrderPublish.ts
+++ b/src/lib/orders/nip17OrderPublish.ts
@@ -33,6 +33,11 @@ export type PublishNip17OrderMessageResult = {
 export async function publishNip17OrderMessage(params: PublishNip17OrderMessageParams): Promise<PublishNip17OrderMessageResult> {
 	assertOrderMessageRumor(params.rumor)
 
+	const rumorRecipientPubkey = getOrderRumorRecipientPubkey(params.rumor)
+	if (rumorRecipientPubkey !== params.recipientPubkey) {
+		throw new Error('NIP-17 order rumor recipient does not match recipientPubkey')
+	}
+
 	const signerPubkey = await getSignerPubkey(params.signer)
 	if (signerPubkey !== params.rumor.pubkey) {
 		throw new Error('NIP-17 order rumor pubkey does not match signer pubkey')
@@ -97,6 +102,16 @@ async function getSignerPubkey(signer: NDKSigner): Promise<string> {
 	const user = await signer.user()
 	if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
 	return user.pubkey
+}
+
+function getOrderRumorRecipientPubkey(rumor: OrderMessageRumor): string {
+	const recipientTags = rumor.tags.filter((tag) => tag[0] === 'p')
+
+	if (recipientTags.length !== 1 || typeof recipientTags[0]?.[1] !== 'string' || recipientTags[0][1].length === 0) {
+		throw new Error('NIP-17 order rumor must have exactly one recipient p tag')
+	}
+
+	return recipientTags[0][1]
 }
 
 function publishResultHasRelayDetails(result: unknown): boolean {

--- a/src/lib/orders/nip17OrderPublish.ts
+++ b/src/lib/orders/nip17OrderPublish.ts
@@ -61,16 +61,16 @@ export async function publishNip17OrderMessage(params: PublishNip17OrderMessageP
 	})
 
 	await publishReadyGiftWrap({
-		target: 'recipient',
-		relays: relayTargets.recipient.relays,
-		giftWrap: wraps.recipient.giftWrap,
+		target: 'sender',
+		relays: relayTargets.sender.relays,
+		giftWrap: wraps.sender.giftWrap,
 		publishGiftWrap: params.publishGiftWrap,
 	})
 
 	await publishReadyGiftWrap({
-		target: 'sender',
-		relays: relayTargets.sender.relays,
-		giftWrap: wraps.sender.giftWrap,
+		target: 'recipient',
+		relays: relayTargets.recipient.relays,
+		giftWrap: wraps.recipient.giftWrap,
 		publishGiftWrap: params.publishGiftWrap,
 	})
 

--- a/src/lib/orders/nip17OrderPublish.ts
+++ b/src/lib/orders/nip17OrderPublish.ts
@@ -1,0 +1,113 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
+import type { Event } from 'nostr-tools'
+import { createNip17GiftWrapsWithSigner } from '../nostr/nip17'
+import { resolveNip17RelayTargetsFromEvents, type Nip17DmRelayListEvent, type Nip17RelayTargetsResult } from '../nostr/nip17Relays'
+import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
+
+export type Nip17OrderPublishTarget = 'recipient' | 'sender'
+
+export type PublishNip17GiftWrapParams = {
+	target: Nip17OrderPublishTarget
+	relays: string[]
+	giftWrap: Event
+}
+
+export type PublishNip17GiftWrapResult = unknown
+
+export type PublishNip17OrderMessageParams = {
+	rumor: OrderMessageRumor
+	signer: NDKSigner
+	recipientPubkey: string
+	recipientRelayEvents: Nip17DmRelayListEvent[]
+	senderRelayEvents: Nip17DmRelayListEvent[]
+	publishGiftWrap: (params: PublishNip17GiftWrapParams) => Promise<PublishNip17GiftWrapResult>
+}
+
+export type PublishNip17OrderMessageResult = {
+	rumorId: string
+	recipientGiftWrapId: string
+	senderGiftWrapId: string
+	relayTargets: Nip17RelayTargetsResult
+}
+
+export async function publishNip17OrderMessage(params: PublishNip17OrderMessageParams): Promise<PublishNip17OrderMessageResult> {
+	assertOrderMessageRumor(params.rumor)
+
+	const signerPubkey = await getSignerPubkey(params.signer)
+	if (signerPubkey !== params.rumor.pubkey) {
+		throw new Error('NIP-17 order rumor pubkey does not match signer pubkey')
+	}
+
+	const relayTargets = resolveNip17RelayTargetsFromEvents({
+		recipientPubkey: params.recipientPubkey,
+		senderPubkey: signerPubkey,
+		recipientEvents: params.recipientRelayEvents,
+		senderEvents: params.senderRelayEvents,
+	})
+
+	if (!relayTargets.ready || relayTargets.recipient.status !== 'ready' || relayTargets.sender.status !== 'ready') {
+		throw new Error('NIP-17 relay targets are not ready')
+	}
+
+	const wraps = await createNip17GiftWrapsWithSigner({
+		rumor: params.rumor,
+		signer: params.signer,
+		recipientPubkey: params.recipientPubkey,
+	})
+
+	await publishReadyGiftWrap({
+		target: 'recipient',
+		relays: relayTargets.recipient.relays,
+		giftWrap: wraps.recipient.giftWrap,
+		publishGiftWrap: params.publishGiftWrap,
+	})
+
+	await publishReadyGiftWrap({
+		target: 'sender',
+		relays: relayTargets.sender.relays,
+		giftWrap: wraps.sender.giftWrap,
+		publishGiftWrap: params.publishGiftWrap,
+	})
+
+	return {
+		rumorId: wraps.rumor.id,
+		recipientGiftWrapId: wraps.recipient.giftWrap.id,
+		senderGiftWrapId: wraps.sender.giftWrap.id,
+		relayTargets,
+	}
+}
+
+async function publishReadyGiftWrap(
+	params: PublishNip17GiftWrapParams & {
+		publishGiftWrap: (params: PublishNip17GiftWrapParams) => Promise<PublishNip17GiftWrapResult>
+	},
+): Promise<void> {
+	const result = await params.publishGiftWrap({
+		target: params.target,
+		relays: params.relays,
+		giftWrap: params.giftWrap,
+	})
+
+	if (publishResultHasRelayDetails(result) && !publishResultHasRelaySuccess(result)) {
+		throw new Error(`NIP-17 ${params.target} gift wrap could not be published`)
+	}
+}
+
+async function getSignerPubkey(signer: NDKSigner): Promise<string> {
+	const user = await signer.user()
+	if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
+	return user.pubkey
+}
+
+function publishResultHasRelayDetails(result: unknown): boolean {
+	return result instanceof Set || Array.isArray(result) || (typeof result === 'object' && result !== null && 'size' in result)
+}
+
+function publishResultHasRelaySuccess(result: unknown): boolean {
+	if (result instanceof Set) return result.size > 0
+	if (Array.isArray(result)) return result.length > 0
+	if (typeof result === 'object' && result !== null && 'size' in result && typeof (result as { size?: unknown }).size === 'number') {
+		return (result as { size: number }).size > 0
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Adds a focused NIP-17 order publish helper boundary for issue #1084.

This PR does not flip live checkout, order, payment, or chat publishing yet. It introduces the publish-side helper that later wiring can call after the read-path migration and maintainer-reviewed integration point are ready.

## What changed

- Added `src/lib/orders/nip17OrderPublish.ts`
  - Validates Gamma-shaped order message rumors.
  - Requires the signer pubkey to match the rumor author.
  - Resolves recipient and sender kind `10050` relay targets.
  - Fails closed when either relay target is missing or empty.
  - Creates recipient gift wrap + sender self-wrap using the existing NIP-17 boundary.
  - Publishes recipient wrap only to recipient relays.
  - Publishes sender self-wrap only to sender relays.
  - Fails if a publish result reports zero relay success.

- Added `src/lib/__tests__/nip17OrderPublish.test.ts`
  - Covers recipient and sender relay-targeted gift-wrap publishing.
  - Covers no raw kind `14`/`16`/`17` rumor publishing.
  - Covers public wrapper non-leakage of order/product sentinels.
  - Covers missing relay target fail-closed behavior.
  - Covers signer/rumor pubkey mismatch fail-closed behavior.
  - Covers empty publish result fail-closed behavior.

## Non-goals

- No live checkout/order/payment call-site wiring.
- No read-path migration.
- No `src/queries/*` changes.
- No `ndkActions.publishEvent` or global NDK relay behavior changes.
- No app/default relay fallback.
- No kind `10002` / NIP-65 fallback.
- No removal of legacy raw kind `14`/`16`/`17` reads.

## Validation

- `bun test src/lib/__tests__/nip17OrderPublish.test.ts`
- `bun run format:check`
- `bun run test:unit`

Latest local result:

```text
4 pass
0 fail
19 expect() calls

119 pass
0 fail
472 expect() calls
```
