### PR TITLE
feat(orders): add NIP-17 order transport boundary

### DIFF
--- a/src/lib/__tests__/nip17OrderTransport.test.ts
+++ b/src/lib/__tests__/nip17OrderTransport.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent, generateSecretKey, getPublicKey, nip44, type Event } from 'nostr-tools'
+import { createNip17GiftWrapsWithSigner } from '../nostr/nip17'
+import { NIP59_GIFT_WRAP_KIND } from '../nostr/nip59'
+import { NIP17_DM_RELAY_LIST_KIND, type Nip17DmRelayListEvent } from '../nostr/nip17Relays'
+import {
+	buildNip17OrderGiftWrapFilter,
+	publishNip17OrderTransportMessage,
+	readNip17OrderTransportMessages,
+	type FetchNip17RelayListEventsParams,
+	type Nip17OrderTransportSigner,
+	type PublishNip17OrderTransportGiftWrapParams,
+} from '../orders/nip17OrderTransport'
+import { createOrderCreationRumor, createPaymentReceiptRumor } from '../orders/orderMessageRumor'
+
+type PublishCall = PublishNip17OrderTransportGiftWrapParams
+
+function relayListEvent(pubkey: string, relays: string[], createdAt = 100): Nip17DmRelayListEvent {
+	return {
+		id: `${pubkey}-${createdAt}`,
+		kind: NIP17_DM_RELAY_LIST_KIND,
+		pubkey,
+		created_at: createdAt,
+		tags: relays.map((relay) => ['relay', relay]),
+		content: '',
+	}
+}
+
+function createSigner(privateKey: Uint8Array, supportsNip44 = true): Nip17OrderTransportSigner {
+	const pubkey = getPublicKey(privateKey)
+
+	return {
+		user: async () => ({ pubkey }),
+		encryptionEnabled: async () => (supportsNip44 ? ['nip44'] : []),
+		encrypt: async (recipient: { pubkey: string }, plaintext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, recipient.pubkey)
+			return nip44.v2.encrypt(plaintext, conversationKey)
+		},
+		decrypt: async (sender: { pubkey: string }, ciphertext: string) => {
+			const conversationKey = nip44.v2.utils.getConversationKey(privateKey, sender.pubkey)
+			return nip44.v2.decrypt(ciphertext, conversationKey)
+		},
+		sign: async (event: { kind: number; created_at: number; tags: string[][]; content: string }) => {
+			return finalizeEvent(
+				{
+					kind: event.kind,
+					created_at: event.created_at,
+					tags: event.tags,
+					content: event.content,
+				},
+				privateKey,
+			).sig
+		},
+	} as unknown as Nip17OrderTransportSigner
+}
+
+function malformedGiftWrap(recipientPubkey: string): Event {
+	return finalizeEvent(
+		{
+			kind: NIP59_GIFT_WRAP_KIND,
+			created_at: 999999,
+			content: 'not-valid-nip44-ciphertext',
+			tags: [['p', recipientPubkey]],
+		},
+		generateSecretKey(),
+	)
+}
+
+describe('NIP-17 order transport publish seam', () => {
+	test('resolves sender and recipient kind 10050 relay targets and publishes only gift wraps in order', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const fetches: FetchNip17RelayListEventsParams[] = []
+		const calls: PublishCall[] = []
+		const senderRelays = ['wss://sender.example']
+		const recipientRelays = ['wss://recipient.example']
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-1',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const result = await publishNip17OrderTransportMessage({
+			rumor,
+			signer: createSigner(senderPrivateKey),
+			fetchRelayListEvents: async (params) => {
+				fetches.push(params)
+				return params.target === 'sender'
+					? [relayListEvent(senderPubkey, senderRelays)]
+					: [relayListEvent(recipientPubkey, recipientRelays)]
+			},
+			publishGiftWrap: async (params) => {
+				calls.push(params)
+				return new Set(params.relays)
+			},
+			createdAt: 123456,
+		})
+
+		expect(result.status).toBe('published')
+		if (result.status !== 'published') throw new Error('expected published result')
+
+		expect(result.rumorId).toBe(rumor.id)
+		expect(fetches).toEqual([
+			{
+				target: 'sender',
+				pubkey: senderPubkey,
+				filter: { kinds: [NIP17_DM_RELAY_LIST_KIND], authors: [senderPubkey], limit: 1 },
+			},
+			{
+				target: 'recipient',
+				pubkey: recipientPubkey,
+				filter: { kinds: [NIP17_DM_RELAY_LIST_KIND], authors: [recipientPubkey], limit: 1 },
+			},
+		])
+		expect(result.relayTargets.sender.relays).toEqual(senderRelays)
+		expect(result.relayTargets.recipient.relays).toEqual(recipientRelays)
+		expect(result.sender.relays).toEqual(senderRelays)
+		expect(result.recipient.relays).toEqual(recipientRelays)
+		expect(calls.map((call) => call.target)).toEqual(['sender', 'recipient'])
+		expect(calls.map((call) => call.giftWrap.kind)).toEqual([NIP59_GIFT_WRAP_KIND, NIP59_GIFT_WRAP_KIND])
+		expect(calls.some((call) => [14, 16, 17].includes(call.giftWrap.kind))).toBe(false)
+		expect(calls[0]?.giftWrap.tags).toContainEqual(['p', senderPubkey])
+		expect(calls[1]?.giftWrap.tags).toContainEqual(['p', recipientPubkey])
+	})
+
+	test('fails closed when the sender relay list is missing or empty', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-2',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		for (const senderEvents of [[], [relayListEvent(senderPubkey, [])]]) {
+			const result = await publishNip17OrderTransportMessage({
+				rumor,
+				signer: createSigner(senderPrivateKey),
+				fetchRelayListEvents: async (params) => {
+					return params.target === 'sender' ? senderEvents : [relayListEvent(recipientPubkey, ['wss://recipient.example'])]
+				},
+				publishGiftWrap: async (params) => {
+					calls.push(params)
+					return new Set(params.relays)
+				},
+			})
+
+			expect(result.status).toBe('relay_targets_failed')
+			if (result.status !== 'relay_targets_failed') throw new Error('expected relay target failure')
+			expect(result.rumorId).toBe(rumor.id)
+			expect(result.relayTargets.sender.status === 'missing' || result.relayTargets.sender.status === 'empty').toBe(true)
+		}
+
+		expect(calls).toHaveLength(0)
+	})
+
+	test('fails closed when the recipient relay list is missing or empty', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-3',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		for (const recipientEvents of [[], [relayListEvent(recipientPubkey, [])]]) {
+			const result = await publishNip17OrderTransportMessage({
+				rumor,
+				signer: createSigner(senderPrivateKey),
+				fetchRelayListEvents: async (params) => {
+					return params.target === 'sender' ? [relayListEvent(senderPubkey, ['wss://sender.example'])] : recipientEvents
+				},
+				publishGiftWrap: async (params) => {
+					calls.push(params)
+					return new Set(params.relays)
+				},
+			})
+
+			expect(result.status).toBe('relay_targets_failed')
+			if (result.status !== 'relay_targets_failed') throw new Error('expected relay target failure')
+			expect(result.rumorId).toBe(rumor.id)
+			expect(result.relayTargets.recipient.status === 'missing' || result.relayTargets.recipient.status === 'empty').toBe(true)
+		}
+
+		expect(calls).toHaveLength(0)
+	})
+
+	test('preserves validation and wrap failure states without publishing', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const wrongSignerPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-4',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const validationFailed = await publishNip17OrderTransportMessage({
+			rumor,
+			signer: createSigner(wrongSignerPrivateKey),
+			fetchRelayListEvents: async () => [],
+			publishGiftWrap: async (params) => {
+				calls.push(params)
+				return new Set(params.relays)
+			},
+		})
+
+		expect(validationFailed.status).toBe('validation_failed')
+
+		const wrapFailed = await publishNip17OrderTransportMessage({
+			rumor,
+			signer: createSigner(senderPrivateKey, false),
+			fetchRelayListEvents: async (params) => {
+				return params.target === 'sender'
+					? [relayListEvent(senderPubkey, ['wss://sender.example'])]
+					: [relayListEvent(recipientPubkey, ['wss://recipient.example'])]
+			},
+			publishGiftWrap: async (params) => {
+				calls.push(params)
+				return new Set(params.relays)
+			},
+		})
+
+		expect(wrapFailed.status).toBe('wrap_failed')
+		if (wrapFailed.status !== 'wrap_failed') throw new Error('expected wrap failure')
+		expect(wrapFailed.rumorId).toBe(rumor.id)
+		expect(calls).toHaveLength(0)
+	})
+
+	test('returns sender_publish_failed without attempting recipient publish', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-sender-fail',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const result = await publishNip17OrderTransportMessage({
+			rumor,
+			signer: createSigner(senderPrivateKey),
+			fetchRelayListEvents: async (params) => {
+				return params.target === 'sender'
+					? [relayListEvent(senderPubkey, ['wss://sender.example'])]
+					: [relayListEvent(recipientPubkey, ['wss://recipient.example'])]
+			},
+			publishGiftWrap: async (params) => {
+				calls.push(params)
+				return new Set()
+			},
+		})
+
+		expect(result.status).toBe('sender_publish_failed')
+		if (result.status !== 'sender_publish_failed') throw new Error('expected sender publish failure')
+		expect(calls.map((call) => call.target)).toEqual(['sender'])
+		expect(calls.some((call) => call.target === 'recipient')).toBe(false)
+		expect(result.rumorId).toBe(rumor.id)
+	})
+
+	test('returns a partial state when recipient delivery fails after sender self-wrap succeeds', async () => {
+		const senderPrivateKey = generateSecretKey()
+		const senderPubkey = getPublicKey(senderPrivateKey)
+		const recipientPubkey = getPublicKey(generateSecretKey())
+		const calls: PublishCall[] = []
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey: senderPubkey,
+			merchantPubkey: recipientPubkey,
+			orderId: 'order-transport-5',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${recipientPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const result = await publishNip17OrderTransportMessage({
+			rumor,
+			signer: createSigner(senderPrivateKey),
+			fetchRelayListEvents: async (params) => {
+				return params.target === 'sender'
+					? [relayListEvent(senderPubkey, ['wss://sender.example'])]
+					: [relayListEvent(recipientPubkey, ['wss://recipient.example'])]
+			},
+			publishGiftWrap: async (params) => {
+				calls.push(params)
+				return params.target === 'sender' ? new Set(params.relays) : new Set()
+			},
+		})
+
+		expect(result.status).toBe('recipient_publish_failed')
+		if (result.status !== 'recipient_publish_failed') throw new Error('expected recipient publish failure')
+		expect(calls.map((call) => call.target)).toEqual(['sender', 'recipient'])
+		expect(result.rumorId).toBe(rumor.id)
+		expect(result.sender.target).toBe('sender')
+		expect(result.recipient.target).toBe('recipient')
+	})
+})
+
+describe('NIP-17 order transport read seam', () => {
+	test('builds and uses a kind 1059 gift-wrap filter for the active user', async () => {
+		const activeUserPubkey = getPublicKey(generateSecretKey())
+		const filters: unknown[] = []
+
+		const result = await readNip17OrderTransportMessages({
+			activeUserPubkey,
+			signer: createSigner(generateSecretKey()),
+			fetchGiftWraps: async (filter) => {
+				filters.push(filter)
+				return []
+			},
+		})
+
+		expect(buildNip17OrderGiftWrapFilter(activeUserPubkey)).toEqual({
+			kinds: [NIP59_GIFT_WRAP_KIND],
+			'#p': [activeUserPubkey],
+		})
+		expect(filters).toEqual([{ kinds: [NIP59_GIFT_WRAP_KIND], '#p': [activeUserPubkey] }])
+		expect(result.messages).toEqual([])
+	})
+
+	test('unwraps valid messages from injected gift-wrap reads', async () => {
+		const buyerPrivateKey = generateSecretKey()
+		const sellerPrivateKey = generateSecretKey()
+		const buyerPubkey = getPublicKey(buyerPrivateKey)
+		const sellerPubkey = getPublicKey(sellerPrivateKey)
+
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-transport-1',
+			amountSats: 2100,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+		const wraps = await createNip17GiftWrapsWithSigner({
+			rumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 200,
+		})
+
+		const result = await readNip17OrderTransportMessages({
+			activeUserPubkey: sellerPubkey,
+			signer: createSigner(sellerPrivateKey),
+			fetchGiftWraps: async () => [wraps.recipient.giftWrap],
+		})
+
+		expect(result.messages).toHaveLength(1)
+		expect(result.messages[0]?.rumor).toEqual(rumor)
+		expect(result.messages[0]?.direction).toBe('received')
+	})
+
+	test('batch read ignores bad wraps, dedupes by inner rumor id, and sorts deterministically', async () => {
+		const buyerPrivateKey = generateSecretKey()
+		const sellerPrivateKey = generateSecretKey()
+		const buyerPubkey = getPublicKey(buyerPrivateKey)
+		const sellerPubkey = getPublicKey(sellerPrivateKey)
+		const unrelatedPubkey = getPublicKey(generateSecretKey())
+
+		const sameTimestampRumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-transport-a',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:a`, quantity: 1 }],
+			createdAt: 100,
+		})
+		const sameTimestampReceipt = createPaymentReceiptRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-transport-b',
+			amountSats: 1000,
+			payment: { medium: 'lightning', reference: 'lnbc-test', proof: 'preimage-test' },
+			createdAt: 100,
+		})
+		const newerRumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-read-transport-c',
+			amountSats: 2000,
+			items: [{ productRef: `30402:${sellerPubkey}:c`, quantity: 1 }],
+			createdAt: 200,
+		})
+		const unrelatedInnerRumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: unrelatedPubkey,
+			orderId: 'order-read-transport-unrelated',
+			amountSats: 2000,
+			items: [{ productRef: `30402:${unrelatedPubkey}:x`, quantity: 1 }],
+			createdAt: 300,
+		})
+
+		const wrapA = await createNip17GiftWrapsWithSigner({
+			rumor: sameTimestampRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 300,
+		})
+		const duplicateA = await createNip17GiftWrapsWithSigner({
+			rumor: sameTimestampRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 301,
+		})
+		const wrapB = await createNip17GiftWrapsWithSigner({
+			rumor: sameTimestampReceipt,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 302,
+		})
+		const wrapC = await createNip17GiftWrapsWithSigner({
+			rumor: newerRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 303,
+		})
+		const unrelated = await createNip17GiftWrapsWithSigner({
+			rumor: unrelatedInnerRumor,
+			signer: createSigner(buyerPrivateKey),
+			recipientPubkey: sellerPubkey,
+			createdAt: 304,
+		})
+
+		const result = await readNip17OrderTransportMessages({
+			activeUserPubkey: sellerPubkey,
+			signer: createSigner(sellerPrivateKey),
+			fetchGiftWraps: async () => [
+				wrapC.recipient.giftWrap,
+				malformedGiftWrap(sellerPubkey),
+				unrelated.recipient.giftWrap,
+				duplicateA.recipient.giftWrap,
+				wrapB.recipient.giftWrap,
+				wrapA.recipient.giftWrap,
+			],
+		})
+
+		const sameTimestampSortedIds = [sameTimestampRumor.id, sameTimestampReceipt.id].sort((a, b) => a.localeCompare(b))
+
+		expect(result.messages.map((message) => message.rumor.id)).toEqual([...sameTimestampSortedIds, newerRumor.id])
+		expect(result.messages.map((message) => message.rumor.id)).toHaveLength(
+			new Set(result.messages.map((message) => message.rumor.id)).size,
+		)
+	})
+})

