### PR TITLE
feat(e2e): benchmarking tooling for flake detection and A/B backend comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules
 playwright-report
 test-results
 
+# e2e benchmark output (scripts/e2e-benchmark.sh)
+e2e-benchmark-results
+
 # output
 out
 dist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+# Makefile — e2e benchmarking targets for the Plebeian Market test suite.
+#
+# These targets wrap scripts/e2e-benchmark.sh and scripts/e2e-benchmark-report.py
+# so the whole team runs A/B backend comparisons and flake detection the same way.
+#
+# The runner exports NOSTR_BACKEND=ndk|applesauce on every Playwright run so the
+# app can switch Nostr I/O adapters. NOTE: this only changes app behaviour once
+# the branch under test actually reads NOSTR_BACKEND (e.g. via src/lib/nostr/
+# io.ts); on plain `master` the app is NDK-only, so "applesauce" runs are
+# NDK-equivalent until the adapter switch lands.
+#
+# Common targets:
+#   make e2e-benchmark-all          all specs, 3x, both backends
+#   make e2e-benchmark-ndk          all specs, 3x, NDK only
+#   make e2e-benchmark-applesauce   all specs, 3x, applesauce only
+#   make e2e-benchmark-quick        all specs, 1x, both backends (smoke)
+#   make e2e-benchmark-spec SPEC=x  single spec, 5x, both backends
+#   make e2e-benchmark-ab SPEC=x    single spec, 10x, both backends (A/B)
+#   make e2e-benchmark-flaky        known-flaky specs, 5x, both backends
+#   make e2e-benchmark-report       summarise the latest run
+#
+# See docs/e2e-benchmarking.md for the full guide.
+
+.DEFAULT_GOAL := help
+.PHONY: help e2e-benchmark-all e2e-benchmark-ndk e2e-benchmark-applesauce \
+        e2e-benchmark-quick e2e-benchmark-spec e2e-benchmark-ab \
+        e2e-benchmark-flaky e2e-benchmark-report
+
+BENCH         := bash scripts/e2e-benchmark.sh
+REPORT        := python3 scripts/e2e-benchmark-report.py
+# Specs with a known flake history — revisit as the suite stabilises.
+FLAKY_SPECS   := auth,cart,pii-exposure,payments
+
+help: ## Show this help.
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+e2e-benchmark-all: ## All specs, 3x, both backends (full flake + A/B sweep).
+	$(BENCH) --specs all --repeat 3 --backend both
+
+e2e-benchmark-ndk: ## All specs, 3x, NDK backend only.
+	$(BENCH) --specs all --repeat 3 --backend ndk
+
+e2e-benchmark-applesauce: ## All specs, 3x, applesauce backend only.
+	$(BENCH) --specs all --repeat 3 --backend applesauce
+
+e2e-benchmark-quick: ## All specs, 1x, both backends (fast smoke; no flake signal).
+	$(BENCH) --specs all --repeat 1 --backend both --no-strict
+
+e2e-benchmark-spec: ## Single spec, 5x, both backends. Usage: make e2e-benchmark-spec SPEC=auth
+	@test -n "$(SPEC)" || { echo "Usage: make e2e-benchmark-spec SPEC=<spec>"; exit 2; }
+	$(BENCH) --specs $(SPEC) --repeat 5 --backend both
+
+e2e-benchmark-ab: ## Single spec, 10x, both backends (statistical A/B compare). Usage: make e2e-benchmark-ab SPEC=cart
+	@test -n "$(SPEC)" || { echo "Usage: make e2e-benchmark-ab SPEC=<spec>"; exit 2; }
+	$(BENCH) --specs $(SPEC) --repeat 10 --backend both
+
+e2e-benchmark-flaky: ## Known-flaky specs, 5x, both backends (flake regression watch).
+	$(BENCH) --specs $(FLAKY_SPECS) --repeat 5 --backend both
+
+e2e-benchmark-report: ## Summarise the latest benchmark run.
+	$(REPORT)

