### PR TITLE
fix: harden staging deploy file staging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Create environment file
         run: |
-          cat > deploy-package/.env << EOF
+          cat > deploy-package/.env << 'EOF'
           APP_STAGE=staging
           NODE_ENV=production
           PORT=3000
@@ -152,16 +152,18 @@ jobs:
           script: |
             mkdir -p ~/releases ~/logs
             chmod 755 ~
-            rm -rf /tmp/deploy-package
+            rm -rf ~/deploy-package
+            rm -f ~/deploy-package.tar.gz ~/Caddyfile.staging ~/caddyfile-staging.tar.gz
 
-      - name: Upload files to tmp
+      - name: Upload files to deployer staging
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USER }}
           password: ${{ secrets.STAGING_PASSWORD }}
           source: 'deploy-package/*'
-          target: '/tmp/deploy-package'
+          target: '/home/deployer/deploy-package'
+          tar_tmp_path: '/home/deployer/deploy-package.tar.gz'
           strip_components: 1
 
       - name: Upload Caddyfile
@@ -171,7 +173,8 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           password: ${{ secrets.STAGING_PASSWORD }}
           source: 'deploy-simple/caddyfiles/Caddyfile.staging'
-          target: '/tmp'
+          target: '/home/deployer'
+          tar_tmp_path: '/home/deployer/caddyfile-staging.tar.gz'
           strip_components: 2
 
       - name: Move files to release directory
@@ -181,7 +184,7 @@ jobs:
           username: ${{ secrets.STAGING_USER }}
           password: ${{ secrets.STAGING_PASSWORD }}
           script: |
-            mv /tmp/deploy-package ~/releases/${{ needs.build.outputs.release_name }}
+            mv ~/deploy-package ~/releases/${{ needs.build.outputs.release_name }}
 
       - name: Activate release
         uses: appleboy/ssh-action@v1.0.3
@@ -194,7 +197,7 @@ jobs:
             RELEASE_DIR="/home/deployer/releases/${{ needs.build.outputs.release_name }}"
             APP_DIR="/home/deployer/market-staging"
             PREVIOUS_RELEASE="$(readlink -f "$APP_DIR" || true)"
-            CADDY_BACKUP="$(mktemp)"
+            CADDY_BACKUP="$(mktemp "$HOME/caddy-backup.XXXXXX")"
             sudo cp /etc/caddy/Caddyfile "$CADDY_BACKUP" 2>/dev/null || true
 
             rollback() {
@@ -230,8 +233,8 @@ jobs:
             pm2 save --force
 
             # Update Caddy
-            grep -q 'auctionsdev\.plebeian\.market' /tmp/Caddyfile.staging
-            sudo cp /tmp/Caddyfile.staging /etc/caddy/Caddyfile
+            grep -q 'auctionsdev\.plebeian\.market' "$HOME/Caddyfile.staging"
+            sudo cp "$HOME/Caddyfile.staging" /etc/caddy/Caddyfile
             sudo mkdir -p /var/log/caddy
             sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile || \
               sudo caddy start --config /etc/caddy/Caddyfile --adapter caddyfile


### PR DESCRIPTION
## Summary

Hardens the staging deployment workflow by moving deploy staging artifacts away from `/tmp` and into the deployer's home directory.

## Context

The latest staging deploy on `master` failed during `appleboy/scp-action` tar extraction into `/tmp/deploy-package` because the server hit `No space left on device`.

Staging is currently green again after safe cleanup, but the server remains critically tight on disk, so the workflow should avoid `/tmp` and use explicit tar staging paths.

## Changes

- Stage deploy package under `/home/deployer/deploy-package` instead of `/tmp/deploy-package`
- Set explicit `tar_tmp_path` under `/home/deployer`
- Stage `Caddyfile.staging` under `/home/deployer`
- Quote the `.env` heredoc delimiter
- Use `mktemp` under `$HOME`
- Rename stale “Upload files to tmp” step

## Non-goals

- No app behavior changes
- No relay data cleanup
- No Docker volume pruning
- No server-side cleanup or data pruning