### PR TITLE
feat(orders): add NIP-17 order read boundary

### DIFF
--- a/src/lib/__tests__/nip17OrderRead.test.ts
+++ b/src/lib/__tests__/nip17OrderRead.test.ts
@@ -1,0 +1,189 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, generateSecretKey, getPublicKey, nip44, type Event } from 'nostr-tools'
+import { createNip17GiftWrapsWithSigner } from '../nostr/nip17'
+import { NIP59_GIFT_WRAP_KIND } from '../nostr/nip59'
+import { unwrapNip17OrderMessage, unwrapNip17OrderMessages } from '../orders/nip17OrderRead'
+import { createOrderCreationRumor, createPaymentReceiptRumor } from '../orders/orderMessageRumor'
+
+function createSigner(privateKey: Uint8Array): NDKSigner {
+	const pubkey = getPublicKey(privateKey)
+
+	return {
+		user: async () => ({ pubkey }),
+		encryptionEnabled: async () => ['nip44'],
+		encrypt: async (recipient: { pubkey: string }, plaintext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(plaintext, conversationKey)
+		},
+		decrypt: async (sender: { pubkey: string }, ciphertext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(ciphertext, conversationKey)
+		},
+		sign: async (event: { kind: number; created_at: number; tags: string[][]; content: string }) => {
+			return finalizeEvent(
+				{
+					kind: event.kind,
+					created_at: event.created_at,
+					tags: event.tags,
+					content: event.content,
+				},
+				privateKey,
+			).sig
+		},
+	} as unknown as NDKSigner
+}
+
+function malformedGiftWrap(recipientPubkey: string): Event {
+	return finalizeEvent(
+		{
+			kind: NIP59_GIFT_WRAP_KIND,
+			created_at: 999999,
+			content: 'not-valid-nip44-ciphertext',
+			tags: [['p', recipientPubkey]],
+		},
+		generateSecretKey(),
+	)
+}
+
+describe('NIP-17 order read boundary', () => {
+	test('unwraps received recipient wraps and sent sender self-wraps', async () => {
+		const buyerPrivateKey = generateSecretKey()
+		const sellerPrivateKey = generateSecretKey()
+		const buyerPubkey = getPublicKey(buyerPrivateKey)
+		const sellerPubkey = getPublicKey(sellerPrivateKey)
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-123',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		const wraps = await createNip17GiftWrapsWithSigner({
+			rumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 222222,
+		})
+
+		const received = await unwrapNip17OrderMessage({
+			giftWrap: wraps.recipient.giftWrap,
+			signer: createSigner(sellerPrivateKey),
+		})
+
+		expect(received.direction).toBe('received')
+		expect(received.userPubkey).toBe(sellerPubkey)
+		expect(received.counterpartyPubkey).toBe(buyerPubkey)
+		expect(received.recipientPubkey).toBe(sellerPubkey)
+		expect(received.rumor).toEqual(rumor)
+
+		const sent = await unwrapNip17OrderMessage({
+			giftWrap: wraps.sender.giftWrap,
+			signer: createSigner(buyerPrivateKey),
+		})
+
+		expect(sent.direction).toBe('sent')
+		expect(sent.userPubkey).toBe(buyerPubkey)
+		expect(sent.counterpartyPubkey).toBe(sellerPubkey)
+		expect(sent.recipientPubkey).toBe(sellerPubkey)
+		expect(sent.rumor).toEqual(rumor)
+	})
+
+	test('rejects wraps where the decrypting user is not an inner order participant', async () => {
+		const buyerPrivateKey = generateSecretKey()
+		const sellerPubkey = getPublicKey(generateSecretKey())
+		const thirdPartyPrivateKey = generateSecretKey()
+		const buyerPubkey = getPublicKey(buyerPrivateKey)
+		const thirdPartyPubkey = getPublicKey(thirdPartyPrivateKey)
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-123',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 123456,
+		})
+
+		const wraps = await createNip17GiftWrapsWithSigner({
+			rumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: thirdPartyPubkey,
+			createdAt: 222222,
+		})
+
+		await expect(
+			unwrapNip17OrderMessage({
+				giftWrap: wraps.recipient.giftWrap,
+				signer: createSigner(thirdPartyPrivateKey),
+			}),
+		).rejects.toThrow('NIP-17 order message must include the active user as exactly one side')
+	})
+
+	test('batch unwrap dedupes by inner rumor id, ignores malformed wraps, and sorts deterministically', async () => {
+		const buyerPrivateKey = generateSecretKey()
+		const sellerPrivateKey = generateSecretKey()
+		const buyerPubkey = getPublicKey(buyerPrivateKey)
+		const sellerPubkey = getPublicKey(sellerPrivateKey)
+
+		const olderRumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-old',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:old`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const newerRumor = createPaymentReceiptRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-new',
+			amountSats: 2000,
+			payment: {
+				medium: 'lightning',
+				reference: 'lnbc-test',
+				proof: 'preimage-test',
+			},
+			createdAt: 200,
+		})
+
+		const olderWraps = await createNip17GiftWrapsWithSigner({
+			rumor: olderRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 300,
+		})
+
+		const duplicateOlderWraps = await createNip17GiftWrapsWithSigner({
+			rumor: olderRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 400,
+		})
+
+		const newerWraps = await createNip17GiftWrapsWithSigner({
+			rumor: newerRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 500,
+		})
+
+		const messages = await unwrapNip17OrderMessages({
+			giftWraps: [
+				newerWraps.recipient.giftWrap,
+				malformedGiftWrap(sellerPubkey),
+				duplicateOlderWraps.recipient.giftWrap,
+				olderWraps.recipient.giftWrap,
+			],
+			signer: createSigner(sellerPrivateKey),
+		})
+
+		expect(messages.map((message) => message.rumor.id)).toEqual([olderRumor.id, newerRumor.id])
+		expect(messages.map((message) => message.rumor.created_at)).toEqual([100, 200])
+		expect(messages.every((message) => message.direction === 'received')).toBe(true)
+	})
+})