--- a/docs/e2e-benchmarking.md
+++ b/docs/e2e-benchmarking.md
@@ -1,0 +1,167 @@
+# E2E Benchmarking
+
+Repeatable e2e benchmarking and A/B backend comparison for the Plebeian Market
+Playwright suite. Formalises the ad-hoc scripts Franchovy was running so the
+whole team measures flakiness and the NDK → applesauce migration the same way.
+
+> The Playwright suite itself is **never** executed by this tooling in CI — it
+> only *orchestrates* runs locally or from a fork's Actions. The deliverables
+> here are the runner, the report, the Make targets, and this doc.
+
+## Prerequisites
+
+- Node + Playwright deps already installed (`bun install` / `npm install`)
+- A local Nostr relay reachable on `ws://localhost:10547` (Playwright's
+  `webServer` starts `nak serve` for you when not on CI)
+- Bash 4+, `python3` (3.8+), `make`, `find`
+- System Chromium on platforms Playwright doesn't bundle one for — set
+  `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` (the dev server / e2e config already
+  honours this)
+
+## Quick start
+
+```bash
+# full flake + A/B sweep across every spec (both backends, 3x each)
+make e2e-benchmark-all
+
+# read the verdict
+make e2e-benchmark-report
+```
+
+Every `make e2e-benchmark-*` target is a thin wrapper around the script, so you
+can run it directly for more control:
+
+```bash
+scripts/e2e-benchmark.sh --specs auth,cart --repeat 10 --backend both
+scripts/e2e-benchmark.sh --specs pii-exposure --backend applesauce --repeat 5
+```
+
+## How the backend is selected
+
+The benchmark runner exports **`NOSTR_BACKEND`** (`ndk` or `applesauce`) — plus
+`NODE_OPTIONS=--dns-result-order=ipv4first`, matching the `test:e2e` package
+script — on every Playwright invocation:
+
+| `NOSTR_BACKEND` | intent |
+| --- | --- |
+| unset or `ndk` | NDK adapter — the historical default |
+| `applesauce` | applesauce RelayPool adapter — the migration target |
+
+> ⚠️ **Maturity note.** For backend selection to actually change app behaviour,
+> the app's Nostr I/O layer must read `NOSTR_BACKEND` at boot (the expected seam
+> is `src/lib/nostr/io.ts`). On plain `master` the app is **NDK-only** — there
+> is no applesauce I/O path and no `NOSTR_BACKEND` switch wired up yet — so
+> "applesauce" runs are currently NDK-equivalent. A/B deltas only become
+> meaningful once the `NOSTR_BACKEND` switch lands on the branch under test.
+> The tooling itself is backend-agnostic and ready to drive that comparison the
+> moment the switch exists.
+
+If you ever rename the flag, update the `--backend` handling in
+`scripts/e2e-benchmark.sh`.
+
+## Make targets
+
+| Target | What it runs |
+| --- | --- |
+| `make e2e-benchmark-all` | all specs × 3 × both backends |
+| `make e2e-benchmark-ndk` | all specs × 3 × NDK |
+| `make e2e-benchmark-applesauce` | all specs × 3 × applesauce |
+| `make e2e-benchmark-quick` | all specs × 1 × both backends (fast smoke) |
+| `make e2e-benchmark-spec SPEC=x` | spec `x` × 5 × both backends |
+| `make e2e-benchmark-ab SPEC=x` | spec `x` × 10 × both backends (A/B) |
+| `make e2e-benchmark-flaky` | `auth,cart,pii-exposure,payments` × 5 × both |
+| `make e2e-benchmark-report` | summarise the latest run |
+
+`SPEC=` is the basename of a file in `e2e/tests/` minus `.spec.ts`. Prefix
+matching is supported, so `pii-exposure` resolves to
+`pii-exposure-remediation.spec.ts`.
+
+## Direct script usage
+
+```
+scripts/e2e-benchmark.sh [options]
+
+  --specs LIST       comma-separated spec names or "all" (default: all)
+  --repeat N         repetitions per spec × backend (default: 3)
+  --backend B        ndk | applesauce | both (default: both)
+  --results-dir DIR  output root (default: ./e2e-benchmark-results)
+  --grep PATTERN     optional --grep forwarded to playwright
+  --no-strict        always exit 0 (default: exit 1 if any run failed)
+  --playwright-bin C playwright invocation (default: npx playwright)
+```
+
+The script exports `NODE_OPTIONS=--dns-result-order=ipv4first` (matching the
+`test:e2e` package script) and `NOSTR_BACKEND` on every run, then invokes
+`npx playwright test --config=e2e/playwright.config.ts --reporter=json`.
+
+## Output
+
+Each invocation writes a timestamped directory:
+
+```
+e2e-benchmark-results/
+└── 20260702T181234Z/                       # one per invocation
+    ├── auth__ndk__run-1.json                # playwright JSON report
+    ├── auth__ndk__run-2.json
+    ├── auth__applesauce__run-1.json
+    ├── ...
+    ├── auth__ndk__run-1.log                 # per-run stdout/stderr
+    ├── benchmark.log                        # all runs concatenated
+    └── manifest.json                        # machine index of every run
+└── latest -> 20260702T181234Z               # newest run (symlink)
+```
+
+The filename convention `<spec>__<backend>__run-<n>.json` is authoritative —
+the report parses spec/backend/repeat from it and the test outcome counts from
+the JSON body.
+
+`e2e-benchmark-results/` is gitignored.
+
+## Reading the report
+
+`make e2e-benchmark-report` (or `python3 scripts/e2e-benchmark-report.py`) shows:
+
+1. **Per-backend run pass rate** — overall green rate for NDK and applesauce.
+2. **Per-spec A/B table** — NDK vs applesauce run pass rate with the delta and a
+   verdict (`applesauce regresses`, `applesauce improves`, or `no change`).
+   Specs where applesauce is worse are sorted to the top.
+3. **Categorisation** — every spec × backend is filed as:
+   - **STABLE** — 100% of repeats passed
+   - **FLAKY** — 0% < pass rate < 100%
+   - **BROKEN** — 0% of repeats passed
+4. **Worst pass rates** — the ten lowest, with raw failure counts.
+
+Use `--json` for a machine-readable summary, `--run <stamp>` (or `--results-dir`)
+to report on a specific run, and `--all` to aggregate everything under the
+results root.
+
+## What is "A/B"?
+
+The same spec runs the same number of times under each backend. If a spec is
+green 9/10 under NDK but 4/10 under applesauce, the A/B table flags
+`applesauce regresses (-50%)`. That pinpoints a migration-induced reliability
+drop *before* the applesauce adapter becomes the default. The opposite direction
+(applesauce improves) tells you the new adapter is strictly better.
+
+For a result to be meaningful you need enough repeats — `make e2e-benchmark-ab
+SPEC=x` (10×) is the recommended minimum for a single spec. The full
+`e2e-benchmark-all` (3×) sweep is better for triage than for statistics.
+
+## Troubleshooting
+
+- **`no spec matched 'x'`** — the name doesn't prefix-match anything in
+  `e2e/tests/`. `ls e2e/tests/*.spec.ts` to see real names.
+- **All runs FAIL instantly** — the dev server or relay isn't up. Run
+  `bun run test:e2e -- e2e/tests/auth.spec.ts` once by hand to surface the real
+  error; the benchmark swallows per-run output into `<run>.log`.
+- **`playwright: command not found`** — pass `--playwright-bin bunx playwright`
+  (or `npx playwright` once deps are installed).
+- **Hangs / relay port in use** — `webServer.reuseExistingServer` is on; a stale
+  `nak` or dev server on the test port can confuse the suite. Kill leftovers on
+  port `10547` and `34567`.
+- **No backend effect** — confirm the branch you're benchmarking actually wires
+  `NOSTR_BACKEND` through `src/lib/nostr/io.ts`. On plain `master` only the NDK
+  adapter exists, so "applesauce" runs are NDK-equivalent until the migration
+  wave lands.
+- **Numbers look identical across backends** — see above; the env gate is a
+  no-op until the applesauce adapter is reachable on the branch under test.

