### PR TITLE
feat(orders): add NIP-17 order message merge helper

### DIFF
--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -26,6 +26,10 @@ shared types.
   new shared abstractions.
 - Keep low-level helpers side-effect-light unless their name and tests make the
   side effect obvious.
+- `src/lib/orders/nip17OrderMessageMerge.ts` is a read-side migration helper for
+  building combined order timelines from legacy raw order events and
+  already-unwrapped NIP-17 order messages. Do not treat it as a publish,
+  signing, unwrap, relay I/O, or required order-read boundary.
 - For payment changes, preserve lifecycle distinctions such as attempted,
   acknowledged, settled/proven, receipt published, merchant confirmed, failed,
   refunded, and fulfilled.

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND } from '../schemas/order'
+import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
 import {
@@ -42,6 +42,18 @@ function signedRumor(rumor: OrderMessageRumor, privateKey: Uint8Array): Event {
 			content: rumor.content,
 		},
 		privateKey,
+	)
+}
+
+function signedLegacyEvent(params: { kind: number; createdAt: number; tags: string[][]; content: string; privateKey: Uint8Array }): Event {
+	return finalizeEvent(
+		{
+			kind: params.kind,
+			created_at: params.createdAt,
+			tags: params.tags,
+			content: params.content,
+		},
+		params.privateKey,
 	)
 }
 