--- a/src/lib/orders/nip17OrderRead.ts
+++ b/src/lib/orders/nip17OrderRead.ts
@@ -1,0 +1,108 @@
+import type { NDKSigner } from '@nostr-dev-kit/ndk'
+import type { Event } from 'nostr-tools'
+import { unwrapNip59GiftWrapWithSigner } from '../nostr/nip59'
+import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
+
+export type Nip17OrderMessageDirection = 'sent' | 'received'
+
+export type UnwrapNip17OrderMessageParams = {
+	giftWrap: Event
+	signer: NDKSigner | null | undefined
+}
+
+export type UnwrappedNip17OrderMessage = {
+	giftWrap: Event
+	seal: Event
+	rumor: OrderMessageRumor
+	direction: Nip17OrderMessageDirection
+	userPubkey: string
+	counterpartyPubkey: string
+	recipientPubkey: string
+}
+
+export type UnwrapNip17OrderMessagesParams = {
+	giftWraps: Event[]
+	signer: NDKSigner | null | undefined
+}
+
+export async function unwrapNip17OrderMessage(params: UnwrapNip17OrderMessageParams): Promise<UnwrappedNip17OrderMessage> {
+	const userPubkey = await getSignerPubkey(params.signer)
+
+	const unwrapped = await unwrapNip59GiftWrapWithSigner({
+		giftWrap: params.giftWrap,
+		signer: params.signer,
+		expectedRecipientPubkey: userPubkey,
+	})
+
+	const rumorValue: unknown = unwrapped.rumor
+	assertOrderMessageRumor(rumorValue)
+
+	const rumor = rumorValue
+	const recipientPubkey = getOrderRumorRecipientPubkey(rumor)
+	const senderPubkey = rumor.pubkey
+
+	const userIsSender = userPubkey === senderPubkey
+	const userIsRecipient = userPubkey === recipientPubkey
+
+	if (userIsSender === userIsRecipient) {
+		throw new Error('NIP-17 order message must include the active user as exactly one side')
+	}
+
+	return {
+		giftWrap: params.giftWrap,
+		seal: unwrapped.seal,
+		rumor,
+		direction: userIsSender ? 'sent' : 'received',
+		userPubkey,
+		counterpartyPubkey: userIsSender ? recipientPubkey : senderPubkey,
+		recipientPubkey,
+	}
+}
+
+export async function unwrapNip17OrderMessages(params: UnwrapNip17OrderMessagesParams): Promise<UnwrappedNip17OrderMessage[]> {
+	const messagesByRumorId = new Map<string, UnwrappedNip17OrderMessage>()
+
+	for (const giftWrap of params.giftWraps) {
+		try {
+			const message = await unwrapNip17OrderMessage({
+				giftWrap,
+				signer: params.signer,
+			})
+
+			if (!messagesByRumorId.has(message.rumor.id)) {
+				messagesByRumorId.set(message.rumor.id, message)
+			}
+		} catch {
+			// Relays can return malformed, unrelated, or undecryptable gift wraps.
+			// Keep order reads best-effort and avoid leaking decrypted/ciphertext details.
+		}
+	}
+
+	return Array.from(messagesByRumorId.values()).sort(compareUnwrappedNip17OrderMessages)
+}
+
+async function getSignerPubkey(signer: NDKSigner | null | undefined): Promise<string> {
+	if (!signer) throw new Error('Signer pubkey unavailable')
+
+	const user = await signer.user()
+	if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
+
+	return user.pubkey
+}
+
+function getOrderRumorRecipientPubkey(rumor: OrderMessageRumor): string {
+	const recipientTags = rumor.tags.filter((tag) => tag[0] === 'p')
+
+	if (recipientTags.length !== 1 || typeof recipientTags[0]?.[1] !== 'string' || recipientTags[0][1].length === 0) {
+		throw new Error('NIP-17 order rumor must have exactly one recipient p tag')
+	}
+
+	return recipientTags[0][1]
+}
+
+function compareUnwrappedNip17OrderMessages(a: UnwrappedNip17OrderMessage, b: UnwrappedNip17OrderMessage): number {
+	const createdAtDiff = a.rumor.created_at - b.rumor.created_at
+	if (createdAtDiff !== 0) return createdAtDiff
+
+	return a.rumor.id.localeCompare(b.rumor.id)
+}