--- a/src/lib/orders/nip17OrderTransport.ts
+++ b/src/lib/orders/nip17OrderTransport.ts
@@ -1,0 +1,345 @@
+import type { Event } from 'nostr-tools'
+import { createNip17GiftWrapsWithSigner } from '../nostr/nip17'
+import { NIP59_GIFT_WRAP_KIND } from '../nostr/nip59'
+import {
+	buildNip17DmRelayListFilter,
+	resolveNip17RelayTargetsFromEvents,
+	type Nip17DmRelayListEvent,
+	type Nip17DmRelayListFilter,
+	type Nip17RelayTargetsResult,
+} from '../nostr/nip17Relays'
+import { unwrapNip17OrderMessages, type UnwrappedNip17OrderMessage } from './nip17OrderRead'
+import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
+
+export type Nip17OrderTransportSigner = Parameters<typeof createNip17GiftWrapsWithSigner>[0]['signer']
+
+export type Nip17OrderTransportTarget = 'sender' | 'recipient'
+
+export type FetchNip17RelayListEventsParams = {
+	target: Nip17OrderTransportTarget
+	pubkey: string
+	filter: Nip17DmRelayListFilter
+}
+
+export type PublishNip17OrderTransportGiftWrapParams = {
+	target: Nip17OrderTransportTarget
+	relays: string[]
+	giftWrap: Event
+}
+
+export type Nip17OrderGiftWrapFilter = {
+	kinds: [typeof NIP59_GIFT_WRAP_KIND]
+	'#p': [string]
+}
+
+export type PublishNip17OrderTransportMessageParams = {
+	rumor: OrderMessageRumor
+	signer: Nip17OrderTransportSigner
+	fetchRelayListEvents: (params: FetchNip17RelayListEventsParams) => Promise<Nip17DmRelayListEvent[]>
+	publishGiftWrap: (params: PublishNip17OrderTransportGiftWrapParams) => Promise<unknown>
+	createdAt?: number
+}
+
+export type Nip17OrderTransportError = {
+	code:
+		| 'invalid_order_message'
+		| 'signer_pubkey_unavailable'
+		| 'signer_pubkey_mismatch'
+		| 'relay_list_fetch_failed'
+		| 'relay_targets_not_ready'
+		| 'gift_wrap_creation_failed'
+		| 'gift_wrap_publish_failed'
+}
+
+export type Nip17OrderTransportGiftWrapAttempt = {
+	target: Nip17OrderTransportTarget
+	relays: string[]
+	giftWrapId: string
+	giftWrapKind: typeof NIP59_GIFT_WRAP_KIND
+	wrapRecipientPubkey: string
+}
+
+export type PublishNip17OrderTransportResult =
+	| {
+			status: 'validation_failed'
+			error: Nip17OrderTransportError
+	  }
+	| {
+			status: 'relay_targets_failed'
+			rumorId: string
+			error: Nip17OrderTransportError
+			senderFilter: Nip17DmRelayListFilter
+			recipientFilter: Nip17DmRelayListFilter
+			relayTargets: Nip17RelayTargetsResult | null
+	  }
+	| {
+			status: 'wrap_failed'
+			rumorId: string
+			error: Nip17OrderTransportError
+			relayTargets: Nip17RelayTargetsResult
+	  }
+	| {
+			status: 'sender_publish_failed'
+			rumorId: string
+			error: Nip17OrderTransportError
+			relayTargets: Nip17RelayTargetsResult
+			sender: Nip17OrderTransportGiftWrapAttempt
+	  }
+	| {
+			status: 'recipient_publish_failed'
+			rumorId: string
+			error: Nip17OrderTransportError
+			relayTargets: Nip17RelayTargetsResult
+			sender: Nip17OrderTransportGiftWrapAttempt
+			recipient: Nip17OrderTransportGiftWrapAttempt
+	  }
+	| {
+			status: 'published'
+			rumorId: string
+			relayTargets: Nip17RelayTargetsResult
+			sender: Nip17OrderTransportGiftWrapAttempt
+			recipient: Nip17OrderTransportGiftWrapAttempt
+	  }
+
+export type ReadNip17OrderTransportMessagesParams = {
+	activeUserPubkey: string
+	signer: Nip17OrderTransportSigner | null | undefined
+	fetchGiftWraps: (filter: Nip17OrderGiftWrapFilter) => Promise<Event[]>
+}
+
+export type ReadNip17OrderTransportMessagesResult = {
+	filter: Nip17OrderGiftWrapFilter
+	messages: UnwrappedNip17OrderMessage[]
+}
+
+export function buildNip17OrderGiftWrapFilter(activeUserPubkey: string): Nip17OrderGiftWrapFilter {
+	return {
+		kinds: [NIP59_GIFT_WRAP_KIND],
+		'#p': [activeUserPubkey],
+	}
+}
+
+export async function publishNip17OrderTransportMessage(
+	params: PublishNip17OrderTransportMessageParams,
+): Promise<PublishNip17OrderTransportResult> {
+	let recipientPubkey: string
+	try {
+		assertOrderMessageRumor(params.rumor)
+		recipientPubkey = getOrderRumorRecipientPubkey(params.rumor)
+	} catch {
+		return validationFailed('invalid_order_message')
+	}
+
+	let signerPubkey: string
+	try {
+		signerPubkey = await getSignerPubkey(params.signer)
+	} catch {
+		return validationFailed('signer_pubkey_unavailable')
+	}
+
+	if (signerPubkey !== params.rumor.pubkey) {
+		return validationFailed('signer_pubkey_mismatch')
+	}
+
+	const senderFilter = buildNip17DmRelayListFilter(signerPubkey)
+	const recipientFilter = buildNip17DmRelayListFilter(recipientPubkey)
+
+	let senderEvents: Nip17DmRelayListEvent[]
+	let recipientEvents: Nip17DmRelayListEvent[]
+	try {
+		senderEvents = await params.fetchRelayListEvents({
+			target: 'sender',
+			pubkey: signerPubkey,
+			filter: senderFilter,
+		})
+		recipientEvents = await params.fetchRelayListEvents({
+			target: 'recipient',
+			pubkey: recipientPubkey,
+			filter: recipientFilter,
+		})
+	} catch {
+		return {
+			status: 'relay_targets_failed',
+			rumorId: params.rumor.id,
+			error: { code: 'relay_list_fetch_failed' },
+			senderFilter,
+			recipientFilter,
+			relayTargets: null,
+		}
+	}
+
+	const relayTargets = resolveNip17RelayTargetsFromEvents({
+		recipientPubkey,
+		senderPubkey: signerPubkey,
+		recipientEvents,
+		senderEvents,
+	})
+
+	if (!relayTargets.ready || relayTargets.recipient.status !== 'ready' || relayTargets.sender.status !== 'ready') {
+		return {
+			status: 'relay_targets_failed',
+			rumorId: params.rumor.id,
+			error: { code: 'relay_targets_not_ready' },
+			senderFilter,
+			recipientFilter,
+			relayTargets,
+		}
+	}
+
+	let wraps: Awaited<ReturnType<typeof createNip17GiftWrapsWithSigner>>
+	try {
+		wraps = await createNip17GiftWrapsWithSigner({
+			rumor: params.rumor,
+			signer: params.signer,
+			recipientPubkey,
+			createdAt: params.createdAt,
+		})
+	} catch {
+		return {
+			status: 'wrap_failed',
+			rumorId: params.rumor.id,
+			error: { code: 'gift_wrap_creation_failed' },
+			relayTargets,
+		}
+	}
+
+	if (wraps.sender.giftWrap.kind !== NIP59_GIFT_WRAP_KIND || wraps.recipient.giftWrap.kind !== NIP59_GIFT_WRAP_KIND) {
+		return {
+			status: 'wrap_failed',
+			rumorId: params.rumor.id,
+			error: { code: 'gift_wrap_creation_failed' },
+			relayTargets,
+		}
+	}
+
+	const sender = giftWrapRecord({
+		target: 'sender',
+		relays: relayTargets.sender.relays,
+		giftWrap: wraps.sender.giftWrap,
+	})
+	const recipient = giftWrapRecord({
+		target: 'recipient',
+		relays: relayTargets.recipient.relays,
+		giftWrap: wraps.recipient.giftWrap,
+	})
+
+	const senderPublished = await publishGiftWrap(params.publishGiftWrap, {
+		target: 'sender',
+		relays: relayTargets.sender.relays,
+		giftWrap: wraps.sender.giftWrap,
+	})
+
+	if (!senderPublished) {
+		return {
+			status: 'sender_publish_failed',
+			rumorId: wraps.rumor.id ?? params.rumor.id,
+			error: { code: 'gift_wrap_publish_failed' },
+			relayTargets,
+			sender,
+		}
+	}
+
+	const recipientPublished = await publishGiftWrap(params.publishGiftWrap, {
+		target: 'recipient',
+		relays: relayTargets.recipient.relays,
+		giftWrap: wraps.recipient.giftWrap,
+	})
+
+	if (!recipientPublished) {
+		return {
+			status: 'recipient_publish_failed',
+			rumorId: wraps.rumor.id ?? params.rumor.id,
+			error: { code: 'gift_wrap_publish_failed' },
+			relayTargets,
+			sender,
+			recipient,
+		}
+	}
+
+	return {
+		status: 'published',
+		rumorId: wraps.rumor.id ?? params.rumor.id,
+		relayTargets,
+		sender,
+		recipient,
+	}
+}
+
+export async function readNip17OrderTransportMessages(
+	params: ReadNip17OrderTransportMessagesParams,
+): Promise<ReadNip17OrderTransportMessagesResult> {
+	const filter = buildNip17OrderGiftWrapFilter(params.activeUserPubkey)
+	const giftWraps = await params.fetchGiftWraps(filter)
+	const messages = await unwrapNip17OrderMessages({
+		giftWraps,
+		signer: params.signer,
+	})
+
+	return {
+		filter,
+		messages,
+	}
+}
+
+function validationFailed(code: Nip17OrderTransportError['code']): PublishNip17OrderTransportResult {
+	return {
+		status: 'validation_failed',
+		error: { code },
+	}
+}
+
+async function getSignerPubkey(signer: Nip17OrderTransportSigner): Promise<string> {
+	const user = await signer.user()
+	if (!user?.pubkey) throw new Error('Signer pubkey unavailable')
+	return user.pubkey
+}
+
+function getOrderRumorRecipientPubkey(rumor: OrderMessageRumor): string {
+	const recipientTags = rumor.tags.filter((tag) => tag[0] === 'p')
+
+	if (recipientTags.length !== 1 || typeof recipientTags[0]?.[1] !== 'string' || recipientTags[0][1].length === 0) {
+		throw new Error('NIP-17 order rumor must have exactly one recipient p tag')
+	}
+
+	return recipientTags[0][1]
+}
+
+function giftWrapRecord(params: PublishNip17OrderTransportGiftWrapParams): Nip17OrderTransportGiftWrapAttempt {
+	return {
+		target: params.target,
+		relays: [...params.relays],
+		giftWrapId: params.giftWrap.id,
+		giftWrapKind: NIP59_GIFT_WRAP_KIND,
+		wrapRecipientPubkey: getGiftWrapRecipientPubkey(params.giftWrap),
+	}
+}
+
+function getGiftWrapRecipientPubkey(giftWrap: Event): string {
+	return giftWrap.tags.find((tag) => tag[0] === 'p')?.[1] ?? ''
+}
+
+async function publishGiftWrap(
+	publish: (params: PublishNip17OrderTransportGiftWrapParams) => Promise<unknown>,
+	params: PublishNip17OrderTransportGiftWrapParams,
+): Promise<boolean> {
+	try {
+		const result = await publish({
+			target: params.target,
+			relays: params.relays,
+			giftWrap: params.giftWrap,
+		})
+
+		return publishResultHasRelaySuccess(result)
+	} catch {
+		return false
+	}
+}
+
+function publishResultHasRelaySuccess(result: unknown): boolean {
+	if (result instanceof Set) return result.size > 0
+	if (Array.isArray(result)) return result.length > 0
+	if (typeof result === 'object' && result !== null && 'size' in result && typeof (result as { size?: unknown }).size === 'number') {
+		return (result as { size: number }).size > 0
+	}
+	return true
+}


