### PR TITLE
ci(e2e): add manual grep input for e2e-full diagnostics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -229,9 +229,11 @@ jobs:
           LOCAL_RELAY_ONLY: 'true'
 
       - name: Run remaining E2E tests
+        env:
+          TEST_GREP: ${{ inputs.test_grep }}
         run: |
-          if [ -n "${{ inputs.test_grep }}" ]; then
-            bun run test:e2e -- --grep "${{ inputs.test_grep }}"
+          if [ -n "$TEST_GREP" ]; then
+            bun run test:e2e -- --grep "$TEST_GREP"
           else
             bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
           fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, master, 'auctions/**']
   workflow_dispatch:
+    inputs:
+      test_grep:
+        description: 'Optional grep filter (runs only matching tests). Empty = default full run.'
+        required: false
+        default: ''
   schedule:
     - cron: '0 6 * * 1'
 
@@ -224,7 +229,12 @@ jobs:
           LOCAL_RELAY_ONLY: 'true'
 
       - name: Run remaining E2E tests
-        run: bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+        run: |
+          if [ -n "${{ inputs.test_grep }}" ]; then
+            bun run test:e2e -- --grep "${{ inputs.test_grep }}"
+          else
+            bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+          fi
 
       - name: Show server logs on failure
         if: failure()


### PR DESCRIPTION
## What

Adds an optional `test_grep` input to the manual `e2e-full` workflow so maintainers can run targeted diagnostic subsets without changing PR-gated E2E behavior.

## Why

#1087 calls for staged E2E reactivation. The next safe step is diagnostic infrastructure, not unskipping tests. This lets maintainers classify specs in isolation before promoting anything into stable coverage.

This follows the closed #1031 one-file diagnostic patch shape.

## Invariants

- No app behavior changes.
- No protocol, payment, wallet, relay, NIP-17, or Applesauce behavior changes.
- No test unskips.
- PR-gated `e2e-pricing` remains unchanged.
- Scheduled/manual default `e2e-full` behavior remains unchanged when `test_grep` is empty.
- No secrets, deploys, environment promotions, or workflow-trigger behavior changes beyond the manual input.

## Test plan

- [x] `git diff --check`
- [x] YAML parse check for `.github/workflows/e2e.yml`

Refs #1087.
Refs #1031.