### PR DESCRIPTION
## Summary

Refs #1084.

Adds a focused NIP-17 order read/unwrapping helper boundary.

This PR does not wire live query integration yet. It introduces a pure helper that can unwrap, validate, classify, dedupe, and sort NIP-17 gift-wrapped order messages after the read integration point is maintainer-reviewed.

## What changed

- Added `src/lib/orders/nip17OrderRead.ts`
  - Unwraps kind `1059` gift wraps using the existing NIP-59 signer helper.
  - Validates the inner rumor with `assertOrderMessageRumor`.
  - Requires exactly one usable recipient `p` tag.
  - Derives `sent` / `received` direction from the active signer pubkey, rumor author, and recipient `p` tag.
  - Rejects messages where the active user is not exactly one side of the inner order message.
  - Batch unwraps best-effort by ignoring malformed, unrelated, or undecryptable wraps.
  - Dedupes by inner rumor id.
  - Sorts deterministically by inner rumor `created_at`, then rumor id.

- Added `src/lib/__tests__/nip17OrderRead.test.ts`
  - Covers received recipient wraps.
  - Covers sent sender self-wraps.
  - Covers non-participant rejection.
  - Covers malformed-wrap ignore behavior in batch reads.
  - Covers dedupe by inner rumor id.
  - Covers deterministic sorting.

## Non-goals

- No `src/queries/orders.tsx` rewrite.
- No `src/queries/messages.tsx` rewrite.
- No live query integration.
- No global relay/read transport changes.
- No Applesauce migration.
- No aggregator relay changes.
- No `ndkActions` changes.
- No `src/publish/*` changes.
- No removal of legacy raw kind `14`/`16`/`17` reads.

## Validation

- `bun test src/lib/__tests__/nip17OrderRead.test.ts`
- `bun test src/lib/__tests__/nip17.test.ts src/lib/__tests__/orderMessageRumor.test.ts src/lib/__tests__/nip17OrderPublish.test.ts src/lib/__tests__/nip17OrderRead.test.ts`
- `bun run format:check`
- `bun run test:unit`