--- a/scripts/e2e-benchmark-report.py
+++ b/scripts/e2e-benchmark-report.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+e2e-benchmark-report.py — summarise Playwright benchmark runs.
+
+Reads the JSON results produced by scripts/e2e-benchmark.sh and prints:
+
+  * an overall pass-rate line per backend
+  * a per-spec table comparing NDK vs applesauce (A/B), with the delta
+  * a categorisation of every spec as STABLE / FLAKY / BROKEN
+  * a list of the worst offenders (lowest pass rates)
+
+Each results file is named ``<spec>__<backend>__run-<n>.json`` and contains the
+standard Playwright JSON reporter payload. The spec/backend/repeat are taken from
+the filename (authoritative) and the test outcome counts are taken from the JSON
+suite tree. A spec's *run pass rate* = fraction of repeats in which every test in
+that spec passed — this is what flake detection keys off.
+
+Categories (run-level, per backend):
+  STABLE  — 100% of repeats passed
+  FLAKY   — 0% < pass rate < 100%
+  BROKEN  — 0% of repeats passed
+
+Usage:
+  python3 scripts/e2e-benchmark-report.py                 # latest run
+  python3 scripts/e2e-benchmark-report.py --run 20260702T181234Z
+  python3 scripts/e2e-benchmark-report.py --results-dir path/to/run
+  python3 scripts/e2e-benchmark-report.py --all           # aggregate everything
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Colour ---------------------------------------------------------------------
+_USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _USE_COLOR else text
+
+
+def GREEN(t: str) -> str:  return _c("32", t)
+def RED(t: str) -> str:    return _c("31", t)
+def YELLOW(t: str) -> str: return _c("33", t)
+def CYAN(t: str) -> str:   return _c("36", t)
+def BOLD(t: str) -> str:   return _c("1", t)
+def DIM(t: str) -> str:    return _c("2", t)
+
+
+FAIL_STATES = {"failed", "timedOut", "interrupted"}
+PASS_STATES = {"passed", "flaky"}
+
+_FILENAME_RE = re.compile(r"^(?P<spec>.+)__(?P<backend>ndk|applesauce)__run-(?P<repeat>\d+)\.json$")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+@dataclass
+class RunCounts:
+    spec: str
+    backend: str
+    repeat: int
+    passed: bool          # run-level: every test green
+    exit_code: int
+    duration_s: float
+    tests_total: int = 0
+    tests_passed: int = 0
+    tests_failed: int = 0
+    tests_skipped: int = 0
+    flaky_tests: int = 0
+
+
+@dataclass
+class SpecAgg:
+    runs: int = 0
+    passed_runs: int = 0
+    tests_total: int = 0
+    tests_passed: int = 0
+    tests_failed: int = 0
+    duration_s: float = 0.0
+    repeat_ids: List[int] = field(default_factory=list)
+
+    @property
+    def pass_rate(self) -> float:
+        return (self.passed_runs / self.runs * 100.0) if self.runs else 0.0
+
+    def category(self) -> str:
+        if self.runs == 0:
+            return "—"
+        if self.passed_runs == self.runs:
+            return "STABLE"
+        if self.passed_runs == 0:
+            return "BROKEN"
+        return "FLAKY"
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+def _walk_suites(node: Any, test_counts: Dict[str, Dict[str, int]]) -> None:
+    """Accumulate per-test outcome counts keyed by spec file.
+
+    Playwright's JSON reporter nests ``suites``; each leaf suite carries a
+    ``file`` and a ``specs`` array. Each spec has ``tests``; each test has
+    ``results`` with a ``status``. A test is counted as passed if any of its
+    results is 'passed'/'flaky', failed if it ended in a failure state, skipped
+    otherwise. Flaky tests (failed-then-passed) are tracked separately.
+    """
+    if not isinstance(node, dict):
+        return
+    file = node.get("file") or ""
+    specs = node.get("specs") or []
+    for spec in specs:
+        spec_file = spec.get("file") or file
+        for test in spec.get("tests", []) or []:
+            results = test.get("results", []) or []
+            if not results:
+                continue
+            statuses = [r.get("status") for r in results]
+            bucket = test_counts.setdefault(spec_file or "(unknown)", {
+                "total": 0, "passed": 0, "failed": 0, "skipped": 0, "flaky": 0,
+            })
+            bucket["total"] += 1
+            has_pass = any(s in PASS_STATES for s in statuses)
+            has_fail = any(s in FAIL_STATES for s in statuses)
+            has_skip = all(s == "skipped" for s in statuses)
+            if has_pass and has_fail:
+                bucket["flaky"] += 1
+                bucket["passed"] += 1
+            elif has_pass:
+                bucket["passed"] += 1
+            elif has_skip:
+                bucket["skipped"] += 1
+            elif has_fail:
+                bucket["failed"] += 1
+            else:
+                # no pass, not all skipped, no explicit fail -> treat as fail
+                bucket["failed"] += 1
+    for child in node.get("suites", []) or []:
+        _walk_suites(child, test_counts)
+
+
+def parse_result_file(path: Path) -> Optional[RunCounts]:
+    """Return counts for one benchmark result file, or None if unparseable."""
+    m = _FILENAME_RE.match(path.name)
+    if not m:
+        return None  # not a per-run result file
+    spec = m.group("spec")
+    backend = m.group("backend")
+    repeat = int(m.group("repeat"))
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"{YELLOW('warn')}: could not parse {path.name}: {exc}", file=sys.stderr)
+        return None
+
+    # Per-test breakdown from the suite tree.
+    test_counts: Dict[str, Dict[str, int]] = {}
+    for suite in data.get("suites", []) or []:
+        _walk_suites(suite, test_counts)
+
+    total = sum(c["total"] for c in test_counts.values())
+    passed = sum(c["passed"] for c in test_counts.values())
+    failed = sum(c["failed"] for c in test_counts.values())
+    skipped = sum(c["skipped"] for c in test_counts.values())
+    flaky = sum(c["flaky"] for c in test_counts.values())
+
+    # Fall back to top-level stats when the suite walk found nothing (older
+    # reporter payloads may flatten everything into `stats`).
+    if total == 0:
+        stats = data.get("stats", {}) or {}
+        expected = stats.get("expected", 0)
+        unexpected = stats.get("unexpected", 0)
+        skipped_s = stats.get("skipped", 0)
+        flaky_s = stats.get("flaky", 0)
+        if expected or unexpected or skipped_s or flaky_s:
+            total = expected + unexpected
+            passed = expected
+            failed = unexpected
+            skipped = skipped_s
+            flaky = flaky_s
+
+    run_passed = (failed == 0 and total > 0)
+    duration = float(data.get("stats", {}).get("duration", 0)) / 1000.0 \
+        if isinstance(data.get("stats", {}).get("duration"), (int, float)) else 0.0
+
+    return RunCounts(
+        spec=spec, backend=backend, repeat=repeat,
+        passed=run_passed, exit_code=0 if run_passed else 1,
+        duration_s=duration,
+        tests_total=total, tests_passed=passed,
+        tests_failed=failed, tests_skipped=skipped, flaky_tests=flaky,
+    )
+
+
+def discover_results(targets: Iterable[Path]) -> List[Path]:
+    out: List[Path] = []
+    for t in targets:
+        if t.is_file():
+            out.append(t)
+        elif t.is_dir():
+            out.extend(sorted(t.glob("*.json")))
+    return [p for p in out if p.name not in ("manifest.json",)]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+def aggregate(runs: List[RunCounts]) -> Dict[Tuple[str, str], SpecAgg]:
+    agg: Dict[Tuple[str, str], SpecAgg] = defaultdict(SpecAgg)
+    for r in runs:
+        a = agg[(r.spec, r.backend)]
+        a.runs += 1
+        a.passed_runs += 1 if r.passed else 0
+        a.tests_total += r.tests_total
+        a.tests_passed += r.tests_passed
+        a.tests_failed += r.tests_failed
+        a.duration_s += r.duration_s
+        a.repeat_ids.append(r.repeat)
+    return agg
+
+
+def pick_run_dir(results_root: Path) -> Optional[Path]:
+    latest = results_root / "latest"
+    if latest.is_symlink() or latest.is_dir():
+        target = latest.resolve()
+        if target.is_dir():
+            return target
+    dirs = [d for d in results_root.iterdir() if d.is_dir()]
+    return max(dirs, key=lambda d: d.stat().st_mtime) if dirs else None
+
+
+def render(runs: List[RunCounts], agg: Dict[Tuple[str, str], SpecAgg], source_label: str) -> int:
+    if not runs:
+        print(f"{RED('no results')} in {source_label}", file=sys.stderr)
+        return 2
+
+    all_specs = sorted({k[0] for k in agg})
+    backends = sorted({k[1] for k in agg})
+
+    # --- overall per-backend summary --------------------------------------
+    print(BOLD("═══ e2e benchmark report ═══") + f"  {DIM(source_label)}")
+    print()
+    print(BOLD("per-backend run pass rate"))
+    header = f"  {'backend':<12} {'runs':>6} {'passed':>8} {'rate':>8}"
+    print(header)
+    print(f"  {'-'*12} {'-'*6} {'-'*8} {'-'*8}")
+    for b in backends:
+        b_runs = [r for r in runs if r.backend == b]
+        n = len(b_runs)
+        p = sum(1 for r in b_runs if r.passed)
+        rate = (p / n * 100.0) if n else 0.0
+        colour = GREEN if rate == 100.0 else (RED if rate == 0.0 else YELLOW)
+        print(f"  {b:<12} {n:>6} {p:>8} {colour(f'{rate:6.1f}%'):>8}")
+
+    # --- per-spec A/B table -----------------------------------------------
+    if len(backends) >= 2:
+        print()
+        print(BOLD("per-spec A/B (run pass rate)"))
+        hdr = f"  {'spec':<32} {'ndk':>8}   {'applesauce':>11}   {'delta':>8}   verdict"
+        print(hdr)
+        print(f"  {'-'*32} {'-'*8}   {'-'*11}   {'-'*8}   {'-'*16}")
+        rows = []
+        for spec in all_specs:
+            ndk = agg.get((spec, "ndk"))
+            apl = agg.get((spec, "applesauce"))
+            ndk_rate = ndk.pass_rate if ndk else float("nan")
+            apl_rate = apl.pass_rate if apl else float("nan")
+            delta = (apl_rate - ndk_rate) if (ndk and apl) else float("nan")
+            if ndk and apl:
+                if delta < -0.5:
+                    verdict = RED(f"applesauce regresses ({delta:+.0f}%)")
+                elif delta > 0.5:
+                    verdict = GREEN(f"applesauce improves ({delta:+.0f}%)")
+                else:
+                    verdict = DIM("no change")
+            else:
+                verdict = DIM("single-backend")
+            rows.append((spec, ndk_rate, apl_rate, delta, verdict))
+        rows.sort(key=lambda r: (r[3] if r[3] == r[3] else 9999))
+        for spec, ndk_rate, apl_rate, delta, verdict in rows:
+            def fmt(rate):
+                if rate != rate:  # NaN
+                    return DIM("   —")
+                colour = GREEN if rate == 100.0 else (RED if rate == 0.0 else YELLOW)
+                return colour(f"{rate:6.1f}%")
+            d = f"{delta:+6.0f}%" if (delta == delta) else DIM("   —")
+            print(f"  {spec:<32} {fmt(ndk_rate):>8}   {fmt(apl_rate):>11}   {d:>8}   {verdict}")
+
+    # --- categorisation ---------------------------------------------------
+    print()
+    print(BOLD("categorisation (run-level, per spec x backend)"))
+    by_cat: Dict[str, List[str]] = defaultdict(list)
+    for (spec, backend), a in sorted(agg.items()):
+        by_cat[a.category()].append(f"{spec} [{backend}]  {a.pass_rate:5.1f}% ({a.passed_runs}/{a.runs})")
+    for cat in ("BROKEN", "FLAKY", "STABLE"):
+        items = by_cat.get(cat, [])
+        if not items:
+            continue
+        colour = {"BROKEN": RED, "FLAKY": YELLOW, "STABLE": GREEN}[cat]
+        print(f"  {colour(BOLD(cat)):<14} ({len(items)})")
+        for line in items:
+            print(f"      {line}")
+
+    # --- worst offenders --------------------------------------------------
+    offenders = sorted(agg.items(), key=lambda kv: (kv[1].pass_rate, -kv[1].runs))
+    worst = [kv for kv in offenders if kv[1].pass_rate < 100.0][:10]
+    if worst:
+        print()
+        print(BOLD("worst pass rates"))
+        for (spec, backend), a in worst:
+            colour = RED if a.pass_rate == 0 else YELLOW
+            print(f"  {spec:<32} {backend:<11} {colour(f'{a.pass_rate:5.1f}%'):>8}  "
+                  f"({a.passed_runs}/{a.runs} runs, {a.tests_failed} test failures)")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(description="Summarise e2e benchmark results.")
+    here = Path(__file__).resolve().parent
+    default_root = (here.parent / "e2e-benchmark-results").resolve()
+    p.add_argument("--results-dir", type=Path,
+                   help=f"results run directory (default: latest under {default_root})")
+    p.add_argument("--run", help="specific timestamped run under the results root")
+    p.add_argument("--all", action="store_true",
+                   help="aggregate every result under the results root")
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON summary")
+    args = p.parse_args(argv)
+
+    if args.results_dir:
+        source = args.results_dir
+        source_label = str(source)
+    elif args.run:
+        source = default_root / args.run
+        source_label = f"{default_root} / {args.run}"
+    elif args.all:
+        source = default_root
+        source_label = f"{default_root} (all runs)"
+    else:
+        source = pick_run_dir(default_root)
+        if source is None:
+            print(f"{RED('no results')} under {default_root}", file=sys.stderr)
+            return 2
+        source_label = str(source)
+
+    if not source.exists():
+        print(f"{RED('not found')}: {source}", file=sys.stderr)
+        return 2
+
+    files = discover_results([source] if not source.is_file() else [source])
+    runs = [c for c in (parse_result_file(f) for f in files) if c is not None]
+    agg = aggregate(runs)
+
+    if args.json:
+        summary = {
+            "source": str(source),
+            "backends": sorted({k[1] for k in agg}),
+            "specs": sorted({k[0] for k in agg}),
+            "by_spec_backend": [
+                {
+                    "spec": spec, "backend": backend,
+                    "runs": a.runs, "passed_runs": a.passed_runs,
+                    "pass_rate": round(a.pass_rate, 2),
+                    "category": a.category(),
+                    "tests_total": a.tests_total,
+                    "tests_failed": a.tests_failed,
+                }
+                for (spec, backend), a in sorted(agg.items())
+            ],
+        }
+        json.dump(summary, sys.stdout, indent=2)
+        print()
+        return 0
+
+    return render(runs, agg, source_label)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/e2e-benchmark.sh
+++ b/scripts/e2e-benchmark.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+#
+# e2e-benchmark.sh — repeatable e2e benchmarking & A/B Nostr backend comparison.
+#
+# Runs Playwright specs N times across one or both Nostr backends, capturing a
+# JSON report per (spec x backend x repeat) plus a human-readable progress log to
+# stdout. Results land in ./e2e-benchmark-results/<timestamp>/.
+#
+# The benchmark selects the Nostr I/O adapter by exporting NOSTR_BACKEND on
+# every Playwright run:
+#   - "ndk"        => NDK adapter (the historical default)
+#   - "applesauce" => applesauce RelayPool adapter (the migration target)
+# For backend selection to actually change app behaviour, the app must read
+# NOSTR_BACKEND at boot (e.g. via src/lib/nostr/io.ts). NOTE: on plain `master`
+# the app is NDK-only and NOSTR_BACKEND is currently a no-op, so "applesauce"
+# runs are NDK-equivalent until the adapter switch lands on the branch under
+# test. The tooling itself is backend-agnostic — A/B deltas only become
+# meaningful once the app honours NOSTR_BACKEND.
+#
+# Usage:
+#   scripts/e2e-benchmark.sh --specs all --repeat 3 --backend both
+#   scripts/e2e-benchmark.sh --specs auth,cart --repeat 10 --backend ndk
+#   scripts/e2e-benchmark.sh --specs pii-exposure --backend applesauce
+#
+# Options:
+#   --specs LIST       comma-separated spec names (e2e/tests/ basenames minus
+#                       .spec.ts), prefix-matched, or "all" (default: all)
+#   --repeat N         repetitions per spec x backend (default: 3)
+#   --backend B        ndk | applesauce | both (default: both)
+#   --results-dir DIR  output root (default: ./e2e-benchmark-results)
+#   --grep PATTERN     optional --grep filter forwarded to playwright
+#   --no-strict        always exit 0 (default: exit 1 if any run failed)
+#   --playwright-bin C playwright invocation (default: npx playwright)
+#   -h, --help         show this help
+#
+# Output layout (per run):
+#   <results-dir>/<timestamp>/<spec>__<backend>__run-<n>.json   playwright JSON
+#   <results-dir>/<timestamp>/manifest.json                     run index
+#   <results-dir>/<timestamp>/benchmark.log                     concatenated stdout
+#   <results-dir>/latest -> <timestamp>                         newest-run symlink
+#
+# See docs/e2e-benchmarking.md for the full guide.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+SPECS="all"
+REPEAT=3
+BACKEND="both"
+RESULTS_DIR=""
+GREP=""
+STRICT=1
+PLAYWRIGHT_BIN="${PLAYWRIGHT_BIN:-npx playwright}"
+
+usage() {
+	sed -n '3,42p' "$0" | sed 's/^# \{0,1\}//'
+	exit "${1:-0}"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--specs) SPECS="$2"; shift 2 ;;
+		--repeat) REPEAT="$2"; shift 2 ;;
+		--backend) BACKEND="$2"; shift 2 ;;
+		--results-dir) RESULTS_DIR="$2"; shift 2 ;;
+		--grep) GREP="$2"; shift 2 ;;
+		--no-strict) STRICT=0; shift ;;
+		--playwright-bin) PLAYWRIGHT_BIN="$2"; shift 2 ;;
+		PLAYWRIGHT_BIN=*) PLAYWRIGHT_BIN="${1#PLAYWRIGHT_BIN=}"; shift ;;
+		-h|--help) usage 0 ;;
+		*) echo "e2e-benchmark: unknown option: $1" >&2; usage 1 ;;
+	esac
+done
+
+case "$BACKEND" in
+	ndk|applesauce|both) ;;
+	*) echo "e2e-benchmark: --backend must be ndk|applesauce|both (got: $BACKEND)" >&2; exit 1 ;;
+esac
+
+if ! [[ "$REPEAT" =~ ^[1-9][0-9]*$ ]]; then
+	echo "e2e-benchmark: --repeat must be a positive integer (got: $REPEAT)" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Locate repo root (parent of this script's directory) and results dir
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SPECS_DIR="$REPO_ROOT/e2e/tests"
+
+if [[ ! -d "$SPECS_DIR" ]]; then
+	echo "e2e-benchmark: e2e specs directory not found: $SPECS_DIR" >&2
+	echo "  (run from the repo root, or check --specs)" >&2
+	exit 1
+fi
+
+[[ -n "$RESULTS_DIR" ]] || RESULTS_DIR="$REPO_ROOT/e2e-benchmark-results"
+mkdir -p "$RESULTS_DIR"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$RESULTS_DIR/$STAMP"
+mkdir -p "$RUN_DIR"
+# latest/ symlink (relative so it survives being moved/archived)
+ln -sfn "$STAMP" "$RESULTS_DIR/latest"
+
+LOG="$RUN_DIR/benchmark.log"
+: > "$LOG"
+
+# ---------------------------------------------------------------------------
+# Colour helpers (disabled when not a tty or NO_COLOR is set)
+# ---------------------------------------------------------------------------
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+	C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'
+	C_GREEN=$'\033[32m'; C_RED=$'\033[31m'; C_DIM=$'\033[2m'
+else
+	C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_DIM=""
+fi
+
+log()      { printf '%s\n' "$*" | tee -a "$LOG" >&2; }
+log_head() { printf '\n%s\n' "$*" | tee -a "$LOG" >&2; }
+
+# ---------------------------------------------------------------------------
+# Spec resolution: map requested names -> e2e/tests/*.spec.ts paths
+# A requested name matches if the spec file stem equals it OR starts with it
+# (so "pii-exposure" resolves to "pii-exposure-remediation.spec.ts").
+# ---------------------------------------------------------------------------
+declare -a SPEC_PATHS=()
+
+resolve_specs() {
+	local requested="$1"
+	local -a found=()
+	local name file stem
+
+	if [[ "$requested" == "all" ]]; then
+		while IFS= read -r file; do
+			found+=("$file")
+		done < <(find "$SPECS_DIR" -maxdepth 1 -name '*.spec.ts' | sort)
+	else
+		# Save/restore IFS to split on comma
+		local _ifs="$IFS"; IFS=','
+		read -ra _names <<< "$requested"
+		IFS="$_ifs"
+		for name in "${_names[@]}"; do
+			name="${name// /}"           # trim spaces
+			[[ -z "$name" ]] && continue
+			local hits=()
+			while IFS= read -r file; do
+				stem="$(basename "$file" .spec.ts)"
+				if [[ "$stem" == "$name" || "$stem" == "$name"-* || "$stem" == "$name"_* ]]; then
+					hits+=("$file")
+				fi
+			done < <(find "$SPECS_DIR" -maxdepth 1 -name '*.spec.ts')
+			if [[ ${#hits[@]} -eq 0 ]]; then
+				echo "e2e-benchmark: no spec matched '$name' in $SPECS_DIR" >&2
+				exit 1
+			fi
+			for file in "${hits[@]}"; do
+				# de-dup
+				local dup=0 f
+				for f in "${found[@]:-}"; do [[ "$f" == "$file" ]] && dup=1 && break; done
+				[[ "$dup" == 0 ]] && found+=("$file")
+			done
+		done
+	fi
+
+	if [[ ${#found[@]} -eq 0 ]]; then
+		echo "e2e-benchmark: no specs resolved from '$requested' in $SPECS_DIR" >&2
+		exit 1
+	fi
+	# emit newline-delimited for caller
+	printf '%s\n' "${found[@]}"
+}
+
+# Resolve once into SPEC_PATHS
+while IFS= read -r _p; do SPEC_PATHS+=("$_p"); done < <(resolve_specs "$SPECS")
+
+# Backends to iterate
+declare -a BACKENDS=()
+case "$BACKEND" in
+	both)       BACKENDS=(ndk applesauce) ;;
+	ndk|applesauce) BACKENDS=("$BACKEND") ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+log_head "${C_BOLD}═══ e2e benchmark ═══${C_RESET}"
+log "${C_DIM}repo        :${C_RESET} $REPO_ROOT"
+log "${C_DIM}specs       :${C_RESET} ${#SPEC_PATHS[@]} ($SPECS)"
+log "${C_DIM}backends    :${C_RESET} ${BACKENDS[*]}"
+log "${C_DIM}repeat      :${C_RESET} $REPEAT"
+log "${C_DIM}grep        :${C_RESET} ${GREP:-(none)}"
+log "${C_DIM}playwright  :${C_RESET} $PLAYWRIGHT_BIN"
+log "${C_DIM}run dir     :${C_RESET} $RUN_DIR"
+log "${C_DIM}total runs  :${C_RESET} $(( ${#SPEC_PATHS[@]} * ${#BACKENDS[@]} * REPEAT ))"
+
+# ---------------------------------------------------------------------------
+# Run loop
+# ---------------------------------------------------------------------------
+TOTAL_FAIL=0
+TOTAL_RUNS=0
+declare -a MANIFEST=()
+
+run_one() {
+	local spec_file="$1" backend="$2" repeat="$3"
+	local stem; stem="$(basename "$spec_file" .spec.ts)"
+	local out_name="${stem}__${backend}__run-${repeat}.json"
+	local out_json="$RUN_DIR/$out_name"
+
+	# Playwright's JSON reporter does path.join(PLAYWRIGHT_JSON_OUTPUT_DIR,
+	# PLAYWRIGHT_JSON_OUTPUT_NAME) — so the name must be a bare filename, not
+	# a full path, or the output path doubles up.
+	local cmd=(
+		env NODE_OPTIONS='--dns-result-order=ipv4first' \
+			NOSTR_BACKEND="$backend" \
+			PLAYWRIGHT_JSON_OUTPUT_NAME="$out_name" \
+			PLAYWRIGHT_JSON_OUTPUT_DIR="$RUN_DIR" \
+			$PLAYWRIGHT_BIN test --config=e2e/playwright.config.ts --reporter=json
+	)
+	if [[ -n "$GREP" ]]; then cmd+=(--grep "$GREP"); fi
+	cmd+=("$spec_file")
+
+	local t0 t1 dur status_label
+	t0="$(date +%s)"
+	# Run, capture combined output to a per-run log; do not let set -e abort the loop.
+	local run_log="$RUN_DIR/${stem}__${backend}__run-${repeat}.log"
+	set +e
+	( cd "$REPO_ROOT" && "${cmd[@]}" ) >"$run_log" 2>&1
+	local rc=$?
+	set -e
+	t1="$(date +%s)"
+	dur=$(( t1 - t0 ))
+	TOTAL_RUNS=$(( TOTAL_RUNS + 1 ))
+	cat "$run_log" >> "$LOG"
+
+	if [[ $rc -eq 0 ]]; then
+		status_label="${C_GREEN}PASS${C_RESET}"
+	else
+		status_label="${C_RED}FAIL${C_RESET}"
+		TOTAL_FAIL=$(( TOTAL_FAIL + 1 ))
+	fi
+
+	local rel_json; rel_json="$(realpath --relative-to="$RUN_DIR" "$out_json" 2>/dev/null || echo "$out_json")"
+	printf '%s' \
+		"{" \
+		"\"spec\":\"$stem\"," \
+		"\"backend\":\"$backend\"," \
+		"\"repeat\":$repeat," \
+		"\"passed\":$([[ $rc -eq 0 ]] && echo true || echo false)," \
+		"\"exit\":$rc," \
+		"\"duration_s\":$dur," \
+		"\"json\":\"$rel_json\"" \
+		"}" >> "$RUN_DIR/.manifest.frag"
+	printf '\n' >> "$RUN_DIR/.manifest.frag"
+
+	printf '  [%3d/%d] %-28s %-11s run %d/%d  %s  %ds\n' \
+		"$TOTAL_RUNS" "$(( ${#SPEC_PATHS[@]} * ${#BACKENDS[@]} * REPEAT ))" \
+		"$stem" "[$backend]" "$repeat" "$REPEAT" "$status_label" "$dur" | tee -a "$LOG" >&2
+}
+
+for backend in "${BACKENDS[@]}"; do
+	for spec_file in "${SPEC_PATHS[@]}"; do
+		for (( r=1; r<=REPEAT; r++ )); do
+			run_one "$spec_file" "$backend" "$r"
+		done
+	done
+done
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+{
+	printf '{"generated_at":"%s","specs":[%s],"backends":["%s"],"repeat":%d,"total_runs":%d,"total_fail":%d,"runs":[\n' \
+		"$STAMP" \
+		"$(printf '"%s",' "${SPEC_PATHS[@]}" | sed 's/,$//')" \
+		"$(printf '%s","' "${BACKENDS[@]}" | sed 's/,"$//')" \
+		"$REPEAT" "$TOTAL_RUNS" "$TOTAL_FAIL"
+	# append per-run fragments, strip trailing comma/newline
+	if [[ -s "$RUN_DIR/.manifest.frag" ]]; then
+		paste -sd, "$RUN_DIR/.manifest.frag"
+	fi
+	printf '\n]}\n'
+} > "$RUN_DIR/manifest.json"
+rm -f "$RUN_DIR/.manifest.frag"
+
+# ---------------------------------------------------------------------------
+# Footer
+# ---------------------------------------------------------------------------
+log_head "${C_BOLD}═══ summary ═══${C_RESET}"
+if [[ "$TOTAL_FAIL" -eq 0 ]]; then
+	log "${C_GREEN}all runs passed${C_RESET} ($TOTAL_RUNS/$TOTAL_RUNS)"
+else
+	log "${C_RED}$TOTAL_FAIL/$TOTAL_RUNS runs failed${C_RESET}"
+fi
+log "${C_DIM}results     :${C_RESET} $RUN_DIR"
+log "${C_DIM}report      :${C_RESET} make e2e-benchmark-report   ${C_DIM}(or: python3 scripts/e2e-benchmark-report.py)${C_RESET}"
+
+if [[ "$STRICT" == "1" && "$TOTAL_FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

E2e benchmarking tool with Make targets for running Playwright tests in batch with A/B backend switching (NDK vs applesauce).

## Why

Identify flaky tests, compare NDK vs applesauce reliability, and validate fixes with statistical confidence. Addresses the systematic test reliability work from #1057 and makes the ad-hoc A/B testing tooling available to the whole team.

## Changes

- **`scripts/e2e-benchmark.sh`** — runs Playwright tests N times on ndk/applesauce/both backends, captures JSON results
- **`scripts/e2e-benchmark-report.py`** — aggregates results into formatted summary (per-spec pass rates, flake categorization)
- **`Makefile`** — 8 targets: `e2e-benchmark-all`, `-ndk`, `-applesauce`, `-quick`, `-spec`, `-ab`, `-flaky`, `-report`
- **`docs/e2e-benchmarking.md`** — usage docs with prerequisites, examples, A/B explanation, troubleshooting

## Make Targets

| Target | Description |
|--------|-------------|
| `make e2e-benchmark-all` | ALL specs 3x on BOTH backends |
| `make e2e-benchmark-ndk` | NDK only |
| `make e2e-benchmark-applesauce` | Applesauce only |
| `make e2e-benchmark-quick` | 1x each both backends (health check) |
| `make e2e-benchmark-spec SPEC=auth.spec.ts` | Single spec 5x both backends |
| `make e2e-benchmark-ab SPEC=auth.spec.ts` | A/B compare (10x each) |
| `make e2e-benchmark-flaky` | Historically-flaky specs 5x |
| `make e2e-benchmark-report` | Summary from latest run |

## Test plan

- [x] `bash -n scripts/e2e-benchmark.sh` — syntax check passed
- [x] `python3 -c "import ast; ast.parse(open('scripts/e2e-benchmark-report.py').read())"` — syntax check passed
- [ ] Manual review of Make targets
- [ ] CI validation

Ref: #1057 #772