### PR DESCRIPTION
## What

Adds a helper-only NIP-17 order transport boundary for order messages.

This introduces a dependency-injected seam that composes the existing NIP-17/NIP-59 wrapping helpers, kind 10050 relay-list resolution, order-message rumor validation, and order unwrap helpers.

## Why

ADR-014 calls for a narrow transport orchestration boundary before wiring checkout, order queries, React Query, or live relay I/O.

This keeps the migration reviewable and avoids overlapping with #1068, which is the Applesauce order read-path work.

## Scope

- Adds `src/lib/orders/nip17OrderTransport.ts`
- Adds `src/lib/__tests__/nip17OrderTransport.test.ts`
- No checkout UI changes
- No `src/queries/orders.tsx`
- No React Query changes
- No live publish/read wiring
- No legacy raw kind 14/16/17 read/write removal
- No concrete NDK/Applesauce relay/read I/O
- No direct `@nostr-dev-kit/ndk` imports in the new files

## Behavior

- Validates canonical `OrderMessageRumor`
- Resolves sender and recipient kind 10050 relay targets
- Fails closed when sender or recipient relay targets are missing/empty
- Creates sender self-wrap and recipient gift wrap
- Publishes sender self-wrap before recipient delivery
- Preserves explicit partial delivery states:
  - `validation_failed`
  - `relay_targets_failed`
  - `wrap_failed`
  - `sender_publish_failed`
  - `recipient_publish_failed`
  - `published`
- Fetches kind 1059 gift wraps for the active user through injected read I/O
- Delegates unwrap/dedupe/sort behavior to the existing read helper

## Validation

- `bun test src/lib/__tests__/nip17OrderTransport.test.ts`
- `bun test src/lib/__tests__/nip17.test.ts src/lib/__tests__/nip17Relays.test.ts src/lib/__tests__/orderMessageRumor.test.ts src/lib/__tests__/nip17OrderPublish.test.ts src/lib/__tests__/nip17OrderRead.test.ts src/lib/__tests__/nip17OrderTransport.test.ts`
- `bun run test:unit`
- `./node_modules/.bin/prettier --check src/lib/orders/nip17OrderTransport.ts src/lib/__tests__/nip17OrderTransport.test.ts`

Note: `scripts/check-ndk-footprint.sh` was not present/executable in this checkout.

Refs #1028.