@@ -134,6 +146,59 @@ describe('mergeOrderMessages', () => {
 		expect(ids(records)).toEqual([`legacy-raw:${legacy.id}`, `nip17:${rumor.id}`])
 		expect(records[0]?.direction).toBe('received')
 		expect(records[1]?.direction).toBe('received')
+	})
+
+	test('preserves current raw legacy order creation events with decimal amount tags', () => {
+		const legacy = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Order created',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-info'],
+				['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
+				['order', 'legacy-decimal-amount'],
+				['amount', '1000.00'],
+				['item', `30402:${sellerPubkey}:coffee`, '1'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [legacy],
+			nip17Messages: [],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${legacy.id}`])
+		expect(records[0]?.direction).toBe('received')
+	})
+
+	test('preserves current raw legacy payment requests with recipient tags', () => {
+		const legacy = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Payment request for your order',
+			tags: [
+				['p', buyerPubkey],
+				['recipient', sellerPubkey],
+				['subject', 'order-payment'],
+				['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
+				['order', 'legacy-payment-request'],
+				['amount', '1000'],
+				['payment', 'lightning', 'lnbc-test'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [legacy],
+			nip17Messages: [],
+			activeUserPubkey: buyerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${legacy.id}`])
+		expect(records[0]?.direction).toBe('received')
 	})
 
 	test('sorts deterministically by createdAt, transport, then id', () => {

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from 'bun:test'
+import type { Event } from 'nostr-tools'
+import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND } from '../schemas/order'
+import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
+import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
+import { createOrderCreationRumor, createPaymentReceiptRumor, type OrderMessageRumor } from '../orders/orderMessageRumor'
+
+const buyerPubkey = 'b'.repeat(64)
+const sellerPubkey = 'c'.repeat(64)
+const otherPubkey = 'd'.repeat(64)
+
+function event(params: Partial<Event> & Pick<Event, 'id' | 'kind' | 'pubkey' | 'created_at'>): Event {
+	return {
+		content: '',
+		tags: [],
+		sig: 'f'.repeat(128),
+		...params,
+	}
+}
+
+function nip17Message(
+	rumor: OrderMessageRumor,
+	direction: UnwrappedNip17OrderMessage['direction'] = 'received',
+): UnwrappedNip17OrderMessage {
+	return {
+		giftWrap: event({
+			id: `gift-${rumor.id}`,
+			kind: 1059,
+			pubkey: otherPubkey,
+			created_at: rumor.created_at + 10,
+			tags: [['p', direction === 'sent' ? buyerPubkey : sellerPubkey]],
+		}),
+		seal: event({
+			id: `seal-${rumor.id}`,
+			kind: 13,
+			pubkey: rumor.pubkey,
+			created_at: rumor.created_at + 5,
+		}),
+		rumor,
+		direction,
+		userPubkey: direction === 'sent' ? buyerPubkey : sellerPubkey,
+		counterpartyPubkey: direction === 'sent' ? sellerPubkey : buyerPubkey,
+		recipientPubkey: sellerPubkey,
+	}
+}
+
+function ids(records: MergedOrderMessageRecord[]): string[] {
+	return records.map((record) => `${record.transport}:${record.id}`)
+}
+
+describe('mergeOrderMessages', () => {
+	test('merges legacy raw events and unwrapped NIP-17 order messages', () => {
+		const legacy = event({
+			id: 'legacy-order-create',
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+			content: 'legacy order create',
+		})
+
+		const rumor = createPaymentReceiptRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-merge-1',
+			amountSats: 2100,
+			payment: { medium: 'lightning', reference: 'lnbc-test', proof: 'preimage-test' },
+			createdAt: 200,
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [legacy],
+			nip17Messages: [nip17Message(rumor)],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${legacy.id}`, `nip17:${rumor.id}`])
+		expect(records[0]?.direction).toBe('received')
+		expect(records[1]?.direction).toBe('received')
+	})
+
+	test('sorts deterministically by createdAt, transport, then id', () => {
+		const legacyB = event({
+			id: 'b',
+			kind: ORDER_GENERAL_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+		})
+		const legacyA = event({
+			id: 'a',
+			kind: ORDER_GENERAL_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+		})
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-merge-sort',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+		const newer = event({
+			id: 'newer',
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 200,
+			tags: [['p', sellerPubkey]],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [newer, legacyB, legacyA],
+			nip17Messages: [nip17Message(rumor)],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${legacyA.id}`, `legacy-raw:${legacyB.id}`, `nip17:${rumor.id}`, `legacy-raw:${newer.id}`])
+	})
+
+	test('dedupes duplicate legacy events by event id', () => {
+		const first = event({
+			id: 'same-legacy-id',
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+			content: 'first',
+		})
+		const duplicate = event({
+			id: 'same-legacy-id',
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 101,
+			tags: [['p', sellerPubkey]],
+			content: 'duplicate',
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [first, duplicate],
+			nip17Messages: [],
+		})
+
+		expect(records).toHaveLength(1)
+		expect(records[0]?.content).toBe('first')
+	})
+
+	test('dedupes duplicate NIP-17 messages by inner rumor id', () => {
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-merge-dedupe-nip17',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [],
+			nip17Messages: [nip17Message(rumor), nip17Message(rumor, 'sent')],
+		})
+
+		expect(records).toHaveLength(1)
+		expect(records[0]?.transport).toBe('nip17')
+		expect(records[0]?.id).toBe(rumor.id)
+		expect(records[0]?.direction).toBe('received')
+	})
+
+	test('preserves legacy and NIP-17 records when cross-transport identity is not proven identical', () => {
+		const legacy = event({
+			id: 'shared-looking-id',
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+		})
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-merge-cross-transport',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [legacy],
+			nip17Messages: [nip17Message(rumor)],
+		})
+
+		expect(records).toHaveLength(2)
+		expect(ids(records)).toContain(`legacy-raw:${legacy.id}`)
+		expect(ids(records)).toContain(`nip17:${rumor.id}`)
+	})
+
+	test('computes legacy sent, received, and unknown directions without throwing', () => {
+		const sent = event({
+			id: 'sent',
+			kind: ORDER_GENERAL_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+		})
+		const received = event({
+			id: 'received',
+			kind: ORDER_GENERAL_KIND,
+			pubkey: sellerPubkey,
+			created_at: 101,
+			tags: [['p', buyerPubkey]],
+		})
+		const unknown = event({
+			id: 'unknown',
+			kind: ORDER_GENERAL_KIND,
+			pubkey: otherPubkey,
+			created_at: 102,
+			tags: [['p', sellerPubkey]],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [sent, received, unknown],
+			nip17Messages: [],
+			activeUserPubkey: buyerPubkey,
+		})
+
+		expect(records.map((record) => record.direction)).toEqual(['sent', 'received', 'unknown'])
+	})
+
+	test('ignores unsupported legacy event kinds', () => {
+		const profile = event({
+			id: 'profile',
+			kind: 0,
+			pubkey: buyerPubkey,
+			created_at: 100,
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [profile],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+})

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -363,6 +363,31 @@ describe('mergeOrderMessages', () => {
 		expect(records[0]?.direction).toBe('received')
 	})
 
+	test('preserves legacy payment receipts with empty proof fields', () => {
+		const receipt = signedLegacyEvent({
+			kind: PAYMENT_RECEIPT_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Payment confirmation',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-receipt'],
+				['order', 'legacy-receipt-empty-proof'],
+				['payment', 'lightning', 'lnbc-test', ''],
+				['amount', '1000'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [receipt],
+			nip17Messages: [],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${receipt.id}`])
+		expect(records[0]?.direction).toBe('received')
+	})
+
 	test('ignores legacy payment receipts without full payment proof tags', () => {
 		const receipt = signedLegacyEvent({
 			kind: PAYMENT_RECEIPT_KIND,

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -597,6 +597,20 @@ describe('mergeOrderMessages', () => {
 		expect(records).toEqual([])
 	})
 
+	test('ignores malformed legacy events that throw during verification', () => {
+		const malformed = {
+			...legacyOrderCreationEvent('order-malformed-verify-throw', 100),
+			tags: undefined as unknown as string[][],
+		}
+
+		const records = mergeOrderMessages({
+			legacyEvents: [malformed],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
 	test('ignores legacy events with invalid signatures', () => {
 		const valid = legacyOrderCreationEvent('order-invalid-signature', 100)
 		const tampered = {

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND, SHIPPING_STATUS } from '../schemas/order'
+import {
+	ORDER_GENERAL_KIND,
+	ORDER_MESSAGE_TYPE,
+	ORDER_PROCESS_KIND,
+	ORDER_STATUS,
+	PAYMENT_RECEIPT_KIND,
+	SHIPPING_STATUS,
+} from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
 import {
@@ -373,6 +380,54 @@ describe('mergeOrderMessages', () => {
 
 		const records = mergeOrderMessages({
 			legacyEvents: [receipt],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('preserves legacy order status updates with known status tags', () => {
+		const status = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Order confirmed',
+			tags: [
+				['p', buyerPubkey],
+				['subject', 'order-status'],
+				['type', ORDER_MESSAGE_TYPE.STATUS_UPDATE],
+				['order', 'legacy-order-valid-status'],
+				['status', ORDER_STATUS.CONFIRMED],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [status],
+			nip17Messages: [],
+			activeUserPubkey: buyerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${status.id}`])
+		expect(records[0]?.direction).toBe('received')
+	})
+
+	test('ignores legacy order status updates with unknown status tags', () => {
+		const status = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Order status update',
+			tags: [
+				['p', buyerPubkey],
+				['subject', 'order-status'],
+				['type', ORDER_MESSAGE_TYPE.STATUS_UPDATE],
+				['order', 'legacy-order-invalid-status'],
+				['status', 'teleported'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [status],
 			nip17Messages: [],
 		})
 

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
+import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND, SHIPPING_STATUS } from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
 import {
@@ -374,6 +374,99 @@ describe('mergeOrderMessages', () => {
 		const records = mergeOrderMessages({
 			legacyEvents: [receipt],
 			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('preserves legacy shipping updates with known status tags', () => {
+		const shipping = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Shipping update',
+			tags: [
+				['p', buyerPubkey],
+				['subject', 'shipping-info'],
+				['type', ORDER_MESSAGE_TYPE.SHIPPING_UPDATE],
+				['order', 'legacy-shipping-valid-status'],
+				['status', SHIPPING_STATUS.SHIPPED],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [shipping],
+			nip17Messages: [],
+			activeUserPubkey: buyerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${shipping.id}`])
+		expect(records[0]?.direction).toBe('received')
+	})
+
+	test('ignores legacy shipping updates with unknown status tags', () => {
+		const shipping = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Shipping update',
+			tags: [
+				['p', buyerPubkey],
+				['subject', 'shipping-info'],
+				['type', ORDER_MESSAGE_TYPE.SHIPPING_UPDATE],
+				['order', 'legacy-shipping-invalid-status'],
+				['status', 'teleported'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [shipping],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy payment requests missing amount tags', () => {
+		const paymentRequest = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Payment request for your order',
+			tags: [
+				['p', buyerPubkey],
+				['recipient', sellerPubkey],
+				['subject', 'order-payment'],
+				['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
+				['order', 'legacy-payment-request-missing-amount'],
+				['payment', 'lightning', 'lnbc-test'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [paymentRequest],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores NIP-17 messages with non-order rumor kinds', () => {
+		const unsignedReaction = {
+			kind: 7,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [],
+			content: '+',
+		}
+		const reactionRumor: OrderMessageRumor = {
+			...unsignedReaction,
+			id: getEventHash(unsignedReaction),
+		}
+
+		const records = mergeOrderMessages({
+			legacyEvents: [],
+			nip17Messages: [nip17Message(reactionRumor)],
 		})
 
 		expect(records).toEqual([])

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -255,6 +255,32 @@ describe('mergeOrderMessages', () => {
 		expect(records[0]?.direction).toBe('received')
 	})
 
+	test('dedupes identical legacy raw and NIP-17 messages by canonical event id', () => {
+		const rumor = createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId: 'order-merge-dedupe-cross-transport',
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt: 100,
+		})
+		const legacy = signedRumor(rumor, buyerPrivateKey)
+
+		expect(legacy.id).toBe(rumor.id)
+
+		const records = mergeOrderMessages({
+			legacyEvents: [legacy],
+			nip17Messages: [nip17Message(rumor)],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(records).toHaveLength(1)
+		expect(records[0]?.id).toBe(rumor.id)
+		expect(records[0]?.transport).toBe('nip17')
+		expect(records[0]?.nip17Message?.rumor.id).toBe(rumor.id)
+		expect(records[0]?.legacyEvent).toBeUndefined()
+	})
+
 	test('preserves legacy and NIP-17 records when cross-transport identity is not proven identical', () => {
 		const legacy = legacyOrderCreationEvent('order-merge-cross-transport-legacy', 100)
 		const rumor = createOrderCreationRumor({

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,20 +1,39 @@
 import { describe, expect, test } from 'bun:test'
-import type { Event } from 'nostr-tools'
+import { getEventHash, type Event } from 'nostr-tools'
 import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND } from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
-import { createOrderCreationRumor, createPaymentReceiptRumor, type OrderMessageRumor } from '../orders/orderMessageRumor'
+import {
+	createOrderChatRumor,
+	createOrderCreationRumor,
+	createPaymentReceiptRumor,
+	type OrderMessageRumor,
+} from '../orders/orderMessageRumor'
 
 const buyerPubkey = 'b'.repeat(64)
 const sellerPubkey = 'c'.repeat(64)
 const otherPubkey = 'd'.repeat(64)
 
-function event(params: Partial<Event> & Pick<Event, 'id' | 'kind' | 'pubkey' | 'created_at'>): Event {
+function event(params: Omit<Event, 'id' | 'sig'> & { id?: string; sig?: string }): Event {
+	const unsigned = {
+		content: params.content,
+		tags: params.tags,
+		created_at: params.created_at,
+		kind: params.kind,
+		pubkey: params.pubkey,
+	}
+
 	return {
-		content: '',
-		tags: [],
-		sig: 'f'.repeat(128),
-		...params,
+		...unsigned,
+		id: params.id ?? getEventHash(unsigned),
+		sig: params.sig ?? 'f'.repeat(128),
+	}
+}
+
+function signedRumor(rumor: OrderMessageRumor, sig = 'f'.repeat(128)): Event {
+	return {
+		...rumor,
+		sig,
 	}
 }
 
@@ -29,12 +48,15 @@ function nip17Message(
 			pubkey: otherPubkey,
 			created_at: rumor.created_at + 10,
 			tags: [['p', direction === 'sent' ? buyerPubkey : sellerPubkey]],
+			content: '',
 		}),
 		seal: event({
 			id: `seal-${rumor.id}`,
 			kind: 13,
 			pubkey: rumor.pubkey,
 			created_at: rumor.created_at + 5,
+			tags: [],
+			content: '',
 		}),
 		rumor,
 		direction,
@@ -44,21 +66,44 @@ function nip17Message(
 	}
 }
 
+function legacyOrderCreationEvent(orderId: string, createdAt: number): Event {
+	return signedRumor(
+		createOrderCreationRumor({
+			buyerPubkey,
+			merchantPubkey: sellerPubkey,
+			orderId,
+			amountSats: 1000,
+			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
+			createdAt,
+		}),
+	)
+}
+
+function legacyChatEvent(params: {
+	subject: string
+	senderPubkey: string
+	recipientPubkey: string
+	createdAt: number
+	content?: string
+}): Event {
+	return signedRumor(
+		createOrderChatRumor({
+			senderPubkey: params.senderPubkey,
+			recipientPubkey: params.recipientPubkey,
+			subject: params.subject,
+			content: params.content ?? params.subject,
+			createdAt: params.createdAt,
+		}),
+	)
+}
+
 function ids(records: MergedOrderMessageRecord[]): string[] {
 	return records.map((record) => `${record.transport}:${record.id}`)
 }
 
 describe('mergeOrderMessages', () => {
-	test('merges legacy raw events and unwrapped NIP-17 order messages', () => {
-		const legacy = event({
-			id: 'legacy-order-create',
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-			content: 'legacy order create',
-		})
-
+	test('merges validated legacy raw events and unwrapped NIP-17 order messages', () => {
+		const legacy = legacyOrderCreationEvent('order-merge-legacy', 100)
 		const rumor = createPaymentReceiptRumor({
 			buyerPubkey,
 			merchantPubkey: sellerPubkey,
@@ -80,62 +125,28 @@ describe('mergeOrderMessages', () => {
 	})
 
 	test('sorts deterministically by createdAt, transport, then id', () => {
-		const legacyB = event({
-			id: 'b',
-			kind: ORDER_GENERAL_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-		})
-		const legacyA = event({
-			id: 'a',
-			kind: ORDER_GENERAL_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-		})
+		const older = legacyOrderCreationEvent('order-older', 100)
 		const rumor = createOrderCreationRumor({
 			buyerPubkey,
 			merchantPubkey: sellerPubkey,
-			orderId: 'order-merge-sort',
+			orderId: 'order-middle',
 			amountSats: 1000,
 			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
-			createdAt: 100,
+			createdAt: 200,
 		})
-		const newer = event({
-			id: 'newer',
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 200,
-			tags: [['p', sellerPubkey]],
-		})
+		const newer = legacyOrderCreationEvent('order-newer', 300)
 
 		const records = mergeOrderMessages({
-			legacyEvents: [newer, legacyB, legacyA],
+			legacyEvents: [newer, older],
 			nip17Messages: [nip17Message(rumor)],
-			activeUserPubkey: sellerPubkey,
 		})
 
-		expect(ids(records)).toEqual([`legacy-raw:${legacyA.id}`, `legacy-raw:${legacyB.id}`, `nip17:${rumor.id}`, `legacy-raw:${newer.id}`])
+		expect(ids(records)).toEqual([`legacy-raw:${older.id}`, `nip17:${rumor.id}`, `legacy-raw:${newer.id}`])
 	})
 
-	test('dedupes duplicate legacy events by event id', () => {
-		const first = event({
-			id: 'same-legacy-id',
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-			content: 'first',
-		})
-		const duplicate = event({
-			id: 'same-legacy-id',
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 101,
-			tags: [['p', sellerPubkey]],
-			content: 'duplicate',
-		})
+	test('dedupes duplicate validated legacy events by event id', () => {
+		const first = legacyOrderCreationEvent('order-dedupe-legacy', 100)
+		const duplicate = signedRumor(first, 'e'.repeat(128))
 
 		const records = mergeOrderMessages({
 			legacyEvents: [first, duplicate],
@@ -143,7 +154,7 @@ describe('mergeOrderMessages', () => {
 		})
 
 		expect(records).toHaveLength(1)
-		expect(records[0]?.content).toBe('first')
+		expect(records[0]?.legacyEvent?.sig).toBe('f'.repeat(128))
 	})
 
 	test('dedupes duplicate NIP-17 messages by inner rumor id', () => {
@@ -168,17 +179,11 @@ describe('mergeOrderMessages', () => {
 	})
 
 	test('preserves legacy and NIP-17 records when cross-transport identity is not proven identical', () => {
-		const legacy = event({
-			id: 'shared-looking-id',
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-		})
+		const legacy = legacyOrderCreationEvent('order-merge-cross-transport-legacy', 100)
 		const rumor = createOrderCreationRumor({
 			buyerPubkey,
 			merchantPubkey: sellerPubkey,
-			orderId: 'order-merge-cross-transport',
+			orderId: 'order-merge-cross-transport-nip17',
 			amountSats: 1000,
 			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
 			createdAt: 100,
@@ -195,26 +200,23 @@ describe('mergeOrderMessages', () => {
 	})
 
 	test('computes legacy sent, received, and unknown directions without throwing', () => {
-		const sent = event({
-			id: 'sent',
-			kind: ORDER_GENERAL_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
+		const sent = legacyChatEvent({
+			subject: 'order-sent',
+			senderPubkey: buyerPubkey,
+			recipientPubkey: sellerPubkey,
+			createdAt: 100,
 		})
-		const received = event({
-			id: 'received',
-			kind: ORDER_GENERAL_KIND,
-			pubkey: sellerPubkey,
-			created_at: 101,
-			tags: [['p', buyerPubkey]],
+		const received = legacyChatEvent({
+			subject: 'order-received',
+			senderPubkey: sellerPubkey,
+			recipientPubkey: buyerPubkey,
+			createdAt: 101,
 		})
-		const unknown = event({
-			id: 'unknown',
-			kind: ORDER_GENERAL_KIND,
-			pubkey: otherPubkey,
-			created_at: 102,
-			tags: [['p', sellerPubkey]],
+		const unknown = legacyChatEvent({
+			subject: 'order-unknown',
+			senderPubkey: otherPubkey,
+			recipientPubkey: sellerPubkey,
+			createdAt: 102,
 		})
 
 		const records = mergeOrderMessages({
@@ -228,14 +230,64 @@ describe('mergeOrderMessages', () => {
 
 	test('ignores unsupported legacy event kinds', () => {
 		const profile = event({
-			id: 'profile',
 			kind: 0,
 			pubkey: buyerPubkey,
 			created_at: 100,
+			tags: [],
+			content: '{}',
 		})
 
 		const records = mergeOrderMessages({
 			legacyEvents: [profile],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores malformed legacy order process events', () => {
+		const malformed = event({
+			kind: ORDER_PROCESS_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+			content: 'missing type and order tags',
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [malformed],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy general communication without subject context', () => {
+		const genericDm = event({
+			kind: ORDER_GENERAL_KIND,
+			pubkey: buyerPubkey,
+			created_at: 100,
+			tags: [['p', sellerPubkey]],
+			content: 'generic public DM',
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [genericDm],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy events with non-canonical event ids', () => {
+		const valid = legacyOrderCreationEvent('order-non-canonical-id', 100)
+		const tampered = {
+			...valid,
+			id: '0'.repeat(64),
+		}
+
+		const records = mergeOrderMessages({
+			legacyEvents: [tampered],
 			nip17Messages: [],
 		})
 

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -459,6 +459,92 @@ describe('mergeOrderMessages', () => {
 		expect(records).toEqual([])
 	})
 
+	test('ignores legacy order creation events with non-numeric amounts or quantities', () => {
+		const invalidAmount = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Order created',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-info'],
+				['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
+				['order', 'legacy-invalid-amount'],
+				['amount', 'abc'],
+				['item', `30402:${sellerPubkey}:coffee`, '1'],
+			],
+		})
+		const invalidQuantity = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 101,
+			privateKey: buyerPrivateKey,
+			content: 'Order created',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-info'],
+				['type', ORDER_MESSAGE_TYPE.ORDER_CREATION],
+				['order', 'legacy-invalid-quantity'],
+				['amount', '1000.00'],
+				['item', `30402:${sellerPubkey}:coffee`, 'many'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [invalidAmount, invalidQuantity],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy payment requests with non-numeric amount tags', () => {
+		const paymentRequest = signedLegacyEvent({
+			kind: ORDER_PROCESS_KIND,
+			createdAt: 100,
+			privateKey: sellerPrivateKey,
+			content: 'Payment request for your order',
+			tags: [
+				['p', buyerPubkey],
+				['recipient', sellerPubkey],
+				['subject', 'order-payment'],
+				['type', ORDER_MESSAGE_TYPE.PAYMENT_REQUEST],
+				['order', 'legacy-payment-request-invalid-amount'],
+				['amount', 'abc'],
+				['payment', 'lightning', 'lnbc-test'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [paymentRequest],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy payment receipts with non-numeric amount tags', () => {
+		const receipt = signedLegacyEvent({
+			kind: PAYMENT_RECEIPT_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Payment confirmation',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-receipt'],
+				['order', 'legacy-receipt-invalid-amount'],
+				['payment', 'lightning', 'lnbc-test', ''],
+				['amount', 'abc'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [receipt],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
 	test('preserves legacy shipping updates with known status tags', () => {
 		const shipping = signedLegacyEvent({
 			kind: ORDER_PROCESS_KIND,

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '../schemas/order'
+import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
 import {
@@ -303,6 +303,54 @@ describe('mergeOrderMessages', () => {
 		})
 
 		expect(records.map((record) => record.direction)).toEqual(['sent', 'received', 'unknown'])
+	})
+
+	test('preserves legacy payment receipts with full payment proof tags', () => {
+		const receipt = signedLegacyEvent({
+			kind: PAYMENT_RECEIPT_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Payment confirmation',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-receipt'],
+				['order', 'legacy-receipt-full-proof'],
+				['payment', 'lightning', 'lnbc-test', 'preimage-test'],
+				['amount', '1000'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [receipt],
+			nip17Messages: [],
+			activeUserPubkey: sellerPubkey,
+		})
+
+		expect(ids(records)).toEqual([`legacy-raw:${receipt.id}`])
+		expect(records[0]?.direction).toBe('received')
+	})
+
+	test('ignores legacy payment receipts without full payment proof tags', () => {
+		const receipt = signedLegacyEvent({
+			kind: PAYMENT_RECEIPT_KIND,
+			createdAt: 100,
+			privateKey: buyerPrivateKey,
+			content: 'Payment confirmation',
+			tags: [
+				['p', sellerPubkey],
+				['subject', 'order-receipt'],
+				['order', 'legacy-receipt-missing-proof'],
+				['payment', 'lightning'],
+				['amount', '1000'],
+			],
+		})
+
+		const records = mergeOrderMessages({
+			legacyEvents: [receipt],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
 	})
 
 	test('ignores unsupported legacy event kinds', () => {

--- a/src/lib/__tests__/nip17OrderMessageMerge.test.ts
+++ b/src/lib/__tests__/nip17OrderMessageMerge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { getEventHash, type Event } from 'nostr-tools'
+import { finalizeEvent, generateSecretKey, getEventHash, getPublicKey, type Event } from 'nostr-tools'
 import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND } from '../schemas/order'
 import { mergeOrderMessages, type MergedOrderMessageRecord } from '../orders/nip17OrderMessageMerge'
 import type { UnwrappedNip17OrderMessage } from '../orders/nip17OrderRead'
@@ -10,9 +10,12 @@ import {
 	type OrderMessageRumor,
 } from '../orders/orderMessageRumor'
 
-const buyerPubkey = 'b'.repeat(64)
-const sellerPubkey = 'c'.repeat(64)
-const otherPubkey = 'd'.repeat(64)
+const buyerPrivateKey = generateSecretKey()
+const sellerPrivateKey = generateSecretKey()
+const otherPrivateKey = generateSecretKey()
+const buyerPubkey = getPublicKey(buyerPrivateKey)
+const sellerPubkey = getPublicKey(sellerPrivateKey)
+const otherPubkey = getPublicKey(otherPrivateKey)
 
 function event(params: Omit<Event, 'id' | 'sig'> & { id?: string; sig?: string }): Event {
 	const unsigned = {
@@ -30,11 +33,16 @@ function event(params: Omit<Event, 'id' | 'sig'> & { id?: string; sig?: string }
 	}
 }
 
-function signedRumor(rumor: OrderMessageRumor, sig = 'f'.repeat(128)): Event {
-	return {
-		...rumor,
-		sig,
-	}
+function signedRumor(rumor: OrderMessageRumor, privateKey: Uint8Array): Event {
+	return finalizeEvent(
+		{
+			kind: rumor.kind,
+			created_at: rumor.created_at,
+			tags: rumor.tags,
+			content: rumor.content,
+		},
+		privateKey,
+	)
 }
 
 function nip17Message(
@@ -76,24 +84,28 @@ function legacyOrderCreationEvent(orderId: string, createdAt: number): Event {
 			items: [{ productRef: `30402:${sellerPubkey}:coffee`, quantity: 1 }],
 			createdAt,
 		}),
+		buyerPrivateKey,
 	)
 }
 
 function legacyChatEvent(params: {
 	subject: string
-	senderPubkey: string
+	senderPrivateKey: Uint8Array
 	recipientPubkey: string
 	createdAt: number
 	content?: string
 }): Event {
+	const senderPubkey = getPublicKey(params.senderPrivateKey)
+
 	return signedRumor(
 		createOrderChatRumor({
-			senderPubkey: params.senderPubkey,
+			senderPubkey,
 			recipientPubkey: params.recipientPubkey,
 			subject: params.subject,
 			content: params.content ?? params.subject,
 			createdAt: params.createdAt,
 		}),
+		params.senderPrivateKey,
 	)
 }
 
@@ -146,7 +158,7 @@ describe('mergeOrderMessages', () => {
 
 	test('dedupes duplicate validated legacy events by event id', () => {
 		const first = legacyOrderCreationEvent('order-dedupe-legacy', 100)
-		const duplicate = signedRumor(first, 'e'.repeat(128))
+		const duplicate = { ...first }
 
 		const records = mergeOrderMessages({
 			legacyEvents: [first, duplicate],
@@ -154,7 +166,7 @@ describe('mergeOrderMessages', () => {
 		})
 
 		expect(records).toHaveLength(1)
-		expect(records[0]?.legacyEvent?.sig).toBe('f'.repeat(128))
+		expect(records[0]?.legacyEvent?.sig).toBe(first.sig)
 	})
 
 	test('dedupes duplicate NIP-17 messages by inner rumor id', () => {
@@ -202,19 +214,19 @@ describe('mergeOrderMessages', () => {
 	test('computes legacy sent, received, and unknown directions without throwing', () => {
 		const sent = legacyChatEvent({
 			subject: 'order-sent',
-			senderPubkey: buyerPubkey,
+			senderPrivateKey: buyerPrivateKey,
 			recipientPubkey: sellerPubkey,
 			createdAt: 100,
 		})
 		const received = legacyChatEvent({
 			subject: 'order-received',
-			senderPubkey: sellerPubkey,
+			senderPrivateKey: sellerPrivateKey,
 			recipientPubkey: buyerPubkey,
 			createdAt: 101,
 		})
 		const unknown = legacyChatEvent({
 			subject: 'order-unknown',
-			senderPubkey: otherPubkey,
+			senderPrivateKey: otherPrivateKey,
 			recipientPubkey: sellerPubkey,
 			createdAt: 102,
 		})
@@ -246,13 +258,15 @@ describe('mergeOrderMessages', () => {
 	})
 
 	test('ignores malformed legacy order process events', () => {
-		const malformed = event({
-			kind: ORDER_PROCESS_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-			content: 'missing type and order tags',
-		})
+		const malformed = finalizeEvent(
+			{
+				kind: ORDER_PROCESS_KIND,
+				created_at: 100,
+				tags: [['p', sellerPubkey]],
+				content: 'missing type and order tags',
+			},
+			buyerPrivateKey,
+		)
 
 		const records = mergeOrderMessages({
 			legacyEvents: [malformed],
@@ -263,13 +277,15 @@ describe('mergeOrderMessages', () => {
 	})
 
 	test('ignores legacy general communication without subject context', () => {
-		const genericDm = event({
-			kind: ORDER_GENERAL_KIND,
-			pubkey: buyerPubkey,
-			created_at: 100,
-			tags: [['p', sellerPubkey]],
-			content: 'generic public DM',
-		})
+		const genericDm = finalizeEvent(
+			{
+				kind: ORDER_GENERAL_KIND,
+				created_at: 100,
+				tags: [['p', sellerPubkey]],
+				content: 'generic public DM',
+			},
+			buyerPrivateKey,
+		)
 
 		const records = mergeOrderMessages({
 			legacyEvents: [genericDm],
@@ -284,6 +300,21 @@ describe('mergeOrderMessages', () => {
 		const tampered = {
 			...valid,
 			id: '0'.repeat(64),
+		}
+
+		const records = mergeOrderMessages({
+			legacyEvents: [tampered],
+			nip17Messages: [],
+		})
+
+		expect(records).toEqual([])
+	})
+
+	test('ignores legacy events with invalid signatures', () => {
+		const valid = legacyOrderCreationEvent('order-invalid-signature', 100)
+		const tampered = {
+			...valid,
+			sig: '0'.repeat(128),
 		}
 
 		const records = mergeOrderMessages({

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,5 +1,12 @@
 import { verifyEvent, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND, SHIPPING_STATUS } from '../schemas/order'
+import {
+	ORDER_GENERAL_KIND,
+	ORDER_MESSAGE_TYPE,
+	ORDER_PROCESS_KIND,
+	ORDER_STATUS,
+	PAYMENT_RECEIPT_KIND,
+	SHIPPING_STATUS,
+} from '../schemas/order'
 import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
 
 export type OrderMessageTransport = 'legacy-raw' | 'nip17'
@@ -120,7 +127,7 @@ function hasLegacyOrderProcessShape(event: Event): boolean {
 		case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
 			return hasNonEmptyTag(event, 'amount')
 		case ORDER_MESSAGE_TYPE.STATUS_UPDATE:
-			return hasNonEmptyTag(event, 'status')
+			return hasKnownOrderStatusTag(event)
 		case ORDER_MESSAGE_TYPE.SHIPPING_UPDATE:
 			return hasKnownShippingStatusTag(event)
 		default:
@@ -143,6 +150,20 @@ function hasPaymentProofTag(event: Event): boolean {
 			tag[2].length > 0 &&
 			typeof tag[3] === 'string' &&
 			tag[3].length > 0,
+	)
+}
+
+function hasKnownOrderStatusTag(event: Event): boolean {
+	return event.tags.some((tag) => tag[0] === 'status' && isOrderStatus(tag[1]))
+}
+
+function isOrderStatus(value: unknown): value is (typeof ORDER_STATUS)[keyof typeof ORDER_STATUS] {
+	return (
+		value === ORDER_STATUS.PENDING ||
+		value === ORDER_STATUS.CONFIRMED ||
+		value === ORDER_STATUS.PROCESSING ||
+		value === ORDER_STATUS.COMPLETED ||
+		value === ORDER_STATUS.CANCELLED
 	)
 }
 

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -31,7 +31,7 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 	for (const event of params.legacyEvents) {
 		if (!isValidLegacyOrderMessageEvent(event)) continue
 
-		const key = `legacy-raw:${event.id}`
+		const key = event.id
 		if (recordsByKey.has(key)) continue
 
 		recordsByKey.set(key, {
@@ -51,8 +51,9 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 		const rumor = message.rumor
 		if (!isOrderMessageKind(rumor.kind)) continue
 
-		const key = `nip17:${rumor.id}`
-		if (recordsByKey.has(key)) continue
+		const key = rumor.id
+		const existing = recordsByKey.get(key)
+		if (existing?.transport === 'nip17') continue
 
 		recordsByKey.set(key, {
 			transport: 'nip17',

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,0 +1,95 @@
+import type { Event } from 'nostr-tools'
+import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
+import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
+
+export type OrderMessageTransport = 'legacy-raw' | 'nip17'
+export type OrderMessageDirection = 'sent' | 'received' | 'unknown'
+export type OrderMessageKind = typeof ORDER_GENERAL_KIND | typeof ORDER_PROCESS_KIND | typeof PAYMENT_RECEIPT_KIND
+
+export type MergedOrderMessageRecord = {
+	transport: OrderMessageTransport
+	id: string
+	createdAt: number
+	kind: OrderMessageKind
+	pubkey: string
+	tags: string[][]
+	content: string
+	direction: OrderMessageDirection
+	legacyEvent?: Event
+	nip17Message?: UnwrappedNip17OrderMessage
+}
+
+export type MergeOrderMessagesParams = {
+	legacyEvents: Event[]
+	nip17Messages: UnwrappedNip17OrderMessage[]
+	activeUserPubkey?: string
+}
+
+export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrderMessageRecord[] {
+	const recordsByKey = new Map<string, MergedOrderMessageRecord>()
+
+	for (const event of params.legacyEvents) {
+		if (!isOrderMessageKind(event.kind)) continue
+
+		const key = `legacy:${event.id}`
+		if (recordsByKey.has(key)) continue
+
+		recordsByKey.set(key, {
+			transport: 'legacy-raw',
+			id: event.id,
+			createdAt: event.created_at,
+			kind: event.kind,
+			pubkey: event.pubkey,
+			tags: event.tags,
+			content: event.content,
+			direction: directionForLegacyEvent(event, params.activeUserPubkey),
+			legacyEvent: event,
+		})
+	}
+
+	for (const message of params.nip17Messages) {
+		const rumor = message.rumor
+		if (!isOrderMessageKind(rumor.kind)) continue
+
+		const key = `nip17:${rumor.id}`
+		if (recordsByKey.has(key)) continue
+
+		recordsByKey.set(key, {
+			transport: 'nip17',
+			id: rumor.id,
+			createdAt: rumor.created_at,
+			kind: rumor.kind,
+			pubkey: rumor.pubkey,
+			tags: rumor.tags,
+			content: rumor.content,
+			direction: message.direction,
+			nip17Message: message,
+		})
+	}
+
+	return Array.from(recordsByKey.values()).sort(compareMergedOrderMessages)
+}
+
+function isOrderMessageKind(kind: number): kind is OrderMessageKind {
+	return kind === ORDER_GENERAL_KIND || kind === ORDER_PROCESS_KIND || kind === PAYMENT_RECEIPT_KIND
+}
+
+function directionForLegacyEvent(event: Event, activeUserPubkey?: string): OrderMessageDirection {
+	if (!activeUserPubkey) return 'unknown'
+	if (event.pubkey === activeUserPubkey) return 'sent'
+
+	const recipientPubkey = event.tags.find((tag) => tag[0] === 'p')?.[1]
+	if (recipientPubkey === activeUserPubkey) return 'received'
+
+	return 'unknown'
+}
+
+function compareMergedOrderMessages(a: MergedOrderMessageRecord, b: MergedOrderMessageRecord): number {
+	const createdAtDiff = a.createdAt - b.createdAt
+	if (createdAtDiff !== 0) return createdAtDiff
+
+	const transportDiff = a.transport.localeCompare(b.transport)
+	if (transportDiff !== 0) return transportDiff
+
+	return a.id.localeCompare(b.id)
+}

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -148,12 +148,7 @@ function hasItemTag(event: Event): boolean {
 function hasPaymentProofTag(event: Event): boolean {
 	return event.tags.some(
 		(tag) =>
-			tag[0] === 'payment' &&
-			isPaymentMedium(tag[1]) &&
-			typeof tag[2] === 'string' &&
-			tag[2].length > 0 &&
-			typeof tag[3] === 'string' &&
-			tag[3].length > 0,
+			tag[0] === 'payment' && isPaymentMedium(tag[1]) && typeof tag[2] === 'string' && tag[2].length > 0 && typeof tag[3] === 'string',
 	)
 }
 

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -111,7 +111,7 @@ function hasLegacyOrderMessageShape(event: Event & { kind: OrderMessageKind }): 
 			hasNonEmptyTag(event, 'subject') &&
 			hasNonEmptyTag(event, 'order') &&
 			hasPaymentProofTag(event) &&
-			hasNonEmptyTag(event, 'amount')
+			hasNumericAmountTag(event)
 		)
 	}
 
@@ -127,9 +127,9 @@ function hasLegacyOrderProcessShape(event: Event): boolean {
 
 	switch (messageType) {
 		case ORDER_MESSAGE_TYPE.ORDER_CREATION:
-			return hasNonEmptyTag(event, 'amount') && hasItemTag(event)
+			return hasNumericAmountTag(event) && hasItemTag(event)
 		case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
-			return hasNonEmptyTag(event, 'amount')
+			return hasNumericAmountTag(event)
 		case ORDER_MESSAGE_TYPE.STATUS_UPDATE:
 			return hasKnownOrderStatusTag(event)
 		case ORDER_MESSAGE_TYPE.SHIPPING_UPDATE:
@@ -140,9 +140,19 @@ function hasLegacyOrderProcessShape(event: Event): boolean {
 }
 
 function hasItemTag(event: Event): boolean {
-	return event.tags.some(
-		(tag) => tag[0] === 'item' && typeof tag[1] === 'string' && tag[1].length > 0 && typeof tag[2] === 'string' && tag[2].length > 0,
-	)
+	return event.tags.some((tag) => tag[0] === 'item' && typeof tag[1] === 'string' && tag[1].length > 0 && isIntegerString(tag[2]))
+}
+
+function hasNumericAmountTag(event: Event): boolean {
+	return event.tags.some((tag) => tag[0] === 'amount' && isDecimalString(tag[1]))
+}
+
+function isDecimalString(value: unknown): value is string {
+	return typeof value === 'string' && /^\d+(?:\.\d+)?$/.test(value)
+}
+
+function isIntegerString(value: unknown): value is string {
+	return typeof value === 'string' && /^\d+$/.test(value)
 }
 
 function hasPaymentProofTag(event: Event): boolean {

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -98,7 +98,7 @@ function hasLegacyOrderMessageShape(event: Event & { kind: OrderMessageKind }): 
 			hasNonEmptyTag(event, 'p') &&
 			hasNonEmptyTag(event, 'subject') &&
 			hasNonEmptyTag(event, 'order') &&
-			hasNonEmptyTag(event, 'payment') &&
+			hasPaymentProofTag(event) &&
 			hasNonEmptyTag(event, 'amount')
 		)
 	}
@@ -130,6 +130,22 @@ function hasItemTag(event: Event): boolean {
 	return event.tags.some(
 		(tag) => tag[0] === 'item' && typeof tag[1] === 'string' && tag[1].length > 0 && typeof tag[2] === 'string' && tag[2].length > 0,
 	)
+}
+
+function hasPaymentProofTag(event: Event): boolean {
+	return event.tags.some(
+		(tag) =>
+			tag[0] === 'payment' &&
+			isPaymentMedium(tag[1]) &&
+			typeof tag[2] === 'string' &&
+			tag[2].length > 0 &&
+			typeof tag[3] === 'string' &&
+			tag[3].length > 0,
+	)
+}
+
+function isPaymentMedium(value: unknown): value is 'lightning' | 'bitcoin' | 'fiat' | 'other' {
+	return value === 'lightning' || value === 'bitcoin' || value === 'fiat' || value === 'other'
 }
 
 function isOrderMessageKind(kind: number): kind is OrderMessageKind {

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,4 +1,4 @@
-import type { Event } from 'nostr-tools'
+import { verifyEvent, type Event } from 'nostr-tools'
 import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
 import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
 import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
@@ -74,13 +74,25 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 function isValidLegacyOrderMessageEvent(event: Event): event is Event & { kind: OrderMessageKind } {
 	if (!isOrderMessageKind(event.kind)) return false
 
-	const rumorCandidate: OrderMessageRumor = {
+	const eventForVerification: Event = {
 		id: event.id,
 		pubkey: event.pubkey,
 		created_at: event.created_at,
 		kind: event.kind,
 		tags: event.tags,
 		content: event.content,
+		sig: event.sig,
+	}
+
+	if (!verifyEvent(eventForVerification)) return false
+
+	const rumorCandidate: OrderMessageRumor = {
+		id: eventForVerification.id,
+		pubkey: eventForVerification.pubkey,
+		created_at: eventForVerification.created_at,
+		kind: eventForVerification.kind,
+		tags: eventForVerification.tags,
+		content: eventForVerification.content,
 	}
 
 	try {

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -91,7 +91,11 @@ function isValidLegacyOrderMessageEvent(event: Event): event is Event & { kind: 
 		sig: event.sig,
 	}
 
-	if (!verifyEvent(eventForVerification)) return false
+	try {
+		if (!verifyEvent(eventForVerification)) return false
+	} catch {
+		return false
+	}
 
 	return hasLegacyOrderMessageShape(eventForVerification)
 }

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,6 +1,5 @@
 import { verifyEvent, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
-import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
+import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
 import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
 
 export type OrderMessageTransport = 'legacy-raw' | 'nip17'
@@ -74,7 +73,7 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 function isValidLegacyOrderMessageEvent(event: Event): event is Event & { kind: OrderMessageKind } {
 	if (!isOrderMessageKind(event.kind)) return false
 
-	const eventForVerification: Event = {
+	const eventForVerification: Event & { kind: OrderMessageKind } = {
 		id: event.id,
 		pubkey: event.pubkey,
 		created_at: event.created_at,
@@ -86,26 +85,51 @@ function isValidLegacyOrderMessageEvent(event: Event): event is Event & { kind: 
 
 	if (!verifyEvent(eventForVerification)) return false
 
-	const rumorCandidate: OrderMessageRumor = {
-		id: eventForVerification.id,
-		pubkey: eventForVerification.pubkey,
-		created_at: eventForVerification.created_at,
-		kind: eventForVerification.kind,
-		tags: eventForVerification.tags,
-		content: eventForVerification.content,
+	return hasLegacyOrderMessageShape(eventForVerification)
+}
+
+function hasLegacyOrderMessageShape(event: Event & { kind: OrderMessageKind }): boolean {
+	if (event.kind === ORDER_GENERAL_KIND) {
+		return hasNonEmptyTag(event, 'p') && hasNonEmptyTag(event, 'subject')
 	}
 
-	try {
-		assertOrderMessageRumor(rumorCandidate)
-	} catch {
+	if (event.kind === PAYMENT_RECEIPT_KIND) {
+		return (
+			hasNonEmptyTag(event, 'p') &&
+			hasNonEmptyTag(event, 'subject') &&
+			hasNonEmptyTag(event, 'order') &&
+			hasNonEmptyTag(event, 'payment') &&
+			hasNonEmptyTag(event, 'amount')
+		)
+	}
+
+	return hasLegacyOrderProcessShape(event)
+}
+
+function hasLegacyOrderProcessShape(event: Event): boolean {
+	if (!hasNonEmptyTag(event, 'p') || !hasNonEmptyTag(event, 'subject') || !hasNonEmptyTag(event, 'order')) {
 		return false
 	}
 
-	if (event.kind === ORDER_GENERAL_KIND && !hasNonEmptyTag(event, 'subject')) {
-		return false
-	}
+	const messageType = event.tags.find((tag) => tag[0] === 'type')?.[1]
 
-	return true
+	switch (messageType) {
+		case ORDER_MESSAGE_TYPE.ORDER_CREATION:
+			return hasNonEmptyTag(event, 'amount') && hasItemTag(event)
+		case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
+			return hasNonEmptyTag(event, 'amount')
+		case ORDER_MESSAGE_TYPE.STATUS_UPDATE:
+		case ORDER_MESSAGE_TYPE.SHIPPING_UPDATE:
+			return hasNonEmptyTag(event, 'status')
+		default:
+			return false
+	}
+}
+
+function hasItemTag(event: Event): boolean {
+	return event.tags.some(
+		(tag) => tag[0] === 'item' && typeof tag[1] === 'string' && tag[1].length > 0 && typeof tag[2] === 'string' && tag[2].length > 0,
+	)
 }
 
 function isOrderMessageKind(kind: number): kind is OrderMessageKind {

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,10 +1,10 @@
 import { verifyEvent, type Event } from 'nostr-tools'
-import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
+import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND, SHIPPING_STATUS } from '../schemas/order'
 import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
 
 export type OrderMessageTransport = 'legacy-raw' | 'nip17'
 export type OrderMessageDirection = 'sent' | 'received' | 'unknown'
-export type OrderMessageKind = typeof ORDER_GENERAL_KIND | typeof ORDER_PROCESS_KIND | typeof PAYMENT_RECEIPT_KIND
+export type OrderMessageKind = 14 | 16 | 17
 
 export type MergedOrderMessageRecord = {
 	transport: OrderMessageTransport
@@ -120,8 +120,9 @@ function hasLegacyOrderProcessShape(event: Event): boolean {
 		case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
 			return hasNonEmptyTag(event, 'amount')
 		case ORDER_MESSAGE_TYPE.STATUS_UPDATE:
-		case ORDER_MESSAGE_TYPE.SHIPPING_UPDATE:
 			return hasNonEmptyTag(event, 'status')
+		case ORDER_MESSAGE_TYPE.SHIPPING_UPDATE:
+			return hasKnownShippingStatusTag(event)
 		default:
 			return false
 	}
@@ -142,6 +143,19 @@ function hasPaymentProofTag(event: Event): boolean {
 			tag[2].length > 0 &&
 			typeof tag[3] === 'string' &&
 			tag[3].length > 0,
+	)
+}
+
+function hasKnownShippingStatusTag(event: Event): boolean {
+	return event.tags.some((tag) => tag[0] === 'status' && isShippingStatus(tag[1]))
+}
+
+function isShippingStatus(value: unknown): value is (typeof SHIPPING_STATUS)[keyof typeof SHIPPING_STATUS] {
+	return (
+		value === SHIPPING_STATUS.PROCESSING ||
+		value === SHIPPING_STATUS.SHIPPED ||
+		value === SHIPPING_STATUS.DELIVERED ||
+		value === SHIPPING_STATUS.EXCEPTION
 	)
 }
 

--- a/src/lib/orders/nip17OrderMessageMerge.ts
+++ b/src/lib/orders/nip17OrderMessageMerge.ts
@@ -1,5 +1,6 @@
 import type { Event } from 'nostr-tools'
 import { ORDER_GENERAL_KIND, ORDER_PROCESS_KIND, PAYMENT_RECEIPT_KIND } from '../schemas/order'
+import { assertOrderMessageRumor, type OrderMessageRumor } from './orderMessageRumor'
 import type { UnwrappedNip17OrderMessage } from './nip17OrderRead'
 
 export type OrderMessageTransport = 'legacy-raw' | 'nip17'
@@ -29,9 +30,9 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 	const recordsByKey = new Map<string, MergedOrderMessageRecord>()
 
 	for (const event of params.legacyEvents) {
-		if (!isOrderMessageKind(event.kind)) continue
+		if (!isValidLegacyOrderMessageEvent(event)) continue
 
-		const key = `legacy:${event.id}`
+		const key = `legacy-raw:${event.id}`
 		if (recordsByKey.has(key)) continue
 
 		recordsByKey.set(key, {
@@ -70,8 +71,37 @@ export function mergeOrderMessages(params: MergeOrderMessagesParams): MergedOrde
 	return Array.from(recordsByKey.values()).sort(compareMergedOrderMessages)
 }
 
+function isValidLegacyOrderMessageEvent(event: Event): event is Event & { kind: OrderMessageKind } {
+	if (!isOrderMessageKind(event.kind)) return false
+
+	const rumorCandidate: OrderMessageRumor = {
+		id: event.id,
+		pubkey: event.pubkey,
+		created_at: event.created_at,
+		kind: event.kind,
+		tags: event.tags,
+		content: event.content,
+	}
+
+	try {
+		assertOrderMessageRumor(rumorCandidate)
+	} catch {
+		return false
+	}
+
+	if (event.kind === ORDER_GENERAL_KIND && !hasNonEmptyTag(event, 'subject')) {
+		return false
+	}
+
+	return true
+}
+
 function isOrderMessageKind(kind: number): kind is OrderMessageKind {
 	return kind === ORDER_GENERAL_KIND || kind === ORDER_PROCESS_KIND || kind === PAYMENT_RECEIPT_KIND
+}
+
+function hasNonEmptyTag(event: Event, tagName: string): boolean {
+	return event.tags.some((tag) => tag[0] === tagName && typeof tag[1] === 'string' && tag[1].length > 0)
 }
 
 function directionForLegacyEvent(event: Event, activeUserPubkey?: string): OrderMessageDirection {


### PR DESCRIPTION
## What

Adds a pure helper for merging legacy raw order-message events with unwrapped NIP-17 order messages.

## Why

ADR-014 defines the next migration slice after the transport boundary as a narrow read helper that can merge legacy raw kind 14/16/17 reads with unwrapped NIP-17 inner rumors, without wiring checkout, React Query, or live relay I/O yet.

## Scope

- Adds `src/lib/orders/nip17OrderMessageMerge.ts`
- Adds focused unit tests
- No checkout UI wiring
- No `src/queries/orders.tsx` rewrite
- No React Query changes
- No publish wiring
- No legacy raw read/write removal
- No Applesauce migration overlap

## Test plan

- [x] `bun test src/lib/__tests__/nip17OrderMessageMerge.test.ts` — 7 pass / 0 fail
- [x] `bun test src/lib/__tests__/nip17OrderTransport.test.ts` — 9 pass / 0 fail
- [x] `git diff --cached --check`

Refs #1084.
Follows ADR-014.
