### PR TITLE
feat: auction notifications

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -206,7 +206,10 @@ export function Header() {
 		unseenMessages,
 		unseenPurchases,
 		unseenAuctionBids,
-		unseenAuctionLive,
+		unseenAuctionComments: unseenAuctionLiveChatComments,
+		unseenAuctionEventComments: unseenAuctionThreadComments,
+		unseenProductComments: unseenProductThreadComments,
+		unseenAuctionLive: unseenScheduledAuctionsNowLive,
 		unseenAuctionSettlementBegins,
 		unseenBidUpdates,
 	} = useStore(notificationStore)
@@ -221,7 +224,10 @@ export function Header() {
 		unseenMessages +
 		unseenPurchases +
 		unseenAuctionBids +
-		unseenAuctionLive +
+		unseenAuctionLiveChatComments +
+		unseenAuctionThreadComments +
+		unseenProductThreadComments +
+		unseenScheduledAuctionsNowLive +
 		unseenAuctionSettlementBegins +
 		unseenBidUpdates
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -201,14 +201,29 @@ export function Header() {
 	const { data: config } = useConfigQuery()
 	const { isAuthenticated, isAuthenticating, user } = useStore(authStore)
 	const { mobileMenuOpen } = useStore(uiStore)
-	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
+	const {
+		unseenOrders,
+		unseenMessages,
+		unseenPurchases,
+		unseenAuctionBids,
+		unseenAuctionLive,
+		unseenAuctionSettlementBegins,
+		unseenBidUpdates,
+	} = useStore(notificationStore)
 	const location = useLocation()
 	const [scrollY, setScrollY] = useState(0)
 	const breakpoint = useBreakpoint()
 	const isMobile = breakpoint === 'sm' || breakpoint === 'md'
 
 	// Calculate total notification count for dashboard button
-	const totalNotifications = unseenOrders + unseenMessages + unseenPurchases + unseenAuctionBids + unseenBidUpdates
+	const totalNotifications =
+		unseenOrders +
+		unseenMessages +
+		unseenPurchases +
+		unseenAuctionBids +
+		unseenAuctionLive +
+		unseenAuctionSettlementBegins +
+		unseenBidUpdates
 
 	// Check if we're on any product page (index page or individual product) or homepage
 	const isProductPage = location.pathname === '/products' || location.pathname.startsWith('/products/')

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -549,8 +549,18 @@ export const useNotificationMonitor = () => {
 						sellerAuctionKeyByRootEventId,
 						sellerAuctionKeyByCoordinate,
 					])
-					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event, auctionKey)
+					return event.pubkey !== user.pubkey && !!auctionKey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event, auctionKey)
 				})
+
+				const newSellerBidCountsByAuction = newSellerBidEvents.reduce<Record<string, number>>((counts, event) => {
+					const auctionKey = resolveScopedKeyFromLookups([getEventAuctionRootId(event), getEventAuctionCoordinate(event)].filter(Boolean), [
+						sellerAuctionKeyByRootEventId,
+						sellerAuctionKeyByCoordinate,
+					])
+					if (!auctionKey) return counts
+					counts[auctionKey] = (counts[auctionKey] || 0) + 1
+					return counts
+				}, {})
 
 				const newSellerLiveChatEvents = sellerLiveChatEvents.filter((event) => {
 					seenAuctionCommentEventIds.add(event.id)
@@ -643,6 +653,7 @@ export const useNotificationMonitor = () => {
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
+					auctionBidCountsByAuction: newSellerBidCountsByAuction,
 					auctionCommentCount: newSellerLiveChatEvents.length,
 					auctionEventCommentCount: newSellerAuctionCommentEvents.length,
 					productCommentCount: newSellerProductCommentEvents.length,
@@ -675,10 +686,11 @@ export const useNotificationMonitor = () => {
 						sellerAuctionKeyByRootEventId,
 						sellerAuctionKeyByCoordinate,
 					])
-					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event, auctionKey)) return
+					if (event.pubkey === user.pubkey || !auctionKey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event, auctionKey))
+						return
 
 					console.log('[NotificationMonitor] New auction bid received:', event.id)
-					notificationActions.incrementUnseenAuctionBids()
+					notificationActions.incrementUnseenAuctionBids(auctionKey)
 				}
 
 				const handleWatchedBidEvent = (event: NDKEvent) => {

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -64,6 +64,19 @@ const getAddressableEventCoordinate = (event: NDKEvent): string => {
 	return dTag ? `${event.kind}:${event.pubkey}:${dTag}` : ''
 }
 
+const getTagValues = (event: NDKEvent, tagNames: string[]): string[] =>
+	event.tags.filter((tag) => tagNames.includes(tag[0]) && Boolean(tag[1])).map((tag) => tag[1])
+
+const resolveScopedKeyFromLookups = (values: string[], lookups: Array<Map<string, string>>): string => {
+	for (const value of values) {
+		for (const lookup of lookups) {
+			const scopedKey = lookup.get(value)
+			if (scopedKey) return scopedKey
+		}
+	}
+	return ''
+}
+
 const getAuctionNotificationKey = (auction: NDKEvent): string =>
 	getAuctionRootEventId(auction) || getAuctionCoordinate(auction) || auction.id
 
@@ -290,8 +303,8 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
-		const isNewAuctionBid = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenAuctionBids()
+		const isNewAuctionBid = (event: NDKEvent, auctionKey?: string): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionBids(auctionKey)
 			return (event.created_at || 0) > lastSeen
 		}
 
@@ -300,18 +313,18 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
-		const isNewAuctionComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenAuctionComments()
+		const isNewAuctionComment = (event: NDKEvent, auctionKey?: string): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionComments(auctionKey)
 			return (event.created_at || 0) > lastSeen
 		}
 
-		const isNewAuctionEventComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenAuctionEventComments()
+		const isNewAuctionEventComment = (event: NDKEvent, auctionKey?: string): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionEventComments(auctionKey)
 			return (event.created_at || 0) > lastSeen
 		}
 
-		const isNewProductComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenProductComments()
+		const isNewProductComment = (event: NDKEvent, productKey?: string): boolean => {
+			const lastSeen = notificationActions.getLastSeenProductComments(productKey)
 			return (event.created_at || 0) > lastSeen
 		}
 
@@ -366,7 +379,7 @@ export const useNotificationMonitor = () => {
 			}
 
 			const startAt = getAuctionStartAt(auction)
-			if (startAt > notificationActions.getLastSeenAuctionLive()) {
+			if (startAt > notificationActions.getLastSeenAuctionLive(auctionKey)) {
 				scheduleAt(startAt, scheduledAuctionLiveKeys, () => {
 					console.log('[NotificationMonitor] Seller auction went live:', auction.id)
 					notificationActions.incrementUnseenAuctionLive()
@@ -374,7 +387,7 @@ export const useNotificationMonitor = () => {
 			}
 
 			const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-			if (biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins()) {
+			if (biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(auctionKey)) {
 				scheduleAt(biddingCutoffAt, scheduledAuctionSettlementKeys, () => {
 					console.log('[NotificationMonitor] Seller auction entered settlement:', auction.id)
 					notificationActions.incrementUnseenAuctionSettlementBegins()
@@ -458,6 +471,30 @@ export const useNotificationMonitor = () => {
 
 				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
 				const sellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
+				const sellerAuctionKeyByRootEventId = new Map<string, string>()
+				const sellerAuctionKeyByCoordinate = new Map<string, string>()
+				const sellerProductKeyByEventId = new Map<string, string>()
+				const sellerProductKeyByCoordinate = new Map<string, string>()
+
+				for (const auction of sellerAuctions) {
+					const auctionKey = getAuctionNotificationKey(auction)
+					if (!auctionKey) continue
+
+					const rootEventId = getAuctionRootEventId(auction) || auction.id
+					const coordinate = getAuctionCoordinate(auction)
+					if (rootEventId) sellerAuctionKeyByRootEventId.set(rootEventId, auctionKey)
+					if (coordinate) sellerAuctionKeyByCoordinate.set(coordinate, auctionKey)
+				}
+
+				for (const product of sellerProducts) {
+					const productKey = getProductCoordinates(product) || product.id
+					if (!productKey) continue
+
+					sellerProductKeyByEventId.set(product.id, productKey)
+					const coordinate = getProductCoordinates(product)
+					if (coordinate) sellerProductKeyByCoordinate.set(coordinate, productKey)
+				}
+
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
 				const sellerProductEventIds = uniqueStrings(sellerProducts.map((product) => product.id))
@@ -476,6 +513,17 @@ export const useNotificationMonitor = () => {
 				const sellerLiveActivityCoords = uniqueStrings(
 					sellerLiveActivityEvents.map((event) => getAddressableEventCoordinate(event)).filter(Boolean),
 				)
+				const sellerAuctionKeyByLiveActivityCoordinate = new Map<string, string>()
+				for (const event of sellerLiveActivityEvents) {
+					const liveActivityCoordinate = getAddressableEventCoordinate(event)
+					if (!liveActivityCoordinate) continue
+
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerAuctionKeyByCoordinate,
+						sellerAuctionKeyByRootEventId,
+					])
+					if (auctionKey) sellerAuctionKeyByLiveActivityCoordinate.set(liveActivityCoordinate, auctionKey)
+				}
 				const sellerLiveChatEvents = await fetchTaggedAuctionEvents({
 					kind: LIVE_CHAT_KIND_NDK,
 					auctionRootEventIds: [],
@@ -497,32 +545,48 @@ export const useNotificationMonitor = () => {
 
 				const newSellerBidEvents = sellerBidEvents.filter((event) => {
 					seenAuctionEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event)
+					const auctionKey = resolveScopedKeyFromLookups([getEventAuctionRootId(event), getEventAuctionCoordinate(event)].filter(Boolean), [
+						sellerAuctionKeyByRootEventId,
+						sellerAuctionKeyByCoordinate,
+					])
+					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event, auctionKey)
 				})
 
 				const newSellerLiveChatEvents = sellerLiveChatEvents.filter((event) => {
 					seenAuctionCommentEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewAuctionComment(event)
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A']), [sellerAuctionKeyByLiveActivityCoordinate])
+					return event.pubkey !== user.pubkey && isNewAuctionComment(event, auctionKey)
 				})
 
 				const newSellerAuctionCommentEvents = sellerAuctionCommentEvents.filter((event) => {
 					seenAuctionThreadCommentEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event)
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerAuctionKeyByCoordinate,
+						sellerAuctionKeyByRootEventId,
+					])
+					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event, auctionKey)
 				})
 
 				const newSellerProductCommentEvents = sellerProductCommentEvents.filter((event) => {
 					seenProductCommentEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewProductComment(event)
+					const productKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerProductKeyByCoordinate,
+						sellerProductKeyByEventId,
+					])
+					return event.pubkey !== user.pubkey && isNewProductComment(event, productKey)
 				})
 
 				const unseenAuctionLiveCount = sellerAuctions.filter((auction) => {
 					const startAt = getAuctionStartAt(auction)
-					return startAt > notificationActions.getLastSeenAuctionLive() && startAt <= now
+					return startAt > notificationActions.getLastSeenAuctionLive(getAuctionNotificationKey(auction)) && startAt <= now
 				}).length
 
 				const unseenAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
 					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-					return biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins() && biddingCutoffAt <= now
+					return (
+						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(getAuctionNotificationKey(auction)) &&
+						biddingCutoffAt <= now
+					)
 				}).length
 
 				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
@@ -606,7 +670,12 @@ export const useNotificationMonitor = () => {
 				const handleSellerBidEvent = (event: NDKEvent) => {
 					if (!event.id || seenAuctionEventIds.has(event.id)) return
 					seenAuctionEventIds.add(event.id)
-					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event)) return
+
+					const auctionKey = resolveScopedKeyFromLookups([getEventAuctionRootId(event), getEventAuctionCoordinate(event)].filter(Boolean), [
+						sellerAuctionKeyByRootEventId,
+						sellerAuctionKeyByCoordinate,
+					])
+					if (event.pubkey === user.pubkey || !isCountableAuctionBidEvent(event) || !isNewAuctionBid(event, auctionKey)) return
 
 					console.log('[NotificationMonitor] New auction bid received:', event.id)
 					notificationActions.incrementUnseenAuctionBids()
@@ -627,7 +696,9 @@ export const useNotificationMonitor = () => {
 				const handleSellerLiveChatEvent = (event: NDKEvent) => {
 					if (!event.id || seenAuctionCommentEventIds.has(event.id)) return
 					seenAuctionCommentEventIds.add(event.id)
-					if (event.pubkey === user.pubkey || !isNewAuctionComment(event)) return
+
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A']), [sellerAuctionKeyByLiveActivityCoordinate])
+					if (event.pubkey === user.pubkey || !isNewAuctionComment(event, auctionKey)) return
 
 					console.log('[NotificationMonitor] New live chat comment on seller auction:', event.id)
 					notificationActions.incrementUnseenAuctionComments()
@@ -636,7 +707,12 @@ export const useNotificationMonitor = () => {
 				const handleSellerAuctionCommentEvent = (event: NDKEvent) => {
 					if (!event.id || seenAuctionThreadCommentEventIds.has(event.id)) return
 					seenAuctionThreadCommentEventIds.add(event.id)
-					if (event.pubkey === user.pubkey || !isNewAuctionEventComment(event)) return
+
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerAuctionKeyByCoordinate,
+						sellerAuctionKeyByRootEventId,
+					])
+					if (event.pubkey === user.pubkey || !isNewAuctionEventComment(event, auctionKey)) return
 
 					console.log('[NotificationMonitor] New thread comment on seller auction:', event.id)
 					notificationActions.incrementUnseenAuctionEventComments()
@@ -645,7 +721,12 @@ export const useNotificationMonitor = () => {
 				const handleSellerProductCommentEvent = (event: NDKEvent) => {
 					if (!event.id || seenProductCommentEventIds.has(event.id)) return
 					seenProductCommentEventIds.add(event.id)
-					if (event.pubkey === user.pubkey || !isNewProductComment(event)) return
+
+					const productKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerProductKeyByCoordinate,
+						sellerProductKeyByEventId,
+					])
+					if (event.pubkey === user.pubkey || !isNewProductComment(event, productKey)) return
 
 					console.log('[NotificationMonitor] New thread comment on seller product:', event.id)
 					notificationActions.incrementUnseenProductComments()

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -280,6 +280,9 @@ export const useNotificationMonitor = () => {
 		const seenSettlementEventIds = new Set<string>()
 		const scheduledAuctionLiveKeys = new Set<string>()
 		const scheduledAuctionSettlementKeys = new Set<string>()
+		const subscribedSellerAuctionRootEventIds = new Set<string>()
+		const subscribedSellerAuctionCoordinates = new Set<string>()
+		const subscribedSellerLiveActivityCoordinates = new Set<string>()
 		const phaseTimeoutIds: number[] = []
 
 		// Mark as monitoring to prevent duplicate subscriptions
@@ -749,6 +752,80 @@ export const useNotificationMonitor = () => {
 					notificationActions.incrementUnseenAuctionComments()
 				}
 
+				const subscribeSellerLiveActivityCoordinate = (liveActivityCoordinate: string) => {
+					if (!liveActivityCoordinate || subscribedSellerLiveActivityCoordinates.has(liveActivityCoordinate)) return
+					subscribedSellerLiveActivityCoordinates.add(liveActivityCoordinate)
+
+					subscribeToTaggedAuctionEvents({
+						kind: LIVE_CHAT_KIND_NDK,
+						tagName: '#a',
+						values: [liveActivityCoordinate],
+						onEvent: handleSellerLiveChatEvent,
+					})
+				}
+
+				const handleSellerLiveActivityEvent = (event: NDKEvent) => {
+					const liveActivityCoordinate = getAddressableEventCoordinate(event)
+					if (!liveActivityCoordinate) return
+
+					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
+						sellerAuctionKeyByCoordinate,
+						sellerAuctionKeyByRootEventId,
+					])
+					if (!auctionKey) return
+
+					sellerAuctionKeyByLiveActivityCoordinate.set(liveActivityCoordinate, auctionKey)
+					subscribeSellerLiveActivityCoordinate(liveActivityCoordinate)
+				}
+
+				const subscribeSellerAuctionRootScope = (auctionRootEventId: string) => {
+					if (!auctionRootEventId || subscribedSellerAuctionRootEventIds.has(auctionRootEventId)) return
+					subscribedSellerAuctionRootEventIds.add(auctionRootEventId)
+
+					subscribeToTaggedAuctionEvents({
+						kind: AUCTION_BID_KIND,
+						tagName: '#e',
+						values: [auctionRootEventId],
+						onEvent: handleSellerBidEvent,
+					})
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName: '#E',
+						values: [auctionRootEventId],
+						onEvent: handleSellerAuctionCommentEvent,
+					})
+				}
+
+				const subscribeSellerAuctionCoordinateScope = (auctionCoordinate: string) => {
+					if (!auctionCoordinate || subscribedSellerAuctionCoordinates.has(auctionCoordinate)) return
+					subscribedSellerAuctionCoordinates.add(auctionCoordinate)
+
+					subscribeToTaggedAuctionEvents({
+						kind: AUCTION_BID_KIND,
+						tagName: '#a',
+						values: [auctionCoordinate],
+						onEvent: handleSellerBidEvent,
+					})
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName: '#a',
+						values: [auctionCoordinate],
+						onEvent: handleSellerAuctionCommentEvent,
+					})
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName: '#A',
+						values: [auctionCoordinate],
+						onEvent: handleSellerAuctionCommentEvent,
+					})
+					subscribeToTaggedAuctionEvents({
+						kind: LIVE_ACTIVITY_KIND_NDK,
+						tagName: '#a',
+						values: [auctionCoordinate],
+						onEvent: handleSellerLiveActivityEvent,
+					})
+				}
+
 				const handleSellerAuctionCommentEvent = (event: NDKEvent) => {
 					if (!event.id || seenAuctionThreadCommentEventIds.has(event.id)) return
 					seenAuctionThreadCommentEventIds.add(event.id)
@@ -788,21 +865,39 @@ export const useNotificationMonitor = () => {
 
 				const handleOwnAuctionEvent = (event: NDKEvent) => {
 					if (event.pubkey !== user.pubkey) return
+
+					const auctionKey = getAuctionNotificationKey(event)
+					if (!auctionKey) return
+
+					const auctionRootEventId = getAuctionRootEventId(event) || event.id
+					const auctionCoordinate = getAuctionCoordinate(event)
+
+					sellerAuctionKeyByRootEventId.set(auctionRootEventId, auctionKey)
+					if (auctionCoordinate) sellerAuctionKeyByCoordinate.set(auctionCoordinate, auctionKey)
+
+					subscribeSellerAuctionRootScope(auctionRootEventId)
+					if (auctionCoordinate) {
+						subscribeSellerAuctionCoordinateScope(auctionCoordinate)
+
+						void fetchTaggedAuctionEvents({
+							kind: LIVE_ACTIVITY_KIND_NDK,
+							auctionRootEventIds: [],
+							auctionCoordinates: [auctionCoordinate],
+						})
+							.then((events) => {
+								events.forEach(handleSellerLiveActivityEvent)
+							})
+							.catch((error) => {
+								console.error('[NotificationMonitor] Failed to refresh live-activity scopes for new auction:', error)
+							})
+					}
+
 					scheduleAuctionPhaseNotification(event)
 				}
 
-				subscribeToTaggedAuctionEvents({
-					kind: AUCTION_BID_KIND,
-					tagName: '#e',
-					values: sellerAuctionRootEventIds,
-					onEvent: handleSellerBidEvent,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: AUCTION_BID_KIND,
-					tagName: '#a',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerBidEvent,
-				})
+				sellerAuctionRootEventIds.forEach(subscribeSellerAuctionRootScope)
+				sellerAuctionCoordinates.forEach(subscribeSellerAuctionCoordinateScope)
+				sellerLiveActivityCoords.forEach(subscribeSellerLiveActivityCoordinate)
 				subscribeToTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					tagName: '#e',
@@ -826,24 +921,6 @@ export const useNotificationMonitor = () => {
 					tagName: '#a',
 					values: watchedAuctionCoordinates,
 					onEvent: handleWatchedSettlementEvent,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#a',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerAuctionCommentEvent,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#A',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerAuctionCommentEvent,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#E',
-					values: sellerAuctionRootEventIds,
-					onEvent: handleSellerAuctionCommentEvent,
 				})
 				subscribeToTaggedAuctionEvents({
 					kind: COMMENT_KIND_NDK,
@@ -862,12 +939,6 @@ export const useNotificationMonitor = () => {
 					tagName: '#E',
 					values: sellerProductEventIds,
 					onEvent: handleSellerProductCommentEvent,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: LIVE_CHAT_KIND_NDK,
-					tagName: '#a',
-					values: sellerLiveActivityCoords,
-					onEvent: handleSellerLiveChatEvent,
 				})
 
 				const auctionListingSubscription = ndk.subscribe(

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -8,8 +8,10 @@ import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/li
 import {
 	fetchAuctionBidsByBidder,
 	fetchAuctionsByPubkey,
+	getAuctionBiddingCutoffAt,
 	getAuctionId,
 	getAuctionRootEventId,
+	getAuctionStartAt,
 	getBidAmount,
 	getBidAuctionCoordinates,
 	getBidAuctionEventId,
@@ -18,6 +20,7 @@ import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
+const AUCTION_LIFECYCLE_POLL_INTERVAL_MS = 60000
 const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
 
 const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
@@ -47,6 +50,56 @@ const getAuctionCoordinate = (auction: NDKEvent): string => {
 const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
 
 const getEventAuctionCoordinate = (event: NDKEvent): string => getBidAuctionCoordinates(event)
+
+const isScheduledAuction = (auction: NDKEvent): boolean => {
+	const startAt = getAuctionStartAt(auction)
+	const createdAt = auction.created_at ?? 0
+	return startAt > 0 && startAt > createdAt
+}
+
+const collectSellerAuctionLifecycleNotifications = (
+	sellerAuctions: NDKEvent[],
+	lastSeenAuctionLive: number,
+	lastSeenAuctionSettlementBegins: number,
+	seenAuctionLiveEventIds: Set<string>,
+	seenAuctionSettlementBeginsEventIds: Set<string>,
+): {
+	liveEvents: NDKEvent[]
+	settlementBeginsEvents: NDKEvent[]
+} => {
+	const now = Math.floor(Date.now() / 1000)
+	const liveEvents: NDKEvent[] = []
+	const settlementBeginsEvents: NDKEvent[] = []
+
+	for (const auction of sellerAuctions) {
+		if (!auction.id) continue
+
+		const startAt = getAuctionStartAt(auction)
+		const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+		const scheduledAuction = isScheduledAuction(auction)
+
+		if (
+			scheduledAuction &&
+			!seenAuctionLiveEventIds.has(auction.id) &&
+			startAt > lastSeenAuctionLive &&
+			now >= startAt &&
+			(biddingCutoffAt <= 0 || now < biddingCutoffAt)
+		) {
+			liveEvents.push(auction)
+		}
+
+		if (
+			!seenAuctionSettlementBeginsEventIds.has(auction.id) &&
+			biddingCutoffAt > 0 &&
+			biddingCutoffAt > lastSeenAuctionSettlementBegins &&
+			now >= biddingCutoffAt
+		) {
+			settlementBeginsEvents.push(auction)
+		}
+	}
+
+	return { liveEvents, settlementBeginsEvents }
+}
 
 const getAuctionBidStatus = (event: NDKEvent): string =>
 	event.tags
@@ -134,8 +187,11 @@ export const useNotificationMonitor = () => {
 		let isCancelled = false
 		const subscriptionSince = Math.floor(Date.now() / 1000)
 		const seenAuctionEventIds = new Set<string>()
+		const seenAuctionLiveEventIds = new Set<string>()
+		const seenAuctionSettlementBeginsEventIds = new Set<string>()
 		const seenBidEventIds = new Set<string>()
 		const seenSettlementEventIds = new Set<string>()
+		let auctionLifecyclePollId: number | null = null
 
 		// Mark as monitoring to prevent duplicate subscriptions
 		isMonitoringRef.current = true
@@ -271,6 +327,20 @@ export const useNotificationMonitor = () => {
 				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
+				const { liveEvents: initialAuctionLiveEvents, settlementBeginsEvents: initialAuctionSettlementBeginsEvents } =
+					collectSellerAuctionLifecycleNotifications(
+						sellerAuctions,
+						notificationActions.getLastSeenAuctionLive(),
+						notificationActions.getLastSeenAuctionSettlementBegins(),
+						seenAuctionLiveEventIds,
+						seenAuctionSettlementBeginsEventIds,
+					)
+				for (const auction of initialAuctionLiveEvents) {
+					if (auction.id) seenAuctionLiveEventIds.add(auction.id)
+				}
+				for (const auction of initialAuctionSettlementBeginsEvents) {
+					if (auction.id) seenAuctionSettlementBeginsEventIds.add(auction.id)
+				}
 				const sellerBidEvents = await fetchTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					auctionRootEventIds: sellerAuctionRootEventIds,
@@ -337,6 +407,8 @@ export const useNotificationMonitor = () => {
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
+					auctionLiveCount: initialAuctionLiveEvents.length,
+					auctionSettlementBeginsCount: initialAuctionSettlementBeginsEvents.length,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -345,6 +417,8 @@ export const useNotificationMonitor = () => {
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
 					auctionBids: newSellerBidEvents.length,
+					auctionLive: initialAuctionLiveEvents.length,
+					auctionSettlementBegins: initialAuctionSettlementBeginsEvents.length,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
@@ -417,6 +491,33 @@ export const useNotificationMonitor = () => {
 				})
 
 				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
+
+				auctionLifecyclePollId = window.setInterval(async () => {
+					try {
+						const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+						const { liveEvents, settlementBeginsEvents } = collectSellerAuctionLifecycleNotifications(
+							sellerAuctions,
+							notificationActions.getLastSeenAuctionLive(),
+							notificationActions.getLastSeenAuctionSettlementBegins(),
+							seenAuctionLiveEventIds,
+							seenAuctionSettlementBeginsEventIds,
+						)
+
+						for (const auction of liveEvents) {
+							if (!auction.id) continue
+							seenAuctionLiveEventIds.add(auction.id)
+							notificationActions.incrementUnseenAuctionLive()
+						}
+
+						for (const auction of settlementBeginsEvents) {
+							if (!auction.id) continue
+							seenAuctionSettlementBeginsEventIds.add(auction.id)
+							notificationActions.incrementUnseenAuctionSettlementBegins()
+						}
+					} catch (error) {
+						console.error('[NotificationMonitor] Failed to poll auction lifecycle notifications:', error)
+					}
+				}, AUCTION_LIFECYCLE_POLL_INTERVAL_MS)
 			} catch (error) {
 				console.error('[NotificationMonitor] Failed to initialize notifications:', error)
 			}
@@ -521,6 +622,9 @@ export const useNotificationMonitor = () => {
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
 			isCancelled = true
+			if (auctionLifecyclePollId) {
+				window.clearInterval(auctionLifecyclePollId)
+			}
 			subscriptionsRef.current.forEach((sub) => {
 				sub.stop()
 			})

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -2,9 +2,11 @@ import { useEffect, useRef } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
+import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND, parseLiveActivity } from '@/lib/nip53'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
+import { toast } from 'sonner'
 import {
 	fetchAuctionBidsByBidder,
 	fetchAuctionsByPubkey,
@@ -16,12 +18,16 @@ import {
 	getBidAuctionCoordinates,
 	getBidAuctionEventId,
 } from '@/queries/auctions'
+import { fetchProductsByPubkey, getProductId } from '@/queries/products'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
 const AUCTION_LIFECYCLE_POLL_INTERVAL_MS = 60000
 const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
+const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
+const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
+const COMMENT_KIND_NDK = 1111 as unknown as NonNullable<NDKFilter['kinds']>[number]
 
 const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
 
@@ -45,6 +51,11 @@ const dedupeEvents = (events: NDKEvent[]): NDKEvent[] => {
 const getAuctionCoordinate = (auction: NDKEvent): string => {
 	const auctionDTag = getAuctionId(auction)
 	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
+}
+
+const getProductCoordinate = (product: NDKEvent): string => {
+	const productDTag = getProductId(product)
+	return productDTag ? `30402:${product.pubkey}:${productDTag}` : ''
 }
 
 const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
@@ -165,6 +176,94 @@ const fetchTaggedAuctionEvents = async ({
 	return dedupeEvents(Array.from(events))
 }
 
+const fetchSellerProductCommentEvents = async ({
+	productCoordinates,
+	productEventIds,
+	since,
+}: {
+	productCoordinates: string[]
+	productEventIds: string[]
+	since?: number
+}): Promise<NDKEvent[]> => {
+	const filters: NDKFilter[] = []
+	const baseFilter = {
+		kinds: [COMMENT_KIND_NDK],
+		limit: AUCTION_MONITOR_LIMIT,
+		...(typeof since === 'number' ? { since } : {}),
+	}
+
+	for (const coordinateChunk of chunkValues(productCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#a': coordinateChunk,
+		})
+		filters.push({
+			...baseFilter,
+			'#A': coordinateChunk,
+		})
+	}
+
+	for (const eventIdChunk of chunkValues(productEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#e': eventIdChunk,
+		})
+		filters.push({
+			...baseFilter,
+			'#E': eventIdChunk,
+		})
+	}
+
+	if (filters.length === 0) return []
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	return dedupeEvents(Array.from(events))
+}
+
+const fetchSellerAuctionCommentEvents = async ({
+	auctionCoordinates,
+	auctionEventIds,
+	since,
+}: {
+	auctionCoordinates: string[]
+	auctionEventIds: string[]
+	since?: number
+}): Promise<NDKEvent[]> => {
+	const filters: NDKFilter[] = []
+	const baseFilter = {
+		kinds: [COMMENT_KIND_NDK],
+		limit: AUCTION_MONITOR_LIMIT,
+		...(typeof since === 'number' ? { since } : {}),
+	}
+
+	for (const coordinateChunk of chunkValues(auctionCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#a': coordinateChunk,
+		})
+		filters.push({
+			...baseFilter,
+			'#A': coordinateChunk,
+		})
+	}
+
+	for (const eventIdChunk of chunkValues(auctionEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			'#e': eventIdChunk,
+		})
+		filters.push({
+			...baseFilter,
+			'#E': eventIdChunk,
+		})
+	}
+
+	if (filters.length === 0) return []
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	return dedupeEvents(Array.from(events))
+}
+
 /**
  * Monitor nostr events and update notification counts in real-time
  * This hook should be used once at the app/dashboard level
@@ -187,6 +286,11 @@ export const useNotificationMonitor = () => {
 		let isCancelled = false
 		const subscriptionSince = Math.floor(Date.now() / 1000)
 		const seenAuctionEventIds = new Set<string>()
+		const seenAuctionCommentEventIds = new Set<string>()
+		const seenAuctionEventCommentIds = new Set<string>()
+		const seenProductCommentEventIds = new Set<string>()
+		const subscribedLiveChatCoords = new Set<string>()
+		const subscribedProductCommentCoords = new Set<string>()
 		const seenAuctionLiveEventIds = new Set<string>()
 		const seenAuctionSettlementBeginsEventIds = new Set<string>()
 		const seenBidEventIds = new Set<string>()
@@ -198,7 +302,6 @@ export const useNotificationMonitor = () => {
 
 		console.log('[NotificationMonitor] Starting notification monitoring for user:', user.pubkey)
 
-		// Helper to check if an event is newer than last seen
 		const isNewOrder = (event: NDKEvent): boolean => {
 			const lastSeen = notificationActions.getLastSeenOrders()
 			return (event.created_at || 0) > lastSeen
@@ -219,6 +322,21 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
+		const isNewAuctionComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionComments()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewAuctionEventComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionEventComments()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewProductComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenProductComments()
+			return (event.created_at || 0) > lastSeen
+		}
+
 		const isNewBidUpdate = (event: NDKEvent): boolean => {
 			const lastSeen = notificationActions.getLastSeenBidUpdates()
 			return (event.created_at || 0) > lastSeen
@@ -231,7 +349,7 @@ export const useNotificationMonitor = () => {
 			onEvent,
 		}: {
 			kind: NonNullable<NDKFilter['kinds']>[number]
-			tagName: '#e' | '#a'
+			tagName: '#e' | '#E' | '#a' | '#A'
 			values: string[]
 			onEvent: (event: NDKEvent) => void
 		}) => {
@@ -263,10 +381,8 @@ export const useNotificationMonitor = () => {
 			return Math.max(rootAmount, coordinateAmount)
 		}
 
-		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
-				// Fetch recent orders where user is seller (recipient)
 				const orderFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
 					'#p': [user.pubkey],
@@ -274,14 +390,11 @@ export const useNotificationMonitor = () => {
 				}
 
 				const orderEvents = await ndk.fetchEvents(orderFilter)
-
-				// Filter for order creation events
 				const newOrders = Array.from(orderEvents).filter((event) => {
 					const typeTag = event.tags.find((tag) => tag[0] === 'type')
 					return typeTag?.[1] === ORDER_MESSAGE_TYPE.ORDER_CREATION && isNewOrder(event)
 				})
 
-				// Fetch recent messages (kind 14)
 				const messageFilter: NDKFilter = {
 					kinds: [ORDER_GENERAL_KIND],
 					'#p': [user.pubkey],
@@ -289,8 +402,6 @@ export const useNotificationMonitor = () => {
 				}
 
 				const messageEvents = await ndk.fetchEvents(messageFilter)
-
-				// Group messages by sender and count unseen per conversation
 				const conversationCounts: Record<string, number> = {}
 				let totalUnseenMessages = 0
 
@@ -302,7 +413,6 @@ export const useNotificationMonitor = () => {
 					}
 				})
 
-				// Fetch recent purchase updates (orders where user is buyer)
 				const purchaseFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
 					authors: [user.pubkey],
@@ -310,9 +420,6 @@ export const useNotificationMonitor = () => {
 				}
 
 				const purchaseEvents = await ndk.fetchEvents(purchaseFilter)
-
-				// Filter for purchase updates (payment requests, status updates, shipping updates)
-				// Exclude order creation events since those are initiated by the buyer
 				const newPurchaseUpdates = Array.from(purchaseEvents).filter((event) => {
 					const typeTag = event.tags.find((tag) => tag[0] === 'type')
 					const isUpdate =
@@ -320,13 +427,56 @@ export const useNotificationMonitor = () => {
 						typeTag?.[1] === ORDER_MESSAGE_TYPE.STATUS_UPDATE ||
 						typeTag?.[1] === ORDER_MESSAGE_TYPE.SHIPPING_UPDATE
 
-					// Only count if it's an update type AND it's from the seller (not the buyer)
 					return isUpdate && event.pubkey !== user.pubkey && isNewPurchaseUpdate(event)
 				})
 
 				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+				const sellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
+				const sellerAuctionEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
+				const sellerProductCoordinates = uniqueStrings(sellerProducts.map(getProductCoordinate))
+				const sellerProductEventIds = uniqueStrings(sellerProducts.map((product) => product.id))
+
+				const sellerLiveActivityEvents = await fetchTaggedAuctionEvents({
+					kind: LIVE_ACTIVITY_KIND_NDK,
+					auctionRootEventIds: [],
+					auctionCoordinates: sellerAuctionCoordinates,
+				})
+				const sellerLiveActivityCoordinates = uniqueStrings(
+					sellerLiveActivityEvents.map((event) => parseLiveActivity(event).coord).filter(Boolean),
+				)
+				const sellerLiveChatEvents = await fetchTaggedAuctionEvents({
+					kind: LIVE_CHAT_KIND_NDK,
+					auctionRootEventIds: [],
+					auctionCoordinates: sellerLiveActivityCoordinates,
+					since: notificationActions.getLastSeenAuctionComments() + 1,
+				})
+				const newSellerCommentEvents = sellerLiveChatEvents.filter((event) => {
+					seenAuctionCommentEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewAuctionComment(event)
+				})
+
+				const sellerAuctionCommentEvents = await fetchSellerAuctionCommentEvents({
+					auctionCoordinates: sellerAuctionCoordinates,
+					auctionEventIds: sellerAuctionEventIds,
+					since: notificationActions.getLastSeenAuctionEventComments() + 1,
+				})
+				const newSellerAuctionEventCommentEvents = sellerAuctionCommentEvents.filter((event) => {
+					seenAuctionEventCommentIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event)
+				})
+
+				const sellerProductCommentEvents = await fetchSellerProductCommentEvents({
+					productCoordinates: sellerProductCoordinates,
+					productEventIds: sellerProductEventIds,
+					since: notificationActions.getLastSeenProductComments() + 1,
+				})
+				const newSellerProductCommentEvents = sellerProductCommentEvents.filter((event) => {
+					seenProductCommentEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewProductComment(event)
+				})
+
 				const { liveEvents: initialAuctionLiveEvents, settlementBeginsEvents: initialAuctionSettlementBeginsEvents } =
 					collectSellerAuctionLifecycleNotifications(
 						sellerAuctions,
@@ -341,6 +491,7 @@ export const useNotificationMonitor = () => {
 				for (const auction of initialAuctionSettlementBeginsEvents) {
 					if (auction.id) seenAuctionSettlementBeginsEventIds.add(auction.id)
 				}
+
 				const sellerBidEvents = await fetchTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					auctionRootEventIds: sellerAuctionRootEventIds,
@@ -400,13 +551,15 @@ export const useNotificationMonitor = () => {
 
 				if (isCancelled) return
 
-				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
 					orderCount: newOrders.length,
 					messageCount: totalUnseenMessages,
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
+					auctionCommentCount: newSellerCommentEvents.length,
+					auctionEventCommentCount: newSellerAuctionEventCommentEvents.length,
+					productCommentCount: newSellerProductCommentEvents.length,
 					auctionLiveCount: initialAuctionLiveEvents.length,
 					auctionSettlementBeginsCount: initialAuctionSettlementBeginsEvents.length,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
@@ -417,6 +570,9 @@ export const useNotificationMonitor = () => {
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
 					auctionBids: newSellerBidEvents.length,
+					auctionComments: newSellerCommentEvents.length,
+					auctionEventComments: newSellerAuctionEventCommentEvents.length,
+					productComments: newSellerProductCommentEvents.length,
 					auctionLive: initialAuctionLiveEvents.length,
 					auctionSettlementBegins: initialAuctionSettlementBeginsEvents.length,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
@@ -430,6 +586,66 @@ export const useNotificationMonitor = () => {
 
 					console.log('[NotificationMonitor] New auction bid received:', event.id)
 					notificationActions.incrementUnseenAuctionBids()
+				}
+
+				const handleSellerLiveChatEvent = (event: NDKEvent) => {
+					if (!event.id || seenAuctionCommentEventIds.has(event.id)) return
+					seenAuctionCommentEventIds.add(event.id)
+					if (event.pubkey === user.pubkey) return
+
+					console.log('[NotificationMonitor] New auction live-chat comment received:', event.id)
+					notificationActions.incrementUnseenAuctionComments()
+				}
+
+				const handleSellerProductCommentEvent = (event: NDKEvent) => {
+					if (!event.id || seenProductCommentEventIds.has(event.id)) return
+					seenProductCommentEventIds.add(event.id)
+					if (event.pubkey === user.pubkey) return
+
+					console.log('[NotificationMonitor] New product comment received:', event.id)
+					notificationActions.incrementUnseenProductComments()
+				}
+
+				const handleSellerAuctionEventComment = (event: NDKEvent) => {
+					if (!event.id || seenAuctionEventCommentIds.has(event.id)) return
+					seenAuctionEventCommentIds.add(event.id)
+					if (event.pubkey === user.pubkey) return
+
+					console.log('[NotificationMonitor] New auction thread comment received:', event.id)
+					notificationActions.incrementUnseenAuctionEventComments()
+				}
+
+				const subscribeToLiveChatCoord = (coord: string) => {
+					if (!coord || subscribedLiveChatCoords.has(coord)) return
+					subscribedLiveChatCoords.add(coord)
+					subscribeToTaggedAuctionEvents({
+						kind: LIVE_CHAT_KIND_NDK,
+						tagName: '#a',
+						values: [coord],
+						onEvent: handleSellerLiveChatEvent,
+					})
+				}
+
+				const subscribeToProductCommentCoord = (coord: string) => {
+					if (!coord || subscribedProductCommentCoords.has(coord)) return
+					subscribedProductCommentCoords.add(coord)
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName: '#a',
+						values: [coord],
+						onEvent: handleSellerProductCommentEvent,
+					})
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName: '#A',
+						values: [coord],
+						onEvent: handleSellerProductCommentEvent,
+					})
+				}
+
+				const handleSellerLiveActivityEvent = (event: NDKEvent) => {
+					const coord = parseLiveActivity(event).coord
+					subscribeToLiveChatCoord(coord)
 				}
 
 				const handleWatchedBidEvent = (event: NDKEvent) => {
@@ -453,6 +669,42 @@ export const useNotificationMonitor = () => {
 					notificationActions.incrementUnseenBidUpdates()
 				}
 
+				for (const coord of sellerLiveActivityCoordinates) {
+					subscribeToLiveChatCoord(coord)
+				}
+				for (const coord of sellerProductCoordinates) {
+					subscribeToProductCommentCoord(coord)
+				}
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#a',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerAuctionEventComment,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#A',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerAuctionEventComment,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#e',
+					values: sellerAuctionEventIds,
+					onEvent: handleSellerAuctionEventComment,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#E',
+					values: sellerAuctionEventIds,
+					onEvent: handleSellerAuctionEventComment,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: LIVE_ACTIVITY_KIND_NDK,
+					tagName: '#a',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerLiveActivityEvent,
+				})
 				subscribeToTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					tagName: '#e',
@@ -494,9 +746,9 @@ export const useNotificationMonitor = () => {
 
 				auctionLifecyclePollId = window.setInterval(async () => {
 					try {
-						const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+						const pollSellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
 						const { liveEvents, settlementBeginsEvents } = collectSellerAuctionLifecycleNotifications(
-							sellerAuctions,
+							pollSellerAuctions,
 							notificationActions.getLastSeenAuctionLive(),
 							notificationActions.getLastSeenAuctionSettlementBegins(),
 							seenAuctionLiveEventIds,
@@ -514,6 +766,62 @@ export const useNotificationMonitor = () => {
 							seenAuctionSettlementBeginsEventIds.add(auction.id)
 							notificationActions.incrementUnseenAuctionSettlementBegins()
 						}
+
+						const pollSellerAuctionCoordinates = uniqueStrings(pollSellerAuctions.map(getAuctionCoordinate))
+						const pollLiveActivityEvents = await fetchTaggedAuctionEvents({
+							kind: LIVE_ACTIVITY_KIND_NDK,
+							auctionRootEventIds: [],
+							auctionCoordinates: pollSellerAuctionCoordinates,
+						})
+						const pollLiveActivityCoordinates = uniqueStrings(
+							pollLiveActivityEvents.map((event) => parseLiveActivity(event).coord).filter(Boolean),
+						)
+						const pollLiveChatEvents = await fetchTaggedAuctionEvents({
+							kind: LIVE_CHAT_KIND_NDK,
+							auctionRootEventIds: [],
+							auctionCoordinates: pollLiveActivityCoordinates,
+							since: notificationActions.getLastSeenAuctionComments() + 1,
+						})
+						for (const event of pollLiveChatEvents) {
+							if (!event.id || seenAuctionCommentEventIds.has(event.id)) continue
+							seenAuctionCommentEventIds.add(event.id)
+							if (event.pubkey === user.pubkey) continue
+							notificationActions.incrementUnseenAuctionComments()
+						}
+
+						const pollSellerAuctionEventIds = uniqueStrings(
+							pollSellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id),
+						)
+						const pollAuctionCommentEvents = await fetchSellerAuctionCommentEvents({
+							auctionCoordinates: pollSellerAuctionCoordinates,
+							auctionEventIds: pollSellerAuctionEventIds,
+							since: notificationActions.getLastSeenAuctionEventComments() + 1,
+						})
+						for (const event of pollAuctionCommentEvents) {
+							if (!event.id || seenAuctionEventCommentIds.has(event.id)) continue
+							seenAuctionEventCommentIds.add(event.id)
+							if (event.pubkey === user.pubkey) continue
+							notificationActions.incrementUnseenAuctionEventComments()
+						}
+
+						const pollSellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
+						const pollSellerProductCoordinates = uniqueStrings(pollSellerProducts.map(getProductCoordinate))
+						const pollSellerProductEventIds = uniqueStrings(pollSellerProducts.map((product) => product.id))
+						for (const coord of pollSellerProductCoordinates) {
+							subscribeToProductCommentCoord(coord)
+						}
+
+						const pollProductCommentEvents = await fetchSellerProductCommentEvents({
+							productCoordinates: pollSellerProductCoordinates,
+							productEventIds: pollSellerProductEventIds,
+							since: notificationActions.getLastSeenProductComments() + 1,
+						})
+						for (const event of pollProductCommentEvents) {
+							if (!event.id || seenProductCommentEventIds.has(event.id)) continue
+							seenProductCommentEventIds.add(event.id)
+							if (event.pubkey === user.pubkey) continue
+							notificationActions.incrementUnseenProductComments()
+						}
 					} catch (error) {
 						console.error('[NotificationMonitor] Failed to poll auction lifecycle notifications:', error)
 					}
@@ -523,17 +831,13 @@ export const useNotificationMonitor = () => {
 			}
 		}
 
-		// Start initial fetch
 		initializeNotifications()
 
-		// Set up real-time subscriptions
-
-		// 1. Subscribe to new orders where user is seller
 		const orderSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: subscriptionSince, // Only new events from now
+				since: subscriptionSince,
 			},
 			{
 				closeOnEose: false,
@@ -541,10 +845,8 @@ export const useNotificationMonitor = () => {
 		)
 
 		orderSubscription.on('event', (event: NDKEvent) => {
-			// Check if it's an order creation event
 			const typeTag = event.tags.find((tag) => tag[0] === 'type')
 			if (typeTag?.[1] === ORDER_MESSAGE_TYPE.ORDER_CREATION) {
-				// Only increment if it's newer than last seen
 				if (isNewOrder(event)) {
 					console.log('[NotificationMonitor] New order received:', event.id)
 					notificationActions.incrementUnseenOrders()
@@ -554,12 +856,11 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(orderSubscription)
 
-		// 2. Subscribe to new messages where user is recipient
 		const messageSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_GENERAL_KIND],
 				'#p': [user.pubkey],
-				since: subscriptionSince, // Only new events from now
+				since: subscriptionSince,
 			},
 			{
 				closeOnEose: false,
@@ -568,7 +869,6 @@ export const useNotificationMonitor = () => {
 
 		messageSubscription.on('event', (event: NDKEvent) => {
 			const senderPubkey = event.pubkey
-			// Don't count messages we sent
 			if (senderPubkey !== user.pubkey && isNewMessage(event, senderPubkey)) {
 				console.log('[NotificationMonitor] New message received from:', senderPubkey)
 				notificationActions.incrementUnseenForConversation(senderPubkey)
@@ -577,8 +877,6 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(messageSubscription)
 
-		// 3. Subscribe to purchase updates (orders where user is buyer)
-		// Listen for events tagged with user's pubkey that are updates from sellers
 		const purchaseUpdateSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_PROCESS_KIND],
@@ -591,12 +889,9 @@ export const useNotificationMonitor = () => {
 		)
 
 		purchaseUpdateSubscription.on('event', (event: NDKEvent) => {
-			// Only count if event is from someone else (the seller)
 			if (event.pubkey === user.pubkey) return
 
 			const typeTag = event.tags.find((tag) => tag[0] === 'type')
-
-			// Handle purchase-related updates (seller sending updates to buyer)
 			if (typeTag) {
 				switch (typeTag[1]) {
 					case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
@@ -608,7 +903,6 @@ export const useNotificationMonitor = () => {
 						}
 						break
 					case ORDER_MESSAGE_TYPE.ORDER_CREATION:
-						// This is a new order where user is seller - already handled above
 						break
 				}
 			}
@@ -618,7 +912,6 @@ export const useNotificationMonitor = () => {
 
 		console.log('[NotificationMonitor] Base subscriptions active:', subscriptionsRef.current.length)
 
-		// Cleanup function
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
 			isCancelled = true

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -2,32 +2,23 @@ import { useEffect, useRef } from 'react'
 import { useStore } from '@tanstack/react-store'
 import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
-import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND, parseLiveActivity } from '@/lib/nip53'
-import { ndkActions, ndkStore } from '@/lib/stores/ndk'
+import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import {
 	fetchAuctionBidsByBidder,
 	fetchAuctionsByPubkey,
-	getAuctionBiddingCutoffAt,
 	getAuctionId,
 	getAuctionRootEventId,
-	getAuctionStartAt,
 	getBidAmount,
 	getBidAuctionCoordinates,
 	getBidAuctionEventId,
 } from '@/queries/auctions'
-import { fetchProductsByPubkey, getProductId } from '@/queries/products'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
-const AUCTION_LIFECYCLE_POLL_INTERVAL_MS = 60000
-const SUBSCRIPTION_LOOKBACK_SECONDS = 300
 const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
-const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
-const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
-const COMMENT_KIND_NDK = 1111 as unknown as NonNullable<NDKFilter['kinds']>[number]
 
 const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
 
@@ -53,64 +44,9 @@ const getAuctionCoordinate = (auction: NDKEvent): string => {
 	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 }
 
-const getProductCoordinate = (product: NDKEvent): string => {
-	const productDTag = getProductId(product)
-	return productDTag ? `30402:${product.pubkey}:${productDTag}` : ''
-}
-
 const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
 
 const getEventAuctionCoordinate = (event: NDKEvent): string => getBidAuctionCoordinates(event)
-
-const isScheduledAuction = (auction: NDKEvent): boolean => {
-	const startAt = getAuctionStartAt(auction)
-	const createdAt = auction.created_at ?? 0
-	return startAt > 0 && startAt > createdAt
-}
-
-const collectSellerAuctionLifecycleNotifications = (
-	sellerAuctions: NDKEvent[],
-	lastSeenAuctionLive: number,
-	lastSeenAuctionSettlementBegins: number,
-	seenAuctionLiveEventIds: Set<string>,
-	seenAuctionSettlementBeginsEventIds: Set<string>,
-): {
-	liveEvents: NDKEvent[]
-	settlementBeginsEvents: NDKEvent[]
-} => {
-	const now = Math.floor(Date.now() / 1000)
-	const liveEvents: NDKEvent[] = []
-	const settlementBeginsEvents: NDKEvent[] = []
-
-	for (const auction of sellerAuctions) {
-		if (!auction.id) continue
-
-		const startAt = getAuctionStartAt(auction)
-		const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-		const scheduledAuction = isScheduledAuction(auction)
-
-		if (
-			scheduledAuction &&
-			!seenAuctionLiveEventIds.has(auction.id) &&
-			startAt > lastSeenAuctionLive &&
-			now >= startAt &&
-			(biddingCutoffAt <= 0 || now < biddingCutoffAt)
-		) {
-			liveEvents.push(auction)
-		}
-
-		if (
-			!seenAuctionSettlementBeginsEventIds.has(auction.id) &&
-			biddingCutoffAt > 0 &&
-			biddingCutoffAt > lastSeenAuctionSettlementBegins &&
-			now >= biddingCutoffAt
-		) {
-			settlementBeginsEvents.push(auction)
-		}
-	}
-
-	return { liveEvents, settlementBeginsEvents }
-}
 
 const getAuctionBidStatus = (event: NDKEvent): string =>
 	event.tags
@@ -176,94 +112,6 @@ const fetchTaggedAuctionEvents = async ({
 	return dedupeEvents(Array.from(events))
 }
 
-const fetchSellerProductCommentEvents = async ({
-	productCoordinates,
-	productEventIds,
-	since,
-}: {
-	productCoordinates: string[]
-	productEventIds: string[]
-	since?: number
-}): Promise<NDKEvent[]> => {
-	const filters: NDKFilter[] = []
-	const baseFilter = {
-		kinds: [COMMENT_KIND_NDK],
-		limit: AUCTION_MONITOR_LIMIT,
-		...(typeof since === 'number' ? { since } : {}),
-	}
-
-	for (const coordinateChunk of chunkValues(productCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
-		filters.push({
-			...baseFilter,
-			'#a': coordinateChunk,
-		})
-		filters.push({
-			...baseFilter,
-			'#A': coordinateChunk,
-		})
-	}
-
-	for (const eventIdChunk of chunkValues(productEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
-		filters.push({
-			...baseFilter,
-			'#e': eventIdChunk,
-		})
-		filters.push({
-			...baseFilter,
-			'#E': eventIdChunk,
-		})
-	}
-
-	if (filters.length === 0) return []
-
-	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
-	return dedupeEvents(Array.from(events))
-}
-
-const fetchSellerAuctionCommentEvents = async ({
-	auctionCoordinates,
-	auctionEventIds,
-	since,
-}: {
-	auctionCoordinates: string[]
-	auctionEventIds: string[]
-	since?: number
-}): Promise<NDKEvent[]> => {
-	const filters: NDKFilter[] = []
-	const baseFilter = {
-		kinds: [COMMENT_KIND_NDK],
-		limit: AUCTION_MONITOR_LIMIT,
-		...(typeof since === 'number' ? { since } : {}),
-	}
-
-	for (const coordinateChunk of chunkValues(auctionCoordinates, AUCTION_FILTER_CHUNK_SIZE)) {
-		filters.push({
-			...baseFilter,
-			'#a': coordinateChunk,
-		})
-		filters.push({
-			...baseFilter,
-			'#A': coordinateChunk,
-		})
-	}
-
-	for (const eventIdChunk of chunkValues(auctionEventIds, AUCTION_FILTER_CHUNK_SIZE)) {
-		filters.push({
-			...baseFilter,
-			'#e': eventIdChunk,
-		})
-		filters.push({
-			...baseFilter,
-			'#E': eventIdChunk,
-		})
-	}
-
-	if (filters.length === 0) return []
-
-	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
-	return dedupeEvents(Array.from(events))
-}
-
 /**
  * Monitor nostr events and update notification counts in real-time
  * This hook should be used once at the app/dashboard level
@@ -271,7 +119,6 @@ const fetchSellerAuctionCommentEvents = async ({
 export const useNotificationMonitor = () => {
 	const { user } = useStore(authStore)
 	const { isInitialized } = useStore(notificationStore)
-	const ndk = useStore(ndkStore, (state) => state.ndk)
 	const subscriptionsRef = useRef<NDKSubscription[]>([])
 	const isMonitoringRef = useRef(false)
 
@@ -281,29 +128,21 @@ export const useNotificationMonitor = () => {
 			return
 		}
 
+		const ndk = ndkActions.getNDK()
 		if (!ndk) return
 
 		let isCancelled = false
-		// Nostr events use publisher-provided timestamps, so a small lookback avoids
-		// missing fresh events when peer clocks drift behind local time.
-		const subscriptionSince = Math.max(0, Math.floor(Date.now() / 1000) - SUBSCRIPTION_LOOKBACK_SECONDS)
+		const subscriptionSince = Math.floor(Date.now() / 1000)
 		const seenAuctionEventIds = new Set<string>()
-		const seenAuctionCommentEventIds = new Set<string>()
-		const seenAuctionEventCommentIds = new Set<string>()
-		const seenProductCommentEventIds = new Set<string>()
-		const subscribedLiveChatCoords = new Set<string>()
-		const subscribedProductCommentCoords = new Set<string>()
-		const seenAuctionLiveEventIds = new Set<string>()
-		const seenAuctionSettlementBeginsEventIds = new Set<string>()
 		const seenBidEventIds = new Set<string>()
 		const seenSettlementEventIds = new Set<string>()
-		let auctionLifecyclePollId: number | null = null
 
 		// Mark as monitoring to prevent duplicate subscriptions
 		isMonitoringRef.current = true
 
 		console.log('[NotificationMonitor] Starting notification monitoring for user:', user.pubkey)
 
+		// Helper to check if an event is newer than last seen
 		const isNewOrder = (event: NDKEvent): boolean => {
 			const lastSeen = notificationActions.getLastSeenOrders()
 			return (event.created_at || 0) > lastSeen
@@ -324,21 +163,6 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
-		const isNewAuctionComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenAuctionComments()
-			return (event.created_at || 0) > lastSeen
-		}
-
-		const isNewAuctionEventComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenAuctionEventComments()
-			return (event.created_at || 0) > lastSeen
-		}
-
-		const isNewProductComment = (event: NDKEvent): boolean => {
-			const lastSeen = notificationActions.getLastSeenProductComments()
-			return (event.created_at || 0) > lastSeen
-		}
-
 		const isNewBidUpdate = (event: NDKEvent): boolean => {
 			const lastSeen = notificationActions.getLastSeenBidUpdates()
 			return (event.created_at || 0) > lastSeen
@@ -351,7 +175,7 @@ export const useNotificationMonitor = () => {
 			onEvent,
 		}: {
 			kind: NonNullable<NDKFilter['kinds']>[number]
-			tagName: '#e' | '#E' | '#a' | '#A'
+			tagName: '#e' | '#a'
 			values: string[]
 			onEvent: (event: NDKEvent) => void
 		}) => {
@@ -383,8 +207,10 @@ export const useNotificationMonitor = () => {
 			return Math.max(rootAmount, coordinateAmount)
 		}
 
+		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
+				// Fetch recent orders where user is seller (recipient)
 				const orderFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
 					'#p': [user.pubkey],
@@ -392,11 +218,14 @@ export const useNotificationMonitor = () => {
 				}
 
 				const orderEvents = await ndk.fetchEvents(orderFilter)
+
+				// Filter for order creation events
 				const newOrders = Array.from(orderEvents).filter((event) => {
 					const typeTag = event.tags.find((tag) => tag[0] === 'type')
 					return typeTag?.[1] === ORDER_MESSAGE_TYPE.ORDER_CREATION && isNewOrder(event)
 				})
 
+				// Fetch recent messages (kind 14)
 				const messageFilter: NDKFilter = {
 					kinds: [ORDER_GENERAL_KIND],
 					'#p': [user.pubkey],
@@ -404,6 +233,8 @@ export const useNotificationMonitor = () => {
 				}
 
 				const messageEvents = await ndk.fetchEvents(messageFilter)
+
+				// Group messages by sender and count unseen per conversation
 				const conversationCounts: Record<string, number> = {}
 				let totalUnseenMessages = 0
 
@@ -415,6 +246,7 @@ export const useNotificationMonitor = () => {
 					}
 				})
 
+				// Fetch recent purchase updates (orders where user is buyer)
 				const purchaseFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
 					authors: [user.pubkey],
@@ -422,6 +254,9 @@ export const useNotificationMonitor = () => {
 				}
 
 				const purchaseEvents = await ndk.fetchEvents(purchaseFilter)
+
+				// Filter for purchase updates (payment requests, status updates, shipping updates)
+				// Exclude order creation events since those are initiated by the buyer
 				const newPurchaseUpdates = Array.from(purchaseEvents).filter((event) => {
 					const typeTag = event.tags.find((tag) => tag[0] === 'type')
 					const isUpdate =
@@ -429,71 +264,13 @@ export const useNotificationMonitor = () => {
 						typeTag?.[1] === ORDER_MESSAGE_TYPE.STATUS_UPDATE ||
 						typeTag?.[1] === ORDER_MESSAGE_TYPE.SHIPPING_UPDATE
 
+					// Only count if it's an update type AND it's from the seller (not the buyer)
 					return isUpdate && event.pubkey !== user.pubkey && isNewPurchaseUpdate(event)
 				})
 
 				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
-				const sellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
-				const sellerAuctionEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
-				const sellerProductCoordinates = uniqueStrings(sellerProducts.map(getProductCoordinate))
-				const sellerProductEventIds = uniqueStrings(sellerProducts.map((product) => product.id))
-
-				const sellerLiveActivityEvents = await fetchTaggedAuctionEvents({
-					kind: LIVE_ACTIVITY_KIND_NDK,
-					auctionRootEventIds: [],
-					auctionCoordinates: sellerAuctionCoordinates,
-				})
-				const sellerLiveActivityCoordinates = uniqueStrings(
-					sellerLiveActivityEvents.map((event) => parseLiveActivity(event).coord).filter(Boolean),
-				)
-				const sellerLiveChatEvents = await fetchTaggedAuctionEvents({
-					kind: LIVE_CHAT_KIND_NDK,
-					auctionRootEventIds: [],
-					auctionCoordinates: sellerLiveActivityCoordinates,
-					since: notificationActions.getLastSeenAuctionComments() + 1,
-				})
-				const newSellerCommentEvents = sellerLiveChatEvents.filter((event) => {
-					seenAuctionCommentEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewAuctionComment(event)
-				})
-
-				const sellerAuctionCommentEvents = await fetchSellerAuctionCommentEvents({
-					auctionCoordinates: sellerAuctionCoordinates,
-					auctionEventIds: sellerAuctionEventIds,
-					since: notificationActions.getLastSeenAuctionEventComments() + 1,
-				})
-				const newSellerAuctionEventCommentEvents = sellerAuctionCommentEvents.filter((event) => {
-					seenAuctionEventCommentIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event)
-				})
-
-				const sellerProductCommentEvents = await fetchSellerProductCommentEvents({
-					productCoordinates: sellerProductCoordinates,
-					productEventIds: sellerProductEventIds,
-					since: notificationActions.getLastSeenProductComments() + 1,
-				})
-				const newSellerProductCommentEvents = sellerProductCommentEvents.filter((event) => {
-					seenProductCommentEventIds.add(event.id)
-					return event.pubkey !== user.pubkey && isNewProductComment(event)
-				})
-
-				const { liveEvents: initialAuctionLiveEvents, settlementBeginsEvents: initialAuctionSettlementBeginsEvents } =
-					collectSellerAuctionLifecycleNotifications(
-						sellerAuctions,
-						notificationActions.getLastSeenAuctionLive(),
-						notificationActions.getLastSeenAuctionSettlementBegins(),
-						seenAuctionLiveEventIds,
-						seenAuctionSettlementBeginsEventIds,
-					)
-				for (const auction of initialAuctionLiveEvents) {
-					if (auction.id) seenAuctionLiveEventIds.add(auction.id)
-				}
-				for (const auction of initialAuctionSettlementBeginsEvents) {
-					if (auction.id) seenAuctionSettlementBeginsEventIds.add(auction.id)
-				}
-
 				const sellerBidEvents = await fetchTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					auctionRootEventIds: sellerAuctionRootEventIds,
@@ -553,17 +330,13 @@ export const useNotificationMonitor = () => {
 
 				if (isCancelled) return
 
+				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
 					orderCount: newOrders.length,
 					messageCount: totalUnseenMessages,
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
-					auctionCommentCount: newSellerCommentEvents.length,
-					auctionEventCommentCount: newSellerAuctionEventCommentEvents.length,
-					productCommentCount: newSellerProductCommentEvents.length,
-					auctionLiveCount: initialAuctionLiveEvents.length,
-					auctionSettlementBeginsCount: initialAuctionSettlementBeginsEvents.length,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -572,11 +345,6 @@ export const useNotificationMonitor = () => {
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
 					auctionBids: newSellerBidEvents.length,
-					auctionComments: newSellerCommentEvents.length,
-					auctionEventComments: newSellerAuctionEventCommentEvents.length,
-					productComments: newSellerProductCommentEvents.length,
-					auctionLive: initialAuctionLiveEvents.length,
-					auctionSettlementBegins: initialAuctionSettlementBeginsEvents.length,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
@@ -588,66 +356,6 @@ export const useNotificationMonitor = () => {
 
 					console.log('[NotificationMonitor] New auction bid received:', event.id)
 					notificationActions.incrementUnseenAuctionBids()
-				}
-
-				const handleSellerLiveChatEvent = (event: NDKEvent) => {
-					if (!event.id || seenAuctionCommentEventIds.has(event.id)) return
-					seenAuctionCommentEventIds.add(event.id)
-					if (event.pubkey === user.pubkey) return
-
-					console.log('[NotificationMonitor] New auction live-chat comment received:', event.id)
-					notificationActions.incrementUnseenAuctionComments()
-				}
-
-				const handleSellerProductCommentEvent = (event: NDKEvent) => {
-					if (!event.id || seenProductCommentEventIds.has(event.id)) return
-					seenProductCommentEventIds.add(event.id)
-					if (event.pubkey === user.pubkey) return
-
-					console.log('[NotificationMonitor] New product comment received:', event.id)
-					notificationActions.incrementUnseenProductComments()
-				}
-
-				const handleSellerAuctionEventComment = (event: NDKEvent) => {
-					if (!event.id || seenAuctionEventCommentIds.has(event.id)) return
-					seenAuctionEventCommentIds.add(event.id)
-					if (event.pubkey === user.pubkey) return
-
-					console.log('[NotificationMonitor] New auction thread comment received:', event.id)
-					notificationActions.incrementUnseenAuctionEventComments()
-				}
-
-				const subscribeToLiveChatCoord = (coord: string) => {
-					if (!coord || subscribedLiveChatCoords.has(coord)) return
-					subscribedLiveChatCoords.add(coord)
-					subscribeToTaggedAuctionEvents({
-						kind: LIVE_CHAT_KIND_NDK,
-						tagName: '#a',
-						values: [coord],
-						onEvent: handleSellerLiveChatEvent,
-					})
-				}
-
-				const subscribeToProductCommentCoord = (coord: string) => {
-					if (!coord || subscribedProductCommentCoords.has(coord)) return
-					subscribedProductCommentCoords.add(coord)
-					subscribeToTaggedAuctionEvents({
-						kind: COMMENT_KIND_NDK,
-						tagName: '#a',
-						values: [coord],
-						onEvent: handleSellerProductCommentEvent,
-					})
-					subscribeToTaggedAuctionEvents({
-						kind: COMMENT_KIND_NDK,
-						tagName: '#A',
-						values: [coord],
-						onEvent: handleSellerProductCommentEvent,
-					})
-				}
-
-				const handleSellerLiveActivityEvent = (event: NDKEvent) => {
-					const coord = parseLiveActivity(event).coord
-					subscribeToLiveChatCoord(coord)
 				}
 
 				const handleWatchedBidEvent = (event: NDKEvent) => {
@@ -671,42 +379,6 @@ export const useNotificationMonitor = () => {
 					notificationActions.incrementUnseenBidUpdates()
 				}
 
-				for (const coord of sellerLiveActivityCoordinates) {
-					subscribeToLiveChatCoord(coord)
-				}
-				for (const coord of sellerProductCoordinates) {
-					subscribeToProductCommentCoord(coord)
-				}
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#a',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerAuctionEventComment,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#A',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerAuctionEventComment,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#e',
-					values: sellerAuctionEventIds,
-					onEvent: handleSellerAuctionEventComment,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: COMMENT_KIND_NDK,
-					tagName: '#E',
-					values: sellerAuctionEventIds,
-					onEvent: handleSellerAuctionEventComment,
-				})
-				subscribeToTaggedAuctionEvents({
-					kind: LIVE_ACTIVITY_KIND_NDK,
-					tagName: '#a',
-					values: sellerAuctionCoordinates,
-					onEvent: handleSellerLiveActivityEvent,
-				})
 				subscribeToTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					tagName: '#e',
@@ -745,101 +417,22 @@ export const useNotificationMonitor = () => {
 				})
 
 				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
-
-				auctionLifecyclePollId = window.setInterval(async () => {
-					try {
-						const pollSellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
-						const { liveEvents, settlementBeginsEvents } = collectSellerAuctionLifecycleNotifications(
-							pollSellerAuctions,
-							notificationActions.getLastSeenAuctionLive(),
-							notificationActions.getLastSeenAuctionSettlementBegins(),
-							seenAuctionLiveEventIds,
-							seenAuctionSettlementBeginsEventIds,
-						)
-
-						for (const auction of liveEvents) {
-							if (!auction.id) continue
-							seenAuctionLiveEventIds.add(auction.id)
-							notificationActions.incrementUnseenAuctionLive()
-						}
-
-						for (const auction of settlementBeginsEvents) {
-							if (!auction.id) continue
-							seenAuctionSettlementBeginsEventIds.add(auction.id)
-							notificationActions.incrementUnseenAuctionSettlementBegins()
-						}
-
-						const pollSellerAuctionCoordinates = uniqueStrings(pollSellerAuctions.map(getAuctionCoordinate))
-						const pollLiveActivityEvents = await fetchTaggedAuctionEvents({
-							kind: LIVE_ACTIVITY_KIND_NDK,
-							auctionRootEventIds: [],
-							auctionCoordinates: pollSellerAuctionCoordinates,
-						})
-						const pollLiveActivityCoordinates = uniqueStrings(
-							pollLiveActivityEvents.map((event) => parseLiveActivity(event).coord).filter(Boolean),
-						)
-						const pollLiveChatEvents = await fetchTaggedAuctionEvents({
-							kind: LIVE_CHAT_KIND_NDK,
-							auctionRootEventIds: [],
-							auctionCoordinates: pollLiveActivityCoordinates,
-							since: notificationActions.getLastSeenAuctionComments() + 1,
-						})
-						for (const event of pollLiveChatEvents) {
-							if (!event.id || seenAuctionCommentEventIds.has(event.id)) continue
-							seenAuctionCommentEventIds.add(event.id)
-							if (event.pubkey === user.pubkey) continue
-							notificationActions.incrementUnseenAuctionComments()
-						}
-
-						const pollSellerAuctionEventIds = uniqueStrings(
-							pollSellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id),
-						)
-						const pollAuctionCommentEvents = await fetchSellerAuctionCommentEvents({
-							auctionCoordinates: pollSellerAuctionCoordinates,
-							auctionEventIds: pollSellerAuctionEventIds,
-							since: notificationActions.getLastSeenAuctionEventComments() + 1,
-						})
-						for (const event of pollAuctionCommentEvents) {
-							if (!event.id || seenAuctionEventCommentIds.has(event.id)) continue
-							seenAuctionEventCommentIds.add(event.id)
-							if (event.pubkey === user.pubkey) continue
-							notificationActions.incrementUnseenAuctionEventComments()
-						}
-
-						const pollSellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
-						const pollSellerProductCoordinates = uniqueStrings(pollSellerProducts.map(getProductCoordinate))
-						const pollSellerProductEventIds = uniqueStrings(pollSellerProducts.map((product) => product.id))
-						for (const coord of pollSellerProductCoordinates) {
-							subscribeToProductCommentCoord(coord)
-						}
-
-						const pollProductCommentEvents = await fetchSellerProductCommentEvents({
-							productCoordinates: pollSellerProductCoordinates,
-							productEventIds: pollSellerProductEventIds,
-							since: notificationActions.getLastSeenProductComments() + 1,
-						})
-						for (const event of pollProductCommentEvents) {
-							if (!event.id || seenProductCommentEventIds.has(event.id)) continue
-							seenProductCommentEventIds.add(event.id)
-							if (event.pubkey === user.pubkey) continue
-							notificationActions.incrementUnseenProductComments()
-						}
-					} catch (error) {
-						console.error('[NotificationMonitor] Failed to poll auction lifecycle notifications:', error)
-					}
-				}, AUCTION_LIFECYCLE_POLL_INTERVAL_MS)
 			} catch (error) {
 				console.error('[NotificationMonitor] Failed to initialize notifications:', error)
 			}
 		}
 
+		// Start initial fetch
 		initializeNotifications()
 
+		// Set up real-time subscriptions
+
+		// 1. Subscribe to new orders where user is seller
 		const orderSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_PROCESS_KIND],
 				'#p': [user.pubkey],
-				since: subscriptionSince,
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -847,8 +440,10 @@ export const useNotificationMonitor = () => {
 		)
 
 		orderSubscription.on('event', (event: NDKEvent) => {
+			// Check if it's an order creation event
 			const typeTag = event.tags.find((tag) => tag[0] === 'type')
 			if (typeTag?.[1] === ORDER_MESSAGE_TYPE.ORDER_CREATION) {
+				// Only increment if it's newer than last seen
 				if (isNewOrder(event)) {
 					console.log('[NotificationMonitor] New order received:', event.id)
 					notificationActions.incrementUnseenOrders()
@@ -858,11 +453,12 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(orderSubscription)
 
+		// 2. Subscribe to new messages where user is recipient
 		const messageSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_GENERAL_KIND],
 				'#p': [user.pubkey],
-				since: subscriptionSince,
+				since: subscriptionSince, // Only new events from now
 			},
 			{
 				closeOnEose: false,
@@ -871,6 +467,7 @@ export const useNotificationMonitor = () => {
 
 		messageSubscription.on('event', (event: NDKEvent) => {
 			const senderPubkey = event.pubkey
+			// Don't count messages we sent
 			if (senderPubkey !== user.pubkey && isNewMessage(event, senderPubkey)) {
 				console.log('[NotificationMonitor] New message received from:', senderPubkey)
 				notificationActions.incrementUnseenForConversation(senderPubkey)
@@ -879,6 +476,8 @@ export const useNotificationMonitor = () => {
 
 		subscriptionsRef.current.push(messageSubscription)
 
+		// 3. Subscribe to purchase updates (orders where user is buyer)
+		// Listen for events tagged with user's pubkey that are updates from sellers
 		const purchaseUpdateSubscription = ndk.subscribe(
 			{
 				kinds: [ORDER_PROCESS_KIND],
@@ -891,9 +490,12 @@ export const useNotificationMonitor = () => {
 		)
 
 		purchaseUpdateSubscription.on('event', (event: NDKEvent) => {
+			// Only count if event is from someone else (the seller)
 			if (event.pubkey === user.pubkey) return
 
 			const typeTag = event.tags.find((tag) => tag[0] === 'type')
+
+			// Handle purchase-related updates (seller sending updates to buyer)
 			if (typeTag) {
 				switch (typeTag[1]) {
 					case ORDER_MESSAGE_TYPE.PAYMENT_REQUEST:
@@ -905,6 +507,7 @@ export const useNotificationMonitor = () => {
 						}
 						break
 					case ORDER_MESSAGE_TYPE.ORDER_CREATION:
+						// This is a new order where user is seller - already handled above
 						break
 				}
 			}
@@ -914,17 +517,15 @@ export const useNotificationMonitor = () => {
 
 		console.log('[NotificationMonitor] Base subscriptions active:', subscriptionsRef.current.length)
 
+		// Cleanup function
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
 			isCancelled = true
-			if (auctionLifecyclePollId) {
-				window.clearInterval(auctionLifecyclePollId)
-			}
 			subscriptionsRef.current.forEach((sub) => {
 				sub.stop()
 			})
 			subscriptionsRef.current = []
 			isMonitoringRef.current = false
 		}
-	}, [user?.pubkey, isInitialized, ndk])
+	}, [user?.pubkey, isInitialized])
 }

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -6,7 +6,6 @@ import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND, parseLiveActivity } from '@/lib/nip
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
-import { toast } from 'sonner'
 import {
 	fetchAuctionBidsByBidder,
 	fetchAuctionsByPubkey,

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -4,7 +4,7 @@ import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
-import { LIVE_ACTIVITY_KIND } from '@/lib/nip53'
+import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND } from '@/lib/nip53'
 import { configStore } from '@/lib/stores/config'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import {
@@ -20,6 +20,7 @@ import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 type NDKKind = NonNullable<NDKFilter['kinds']>[number]
 const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NDKKind
+const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NDKKind
 
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
@@ -52,6 +53,11 @@ const getAuctionCoordinate = (auction: NDKEvent): string => {
 const getEventAuctionRootId = (event: NDKEvent): string => getBidAuctionEventId(event)
 
 const getEventAuctionCoordinate = (event: NDKEvent): string => getBidAuctionCoordinates(event)
+
+const getAddressableEventCoordinate = (event: NDKEvent): string => {
+	const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1]
+	return dTag ? `${event.kind}:${event.pubkey}:${dTag}` : ''
+}
 
 const getAuctionBidStatus = (event: NDKEvent): string =>
 	event.tags
@@ -156,6 +162,7 @@ export const useNotificationMonitor = () => {
 		let isCancelled = false
 		const subscriptionSince = Math.floor(Date.now() / 1000)
 		const seenAuctionEventIds = new Set<string>()
+		const seenAuctionCommentEventIds = new Set<string>()
 		const seenBidEventIds = new Set<string>()
 		const seenSettlementEventIds = new Set<string>()
 
@@ -187,6 +194,11 @@ export const useNotificationMonitor = () => {
 
 		const isNewBidUpdate = (event: NDKEvent): boolean => {
 			const lastSeen = notificationActions.getLastSeenBidUpdates()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewAuctionComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionComments()
 			return (event.created_at || 0) > lastSeen
 		}
 
@@ -302,10 +314,29 @@ export const useNotificationMonitor = () => {
 					auctionCoordinates: sellerAuctionCoordinates,
 					since: notificationActions.getLastSeenAuctionBids() + 1,
 				})
+				const sellerLiveActivityEvents = await fetchTaggedAuctionEvents({
+					kind: LIVE_ACTIVITY_KIND_NDK,
+					auctionRootEventIds: [],
+					auctionCoordinates: sellerAuctionCoordinates,
+				})
+				const sellerLiveActivityCoords = uniqueStrings(
+					sellerLiveActivityEvents.map((event) => getAddressableEventCoordinate(event)).filter(Boolean),
+				)
+				const sellerLiveChatEvents = await fetchTaggedAuctionEvents({
+					kind: LIVE_CHAT_KIND_NDK,
+					auctionRootEventIds: [],
+					auctionCoordinates: sellerLiveActivityCoords,
+					since: notificationActions.getLastSeenAuctionComments() + 1,
+				})
 
 				const newSellerBidEvents = sellerBidEvents.filter((event) => {
 					seenAuctionEventIds.add(event.id)
 					return event.pubkey !== user.pubkey && isCountableAuctionBidEvent(event) && isNewAuctionBid(event)
+				})
+
+				const newSellerLiveChatEvents = sellerLiveChatEvents.filter((event) => {
+					seenAuctionCommentEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewAuctionComment(event)
 				})
 
 				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
@@ -362,6 +393,7 @@ export const useNotificationMonitor = () => {
 					purchaseCount: newPurchaseUpdates.length,
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
+					auctionCommentCount: newSellerLiveChatEvents.length,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -370,6 +402,7 @@ export const useNotificationMonitor = () => {
 					messages: totalUnseenMessages,
 					purchases: newPurchaseUpdates.length,
 					auctionBids: newSellerBidEvents.length,
+					auctionComments: newSellerLiveChatEvents.length,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
@@ -393,6 +426,15 @@ export const useNotificationMonitor = () => {
 
 					console.log('[NotificationMonitor] New higher bid on watched auction:', event.id)
 					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				const handleSellerLiveChatEvent = (event: NDKEvent) => {
+					if (!event.id || seenAuctionCommentEventIds.has(event.id)) return
+					seenAuctionCommentEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isNewAuctionComment(event)) return
+
+					console.log('[NotificationMonitor] New live chat comment on seller auction:', event.id)
+					notificationActions.incrementUnseenAuctionComments()
 				}
 
 				const handleWatchedSettlementEvent = (event: NDKEvent) => {
@@ -439,6 +481,12 @@ export const useNotificationMonitor = () => {
 					tagName: '#a',
 					values: watchedAuctionCoordinates,
 					onEvent: handleWatchedSettlementEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: LIVE_CHAT_KIND_NDK,
+					tagName: '#a',
+					values: sellerLiveActivityCoords,
+					onEvent: handleSellerLiveChatEvent,
 				})
 
 				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -3,7 +3,7 @@ import { useStore } from '@tanstack/react-store'
 import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND, parseLiveActivity } from '@/lib/nip53'
-import { ndkActions } from '@/lib/stores/ndk'
+import { ndkActions, ndkStore } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import {
@@ -23,6 +23,7 @@ import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
 const AUCTION_LIFECYCLE_POLL_INTERVAL_MS = 60000
+const SUBSCRIPTION_LOOKBACK_SECONDS = 300
 const IGNORED_AUCTION_BID_STATUSES = new Set(['cancelled', 'canceled', 'rejected', 'failed', 'expired', 'refunded', 'reclaimed', 'claimed'])
 const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
 const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NonNullable<NDKFilter['kinds']>[number]
@@ -270,6 +271,7 @@ const fetchSellerAuctionCommentEvents = async ({
 export const useNotificationMonitor = () => {
 	const { user } = useStore(authStore)
 	const { isInitialized } = useStore(notificationStore)
+	const ndk = useStore(ndkStore, (state) => state.ndk)
 	const subscriptionsRef = useRef<NDKSubscription[]>([])
 	const isMonitoringRef = useRef(false)
 
@@ -279,11 +281,12 @@ export const useNotificationMonitor = () => {
 			return
 		}
 
-		const ndk = ndkActions.getNDK()
 		if (!ndk) return
 
 		let isCancelled = false
-		const subscriptionSince = Math.floor(Date.now() / 1000)
+		// Nostr events use publisher-provided timestamps, so a small lookback avoids
+		// missing fresh events when peer clocks drift behind local time.
+		const subscriptionSince = Math.max(0, Math.floor(Date.now() / 1000) - SUBSCRIPTION_LOOKBACK_SECONDS)
 		const seenAuctionEventIds = new Set<string>()
 		const seenAuctionCommentEventIds = new Set<string>()
 		const seenAuctionEventCommentIds = new Set<string>()
@@ -923,5 +926,5 @@ export const useNotificationMonitor = () => {
 			subscriptionsRef.current = []
 			isMonitoringRef.current = false
 		}
-	}, [user?.pubkey, isInitialized])
+	}, [user?.pubkey, isInitialized, ndk])
 }

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -10,15 +10,20 @@ import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/li
 import {
 	fetchAuctionBidsByBidder,
 	fetchAuctionsByPubkey,
+	getAuctionBiddingCutoffAt,
 	getAuctionId,
 	getAuctionRootEventId,
+	getAuctionStartAt,
 	getBidAmount,
 	getBidAuctionCoordinates,
 	getBidAuctionEventId,
 } from '@/queries/auctions'
+import { fetchProductsByPubkey, getProductCoordinates } from '@/queries/products'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 type NDKKind = NonNullable<NDKFilter['kinds']>[number]
+const AUCTION_KIND_NDK = 30408 as NDKKind
+const COMMENT_KIND_NDK = 1111 as NDKKind
 const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NDKKind
 const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NDKKind
 
@@ -58,6 +63,9 @@ const getAddressableEventCoordinate = (event: NDKEvent): string => {
 	const dTag = event.tags.find((tag) => tag[0] === 'd')?.[1]
 	return dTag ? `${event.kind}:${event.pubkey}:${dTag}` : ''
 }
+
+const getAuctionNotificationKey = (auction: NDKEvent): string =>
+	getAuctionRootEventId(auction) || getAuctionCoordinate(auction) || auction.id
 
 const getAuctionBidStatus = (event: NDKEvent): string =>
 	event.tags
@@ -108,6 +116,37 @@ const makeTaggedAuctionFilters = ({
 	return filters
 }
 
+const makeTaggedValueFilters = ({
+	kind,
+	tagName,
+	values,
+	since,
+	authors,
+}: {
+	kind: NDKKind
+	tagName: '#a' | '#A' | '#e' | '#E'
+	values: string[]
+	since?: number
+	authors?: string[]
+}): NDKFilter[] => {
+	const filters: NDKFilter[] = []
+	const baseFilter = {
+		kinds: [kind],
+		limit: AUCTION_MONITOR_LIMIT,
+		...(authors && authors.length > 0 ? { authors } : {}),
+		...(typeof since === 'number' ? { since } : {}),
+	}
+
+	for (const valueChunk of chunkValues(uniqueStrings(values), AUCTION_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			...baseFilter,
+			[tagName]: valueChunk,
+		})
+	}
+
+	return filters
+}
+
 const getTrustedAuthorsForKind = (kind: NDKKind): string[] | undefined => {
 	if (kind !== LIVE_ACTIVITY_KIND_NDK) return undefined
 
@@ -140,6 +179,65 @@ const fetchTaggedAuctionEvents = async ({
 	return dedupeEvents(Array.from(events))
 }
 
+const fetchTaggedEvents = async ({
+	kind,
+	tagName,
+	values,
+	since,
+	authors,
+}: {
+	kind: NDKKind
+	tagName: '#a' | '#A' | '#e' | '#E'
+	values: string[]
+	since?: number
+	authors?: string[]
+}): Promise<NDKEvent[]> => {
+	const filters = makeTaggedValueFilters({
+		kind,
+		tagName,
+		values,
+		since,
+		authors,
+	})
+	if (filters.length === 0) return []
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	return dedupeEvents(Array.from(events))
+}
+
+const fetchAddressableCommentEvents = async ({
+	targetEventIds,
+	targetCoordinates,
+	since,
+}: {
+	targetEventIds: string[]
+	targetCoordinates: string[]
+	since?: number
+}): Promise<NDKEvent[]> => {
+	const [byCoordinates, byUpperCoordinates, byUpperEventIds] = await Promise.all([
+		fetchTaggedEvents({
+			kind: COMMENT_KIND_NDK,
+			tagName: '#a',
+			values: targetCoordinates,
+			since,
+		}),
+		fetchTaggedEvents({
+			kind: COMMENT_KIND_NDK,
+			tagName: '#A',
+			values: targetCoordinates,
+			since,
+		}),
+		fetchTaggedEvents({
+			kind: COMMENT_KIND_NDK,
+			tagName: '#E',
+			values: targetEventIds,
+			since,
+		}),
+	])
+
+	return dedupeEvents([...byCoordinates, ...byUpperCoordinates, ...byUpperEventIds])
+}
+
 /**
  * Monitor nostr events and update notification counts in real-time
  * This hook should be used once at the app/dashboard level
@@ -163,8 +261,13 @@ export const useNotificationMonitor = () => {
 		const subscriptionSince = Math.floor(Date.now() / 1000)
 		const seenAuctionEventIds = new Set<string>()
 		const seenAuctionCommentEventIds = new Set<string>()
+		const seenAuctionThreadCommentEventIds = new Set<string>()
 		const seenBidEventIds = new Set<string>()
+		const seenProductCommentEventIds = new Set<string>()
 		const seenSettlementEventIds = new Set<string>()
+		const scheduledAuctionLiveKeys = new Set<string>()
+		const scheduledAuctionSettlementKeys = new Set<string>()
+		const phaseTimeoutIds: number[] = []
 
 		// Mark as monitoring to prevent duplicate subscriptions
 		isMonitoringRef.current = true
@@ -202,6 +305,16 @@ export const useNotificationMonitor = () => {
 			return (event.created_at || 0) > lastSeen
 		}
 
+		const isNewAuctionEventComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenAuctionEventComments()
+			return (event.created_at || 0) > lastSeen
+		}
+
+		const isNewProductComment = (event: NDKEvent): boolean => {
+			const lastSeen = notificationActions.getLastSeenProductComments()
+			return (event.created_at || 0) > lastSeen
+		}
+
 		const subscribeToTaggedAuctionEvents = ({
 			kind,
 			tagName,
@@ -209,7 +322,7 @@ export const useNotificationMonitor = () => {
 			onEvent,
 		}: {
 			kind: NDKKind
-			tagName: '#e' | '#a'
+			tagName: '#e' | '#a' | '#A' | '#E'
 			values: string[]
 			onEvent: (event: NDKEvent) => void
 		}) => {
@@ -217,19 +330,56 @@ export const useNotificationMonitor = () => {
 
 			const trustedAuthors = getTrustedAuthorsForKind(kind)
 
-			const filter = {
-				kinds: [kind],
-				[tagName]: values,
-				...(trustedAuthors ? { authors: trustedAuthors } : {}),
-				since: subscriptionSince,
-			} as NDKFilter
+			for (const valueChunk of chunkValues(uniqueStrings(values), AUCTION_FILTER_CHUNK_SIZE)) {
+				const filter = {
+					kinds: [kind],
+					[tagName]: valueChunk,
+					...(trustedAuthors ? { authors: trustedAuthors } : {}),
+					since: subscriptionSince,
+				} as NDKFilter
 
-			const subscription = ndk.subscribe(filter, {
-				closeOnEose: false,
-			})
+				const subscription = ndk.subscribe(filter, {
+					closeOnEose: false,
+				})
 
-			subscription.on('event', onEvent)
-			subscriptionsRef.current.push(subscription)
+				subscription.on('event', onEvent)
+				subscriptionsRef.current.push(subscription)
+			}
+		}
+
+		const scheduleAuctionPhaseNotification = (auction: NDKEvent) => {
+			const auctionKey = getAuctionNotificationKey(auction)
+			if (!auctionKey) return
+
+			const scheduleAt = (runAt: number, scheduledKeys: Set<string>, callback: () => void) => {
+				if (!runAt || runAt <= Math.floor(Date.now() / 1000) || scheduledKeys.has(auctionKey)) return
+				scheduledKeys.add(auctionKey)
+				const timeoutId = window.setTimeout(
+					() => {
+						scheduledKeys.delete(auctionKey)
+						if (isCancelled) return
+						callback()
+					},
+					Math.max(0, runAt * 1000 - Date.now()),
+				)
+				phaseTimeoutIds.push(timeoutId)
+			}
+
+			const startAt = getAuctionStartAt(auction)
+			if (startAt > notificationActions.getLastSeenAuctionLive()) {
+				scheduleAt(startAt, scheduledAuctionLiveKeys, () => {
+					console.log('[NotificationMonitor] Seller auction went live:', auction.id)
+					notificationActions.incrementUnseenAuctionLive()
+				})
+			}
+
+			const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+			if (biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins()) {
+				scheduleAt(biddingCutoffAt, scheduledAuctionSettlementKeys, () => {
+					console.log('[NotificationMonitor] Seller auction entered settlement:', auction.id)
+					notificationActions.incrementUnseenAuctionSettlementBegins()
+				})
+			}
 		}
 
 		const getHighestOwnBidAmountForAuction = (
@@ -247,6 +397,7 @@ export const useNotificationMonitor = () => {
 		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
+				const now = Math.floor(Date.now() / 1000)
 				// Fetch recent orders where user is seller (recipient)
 				const orderFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
@@ -306,8 +457,11 @@ export const useNotificationMonitor = () => {
 				})
 
 				const sellerAuctions = await fetchAuctionsByPubkey(user.pubkey, 500)
+				const sellerProducts = await fetchProductsByPubkey(user.pubkey, true, 500)
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
+				const sellerProductEventIds = uniqueStrings(sellerProducts.map((product) => product.id))
+				const sellerProductCoordinates = uniqueStrings(sellerProducts.map(getProductCoordinates))
 				const sellerBidEvents = await fetchTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					auctionRootEventIds: sellerAuctionRootEventIds,
@@ -328,6 +482,18 @@ export const useNotificationMonitor = () => {
 					auctionCoordinates: sellerLiveActivityCoords,
 					since: notificationActions.getLastSeenAuctionComments() + 1,
 				})
+				const [sellerAuctionCommentEvents, sellerProductCommentEvents] = await Promise.all([
+					fetchAddressableCommentEvents({
+						targetEventIds: sellerAuctionRootEventIds,
+						targetCoordinates: sellerAuctionCoordinates,
+						since: notificationActions.getLastSeenAuctionEventComments() + 1,
+					}),
+					fetchAddressableCommentEvents({
+						targetEventIds: sellerProductEventIds,
+						targetCoordinates: sellerProductCoordinates,
+						since: notificationActions.getLastSeenProductComments() + 1,
+					}),
+				])
 
 				const newSellerBidEvents = sellerBidEvents.filter((event) => {
 					seenAuctionEventIds.add(event.id)
@@ -338,6 +504,26 @@ export const useNotificationMonitor = () => {
 					seenAuctionCommentEventIds.add(event.id)
 					return event.pubkey !== user.pubkey && isNewAuctionComment(event)
 				})
+
+				const newSellerAuctionCommentEvents = sellerAuctionCommentEvents.filter((event) => {
+					seenAuctionThreadCommentEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event)
+				})
+
+				const newSellerProductCommentEvents = sellerProductCommentEvents.filter((event) => {
+					seenProductCommentEventIds.add(event.id)
+					return event.pubkey !== user.pubkey && isNewProductComment(event)
+				})
+
+				const unseenAuctionLiveCount = sellerAuctions.filter((auction) => {
+					const startAt = getAuctionStartAt(auction)
+					return startAt > notificationActions.getLastSeenAuctionLive() && startAt <= now
+				}).length
+
+				const unseenAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
+					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+					return biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins() && biddingCutoffAt <= now
+				}).length
 
 				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
 				const highestOwnBidByRootId = new Map<string, number>()
@@ -394,6 +580,10 @@ export const useNotificationMonitor = () => {
 					conversationCounts,
 					auctionBidCount: newSellerBidEvents.length,
 					auctionCommentCount: newSellerLiveChatEvents.length,
+					auctionEventCommentCount: newSellerAuctionCommentEvents.length,
+					productCommentCount: newSellerProductCommentEvents.length,
+					auctionLiveCount: unseenAuctionLiveCount,
+					auctionSettlementBeginsCount: unseenAuctionSettlementBeginsCount,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -403,9 +593,15 @@ export const useNotificationMonitor = () => {
 					purchases: newPurchaseUpdates.length,
 					auctionBids: newSellerBidEvents.length,
 					auctionComments: newSellerLiveChatEvents.length,
+					auctionEventComments: newSellerAuctionCommentEvents.length,
+					productComments: newSellerProductCommentEvents.length,
+					auctionLive: unseenAuctionLiveCount,
+					auctionSettlementBegins: unseenAuctionSettlementBeginsCount,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					conversations: Object.keys(conversationCounts).length,
 				})
+
+				sellerAuctions.forEach(scheduleAuctionPhaseNotification)
 
 				const handleSellerBidEvent = (event: NDKEvent) => {
 					if (!event.id || seenAuctionEventIds.has(event.id)) return
@@ -437,6 +633,24 @@ export const useNotificationMonitor = () => {
 					notificationActions.incrementUnseenAuctionComments()
 				}
 
+				const handleSellerAuctionCommentEvent = (event: NDKEvent) => {
+					if (!event.id || seenAuctionThreadCommentEventIds.has(event.id)) return
+					seenAuctionThreadCommentEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isNewAuctionEventComment(event)) return
+
+					console.log('[NotificationMonitor] New thread comment on seller auction:', event.id)
+					notificationActions.incrementUnseenAuctionEventComments()
+				}
+
+				const handleSellerProductCommentEvent = (event: NDKEvent) => {
+					if (!event.id || seenProductCommentEventIds.has(event.id)) return
+					seenProductCommentEventIds.add(event.id)
+					if (event.pubkey === user.pubkey || !isNewProductComment(event)) return
+
+					console.log('[NotificationMonitor] New thread comment on seller product:', event.id)
+					notificationActions.incrementUnseenProductComments()
+				}
+
 				const handleWatchedSettlementEvent = (event: NDKEvent) => {
 					if (!event.id || seenSettlementEventIds.has(event.id)) return
 					seenSettlementEventIds.add(event.id)
@@ -444,6 +658,11 @@ export const useNotificationMonitor = () => {
 
 					console.log('[NotificationMonitor] New settlement on watched auction:', event.id)
 					notificationActions.incrementUnseenBidUpdates()
+				}
+
+				const handleOwnAuctionEvent = (event: NDKEvent) => {
+					if (event.pubkey !== user.pubkey) return
+					scheduleAuctionPhaseNotification(event)
 				}
 
 				subscribeToTaggedAuctionEvents({
@@ -483,11 +702,61 @@ export const useNotificationMonitor = () => {
 					onEvent: handleWatchedSettlementEvent,
 				})
 				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#a',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerAuctionCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#A',
+					values: sellerAuctionCoordinates,
+					onEvent: handleSellerAuctionCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#E',
+					values: sellerAuctionRootEventIds,
+					onEvent: handleSellerAuctionCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#a',
+					values: sellerProductCoordinates,
+					onEvent: handleSellerProductCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#A',
+					values: sellerProductCoordinates,
+					onEvent: handleSellerProductCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
+					kind: COMMENT_KIND_NDK,
+					tagName: '#E',
+					values: sellerProductEventIds,
+					onEvent: handleSellerProductCommentEvent,
+				})
+				subscribeToTaggedAuctionEvents({
 					kind: LIVE_CHAT_KIND_NDK,
 					tagName: '#a',
 					values: sellerLiveActivityCoords,
 					onEvent: handleSellerLiveChatEvent,
 				})
+
+				const auctionListingSubscription = ndk.subscribe(
+					{
+						kinds: [AUCTION_KIND_NDK],
+						authors: [user.pubkey],
+						since: subscriptionSince,
+					},
+					{
+						closeOnEose: false,
+					},
+				)
+
+				auctionListingSubscription.on('event', handleOwnAuctionEvent)
+				subscriptionsRef.current.push(auctionListingSubscription)
 
 				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
 			} catch (error) {
@@ -594,6 +863,7 @@ export const useNotificationMonitor = () => {
 		return () => {
 			console.log('[NotificationMonitor] Stopping notification monitoring')
 			isCancelled = true
+			phaseTimeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId))
 			subscriptionsRef.current.forEach((sub) => {
 				sub.stop()
 			})

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -4,6 +4,8 @@ import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
+import { LIVE_ACTIVITY_KIND } from '@/lib/nip53'
+import { configStore } from '@/lib/stores/config'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import {
 	fetchAuctionBidsByBidder,
@@ -15,6 +17,9 @@ import {
 	getBidAuctionEventId,
 } from '@/queries/auctions'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
+
+type NDKKind = NonNullable<NDKFilter['kinds']>[number]
+const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NDKKind
 
 const AUCTION_MONITOR_LIMIT = 500
 const AUCTION_FILTER_CHUNK_SIZE = 80
@@ -64,16 +69,19 @@ const makeTaggedAuctionFilters = ({
 	auctionRootEventIds,
 	auctionCoordinates,
 	since,
+	authors,
 }: {
-	kind: NonNullable<NDKFilter['kinds']>[number]
+	kind: NDKKind
 	auctionRootEventIds: string[]
 	auctionCoordinates: string[]
 	since?: number
+	authors?: string[]
 }): NDKFilter[] => {
 	const filters: NDKFilter[] = []
 	const baseFilter = {
 		kinds: [kind],
 		limit: AUCTION_MONITOR_LIMIT,
+		...(authors && authors.length > 0 ? { authors } : {}),
 		...(typeof since === 'number' ? { since } : {}),
 	}
 
@@ -94,18 +102,32 @@ const makeTaggedAuctionFilters = ({
 	return filters
 }
 
+const getTrustedAuthorsForKind = (kind: NDKKind): string[] | undefined => {
+	if (kind !== LIVE_ACTIVITY_KIND_NDK) return undefined
+
+	const cvmServerPubkey = configStore.state.config.cvmServerPubkey?.trim()
+	return cvmServerPubkey ? [cvmServerPubkey] : undefined
+}
+
 const fetchTaggedAuctionEvents = async ({
 	kind,
 	auctionRootEventIds,
 	auctionCoordinates,
 	since,
 }: {
-	kind: NonNullable<NDKFilter['kinds']>[number]
+	kind: NDKKind
 	auctionRootEventIds: string[]
 	auctionCoordinates: string[]
 	since?: number
 }): Promise<NDKEvent[]> => {
-	const filters = makeTaggedAuctionFilters({ kind, auctionRootEventIds, auctionCoordinates, since })
+	const trustedAuthors = getTrustedAuthorsForKind(kind)
+	const filters = makeTaggedAuctionFilters({
+		kind,
+		auctionRootEventIds,
+		auctionCoordinates,
+		since,
+		authors: trustedAuthors,
+	})
 	if (filters.length === 0) return []
 
 	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
@@ -174,16 +196,19 @@ export const useNotificationMonitor = () => {
 			values,
 			onEvent,
 		}: {
-			kind: NonNullable<NDKFilter['kinds']>[number]
+			kind: NDKKind
 			tagName: '#e' | '#a'
 			values: string[]
 			onEvent: (event: NDKEvent) => void
 		}) => {
 			if (isCancelled || values.length === 0) return
 
+			const trustedAuthors = getTrustedAuthorsForKind(kind)
+
 			const filter = {
 				kinds: [kind],
 				[tagName]: values,
+				...(trustedAuthors ? { authors: trustedAuthors } : {}),
 				since: subscriptionSince,
 			} as NDKFilter
 

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -410,7 +410,7 @@ export const useNotificationMonitor = () => {
 		// Initial fetch to calculate current unseen counts and set up auction-specific subscriptions
 		const initializeNotifications = async () => {
 			try {
-				const now = Math.floor(Date.now() / 1000)
+				const initializationStartedAt = Math.floor(Date.now() / 1000)
 				// Fetch recent orders where user is seller (recipient)
 				const orderFilter: NDKFilter = {
 					kinds: [ORDER_PROCESS_KIND],
@@ -588,14 +588,16 @@ export const useNotificationMonitor = () => {
 
 				const unseenAuctionLiveCount = sellerAuctions.filter((auction) => {
 					const startAt = getAuctionStartAt(auction)
-					return startAt > notificationActions.getLastSeenAuctionLive(getAuctionNotificationKey(auction)) && startAt <= now
+					return (
+						startAt > notificationActions.getLastSeenAuctionLive(getAuctionNotificationKey(auction)) && startAt <= initializationStartedAt
+					)
 				}).length
 
 				const unseenAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
 					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 					return (
 						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(getAuctionNotificationKey(auction)) &&
-						biddingCutoffAt <= now
+						biddingCutoffAt <= initializationStartedAt
 					)
 				}).length
 
@@ -646,6 +648,34 @@ export const useNotificationMonitor = () => {
 
 				if (isCancelled) return
 
+				// Reconcile lifecycle transitions that can happen while async initialization
+				// is still fetching relay data. This bounded window closes gaps where a
+				// transition can be missed by both initial counting and one-shot timer setup.
+				const initializationCompletedAt = Math.floor(Date.now() / 1000)
+				const reconciledAuctionLiveCount = sellerAuctions.filter((auction) => {
+					const auctionKey = getAuctionNotificationKey(auction)
+					if (!auctionKey) return false
+
+					const startAt = getAuctionStartAt(auction)
+					return (
+						startAt > initializationStartedAt &&
+						startAt <= initializationCompletedAt &&
+						startAt > notificationActions.getLastSeenAuctionLive(auctionKey)
+					)
+				}).length
+
+				const reconciledAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
+					const auctionKey = getAuctionNotificationKey(auction)
+					if (!auctionKey) return false
+
+					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+					return (
+						biddingCutoffAt > initializationStartedAt &&
+						biddingCutoffAt <= initializationCompletedAt &&
+						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(auctionKey)
+					)
+				}).length
+
 				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
 					orderCount: newOrders.length,
@@ -657,8 +687,8 @@ export const useNotificationMonitor = () => {
 					auctionCommentCount: newSellerLiveChatEvents.length,
 					auctionEventCommentCount: newSellerAuctionCommentEvents.length,
 					productCommentCount: newSellerProductCommentEvents.length,
-					auctionLiveCount: unseenAuctionLiveCount,
-					auctionSettlementBeginsCount: unseenAuctionSettlementBeginsCount,
+					auctionLiveCount: unseenAuctionLiveCount + reconciledAuctionLiveCount,
+					auctionSettlementBeginsCount: unseenAuctionSettlementBeginsCount + reconciledAuctionSettlementBeginsCount,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -670,9 +700,12 @@ export const useNotificationMonitor = () => {
 					auctionComments: newSellerLiveChatEvents.length,
 					auctionEventComments: newSellerAuctionCommentEvents.length,
 					productComments: newSellerProductCommentEvents.length,
-					auctionLive: unseenAuctionLiveCount,
-					auctionSettlementBegins: unseenAuctionSettlementBeginsCount,
+					auctionLive: unseenAuctionLiveCount + reconciledAuctionLiveCount,
+					auctionSettlementBegins: unseenAuctionSettlementBeginsCount + reconciledAuctionSettlementBeginsCount,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
+					reconciledAuctionLive: reconciledAuctionLiveCount,
+					reconciledAuctionSettlementBegins: reconciledAuctionSettlementBeginsCount,
+					initializationWindowSeconds: Math.max(0, initializationCompletedAt - initializationStartedAt),
 					conversations: Object.keys(conversationCounts).length,
 				})
 

--- a/src/hooks/useNotificationMonitor.ts
+++ b/src/hooks/useNotificationMonitor.ts
@@ -4,6 +4,13 @@ import { authStore } from '@/lib/stores/auth'
 import { AUCTION_BID_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auctionSettlement'
 import { ndkActions } from '@/lib/stores/ndk'
 import { notificationActions, notificationStore } from '@/lib/stores/notifications'
+import {
+	PRODUCT_KIND,
+	getSellerProductNotificationScope,
+	registerSellerProductNotificationScope,
+	type ProductNotificationScope,
+	type ProductScopeTag,
+} from '@/lib/productNotificationScopes'
 import { LIVE_ACTIVITY_KIND, LIVE_CHAT_KIND } from '@/lib/nip53'
 import { configStore } from '@/lib/stores/config'
 import { ORDER_GENERAL_KIND, ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
@@ -18,11 +25,12 @@ import {
 	getBidAuctionCoordinates,
 	getBidAuctionEventId,
 } from '@/queries/auctions'
-import { fetchProductsByPubkey, getProductCoordinates } from '@/queries/products'
+import { fetchProductsByPubkey } from '@/queries/products'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 
 type NDKKind = NonNullable<NDKFilter['kinds']>[number]
 const AUCTION_KIND_NDK = 30408 as NDKKind
+const PRODUCT_KIND_NDK = PRODUCT_KIND as NDKKind
 const COMMENT_KIND_NDK = 1111 as NDKKind
 const LIVE_ACTIVITY_KIND_NDK = LIVE_ACTIVITY_KIND as unknown as NDKKind
 const LIVE_CHAT_KIND_NDK = LIVE_CHAT_KIND as unknown as NDKKind
@@ -283,6 +291,9 @@ export const useNotificationMonitor = () => {
 		const subscribedSellerAuctionRootEventIds = new Set<string>()
 		const subscribedSellerAuctionCoordinates = new Set<string>()
 		const subscribedSellerLiveActivityCoordinates = new Set<string>()
+		const subscribedSellerProductEventIds = new Set<string>()
+		const subscribedSellerProductCoordinates = new Set<string>()
+		const refreshedSellerProductEventIds = new Set<string>()
 		const phaseTimeoutIds: number[] = []
 
 		// Mark as monitoring to prevent duplicate subscriptions
@@ -385,7 +396,7 @@ export const useNotificationMonitor = () => {
 			if (startAt > notificationActions.getLastSeenAuctionLive(auctionKey)) {
 				scheduleAt(startAt, scheduledAuctionLiveKeys, () => {
 					console.log('[NotificationMonitor] Seller auction went live:', auction.id)
-					notificationActions.incrementUnseenAuctionLive()
+					notificationActions.incrementUnseenAuctionLive(auctionKey)
 				})
 			}
 
@@ -393,7 +404,7 @@ export const useNotificationMonitor = () => {
 			if (biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(auctionKey)) {
 				scheduleAt(biddingCutoffAt, scheduledAuctionSettlementKeys, () => {
 					console.log('[NotificationMonitor] Seller auction entered settlement:', auction.id)
-					notificationActions.incrementUnseenAuctionSettlementBegins()
+					notificationActions.incrementUnseenAuctionSettlementBegins(auctionKey)
 				})
 			}
 		}
@@ -489,19 +500,19 @@ export const useNotificationMonitor = () => {
 					if (coordinate) sellerAuctionKeyByCoordinate.set(coordinate, auctionKey)
 				}
 
-				for (const product of sellerProducts) {
-					const productKey = getProductCoordinates(product) || product.id
-					if (!productKey) continue
+				const sellerProductScopes = sellerProducts
+					.map((product) => getSellerProductNotificationScope(product, user.pubkey))
+					.filter((scope): scope is ProductNotificationScope => Boolean(scope))
 
-					sellerProductKeyByEventId.set(product.id, productKey)
-					const coordinate = getProductCoordinates(product)
+				for (const { eventId, coordinate, productKey } of sellerProductScopes) {
+					sellerProductKeyByEventId.set(eventId, productKey)
 					if (coordinate) sellerProductKeyByCoordinate.set(coordinate, productKey)
 				}
 
 				const sellerAuctionRootEventIds = uniqueStrings(sellerAuctions.map((auction) => getAuctionRootEventId(auction) || auction.id))
 				const sellerAuctionCoordinates = uniqueStrings(sellerAuctions.map(getAuctionCoordinate))
-				const sellerProductEventIds = uniqueStrings(sellerProducts.map((product) => product.id))
-				const sellerProductCoordinates = uniqueStrings(sellerProducts.map(getProductCoordinates))
+				const sellerProductEventIds = uniqueStrings(sellerProductScopes.map((scope) => scope.eventId))
+				const sellerProductCoordinates = uniqueStrings(sellerProductScopes.map((scope) => scope.coordinate))
 				const sellerBidEvents = await fetchTaggedAuctionEvents({
 					kind: AUCTION_BID_KIND,
 					auctionRootEventIds: sellerAuctionRootEventIds,
@@ -565,19 +576,27 @@ export const useNotificationMonitor = () => {
 					return counts
 				}, {})
 
+				const newSellerLiveChatCountsByAuction: Record<string, number> = {}
 				const newSellerLiveChatEvents = sellerLiveChatEvents.filter((event) => {
 					seenAuctionCommentEventIds.add(event.id)
 					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A']), [sellerAuctionKeyByLiveActivityCoordinate])
-					return event.pubkey !== user.pubkey && isNewAuctionComment(event, auctionKey)
+					if (event.pubkey === user.pubkey || !auctionKey || !isNewAuctionComment(event, auctionKey)) return false
+
+					newSellerLiveChatCountsByAuction[auctionKey] = (newSellerLiveChatCountsByAuction[auctionKey] || 0) + 1
+					return true
 				})
 
+				const newSellerAuctionCommentCountsByAuction: Record<string, number> = {}
 				const newSellerAuctionCommentEvents = sellerAuctionCommentEvents.filter((event) => {
 					seenAuctionThreadCommentEventIds.add(event.id)
 					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A', 'e', 'E']), [
 						sellerAuctionKeyByCoordinate,
 						sellerAuctionKeyByRootEventId,
 					])
-					return event.pubkey !== user.pubkey && isNewAuctionEventComment(event, auctionKey)
+					if (event.pubkey === user.pubkey || !auctionKey || !isNewAuctionEventComment(event, auctionKey)) return false
+
+					newSellerAuctionCommentCountsByAuction[auctionKey] = (newSellerAuctionCommentCountsByAuction[auctionKey] || 0) + 1
+					return true
 				})
 
 				const newSellerProductCommentEvents = sellerProductCommentEvents.filter((event) => {
@@ -586,23 +605,33 @@ export const useNotificationMonitor = () => {
 						sellerProductKeyByCoordinate,
 						sellerProductKeyByEventId,
 					])
-					return event.pubkey !== user.pubkey && isNewProductComment(event, productKey)
+					return event.pubkey !== user.pubkey && !!productKey && isNewProductComment(event, productKey)
 				})
 
-				const unseenAuctionLiveCount = sellerAuctions.filter((auction) => {
-					const startAt = getAuctionStartAt(auction)
-					return (
-						startAt > notificationActions.getLastSeenAuctionLive(getAuctionNotificationKey(auction)) && startAt <= initializationStartedAt
-					)
-				}).length
+				const unseenAuctionLiveCountsByAuction = sellerAuctions.reduce<Record<string, number>>((counts, auction) => {
+					const auctionKey = getAuctionNotificationKey(auction)
+					if (!auctionKey) return counts
 
-				const unseenAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
+					const startAt = getAuctionStartAt(auction)
+					if (startAt > notificationActions.getLastSeenAuctionLive(auctionKey) && startAt <= initializationStartedAt) {
+						counts[auctionKey] = 1
+					}
+					return counts
+				}, {})
+
+				const unseenAuctionSettlementBeginsCountsByAuction = sellerAuctions.reduce<Record<string, number>>((counts, auction) => {
+					const auctionKey = getAuctionNotificationKey(auction)
+					if (!auctionKey) return counts
+
 					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-					return (
-						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(getAuctionNotificationKey(auction)) &&
+					if (
+						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(auctionKey) &&
 						biddingCutoffAt <= initializationStartedAt
-					)
-				}).length
+					) {
+						counts[auctionKey] = 1
+					}
+					return counts
+				}, {})
 
 				const ownBidEvents = await fetchAuctionBidsByBidder(user.pubkey, 500)
 				const highestOwnBidByRootId = new Map<string, number>()
@@ -655,29 +684,39 @@ export const useNotificationMonitor = () => {
 				// is still fetching relay data. This bounded window closes gaps where a
 				// transition can be missed by both initial counting and one-shot timer setup.
 				const initializationCompletedAt = Math.floor(Date.now() / 1000)
-				const reconciledAuctionLiveCount = sellerAuctions.filter((auction) => {
+				let reconciledAuctionLiveCount = 0
+				let reconciledAuctionSettlementBeginsCount = 0
+
+				for (const auction of sellerAuctions) {
 					const auctionKey = getAuctionNotificationKey(auction)
-					if (!auctionKey) return false
+					if (!auctionKey) continue
 
 					const startAt = getAuctionStartAt(auction)
-					return (
+					if (
 						startAt > initializationStartedAt &&
 						startAt <= initializationCompletedAt &&
 						startAt > notificationActions.getLastSeenAuctionLive(auctionKey)
-					)
-				}).length
-
-				const reconciledAuctionSettlementBeginsCount = sellerAuctions.filter((auction) => {
-					const auctionKey = getAuctionNotificationKey(auction)
-					if (!auctionKey) return false
+					) {
+						if (!unseenAuctionLiveCountsByAuction[auctionKey]) reconciledAuctionLiveCount++
+						unseenAuctionLiveCountsByAuction[auctionKey] = 1
+					}
 
 					const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-					return (
+					if (
 						biddingCutoffAt > initializationStartedAt &&
 						biddingCutoffAt <= initializationCompletedAt &&
 						biddingCutoffAt > notificationActions.getLastSeenAuctionSettlementBegins(auctionKey)
-					)
-				}).length
+					) {
+						if (!unseenAuctionSettlementBeginsCountsByAuction[auctionKey]) reconciledAuctionSettlementBeginsCount++
+						unseenAuctionSettlementBeginsCountsByAuction[auctionKey] = 1
+					}
+				}
+
+				const unseenAuctionLiveCount = Object.values(unseenAuctionLiveCountsByAuction).reduce((sum, count) => sum + count, 0)
+				const unseenAuctionSettlementBeginsCount = Object.values(unseenAuctionSettlementBeginsCountsByAuction).reduce(
+					(sum, count) => sum + count,
+					0,
+				)
 
 				// Update store with initial counts
 				notificationActions.recalculateFromEvents({
@@ -688,10 +727,14 @@ export const useNotificationMonitor = () => {
 					auctionBidCount: newSellerBidEvents.length,
 					auctionBidCountsByAuction: newSellerBidCountsByAuction,
 					auctionCommentCount: newSellerLiveChatEvents.length,
+					auctionCommentCountsByAuction: newSellerLiveChatCountsByAuction,
 					auctionEventCommentCount: newSellerAuctionCommentEvents.length,
+					auctionEventCommentCountsByAuction: newSellerAuctionCommentCountsByAuction,
 					productCommentCount: newSellerProductCommentEvents.length,
-					auctionLiveCount: unseenAuctionLiveCount + reconciledAuctionLiveCount,
-					auctionSettlementBeginsCount: unseenAuctionSettlementBeginsCount + reconciledAuctionSettlementBeginsCount,
+					auctionLiveCount: unseenAuctionLiveCount,
+					auctionLiveCountsByAuction: unseenAuctionLiveCountsByAuction,
+					auctionSettlementBeginsCount: unseenAuctionSettlementBeginsCount,
+					auctionSettlementBeginsCountsByAuction: unseenAuctionSettlementBeginsCountsByAuction,
 					bidUpdateCount: newHigherBidEvents.length + newSettlementEvents.length,
 				})
 
@@ -703,8 +746,8 @@ export const useNotificationMonitor = () => {
 					auctionComments: newSellerLiveChatEvents.length,
 					auctionEventComments: newSellerAuctionCommentEvents.length,
 					productComments: newSellerProductCommentEvents.length,
-					auctionLive: unseenAuctionLiveCount + reconciledAuctionLiveCount,
-					auctionSettlementBegins: unseenAuctionSettlementBeginsCount + reconciledAuctionSettlementBeginsCount,
+					auctionLive: unseenAuctionLiveCount,
+					auctionSettlementBegins: unseenAuctionSettlementBeginsCount,
 					bidUpdates: newHigherBidEvents.length + newSettlementEvents.length,
 					reconciledAuctionLive: reconciledAuctionLiveCount,
 					reconciledAuctionSettlementBegins: reconciledAuctionSettlementBeginsCount,
@@ -746,10 +789,10 @@ export const useNotificationMonitor = () => {
 					seenAuctionCommentEventIds.add(event.id)
 
 					const auctionKey = resolveScopedKeyFromLookups(getTagValues(event, ['a', 'A']), [sellerAuctionKeyByLiveActivityCoordinate])
-					if (event.pubkey === user.pubkey || !isNewAuctionComment(event, auctionKey)) return
+					if (event.pubkey === user.pubkey || !auctionKey || !isNewAuctionComment(event, auctionKey)) return
 
 					console.log('[NotificationMonitor] New live chat comment on seller auction:', event.id)
-					notificationActions.incrementUnseenAuctionComments()
+					notificationActions.incrementUnseenAuctionComments(auctionKey)
 				}
 
 				const subscribeSellerLiveActivityCoordinate = (liveActivityCoordinate: string) => {
@@ -834,10 +877,10 @@ export const useNotificationMonitor = () => {
 						sellerAuctionKeyByCoordinate,
 						sellerAuctionKeyByRootEventId,
 					])
-					if (event.pubkey === user.pubkey || !isNewAuctionEventComment(event, auctionKey)) return
+					if (event.pubkey === user.pubkey || !auctionKey || !isNewAuctionEventComment(event, auctionKey)) return
 
 					console.log('[NotificationMonitor] New thread comment on seller auction:', event.id)
-					notificationActions.incrementUnseenAuctionEventComments()
+					notificationActions.incrementUnseenAuctionEventComments(auctionKey)
 				}
 
 				const handleSellerProductCommentEvent = (event: NDKEvent) => {
@@ -848,10 +891,53 @@ export const useNotificationMonitor = () => {
 						sellerProductKeyByCoordinate,
 						sellerProductKeyByEventId,
 					])
-					if (event.pubkey === user.pubkey || !isNewProductComment(event, productKey)) return
+					if (event.pubkey === user.pubkey || !productKey || !isNewProductComment(event, productKey)) return
 
 					console.log('[NotificationMonitor] New thread comment on seller product:', event.id)
 					notificationActions.incrementUnseenProductComments()
+				}
+
+				const subscribeSellerProductScope = (tagName: ProductScopeTag, value: string) => {
+					subscribeToTaggedAuctionEvents({
+						kind: COMMENT_KIND_NDK,
+						tagName,
+						values: [value],
+						onEvent: handleSellerProductCommentEvent,
+					})
+				}
+
+				const sellerProductScopeRegistry = {
+					productKeyByEventId: sellerProductKeyByEventId,
+					productKeyByCoordinate: sellerProductKeyByCoordinate,
+					subscribedEventIds: subscribedSellerProductEventIds,
+					subscribedCoordinates: subscribedSellerProductCoordinates,
+				}
+
+				const handleOwnProductEvent = (event: NDKEvent, refreshComments = false) => {
+					const productKey = registerSellerProductNotificationScope(
+						event,
+						user.pubkey,
+						sellerProductScopeRegistry,
+						subscribeSellerProductScope,
+					)
+					if (!productKey || !refreshComments || refreshedSellerProductEventIds.has(event.id)) return
+
+					const scope = getSellerProductNotificationScope(event, user.pubkey)
+					if (!scope) return
+					refreshedSellerProductEventIds.add(event.id)
+
+					const { eventId, coordinate } = scope
+					void fetchAddressableCommentEvents({
+						targetEventIds: eventId ? [eventId] : [],
+						targetCoordinates: coordinate ? [coordinate] : [],
+						since: notificationActions.getLastSeenProductComments(productKey) + 1,
+					})
+						.then((events) => {
+							events.forEach(handleSellerProductCommentEvent)
+						})
+						.catch((error) => {
+							console.error('[NotificationMonitor] Failed to refresh comment scopes for new product:', error)
+						})
 				}
 
 				const handleWatchedSettlementEvent = (event: NDKEvent) => {
@@ -941,6 +1027,9 @@ export const useNotificationMonitor = () => {
 					onEvent: handleSellerProductCommentEvent,
 				})
 
+				sellerProductEventIds.forEach((eventId) => subscribedSellerProductEventIds.add(eventId))
+				sellerProductCoordinates.forEach((coordinate) => subscribedSellerProductCoordinates.add(coordinate))
+
 				const auctionListingSubscription = ndk.subscribe(
 					{
 						kinds: [AUCTION_KIND_NDK],
@@ -954,6 +1043,20 @@ export const useNotificationMonitor = () => {
 
 				auctionListingSubscription.on('event', handleOwnAuctionEvent)
 				subscriptionsRef.current.push(auctionListingSubscription)
+
+				const productListingSubscription = ndk.subscribe(
+					{
+						kinds: [PRODUCT_KIND_NDK],
+						authors: [user.pubkey],
+						since: subscriptionSince,
+					},
+					{
+						closeOnEose: false,
+					},
+				)
+
+				productListingSubscription.on('event', (event) => handleOwnProductEvent(event, true))
+				subscriptionsRef.current.push(productListingSubscription)
 
 				console.log('[NotificationMonitor] Subscriptions active:', subscriptionsRef.current.length)
 			} catch (error) {

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+class MemoryStorage {
+	private store = new Map<string, string>()
+
+	getItem(key: string) {
+		return this.store.has(key) ? this.store.get(key)! : null
+	}
+
+	setItem(key: string, value: string) {
+		this.store.set(key, value)
+	}
+
+	removeItem(key: string) {
+		this.store.delete(key)
+	}
+
+	clear() {
+		this.store.clear()
+	}
+}
+
+const installLocalStoragePolyfill = (): MemoryStorage => {
+	const storage = new MemoryStorage()
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: storage,
+		writable: true,
+		configurable: true,
+	})
+	return storage
+}
+
+installLocalStoragePolyfill()
+
+const { notificationActions, notificationStore } = await import('@/lib/stores/notifications')
+
+const STORAGE_KEY = 'nostr-market:notifications'
+const realDateNow = Date.now
+const fakeNowMs = 1_725_000_000_000
+const fakeNowSeconds = Math.floor(fakeNowMs / 1000)
+
+describe('notification store scoped last-seen behavior', () => {
+	let storage: MemoryStorage
+
+	beforeEach(() => {
+		storage = installLocalStoragePolyfill()
+		Date.now = () => fakeNowMs
+		notificationActions.reset()
+	})
+
+	afterEach(() => {
+		Date.now = realDateNow
+		storage.clear()
+		notificationActions.reset()
+	})
+
+	test('scoped mark-as-seen only clears the targeted auction and preserves global baselines', () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: 5,
+			unseenAuctionComments: 4,
+			unseenAuctionEventComments: 3,
+			unseenAuctionLive: 2,
+			unseenAuctionSettlementBegins: 2,
+			lastSeenTimestamps: {
+				...state.lastSeenTimestamps,
+				auctionBids: 100,
+				auctionBidsByAuction: { 'auction-b': 220 },
+				auctionComments: 101,
+				auctionCommentsByAuction: { 'auction-b': 221 },
+				auctionEventComments: 102,
+				auctionEventCommentsByAuction: { 'auction-b': 222 },
+				auctionLive: 103,
+				auctionLiveByAuction: { 'auction-b': 223 },
+				auctionSettlementBegins: 104,
+				auctionSettlementBeginsByAuction: { 'auction-b': 224 },
+			},
+		}))
+
+		notificationActions.markAuctionBidsSeen('auction-a', 2)
+		notificationActions.markAuctionCommentsSeen('auction-a', 1)
+		notificationActions.markAuctionEventCommentsSeen('auction-a', 1)
+		notificationActions.markAuctionLiveSeen('auction-a', 1)
+		notificationActions.markAuctionSettlementBeginsSeen('auction-a', 1)
+
+		expect(notificationStore.state.unseenAuctionBids).toBe(3)
+		expect(notificationStore.state.unseenAuctionComments).toBe(3)
+		expect(notificationStore.state.unseenAuctionEventComments).toBe(2)
+		expect(notificationStore.state.unseenAuctionLive).toBe(1)
+		expect(notificationStore.state.unseenAuctionSettlementBegins).toBe(1)
+
+		expect(notificationStore.state.lastSeenTimestamps.auctionBids).toBe(100)
+		expect(notificationStore.state.lastSeenTimestamps.auctionComments).toBe(101)
+		expect(notificationStore.state.lastSeenTimestamps.auctionEventComments).toBe(102)
+		expect(notificationStore.state.lastSeenTimestamps.auctionLive).toBe(103)
+		expect(notificationStore.state.lastSeenTimestamps.auctionSettlementBegins).toBe(104)
+
+		expect(notificationStore.state.lastSeenTimestamps.auctionBidsByAuction).toEqual({
+			'auction-a': fakeNowSeconds,
+			'auction-b': 220,
+		})
+		expect(notificationStore.state.lastSeenTimestamps.auctionCommentsByAuction).toEqual({
+			'auction-a': fakeNowSeconds,
+			'auction-b': 221,
+		})
+		expect(notificationStore.state.lastSeenTimestamps.auctionEventCommentsByAuction).toEqual({
+			'auction-a': fakeNowSeconds,
+			'auction-b': 222,
+		})
+		expect(notificationStore.state.lastSeenTimestamps.auctionLiveByAuction).toEqual({
+			'auction-a': fakeNowSeconds,
+			'auction-b': 223,
+		})
+		expect(notificationStore.state.lastSeenTimestamps.auctionSettlementBeginsByAuction).toEqual({
+			'auction-a': fakeNowSeconds,
+			'auction-b': 224,
+		})
+
+		expect(notificationActions.getLastSeenAuctionBids('auction-a')).toBe(fakeNowSeconds)
+		expect(notificationActions.getLastSeenAuctionBids('auction-b')).toBe(220)
+		expect(notificationActions.getLastSeenAuctionComments('auction-a')).toBe(fakeNowSeconds)
+		expect(notificationActions.getLastSeenAuctionEventComments('auction-b')).toBe(222)
+		expect(notificationActions.getLastSeenAuctionLive('auction-a')).toBe(fakeNowSeconds)
+		expect(notificationActions.getLastSeenAuctionSettlementBegins('auction-b')).toBe(224)
+
+		const persisted = JSON.parse(storage.getItem(STORAGE_KEY) || '{}')
+		expect(persisted.lastSeenTimestamps.auctionBidsByAuction['auction-a']).toBe(fakeNowSeconds)
+		expect(persisted.lastSeenTimestamps.auctionBidsByAuction['auction-b']).toBe(220)
+	})
+
+	test('global mark-as-seen resets aggregate count and becomes the fallback for all auctions', () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionBids: 4,
+			lastSeenTimestamps: {
+				...state.lastSeenTimestamps,
+				auctionBids: 10,
+				auctionBidsByAuction: {
+					'auction-a': 20,
+				},
+			},
+		}))
+
+		notificationActions.markAuctionBidsSeen()
+
+		expect(notificationStore.state.unseenAuctionBids).toBe(0)
+		expect(notificationStore.state.lastSeenTimestamps.auctionBids).toBe(fakeNowSeconds)
+		expect(notificationStore.state.lastSeenTimestamps.auctionBidsByAuction).toEqual({
+			'auction-a': 20,
+		})
+		expect(notificationActions.getLastSeenAuctionBids('auction-a')).toBe(fakeNowSeconds)
+		expect(notificationActions.getLastSeenAuctionBids('auction-missing')).toBe(fakeNowSeconds)
+	})
+
+	test('product comment scoped mark-as-seen only affects the targeted product', () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenProductComments: 3,
+			lastSeenTimestamps: {
+				...state.lastSeenTimestamps,
+				productComments: 50,
+				productCommentsByProduct: {
+					'product-b': 70,
+				},
+			},
+		}))
+
+		notificationActions.markProductCommentsSeen('product-a', 2)
+
+		expect(notificationStore.state.unseenProductComments).toBe(1)
+		expect(notificationStore.state.lastSeenTimestamps.productComments).toBe(50)
+		expect(notificationStore.state.lastSeenTimestamps.productCommentsByProduct).toEqual({
+			'product-a': fakeNowSeconds,
+			'product-b': 70,
+		})
+		expect(notificationActions.getLastSeenProductComments('product-a')).toBe(fakeNowSeconds)
+		expect(notificationActions.getLastSeenProductComments('product-b')).toBe(70)
+	})
+
+	test('reset loads legacy global-only persisted timestamps with empty scoped maps', () => {
+		storage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({
+				lastSeenTimestamps: {
+					orders: 1,
+					purchases: 2,
+					auctionBids: 3,
+					auctionComments: 4,
+					auctionEventComments: 5,
+					productComments: 6,
+					auctionLive: 7,
+					auctionSettlementBegins: 8,
+					bidUpdates: 9,
+					messages: { alice: 10 },
+				},
+			}),
+		)
+
+		notificationActions.reset()
+
+		expect(notificationStore.state.lastSeenTimestamps.auctionBids).toBe(3)
+		expect(notificationStore.state.lastSeenTimestamps.auctionComments).toBe(4)
+		expect(notificationStore.state.lastSeenTimestamps.auctionEventComments).toBe(5)
+		expect(notificationStore.state.lastSeenTimestamps.productComments).toBe(6)
+		expect(notificationStore.state.lastSeenTimestamps.auctionLive).toBe(7)
+		expect(notificationStore.state.lastSeenTimestamps.auctionSettlementBegins).toBe(8)
+		expect(notificationStore.state.lastSeenTimestamps.messages).toEqual({ alice: 10 })
+		expect(notificationStore.state.lastSeenTimestamps.auctionBidsByAuction).toEqual({})
+		expect(notificationStore.state.lastSeenTimestamps.auctionCommentsByAuction).toEqual({})
+		expect(notificationStore.state.lastSeenTimestamps.auctionEventCommentsByAuction).toEqual({})
+		expect(notificationStore.state.lastSeenTimestamps.productCommentsByProduct).toEqual({})
+		expect(notificationStore.state.lastSeenTimestamps.auctionLiveByAuction).toEqual({})
+		expect(notificationStore.state.lastSeenTimestamps.auctionSettlementBeginsByAuction).toEqual({})
+	})
+
+	test('scoped getters prefer the larger of global and scoped timestamps', () => {
+		notificationStore.setState((state) => ({
+			...state,
+			lastSeenTimestamps: {
+				...state.lastSeenTimestamps,
+				auctionBids: 200,
+				auctionBidsByAuction: {
+					'auction-a': 150,
+					'auction-b': 250,
+				},
+				productComments: 300,
+				productCommentsByProduct: {
+					'product-a': 275,
+					'product-b': 325,
+				},
+			},
+		}))
+
+		expect(notificationActions.getLastSeenAuctionBids('auction-a')).toBe(200)
+		expect(notificationActions.getLastSeenAuctionBids('auction-b')).toBe(250)
+		expect(notificationActions.getLastSeenAuctionBids()).toBe(200)
+		expect(notificationActions.getLastSeenProductComments('product-a')).toBe(300)
+		expect(notificationActions.getLastSeenProductComments('product-b')).toBe(325)
+		expect(notificationActions.getLastSeenProductComments()).toBe(300)
+	})
+})

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -58,6 +58,10 @@ describe('notification store scoped last-seen behavior', () => {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: 5,
+			unseenAuctionBidsByAuction: {
+				'auction-a': 2,
+				'auction-b': 3,
+			},
 			unseenAuctionComments: 4,
 			unseenAuctionEventComments: 3,
 			unseenAuctionLive: 2,
@@ -77,13 +81,17 @@ describe('notification store scoped last-seen behavior', () => {
 			},
 		}))
 
-		notificationActions.markAuctionBidsSeen('auction-a', 2)
+		notificationActions.markAuctionBidsSeen('auction-a')
 		notificationActions.markAuctionCommentsSeen('auction-a', 1)
 		notificationActions.markAuctionEventCommentsSeen('auction-a', 1)
 		notificationActions.markAuctionLiveSeen('auction-a', 1)
 		notificationActions.markAuctionSettlementBeginsSeen('auction-a', 1)
 
 		expect(notificationStore.state.unseenAuctionBids).toBe(3)
+		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 3,
+		})
 		expect(notificationStore.state.unseenAuctionComments).toBe(3)
 		expect(notificationStore.state.unseenAuctionEventComments).toBe(2)
 		expect(notificationStore.state.unseenAuctionLive).toBe(1)
@@ -132,6 +140,10 @@ describe('notification store scoped last-seen behavior', () => {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: 4,
+			unseenAuctionBidsByAuction: {
+				'auction-a': 1,
+				'auction-b': 3,
+			},
 			lastSeenTimestamps: {
 				...state.lastSeenTimestamps,
 				auctionBids: 10,
@@ -144,6 +156,7 @@ describe('notification store scoped last-seen behavior', () => {
 		notificationActions.markAuctionBidsSeen()
 
 		expect(notificationStore.state.unseenAuctionBids).toBe(0)
+		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({})
 		expect(notificationStore.state.lastSeenTimestamps.auctionBids).toBe(fakeNowSeconds)
 		expect(notificationStore.state.lastSeenTimestamps.auctionBidsByAuction).toEqual({
 			'auction-a': 20,
@@ -237,5 +250,25 @@ describe('notification store scoped last-seen behavior', () => {
 		expect(notificationActions.getLastSeenProductComments('product-a')).toBe(300)
 		expect(notificationActions.getLastSeenProductComments('product-b')).toBe(325)
 		expect(notificationActions.getLastSeenProductComments()).toBe(300)
+	})
+
+	test('recalculate derives unseen auction bid aggregate from canonical scoped auction counts', () => {
+		notificationActions.recalculateFromEvents({
+			orderCount: 0,
+			messageCount: 0,
+			purchaseCount: 0,
+			conversationCounts: {},
+			auctionBidCount: 99,
+			auctionBidCountsByAuction: {
+				'auction-a': 1,
+				'auction-b': 2,
+			},
+		})
+
+		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({
+			'auction-a': 1,
+			'auction-b': 2,
+		})
+		expect(notificationStore.state.unseenAuctionBids).toBe(3)
 	})
 })

--- a/src/lib/__tests__/notifications.test.ts
+++ b/src/lib/__tests__/notifications.test.ts
@@ -22,11 +22,21 @@ class MemoryStorage {
 
 const installLocalStoragePolyfill = (): MemoryStorage => {
 	const storage = new MemoryStorage()
-	Object.defineProperty(globalThis, 'localStorage', {
-		value: storage,
-		writable: true,
-		configurable: true,
-	})
+	const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'localStorage')
+
+	// Another test may install a non-configurable but writable storage mock.
+	if (descriptor && !descriptor.configurable) {
+		if (!Reflect.set(globalThis, 'localStorage', storage)) {
+			throw new TypeError('globalThis.localStorage is not writable')
+		}
+	} else {
+		Object.defineProperty(globalThis, 'localStorage', {
+			value: storage,
+			writable: true,
+			configurable: true,
+		})
+	}
+
 	return storage
 }
 
@@ -63,9 +73,25 @@ describe('notification store scoped last-seen behavior', () => {
 				'auction-b': 3,
 			},
 			unseenAuctionComments: 4,
+			unseenAuctionCommentsByAuction: {
+				'auction-a': 1,
+				'auction-b': 3,
+			},
 			unseenAuctionEventComments: 3,
+			unseenAuctionEventCommentsByAuction: {
+				'auction-a': 1,
+				'auction-b': 2,
+			},
 			unseenAuctionLive: 2,
+			unseenAuctionLiveByAuction: {
+				'auction-a': 1,
+				'auction-b': 1,
+			},
 			unseenAuctionSettlementBegins: 2,
+			unseenAuctionSettlementBeginsByAuction: {
+				'auction-a': 1,
+				'auction-b': 1,
+			},
 			lastSeenTimestamps: {
 				...state.lastSeenTimestamps,
 				auctionBids: 100,
@@ -82,10 +108,10 @@ describe('notification store scoped last-seen behavior', () => {
 		}))
 
 		notificationActions.markAuctionBidsSeen('auction-a')
-		notificationActions.markAuctionCommentsSeen('auction-a', 1)
-		notificationActions.markAuctionEventCommentsSeen('auction-a', 1)
-		notificationActions.markAuctionLiveSeen('auction-a', 1)
-		notificationActions.markAuctionSettlementBeginsSeen('auction-a', 1)
+		notificationActions.markAuctionCommentsSeen('auction-a')
+		notificationActions.markAuctionEventCommentsSeen('auction-a')
+		notificationActions.markAuctionLiveSeen('auction-a')
+		notificationActions.markAuctionSettlementBeginsSeen('auction-a')
 
 		expect(notificationStore.state.unseenAuctionBids).toBe(3)
 		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({
@@ -93,9 +119,25 @@ describe('notification store scoped last-seen behavior', () => {
 			'auction-b': 3,
 		})
 		expect(notificationStore.state.unseenAuctionComments).toBe(3)
+		expect(notificationStore.state.unseenAuctionCommentsByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 3,
+		})
 		expect(notificationStore.state.unseenAuctionEventComments).toBe(2)
+		expect(notificationStore.state.unseenAuctionEventCommentsByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 2,
+		})
 		expect(notificationStore.state.unseenAuctionLive).toBe(1)
+		expect(notificationStore.state.unseenAuctionLiveByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 1,
+		})
 		expect(notificationStore.state.unseenAuctionSettlementBegins).toBe(1)
+		expect(notificationStore.state.unseenAuctionSettlementBeginsByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 1,
+		})
 
 		expect(notificationStore.state.lastSeenTimestamps.auctionBids).toBe(100)
 		expect(notificationStore.state.lastSeenTimestamps.auctionComments).toBe(101)
@@ -134,6 +176,32 @@ describe('notification store scoped last-seen behavior', () => {
 		const persisted = JSON.parse(storage.getItem(STORAGE_KEY) || '{}')
 		expect(persisted.lastSeenTimestamps.auctionBidsByAuction['auction-a']).toBe(fakeNowSeconds)
 		expect(persisted.lastSeenTimestamps.auctionBidsByAuction['auction-b']).toBe(220)
+	})
+
+	test('scoped clear removes the current auction total without corrupting another auction', () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionComments: 3,
+			unseenAuctionCommentsByAuction: {
+				'auction-a': 1,
+				'auction-b': 2,
+			},
+		}))
+
+		// The row rendered while Auction A had one event, then another event
+		// arrived before the user clicked "Mark as seen".
+		notificationActions.incrementUnseenAuctionComments('auction-a')
+
+		expect(notificationStore.state.unseenAuctionComments).toBe(4)
+		expect(notificationStore.state.unseenAuctionCommentsByAuction['auction-a']).toBe(2)
+
+		notificationActions.markAuctionCommentsSeen('auction-a')
+
+		expect(notificationStore.state.unseenAuctionComments).toBe(2)
+		expect(notificationStore.state.unseenAuctionCommentsByAuction).toEqual({
+			'auction-a': 0,
+			'auction-b': 2,
+		})
 	})
 
 	test('global mark-as-seen resets aggregate count and becomes the fallback for all auctions', () => {
@@ -224,6 +292,11 @@ describe('notification store scoped last-seen behavior', () => {
 		expect(notificationStore.state.lastSeenTimestamps.productCommentsByProduct).toEqual({})
 		expect(notificationStore.state.lastSeenTimestamps.auctionLiveByAuction).toEqual({})
 		expect(notificationStore.state.lastSeenTimestamps.auctionSettlementBeginsByAuction).toEqual({})
+		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({})
+		expect(notificationStore.state.unseenAuctionCommentsByAuction).toEqual({})
+		expect(notificationStore.state.unseenAuctionEventCommentsByAuction).toEqual({})
+		expect(notificationStore.state.unseenAuctionLiveByAuction).toEqual({})
+		expect(notificationStore.state.unseenAuctionSettlementBeginsByAuction).toEqual({})
 	})
 
 	test('scoped getters prefer the larger of global and scoped timestamps', () => {
@@ -252,7 +325,7 @@ describe('notification store scoped last-seen behavior', () => {
 		expect(notificationActions.getLastSeenProductComments()).toBe(300)
 	})
 
-	test('recalculate derives unseen auction bid aggregate from canonical scoped auction counts', () => {
+	test('recalculate derives auction aggregates from canonical scoped counts', () => {
 		notificationActions.recalculateFromEvents({
 			orderCount: 0,
 			messageCount: 0,
@@ -263,6 +336,26 @@ describe('notification store scoped last-seen behavior', () => {
 				'auction-a': 1,
 				'auction-b': 2,
 			},
+			auctionCommentCount: 88,
+			auctionCommentCountsByAuction: {
+				'auction-a': 2,
+				'auction-b': 3,
+			},
+			auctionEventCommentCount: 77,
+			auctionEventCommentCountsByAuction: {
+				'auction-a': 3,
+				'auction-b': 4,
+			},
+			auctionLiveCount: 66,
+			auctionLiveCountsByAuction: {
+				'auction-a': 1,
+				'auction-b': 1,
+			},
+			auctionSettlementBeginsCount: 55,
+			auctionSettlementBeginsCountsByAuction: {
+				'auction-a': 1,
+				'auction-b': 2,
+			},
 		})
 
 		expect(notificationStore.state.unseenAuctionBidsByAuction).toEqual({
@@ -270,5 +363,25 @@ describe('notification store scoped last-seen behavior', () => {
 			'auction-b': 2,
 		})
 		expect(notificationStore.state.unseenAuctionBids).toBe(3)
+		expect(notificationStore.state.unseenAuctionCommentsByAuction).toEqual({
+			'auction-a': 2,
+			'auction-b': 3,
+		})
+		expect(notificationStore.state.unseenAuctionComments).toBe(5)
+		expect(notificationStore.state.unseenAuctionEventCommentsByAuction).toEqual({
+			'auction-a': 3,
+			'auction-b': 4,
+		})
+		expect(notificationStore.state.unseenAuctionEventComments).toBe(7)
+		expect(notificationStore.state.unseenAuctionLiveByAuction).toEqual({
+			'auction-a': 1,
+			'auction-b': 1,
+		})
+		expect(notificationStore.state.unseenAuctionLive).toBe(2)
+		expect(notificationStore.state.unseenAuctionSettlementBeginsByAuction).toEqual({
+			'auction-a': 1,
+			'auction-b': 2,
+		})
+		expect(notificationStore.state.unseenAuctionSettlementBegins).toBe(3)
 	})
 })

--- a/src/lib/__tests__/productNotificationScopes.test.ts
+++ b/src/lib/__tests__/productNotificationScopes.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	PRODUCT_KIND,
+	getProductNotificationScope,
+	getSellerProductNotificationScope,
+	registerSellerProductNotificationScope,
+	type ProductScopeTag,
+	type SellerProductScopeRegistry,
+} from '../productNotificationScopes'
+
+const createRegistry = (): SellerProductScopeRegistry => ({
+	productKeyByEventId: new Map(),
+	productKeyByCoordinate: new Map(),
+	subscribedEventIds: new Set(),
+	subscribedCoordinates: new Set(),
+})
+
+describe('seller product notification scopes', () => {
+	test('registers coordinate and event scopes once, then adds only the replacement event id', () => {
+		const registry = createRegistry()
+		const subscriptions: Array<[ProductScopeTag, string]> = []
+		const subscribe = (tagName: ProductScopeTag, value: string) => subscriptions.push([tagName, value])
+		const coordinate = `${PRODUCT_KIND}:seller:product-a`
+
+		const original = {
+			id: 'event-1',
+			kind: PRODUCT_KIND,
+			pubkey: 'seller',
+			tags: [['d', 'product-a']],
+		}
+		const replacement = {
+			...original,
+			id: 'event-2',
+		}
+
+		expect(registerSellerProductNotificationScope(original, 'seller', registry, subscribe)).toBe(coordinate)
+		expect(registerSellerProductNotificationScope(original, 'seller', registry, subscribe)).toBe(coordinate)
+		expect(registerSellerProductNotificationScope(replacement, 'seller', registry, subscribe)).toBe(coordinate)
+
+		expect(registry.productKeyByEventId).toEqual(
+			new Map([
+				['event-1', coordinate],
+				['event-2', coordinate],
+			]),
+		)
+		expect(registry.productKeyByCoordinate).toEqual(new Map([[coordinate, coordinate]]))
+		expect(subscriptions).toEqual([
+			['#E', 'event-1'],
+			['#a', coordinate],
+			['#A', coordinate],
+			['#E', 'event-2'],
+		])
+	})
+
+	test('preserves an empty d value as the canonical trailing-colon coordinate', () => {
+		const registry = createRegistry()
+		const subscriptions: Array<[ProductScopeTag, string]> = []
+		const event = {
+			id: 'event-empty-d',
+			kind: PRODUCT_KIND,
+			pubkey: 'seller',
+			tags: [['d', '']],
+		}
+		const coordinate = `${PRODUCT_KIND}:seller:`
+
+		expect(getProductNotificationScope(event)).toEqual({
+			eventId: 'event-empty-d',
+			coordinate,
+			productKey: coordinate,
+		})
+		expect(
+			registerSellerProductNotificationScope(event, 'seller', registry, (tagName, value) => subscriptions.push([tagName, value])),
+		).toBe(coordinate)
+		expect(subscriptions).toEqual([
+			['#E', 'event-empty-d'],
+			['#a', coordinate],
+			['#A', coordinate],
+		])
+	})
+
+	test('rejects a product event without a d tag', () => {
+		const registry = createRegistry()
+		const subscriptions: Array<[ProductScopeTag, string]> = []
+		const event = {
+			id: 'event-without-d',
+			kind: PRODUCT_KIND,
+			pubkey: 'seller',
+			tags: [['title', 'Product']],
+		}
+
+		expect(getProductNotificationScope(event)).toBeNull()
+		expect(
+			registerSellerProductNotificationScope(event, 'seller', registry, (tagName, value) => subscriptions.push([tagName, value])),
+		).toBe('')
+		expect(subscriptions).toEqual([])
+		expect(registry.productKeyByEventId.size).toBe(0)
+		expect(registry.productKeyByCoordinate.size).toBe(0)
+	})
+
+	test('rejects events outside the seller-authored kind-30402 boundary', () => {
+		const registry = createRegistry()
+		const subscriptions: Array<[ProductScopeTag, string]> = []
+		const subscribe = (tagName: ProductScopeTag, value: string) => subscriptions.push([tagName, value])
+		const event = {
+			id: 'event-1',
+			kind: PRODUCT_KIND,
+			pubkey: 'seller',
+			tags: [['d', 'product-a']],
+		}
+
+		expect(getSellerProductNotificationScope({ ...event, pubkey: 'other' }, 'seller')).toBeNull()
+		expect(getSellerProductNotificationScope({ ...event, kind: 30408 }, 'seller')).toBeNull()
+		expect(registerSellerProductNotificationScope({ ...event, pubkey: 'other' }, 'seller', registry, subscribe)).toBe('')
+		expect(registerSellerProductNotificationScope({ ...event, kind: 30408 }, 'seller', registry, subscribe)).toBe('')
+		expect(subscriptions).toEqual([])
+		expect(registry.productKeyByEventId.size).toBe(0)
+	})
+})

--- a/src/lib/auctionCountdownLabels.ts
+++ b/src/lib/auctionCountdownLabels.ts
@@ -85,7 +85,7 @@ export function formatAuctionEndTimeLabel(endTimestamp: number, isEnded: boolean
 	const timeStr = endDate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 
 	if (isEnded) {
-		return `Ended on ${endDate.toLocaleDateString()} ${timeStr}`
+		return `Ended ${endDate.toLocaleDateString()} ${timeStr}`
 	}
 
 	if (endDateStr === todayStr) {
@@ -95,7 +95,7 @@ export function formatAuctionEndTimeLabel(endTimestamp: number, isEnded: boolean
 		return `Ends tomorrow at ${timeStr}`
 	}
 
-	return `Ends on ${endDate.toLocaleDateString()} at ${timeStr}`
+	return `Ends ${endDate.toLocaleDateString()} at ${timeStr}`
 }
 
 /**

--- a/src/lib/productNotificationScopes.ts
+++ b/src/lib/productNotificationScopes.ts
@@ -1,0 +1,70 @@
+export const PRODUCT_KIND = 30402
+
+export type ProductScopeTag = '#a' | '#A' | '#E'
+
+export type ProductScopeEvent = {
+	id: string
+	kind: number
+	pubkey: string
+	tags: string[][]
+}
+
+export type ProductNotificationScope = {
+	eventId: string
+	coordinate: string
+	productKey: string
+}
+
+export type SellerProductScopeRegistry = {
+	productKeyByEventId: Map<string, string>
+	productKeyByCoordinate: Map<string, string>
+	subscribedEventIds: Set<string>
+	subscribedCoordinates: Set<string>
+}
+
+export const getProductNotificationScope = (event: ProductScopeEvent): ProductNotificationScope | null => {
+	const dTag = event.tags.find((tag) => tag[0] === 'd')
+	if (!event.id || !dTag || typeof dTag[1] !== 'string') return null
+
+	const coordinate = `${PRODUCT_KIND}:${event.pubkey}:${dTag[1]}`
+	return {
+		eventId: event.id,
+		coordinate,
+		productKey: coordinate,
+	}
+}
+
+export const getSellerProductNotificationScope = (event: ProductScopeEvent, sellerPubkey: string): ProductNotificationScope | null => {
+	if (event.kind !== PRODUCT_KIND || event.pubkey !== sellerPubkey || !event.id) return null
+	return getProductNotificationScope(event)
+}
+
+export const registerSellerProductNotificationScope = (
+	event: ProductScopeEvent,
+	sellerPubkey: string,
+	registry: SellerProductScopeRegistry,
+	subscribe: (tagName: ProductScopeTag, value: string) => void,
+): string => {
+	const scope = getSellerProductNotificationScope(event, sellerPubkey)
+	if (!scope) return ''
+
+	const { eventId, coordinate, productKey } = scope
+	if (!productKey) return ''
+
+	registry.productKeyByEventId.set(eventId, productKey)
+	if (!registry.subscribedEventIds.has(eventId)) {
+		registry.subscribedEventIds.add(eventId)
+		subscribe('#E', eventId)
+	}
+
+	if (coordinate) {
+		registry.productKeyByCoordinate.set(coordinate, productKey)
+		if (!registry.subscribedCoordinates.has(coordinate)) {
+			registry.subscribedCoordinates.add(coordinate)
+			subscribe('#a', coordinate)
+			subscribe('#A', coordinate)
+		}
+	}
+
+	return productKey
+}

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -5,6 +5,17 @@ export type NotificationType = 'order' | 'message' | 'order-update'
 
 // Per-conversation unseen count
 export type ConversationNotifications = Record<string, number> // pubkey -> count
+export type ScopedLastSeenTimestamps = Record<string, number>
+
+const getScopedLastSeen = (globalTimestamp: number, scopedTimestamps: ScopedLastSeenTimestamps, key?: string): number => {
+	if (!key) return globalTimestamp
+	return Math.max(globalTimestamp, scopedTimestamps[key] || 0)
+}
+
+const decrementUnseenCount = (currentCount: number, clearedCount?: number): number => {
+	if (typeof clearedCount !== 'number') return currentCount
+	return Math.max(0, currentCount - Math.max(0, clearedCount))
+}
 
 // Notification state interface
 export interface NotificationState {
@@ -26,11 +37,17 @@ export interface NotificationState {
 		orders: number
 		purchases: number
 		auctionBids: number
+		auctionBidsByAuction: ScopedLastSeenTimestamps
 		auctionComments: number
+		auctionCommentsByAuction: ScopedLastSeenTimestamps
 		auctionEventComments: number
+		auctionEventCommentsByAuction: ScopedLastSeenTimestamps
 		productComments: number
+		productCommentsByProduct: ScopedLastSeenTimestamps
 		auctionLive: number
+		auctionLiveByAuction: ScopedLastSeenTimestamps
 		auctionSettlementBegins: number
+		auctionSettlementBeginsByAuction: ScopedLastSeenTimestamps
 		bidUpdates: number
 		messages: Record<string, number> // pubkey -> timestamp
 	}
@@ -87,11 +104,17 @@ const createInitialState = (): NotificationState => {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
 			auctionBids: stored.lastSeenTimestamps?.auctionBids || 0,
+			auctionBidsByAuction: stored.lastSeenTimestamps?.auctionBidsByAuction || {},
 			auctionComments: stored.lastSeenTimestamps?.auctionComments || 0,
+			auctionCommentsByAuction: stored.lastSeenTimestamps?.auctionCommentsByAuction || {},
 			auctionEventComments: stored.lastSeenTimestamps?.auctionEventComments || 0,
+			auctionEventCommentsByAuction: stored.lastSeenTimestamps?.auctionEventCommentsByAuction || {},
 			productComments: stored.lastSeenTimestamps?.productComments || 0,
+			productCommentsByProduct: stored.lastSeenTimestamps?.productCommentsByProduct || {},
 			auctionLive: stored.lastSeenTimestamps?.auctionLive || 0,
+			auctionLiveByAuction: stored.lastSeenTimestamps?.auctionLiveByAuction || {},
 			auctionSettlementBegins: stored.lastSeenTimestamps?.auctionSettlementBegins || 0,
+			auctionSettlementBeginsByAuction: stored.lastSeenTimestamps?.auctionSettlementBeginsByAuction || {},
 			bidUpdates: stored.lastSeenTimestamps?.bidUpdates || 0,
 			messages: stored.lastSeenTimestamps?.messages || {},
 		},
@@ -432,15 +455,21 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction bid notifications as seen
 	 */
-	markAuctionBidsSeen: () => {
+	markAuctionBidsSeen: (auctionKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenAuctionBids: 0,
+				unseenAuctionBids: auctionKey ? decrementUnseenCount(state.unseenAuctionBids, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					auctionBids: now,
+					auctionBids: auctionKey ? state.lastSeenTimestamps.auctionBids : now,
+					auctionBidsByAuction: auctionKey
+						? {
+								...state.lastSeenTimestamps.auctionBidsByAuction,
+								[auctionKey]: now,
+							}
+						: state.lastSeenTimestamps.auctionBidsByAuction,
 				},
 			}
 			saveToStorage(newState)
@@ -451,15 +480,21 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction live-chat comment notifications as seen
 	 */
-	markAuctionCommentsSeen: () => {
+	markAuctionCommentsSeen: (auctionKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenAuctionComments: 0,
+				unseenAuctionComments: auctionKey ? decrementUnseenCount(state.unseenAuctionComments, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					auctionComments: now,
+					auctionComments: auctionKey ? state.lastSeenTimestamps.auctionComments : now,
+					auctionCommentsByAuction: auctionKey
+						? {
+								...state.lastSeenTimestamps.auctionCommentsByAuction,
+								[auctionKey]: now,
+							}
+						: state.lastSeenTimestamps.auctionCommentsByAuction,
 				},
 			}
 			saveToStorage(newState)
@@ -470,15 +505,21 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction thread comment notifications as seen
 	 */
-	markAuctionEventCommentsSeen: () => {
+	markAuctionEventCommentsSeen: (auctionKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenAuctionEventComments: 0,
+				unseenAuctionEventComments: auctionKey ? decrementUnseenCount(state.unseenAuctionEventComments, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					auctionEventComments: now,
+					auctionEventComments: auctionKey ? state.lastSeenTimestamps.auctionEventComments : now,
+					auctionEventCommentsByAuction: auctionKey
+						? {
+								...state.lastSeenTimestamps.auctionEventCommentsByAuction,
+								[auctionKey]: now,
+							}
+						: state.lastSeenTimestamps.auctionEventCommentsByAuction,
 				},
 			}
 			saveToStorage(newState)
@@ -489,15 +530,21 @@ export const notificationActions = {
 	/**
 	 * Mark seller product comment notifications as seen
 	 */
-	markProductCommentsSeen: () => {
+	markProductCommentsSeen: (productKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenProductComments: 0,
+				unseenProductComments: productKey ? decrementUnseenCount(state.unseenProductComments, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					productComments: now,
+					productComments: productKey ? state.lastSeenTimestamps.productComments : now,
+					productCommentsByProduct: productKey
+						? {
+								...state.lastSeenTimestamps.productCommentsByProduct,
+								[productKey]: now,
+							}
+						: state.lastSeenTimestamps.productCommentsByProduct,
 				},
 			}
 			saveToStorage(newState)
@@ -508,15 +555,21 @@ export const notificationActions = {
 	/**
 	 * Mark scheduled-auction-live notifications as seen
 	 */
-	markAuctionLiveSeen: () => {
+	markAuctionLiveSeen: (auctionKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenAuctionLive: 0,
+				unseenAuctionLive: auctionKey ? decrementUnseenCount(state.unseenAuctionLive, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					auctionLive: now,
+					auctionLive: auctionKey ? state.lastSeenTimestamps.auctionLive : now,
+					auctionLiveByAuction: auctionKey
+						? {
+								...state.lastSeenTimestamps.auctionLiveByAuction,
+								[auctionKey]: now,
+							}
+						: state.lastSeenTimestamps.auctionLiveByAuction,
 				},
 			}
 			saveToStorage(newState)
@@ -527,15 +580,21 @@ export const notificationActions = {
 	/**
 	 * Mark auction-ended / settlement-begins notifications as seen
 	 */
-	markAuctionSettlementBeginsSeen: () => {
+	markAuctionSettlementBeginsSeen: (auctionKey?: string, clearedCount?: number) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
 			const newState = {
 				...state,
-				unseenAuctionSettlementBegins: 0,
+				unseenAuctionSettlementBegins: auctionKey ? decrementUnseenCount(state.unseenAuctionSettlementBegins, clearedCount) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
-					auctionSettlementBegins: now,
+					auctionSettlementBegins: auctionKey ? state.lastSeenTimestamps.auctionSettlementBegins : now,
+					auctionSettlementBeginsByAuction: auctionKey
+						? {
+								...state.lastSeenTimestamps.auctionSettlementBeginsByAuction,
+								[auctionKey]: now,
+							}
+						: state.lastSeenTimestamps.auctionSettlementBeginsByAuction,
 				},
 			}
 			saveToStorage(newState)
@@ -586,43 +645,67 @@ export const notificationActions = {
 	/**
 	 * Get last seen timestamp for seller auction bids
 	 */
-	getLastSeenAuctionBids: (): number => {
-		return notificationStore.state.lastSeenTimestamps.auctionBids
+	getLastSeenAuctionBids: (auctionKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.auctionBids,
+			notificationStore.state.lastSeenTimestamps.auctionBidsByAuction,
+			auctionKey,
+		)
 	},
 
 	/**
 	 * Get last seen timestamp for seller auction live-chat comments
 	 */
-	getLastSeenAuctionComments: (): number => {
-		return notificationStore.state.lastSeenTimestamps.auctionComments
+	getLastSeenAuctionComments: (auctionKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.auctionComments,
+			notificationStore.state.lastSeenTimestamps.auctionCommentsByAuction,
+			auctionKey,
+		)
 	},
 
 	/**
 	 * Get last seen timestamp for seller auction thread comments
 	 */
-	getLastSeenAuctionEventComments: (): number => {
-		return notificationStore.state.lastSeenTimestamps.auctionEventComments
+	getLastSeenAuctionEventComments: (auctionKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.auctionEventComments,
+			notificationStore.state.lastSeenTimestamps.auctionEventCommentsByAuction,
+			auctionKey,
+		)
 	},
 
 	/**
 	 * Get last seen timestamp for seller product comments
 	 */
-	getLastSeenProductComments: (): number => {
-		return notificationStore.state.lastSeenTimestamps.productComments
+	getLastSeenProductComments: (productKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.productComments,
+			notificationStore.state.lastSeenTimestamps.productCommentsByProduct,
+			productKey,
+		)
 	},
 
 	/**
 	 * Get last seen timestamp for scheduled-auction-live notifications
 	 */
-	getLastSeenAuctionLive: (): number => {
-		return notificationStore.state.lastSeenTimestamps.auctionLive
+	getLastSeenAuctionLive: (auctionKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.auctionLive,
+			notificationStore.state.lastSeenTimestamps.auctionLiveByAuction,
+			auctionKey,
+		)
 	},
 
 	/**
 	 * Get last seen timestamp for auction-ended / settlement-begins notifications
 	 */
-	getLastSeenAuctionSettlementBegins: (): number => {
-		return notificationStore.state.lastSeenTimestamps.auctionSettlementBegins
+	getLastSeenAuctionSettlementBegins: (auctionKey?: string): number => {
+		return getScopedLastSeen(
+			notificationStore.state.lastSeenTimestamps.auctionSettlementBegins,
+			notificationStore.state.lastSeenTimestamps.auctionSettlementBeginsByAuction,
+			auctionKey,
+		)
 	},
 
 	/**

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -13,6 +13,8 @@ export interface NotificationState {
 	unseenMessages: number // New messages in conversations
 	unseenPurchases: number // Updates to orders where user is buyer
 	unseenAuctionBids: number // New bids on auctions where user is seller
+	unseenAuctionLive: number // Scheduled auctions that just went live
+	unseenAuctionSettlementBegins: number // Scheduled auctions that just ended
 	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
 	unseenByConversation: ConversationNotifications
 
@@ -21,6 +23,8 @@ export interface NotificationState {
 		orders: number
 		purchases: number
 		auctionBids: number
+		auctionLive: number
+		auctionSettlementBegins: number
 		bidUpdates: number
 		messages: Record<string, number> // pubkey -> timestamp
 	}
@@ -66,12 +70,16 @@ const createInitialState = (): NotificationState => {
 		unseenMessages: 0,
 		unseenPurchases: 0,
 		unseenAuctionBids: 0,
+		unseenAuctionLive: 0,
+		unseenAuctionSettlementBegins: 0,
 		unseenBidUpdates: 0,
 		unseenByConversation: {},
 		lastSeenTimestamps: {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
 			auctionBids: stored.lastSeenTimestamps?.auctionBids || 0,
+			auctionLive: stored.lastSeenTimestamps?.auctionLive || 0,
+			auctionSettlementBegins: stored.lastSeenTimestamps?.auctionSettlementBegins || 0,
 			bidUpdates: stored.lastSeenTimestamps?.bidUpdates || 0,
 			messages: stored.lastSeenTimestamps?.messages || {},
 		},
@@ -132,6 +140,26 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen scheduled-auction-live count
+	 */
+	setUnseenAuctionLive: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionLive: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen auction-ended / settlement-begins count
+	 */
+	setUnseenAuctionSettlementBegins: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionSettlementBegins: Math.max(0, count),
 		}))
 	},
 
@@ -199,6 +227,26 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: state.unseenAuctionBids + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen scheduled-auction-live count
+	 */
+	incrementUnseenAuctionLive: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionLive: state.unseenAuctionLive + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen auction-ended / settlement-begins count
+	 */
+	incrementUnseenAuctionSettlementBegins: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionSettlementBegins: state.unseenAuctionSettlementBegins + 1,
 		}))
 	},
 
@@ -329,6 +377,44 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Mark scheduled-auction-live notifications as seen
+	 */
+	markAuctionLiveSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionLive: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionLive: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
+	 * Mark auction-ended / settlement-begins notifications as seen
+	 */
+	markAuctionSettlementBeginsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionSettlementBegins: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionSettlementBegins: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
 	 * Mark bidder auction update notifications as seen
 	 */
 	markBidUpdatesSeen: () => {
@@ -376,6 +462,20 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Get last seen timestamp for scheduled-auction-live notifications
+	 */
+	getLastSeenAuctionLive: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionLive
+	},
+
+	/**
+	 * Get last seen timestamp for auction-ended / settlement-begins notifications
+	 */
+	getLastSeenAuctionSettlementBegins: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionSettlementBegins
+	},
+
+	/**
 	 * Get last seen timestamp for bidder auction updates
 	 */
 	getLastSeenBidUpdates: (): number => {
@@ -401,6 +501,8 @@ export const notificationActions = {
 		purchaseCount: number
 		conversationCounts: ConversationNotifications
 		auctionBidCount?: number
+		auctionLiveCount?: number
+		auctionSettlementBeginsCount?: number
 		bidUpdateCount?: number
 	}) => {
 		notificationStore.setState((state) => ({
@@ -409,6 +511,8 @@ export const notificationActions = {
 			unseenMessages: data.messageCount,
 			unseenPurchases: data.purchaseCount,
 			unseenAuctionBids: data.auctionBidCount ?? 0,
+			unseenAuctionLive: data.auctionLiveCount ?? 0,
+			unseenAuctionSettlementBegins: data.auctionSettlementBeginsCount ?? 0,
 			unseenBidUpdates: data.bidUpdateCount ?? 0,
 			unseenByConversation: data.conversationCounts,
 		}))

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -6,6 +6,7 @@ export type NotificationType = 'order' | 'message' | 'order-update'
 // Per-conversation unseen count
 export type ConversationNotifications = Record<string, number> // pubkey -> count
 export type ScopedLastSeenTimestamps = Record<string, number>
+export type ScopedUnseenCounts = Record<string, number>
 
 const getScopedLastSeen = (globalTimestamp: number, scopedTimestamps: ScopedLastSeenTimestamps, key?: string): number => {
 	if (!key) return globalTimestamp
@@ -15,6 +16,10 @@ const getScopedLastSeen = (globalTimestamp: number, scopedTimestamps: ScopedLast
 const decrementUnseenCount = (currentCount: number, clearedCount?: number): number => {
 	if (typeof clearedCount !== 'number') return currentCount
 	return Math.max(0, currentCount - Math.max(0, clearedCount))
+}
+
+const sumScopedUnseenCounts = (counts: ScopedUnseenCounts): number => {
+	return Object.values(counts).reduce((sum, count) => sum + Math.max(0, count), 0)
 }
 
 // Notification state interface
@@ -31,6 +36,7 @@ export interface NotificationState {
 	unseenAuctionSettlementBegins: number // Scheduled auctions that just ended
 	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
 	unseenByConversation: ConversationNotifications
+	unseenAuctionBidsByAuction: ScopedUnseenCounts
 
 	// Last seen timestamps (unix timestamp in seconds)
 	lastSeenTimestamps: {
@@ -100,6 +106,7 @@ const createInitialState = (): NotificationState => {
 		unseenAuctionSettlementBegins: 0,
 		unseenBidUpdates: 0,
 		unseenByConversation: {},
+		unseenAuctionBidsByAuction: {},
 		lastSeenTimestamps: {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
@@ -171,10 +178,11 @@ export const notificationActions = {
 	/**
 	 * Update unseen seller auction bid count
 	 */
-	setUnseenAuctionBids: (count: number) => {
+	setUnseenAuctionBids: (count: number, byAuction?: ScopedUnseenCounts) => {
 		notificationStore.setState((state) => ({
 			...state,
-			unseenAuctionBids: Math.max(0, count),
+			unseenAuctionBidsByAuction: byAuction ? { ...byAuction } : {},
+			unseenAuctionBids: byAuction ? sumScopedUnseenCounts(byAuction) : Math.max(0, count),
 		}))
 	},
 
@@ -288,10 +296,24 @@ export const notificationActions = {
 	/**
 	 * Increment unseen seller auction bid count
 	 */
-	incrementUnseenAuctionBids: () => {
+	incrementUnseenAuctionBids: (auctionKey?: string) => {
 		notificationStore.setState((state) => ({
-			...state,
-			unseenAuctionBids: state.unseenAuctionBids + 1,
+			...(auctionKey
+				? {
+						...state,
+						unseenAuctionBidsByAuction: {
+							...state.unseenAuctionBidsByAuction,
+							[auctionKey]: (state.unseenAuctionBidsByAuction[auctionKey] || 0) + 1,
+						},
+						unseenAuctionBids: sumScopedUnseenCounts({
+							...state.unseenAuctionBidsByAuction,
+							[auctionKey]: (state.unseenAuctionBidsByAuction[auctionKey] || 0) + 1,
+						}),
+					}
+				: {
+						...state,
+						unseenAuctionBids: state.unseenAuctionBids + 1,
+					}),
 		}))
 	},
 
@@ -455,12 +477,19 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction bid notifications as seen
 	 */
-	markAuctionBidsSeen: (auctionKey?: string, clearedCount?: number) => {
+	markAuctionBidsSeen: (auctionKey?: string) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
+			const nextUnseenAuctionBidsByAuction = auctionKey
+				? {
+						...state.unseenAuctionBidsByAuction,
+						[auctionKey]: 0,
+					}
+				: {}
 			const newState = {
 				...state,
-				unseenAuctionBids: auctionKey ? decrementUnseenCount(state.unseenAuctionBids, clearedCount) : 0,
+				unseenAuctionBidsByAuction: nextUnseenAuctionBidsByAuction,
+				unseenAuctionBids: auctionKey ? sumScopedUnseenCounts(nextUnseenAuctionBidsByAuction) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
 					auctionBids: auctionKey ? state.lastSeenTimestamps.auctionBids : now,
@@ -734,6 +763,7 @@ export const notificationActions = {
 		purchaseCount: number
 		conversationCounts: ConversationNotifications
 		auctionBidCount?: number
+		auctionBidCountsByAuction?: ScopedUnseenCounts
 		auctionCommentCount?: number
 		auctionEventCommentCount?: number
 		productCommentCount?: number
@@ -741,20 +771,24 @@ export const notificationActions = {
 		auctionSettlementBeginsCount?: number
 		bidUpdateCount?: number
 	}) => {
-		notificationStore.setState((state) => ({
-			...state,
-			unseenOrders: data.orderCount,
-			unseenMessages: data.messageCount,
-			unseenPurchases: data.purchaseCount,
-			unseenAuctionBids: data.auctionBidCount ?? 0,
-			unseenAuctionComments: data.auctionCommentCount ?? 0,
-			unseenAuctionEventComments: data.auctionEventCommentCount ?? 0,
-			unseenProductComments: data.productCommentCount ?? 0,
-			unseenAuctionLive: data.auctionLiveCount ?? 0,
-			unseenAuctionSettlementBegins: data.auctionSettlementBeginsCount ?? 0,
-			unseenBidUpdates: data.bidUpdateCount ?? 0,
-			unseenByConversation: data.conversationCounts,
-		}))
+		notificationStore.setState((state) => {
+			const scopedBidCounts = data.auctionBidCountsByAuction ? { ...data.auctionBidCountsByAuction } : {}
+			return {
+				...state,
+				unseenOrders: data.orderCount,
+				unseenMessages: data.messageCount,
+				unseenPurchases: data.purchaseCount,
+				unseenAuctionBidsByAuction: scopedBidCounts,
+				unseenAuctionBids: data.auctionBidCountsByAuction ? sumScopedUnseenCounts(scopedBidCounts) : (data.auctionBidCount ?? 0),
+				unseenAuctionComments: data.auctionCommentCount ?? 0,
+				unseenAuctionEventComments: data.auctionEventCommentCount ?? 0,
+				unseenProductComments: data.productCommentCount ?? 0,
+				unseenAuctionLive: data.auctionLiveCount ?? 0,
+				unseenAuctionSettlementBegins: data.auctionSettlementBeginsCount ?? 0,
+				unseenBidUpdates: data.bidUpdateCount ?? 0,
+				unseenByConversation: data.conversationCounts,
+			}
+		})
 	},
 }
 

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -13,6 +13,9 @@ export interface NotificationState {
 	unseenMessages: number // New messages in conversations
 	unseenPurchases: number // Updates to orders where user is buyer
 	unseenAuctionBids: number // New bids on auctions where user is seller
+	unseenAuctionComments: number // New live-chat comments on seller auctions
+	unseenAuctionEventComments: number // New NIP-22 comments on seller auctions
+	unseenProductComments: number // New NIP-22 comments on seller products
 	unseenAuctionLive: number // Scheduled auctions that just went live
 	unseenAuctionSettlementBegins: number // Scheduled auctions that just ended
 	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
@@ -23,6 +26,9 @@ export interface NotificationState {
 		orders: number
 		purchases: number
 		auctionBids: number
+		auctionComments: number
+		auctionEventComments: number
+		productComments: number
 		auctionLive: number
 		auctionSettlementBegins: number
 		bidUpdates: number
@@ -70,6 +76,9 @@ const createInitialState = (): NotificationState => {
 		unseenMessages: 0,
 		unseenPurchases: 0,
 		unseenAuctionBids: 0,
+		unseenAuctionComments: 0,
+		unseenAuctionEventComments: 0,
+		unseenProductComments: 0,
 		unseenAuctionLive: 0,
 		unseenAuctionSettlementBegins: 0,
 		unseenBidUpdates: 0,
@@ -78,6 +87,9 @@ const createInitialState = (): NotificationState => {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
 			auctionBids: stored.lastSeenTimestamps?.auctionBids || 0,
+			auctionComments: stored.lastSeenTimestamps?.auctionComments || 0,
+			auctionEventComments: stored.lastSeenTimestamps?.auctionEventComments || 0,
+			productComments: stored.lastSeenTimestamps?.productComments || 0,
 			auctionLive: stored.lastSeenTimestamps?.auctionLive || 0,
 			auctionSettlementBegins: stored.lastSeenTimestamps?.auctionSettlementBegins || 0,
 			bidUpdates: stored.lastSeenTimestamps?.bidUpdates || 0,
@@ -140,6 +152,36 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen seller auction live-chat comment count
+	 */
+	setUnseenAuctionComments: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionComments: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen seller auction thread comment count
+	 */
+	setUnseenAuctionEventComments: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionEventComments: Math.max(0, count),
+		}))
+	},
+
+	/**
+	 * Update unseen seller product comment count
+	 */
+	setUnseenProductComments: (count: number) => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenProductComments: Math.max(0, count),
 		}))
 	},
 
@@ -227,6 +269,36 @@ export const notificationActions = {
 		notificationStore.setState((state) => ({
 			...state,
 			unseenAuctionBids: state.unseenAuctionBids + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen seller auction live-chat comment count
+	 */
+	incrementUnseenAuctionComments: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionComments: state.unseenAuctionComments + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen seller auction thread comment count
+	 */
+	incrementUnseenAuctionEventComments: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenAuctionEventComments: state.unseenAuctionEventComments + 1,
+		}))
+	},
+
+	/**
+	 * Increment unseen seller product comment count
+	 */
+	incrementUnseenProductComments: () => {
+		notificationStore.setState((state) => ({
+			...state,
+			unseenProductComments: state.unseenProductComments + 1,
 		}))
 	},
 
@@ -377,6 +449,63 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Mark seller auction live-chat comment notifications as seen
+	 */
+	markAuctionCommentsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionComments: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionComments: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
+	 * Mark seller auction thread comment notifications as seen
+	 */
+	markAuctionEventCommentsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenAuctionEventComments: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					auctionEventComments: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
+	 * Mark seller product comment notifications as seen
+	 */
+	markProductCommentsSeen: () => {
+		const now = Math.floor(Date.now() / 1000)
+		notificationStore.setState((state) => {
+			const newState = {
+				...state,
+				unseenProductComments: 0,
+				lastSeenTimestamps: {
+					...state.lastSeenTimestamps,
+					productComments: now,
+				},
+			}
+			saveToStorage(newState)
+			return newState
+		})
+	},
+
+	/**
 	 * Mark scheduled-auction-live notifications as seen
 	 */
 	markAuctionLiveSeen: () => {
@@ -462,6 +591,27 @@ export const notificationActions = {
 	},
 
 	/**
+	 * Get last seen timestamp for seller auction live-chat comments
+	 */
+	getLastSeenAuctionComments: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionComments
+	},
+
+	/**
+	 * Get last seen timestamp for seller auction thread comments
+	 */
+	getLastSeenAuctionEventComments: (): number => {
+		return notificationStore.state.lastSeenTimestamps.auctionEventComments
+	},
+
+	/**
+	 * Get last seen timestamp for seller product comments
+	 */
+	getLastSeenProductComments: (): number => {
+		return notificationStore.state.lastSeenTimestamps.productComments
+	},
+
+	/**
 	 * Get last seen timestamp for scheduled-auction-live notifications
 	 */
 	getLastSeenAuctionLive: (): number => {
@@ -501,6 +651,9 @@ export const notificationActions = {
 		purchaseCount: number
 		conversationCounts: ConversationNotifications
 		auctionBidCount?: number
+		auctionCommentCount?: number
+		auctionEventCommentCount?: number
+		productCommentCount?: number
 		auctionLiveCount?: number
 		auctionSettlementBeginsCount?: number
 		bidUpdateCount?: number
@@ -511,6 +664,9 @@ export const notificationActions = {
 			unseenMessages: data.messageCount,
 			unseenPurchases: data.purchaseCount,
 			unseenAuctionBids: data.auctionBidCount ?? 0,
+			unseenAuctionComments: data.auctionCommentCount ?? 0,
+			unseenAuctionEventComments: data.auctionEventCommentCount ?? 0,
+			unseenProductComments: data.productCommentCount ?? 0,
 			unseenAuctionLive: data.auctionLiveCount ?? 0,
 			unseenAuctionSettlementBegins: data.auctionSettlementBeginsCount ?? 0,
 			unseenBidUpdates: data.bidUpdateCount ?? 0,

--- a/src/lib/stores/notifications.ts
+++ b/src/lib/stores/notifications.ts
@@ -37,6 +37,10 @@ export interface NotificationState {
 	unseenBidUpdates: number // New higher bids / settlements on auctions where user is bidder
 	unseenByConversation: ConversationNotifications
 	unseenAuctionBidsByAuction: ScopedUnseenCounts
+	unseenAuctionCommentsByAuction: ScopedUnseenCounts
+	unseenAuctionEventCommentsByAuction: ScopedUnseenCounts
+	unseenAuctionLiveByAuction: ScopedUnseenCounts
+	unseenAuctionSettlementBeginsByAuction: ScopedUnseenCounts
 
 	// Last seen timestamps (unix timestamp in seconds)
 	lastSeenTimestamps: {
@@ -107,6 +111,10 @@ const createInitialState = (): NotificationState => {
 		unseenBidUpdates: 0,
 		unseenByConversation: {},
 		unseenAuctionBidsByAuction: {},
+		unseenAuctionCommentsByAuction: {},
+		unseenAuctionEventCommentsByAuction: {},
+		unseenAuctionLiveByAuction: {},
+		unseenAuctionSettlementBeginsByAuction: {},
 		lastSeenTimestamps: {
 			orders: stored.lastSeenTimestamps?.orders || 0,
 			purchases: stored.lastSeenTimestamps?.purchases || 0,
@@ -189,20 +197,22 @@ export const notificationActions = {
 	/**
 	 * Update unseen seller auction live-chat comment count
 	 */
-	setUnseenAuctionComments: (count: number) => {
+	setUnseenAuctionComments: (count: number, byAuction?: ScopedUnseenCounts) => {
 		notificationStore.setState((state) => ({
 			...state,
-			unseenAuctionComments: Math.max(0, count),
+			unseenAuctionCommentsByAuction: byAuction ? { ...byAuction } : {},
+			unseenAuctionComments: byAuction ? sumScopedUnseenCounts(byAuction) : Math.max(0, count),
 		}))
 	},
 
 	/**
 	 * Update unseen seller auction thread comment count
 	 */
-	setUnseenAuctionEventComments: (count: number) => {
+	setUnseenAuctionEventComments: (count: number, byAuction?: ScopedUnseenCounts) => {
 		notificationStore.setState((state) => ({
 			...state,
-			unseenAuctionEventComments: Math.max(0, count),
+			unseenAuctionEventCommentsByAuction: byAuction ? { ...byAuction } : {},
+			unseenAuctionEventComments: byAuction ? sumScopedUnseenCounts(byAuction) : Math.max(0, count),
 		}))
 	},
 
@@ -219,20 +229,22 @@ export const notificationActions = {
 	/**
 	 * Update unseen scheduled-auction-live count
 	 */
-	setUnseenAuctionLive: (count: number) => {
+	setUnseenAuctionLive: (count: number, byAuction?: ScopedUnseenCounts) => {
 		notificationStore.setState((state) => ({
 			...state,
-			unseenAuctionLive: Math.max(0, count),
+			unseenAuctionLiveByAuction: byAuction ? { ...byAuction } : {},
+			unseenAuctionLive: byAuction ? sumScopedUnseenCounts(byAuction) : Math.max(0, count),
 		}))
 	},
 
 	/**
 	 * Update unseen auction-ended / settlement-begins count
 	 */
-	setUnseenAuctionSettlementBegins: (count: number) => {
+	setUnseenAuctionSettlementBegins: (count: number, byAuction?: ScopedUnseenCounts) => {
 		notificationStore.setState((state) => ({
 			...state,
-			unseenAuctionSettlementBegins: Math.max(0, count),
+			unseenAuctionSettlementBeginsByAuction: byAuction ? { ...byAuction } : {},
+			unseenAuctionSettlementBegins: byAuction ? sumScopedUnseenCounts(byAuction) : Math.max(0, count),
 		}))
 	},
 
@@ -320,21 +332,51 @@ export const notificationActions = {
 	/**
 	 * Increment unseen seller auction live-chat comment count
 	 */
-	incrementUnseenAuctionComments: () => {
-		notificationStore.setState((state) => ({
-			...state,
-			unseenAuctionComments: state.unseenAuctionComments + 1,
-		}))
+	incrementUnseenAuctionComments: (auctionKey?: string) => {
+		notificationStore.setState((state) => {
+			if (!auctionKey) {
+				return {
+					...state,
+					unseenAuctionComments: state.unseenAuctionComments + 1,
+				}
+			}
+
+			const nextCounts = {
+				...state.unseenAuctionCommentsByAuction,
+				[auctionKey]: (state.unseenAuctionCommentsByAuction[auctionKey] || 0) + 1,
+			}
+
+			return {
+				...state,
+				unseenAuctionCommentsByAuction: nextCounts,
+				unseenAuctionComments: sumScopedUnseenCounts(nextCounts),
+			}
+		})
 	},
 
 	/**
 	 * Increment unseen seller auction thread comment count
 	 */
-	incrementUnseenAuctionEventComments: () => {
-		notificationStore.setState((state) => ({
-			...state,
-			unseenAuctionEventComments: state.unseenAuctionEventComments + 1,
-		}))
+	incrementUnseenAuctionEventComments: (auctionKey?: string) => {
+		notificationStore.setState((state) => {
+			if (!auctionKey) {
+				return {
+					...state,
+					unseenAuctionEventComments: state.unseenAuctionEventComments + 1,
+				}
+			}
+
+			const nextCounts = {
+				...state.unseenAuctionEventCommentsByAuction,
+				[auctionKey]: (state.unseenAuctionEventCommentsByAuction[auctionKey] || 0) + 1,
+			}
+
+			return {
+				...state,
+				unseenAuctionEventCommentsByAuction: nextCounts,
+				unseenAuctionEventComments: sumScopedUnseenCounts(nextCounts),
+			}
+		})
 	},
 
 	/**
@@ -350,21 +392,51 @@ export const notificationActions = {
 	/**
 	 * Increment unseen scheduled-auction-live count
 	 */
-	incrementUnseenAuctionLive: () => {
-		notificationStore.setState((state) => ({
-			...state,
-			unseenAuctionLive: state.unseenAuctionLive + 1,
-		}))
+	incrementUnseenAuctionLive: (auctionKey?: string) => {
+		notificationStore.setState((state) => {
+			if (!auctionKey) {
+				return {
+					...state,
+					unseenAuctionLive: state.unseenAuctionLive + 1,
+				}
+			}
+
+			const nextCounts = {
+				...state.unseenAuctionLiveByAuction,
+				[auctionKey]: (state.unseenAuctionLiveByAuction[auctionKey] || 0) + 1,
+			}
+
+			return {
+				...state,
+				unseenAuctionLiveByAuction: nextCounts,
+				unseenAuctionLive: sumScopedUnseenCounts(nextCounts),
+			}
+		})
 	},
 
 	/**
 	 * Increment unseen auction-ended / settlement-begins count
 	 */
-	incrementUnseenAuctionSettlementBegins: () => {
-		notificationStore.setState((state) => ({
-			...state,
-			unseenAuctionSettlementBegins: state.unseenAuctionSettlementBegins + 1,
-		}))
+	incrementUnseenAuctionSettlementBegins: (auctionKey?: string) => {
+		notificationStore.setState((state) => {
+			if (!auctionKey) {
+				return {
+					...state,
+					unseenAuctionSettlementBegins: state.unseenAuctionSettlementBegins + 1,
+				}
+			}
+
+			const nextCounts = {
+				...state.unseenAuctionSettlementBeginsByAuction,
+				[auctionKey]: (state.unseenAuctionSettlementBeginsByAuction[auctionKey] || 0) + 1,
+			}
+
+			return {
+				...state,
+				unseenAuctionSettlementBeginsByAuction: nextCounts,
+				unseenAuctionSettlementBegins: sumScopedUnseenCounts(nextCounts),
+			}
+		})
 	},
 
 	/**
@@ -509,12 +581,19 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction live-chat comment notifications as seen
 	 */
-	markAuctionCommentsSeen: (auctionKey?: string, clearedCount?: number) => {
+	markAuctionCommentsSeen: (auctionKey?: string) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
+			const nextCounts = auctionKey
+				? {
+						...state.unseenAuctionCommentsByAuction,
+						[auctionKey]: 0,
+					}
+				: {}
 			const newState = {
 				...state,
-				unseenAuctionComments: auctionKey ? decrementUnseenCount(state.unseenAuctionComments, clearedCount) : 0,
+				unseenAuctionCommentsByAuction: nextCounts,
+				unseenAuctionComments: auctionKey ? sumScopedUnseenCounts(nextCounts) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
 					auctionComments: auctionKey ? state.lastSeenTimestamps.auctionComments : now,
@@ -534,12 +613,19 @@ export const notificationActions = {
 	/**
 	 * Mark seller auction thread comment notifications as seen
 	 */
-	markAuctionEventCommentsSeen: (auctionKey?: string, clearedCount?: number) => {
+	markAuctionEventCommentsSeen: (auctionKey?: string) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
+			const nextCounts = auctionKey
+				? {
+						...state.unseenAuctionEventCommentsByAuction,
+						[auctionKey]: 0,
+					}
+				: {}
 			const newState = {
 				...state,
-				unseenAuctionEventComments: auctionKey ? decrementUnseenCount(state.unseenAuctionEventComments, clearedCount) : 0,
+				unseenAuctionEventCommentsByAuction: nextCounts,
+				unseenAuctionEventComments: auctionKey ? sumScopedUnseenCounts(nextCounts) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
 					auctionEventComments: auctionKey ? state.lastSeenTimestamps.auctionEventComments : now,
@@ -584,12 +670,19 @@ export const notificationActions = {
 	/**
 	 * Mark scheduled-auction-live notifications as seen
 	 */
-	markAuctionLiveSeen: (auctionKey?: string, clearedCount?: number) => {
+	markAuctionLiveSeen: (auctionKey?: string) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
+			const nextCounts = auctionKey
+				? {
+						...state.unseenAuctionLiveByAuction,
+						[auctionKey]: 0,
+					}
+				: {}
 			const newState = {
 				...state,
-				unseenAuctionLive: auctionKey ? decrementUnseenCount(state.unseenAuctionLive, clearedCount) : 0,
+				unseenAuctionLiveByAuction: nextCounts,
+				unseenAuctionLive: auctionKey ? sumScopedUnseenCounts(nextCounts) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
 					auctionLive: auctionKey ? state.lastSeenTimestamps.auctionLive : now,
@@ -609,12 +702,19 @@ export const notificationActions = {
 	/**
 	 * Mark auction-ended / settlement-begins notifications as seen
 	 */
-	markAuctionSettlementBeginsSeen: (auctionKey?: string, clearedCount?: number) => {
+	markAuctionSettlementBeginsSeen: (auctionKey?: string) => {
 		const now = Math.floor(Date.now() / 1000)
 		notificationStore.setState((state) => {
+			const nextCounts = auctionKey
+				? {
+						...state.unseenAuctionSettlementBeginsByAuction,
+						[auctionKey]: 0,
+					}
+				: {}
 			const newState = {
 				...state,
-				unseenAuctionSettlementBegins: auctionKey ? decrementUnseenCount(state.unseenAuctionSettlementBegins, clearedCount) : 0,
+				unseenAuctionSettlementBeginsByAuction: nextCounts,
+				unseenAuctionSettlementBegins: auctionKey ? sumScopedUnseenCounts(nextCounts) : 0,
 				lastSeenTimestamps: {
 					...state.lastSeenTimestamps,
 					auctionSettlementBegins: auctionKey ? state.lastSeenTimestamps.auctionSettlementBegins : now,
@@ -765,14 +865,25 @@ export const notificationActions = {
 		auctionBidCount?: number
 		auctionBidCountsByAuction?: ScopedUnseenCounts
 		auctionCommentCount?: number
+		auctionCommentCountsByAuction?: ScopedUnseenCounts
 		auctionEventCommentCount?: number
+		auctionEventCommentCountsByAuction?: ScopedUnseenCounts
 		productCommentCount?: number
 		auctionLiveCount?: number
+		auctionLiveCountsByAuction?: ScopedUnseenCounts
 		auctionSettlementBeginsCount?: number
+		auctionSettlementBeginsCountsByAuction?: ScopedUnseenCounts
 		bidUpdateCount?: number
 	}) => {
 		notificationStore.setState((state) => {
 			const scopedBidCounts = data.auctionBidCountsByAuction ? { ...data.auctionBidCountsByAuction } : {}
+			const scopedAuctionCommentCounts = data.auctionCommentCountsByAuction ? { ...data.auctionCommentCountsByAuction } : {}
+			const scopedAuctionEventCommentCounts = data.auctionEventCommentCountsByAuction ? { ...data.auctionEventCommentCountsByAuction } : {}
+			const scopedAuctionLiveCounts = data.auctionLiveCountsByAuction ? { ...data.auctionLiveCountsByAuction } : {}
+			const scopedAuctionSettlementCounts = data.auctionSettlementBeginsCountsByAuction
+				? { ...data.auctionSettlementBeginsCountsByAuction }
+				: {}
+
 			return {
 				...state,
 				unseenOrders: data.orderCount,
@@ -780,11 +891,21 @@ export const notificationActions = {
 				unseenPurchases: data.purchaseCount,
 				unseenAuctionBidsByAuction: scopedBidCounts,
 				unseenAuctionBids: data.auctionBidCountsByAuction ? sumScopedUnseenCounts(scopedBidCounts) : (data.auctionBidCount ?? 0),
-				unseenAuctionComments: data.auctionCommentCount ?? 0,
-				unseenAuctionEventComments: data.auctionEventCommentCount ?? 0,
+				unseenAuctionCommentsByAuction: scopedAuctionCommentCounts,
+				unseenAuctionComments: data.auctionCommentCountsByAuction
+					? sumScopedUnseenCounts(scopedAuctionCommentCounts)
+					: (data.auctionCommentCount ?? 0),
+				unseenAuctionEventCommentsByAuction: scopedAuctionEventCommentCounts,
+				unseenAuctionEventComments: data.auctionEventCommentCountsByAuction
+					? sumScopedUnseenCounts(scopedAuctionEventCommentCounts)
+					: (data.auctionEventCommentCount ?? 0),
 				unseenProductComments: data.productCommentCount ?? 0,
-				unseenAuctionLive: data.auctionLiveCount ?? 0,
-				unseenAuctionSettlementBegins: data.auctionSettlementBeginsCount ?? 0,
+				unseenAuctionLiveByAuction: scopedAuctionLiveCounts,
+				unseenAuctionLive: data.auctionLiveCountsByAuction ? sumScopedUnseenCounts(scopedAuctionLiveCounts) : (data.auctionLiveCount ?? 0),
+				unseenAuctionSettlementBeginsByAuction: scopedAuctionSettlementCounts,
+				unseenAuctionSettlementBegins: data.auctionSettlementBeginsCountsByAuction
+					? sumScopedUnseenCounts(scopedAuctionSettlementCounts)
+					: (data.auctionSettlementBeginsCount ?? 0),
 				unseenBidUpdates: data.bidUpdateCount ?? 0,
 				unseenByConversation: data.conversationCounts,
 			}

--- a/src/queries/__tests__/auctionListHelpers.test.ts
+++ b/src/queries/__tests__/auctionListHelpers.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
+import { AUCTION_KIND, AUCTION_PATH_RELEASE_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auction/constants'
+
+let fetchedRequests: Array<NDKFilter | NDKFilter[]> = []
+let relayEvents = new Set<NDKEvent>()
+
+if (!('localStorage' in globalThis)) {
+	const items = new Map<string, string>()
+	Object.defineProperty(globalThis, 'localStorage', {
+		value: {
+			getItem: (key: string) => items.get(key) ?? null,
+			setItem: (key: string, value: string) => items.set(key, value),
+			removeItem: (key: string) => items.delete(key),
+			clear: () => items.clear(),
+		},
+		configurable: true,
+	})
+}
+
+mock.module('@/lib/stores/blacklist', () => ({
+	blacklistActions: {
+		isBlacklistLoaded: () => false,
+		isPubkeyBlacklisted: () => false,
+		isProductBlacklisted: () => false,
+		isCollectionBlacklisted: () => false,
+	},
+}))
+
+mock.module('@/lib/stores/ndk', () => ({
+	ndkActions: {
+		getNDK: () => ({}),
+		fetchEventsWithTimeout: mock(async (filter: NDKFilter | NDKFilter[]) => {
+			fetchedRequests.push(filter)
+			return relayEvents
+		}),
+	},
+}))
+
+const { fetchAuctionSettlementsForList, fetchAuctionPathReleasesForList, getAuctionTopBidFromBids } = await import('@/queries/auctions')
+
+function makeAuctionEvent(params: { id: string; pubkey: string; dTag: string; rootId: string; startAt: number; endAt: number }): NDKEvent {
+	return {
+		id: params.id,
+		kind: AUCTION_KIND,
+		pubkey: params.pubkey,
+		created_at: params.startAt - 10,
+		content: '',
+		tags: [
+			['d', params.dTag],
+			['auction_root_event_id', params.rootId],
+			['start_at', String(params.startAt)],
+			['end_at', String(params.endAt)],
+		],
+	} as unknown as NDKEvent
+}
+
+function makeBidEvent(params: {
+	id: string
+	pubkey: string
+	rootId: string
+	amount: number
+	createdAt: number
+	status?: string
+}): NDKEvent {
+	return {
+		id: params.id,
+		kind: 1023,
+		pubkey: params.pubkey,
+		created_at: params.createdAt,
+		content: '',
+		tags: [
+			['e', params.rootId],
+			['amount', String(params.amount)],
+			['status', params.status ?? 'active'],
+		],
+	} as unknown as NDKEvent
+}
+
+function makeSettlementEvent(params: { id: string; createdAt: number; rootIds?: string[]; coordinates?: string[] }): NDKEvent {
+	const tags: string[][] = []
+	for (const rootId of params.rootIds ?? []) tags.push(['e', rootId])
+	for (const coordinate of params.coordinates ?? []) tags.push(['a', coordinate])
+
+	return {
+		id: params.id,
+		kind: AUCTION_SETTLEMENT_KIND,
+		pubkey: 's'.repeat(64),
+		created_at: params.createdAt,
+		content: '',
+		tags,
+	} as unknown as NDKEvent
+}
+
+function makePathReleaseEvent(params: { id: string; createdAt: number; coordinates: string[] }): NDKEvent {
+	return {
+		id: params.id,
+		kind: AUCTION_PATH_RELEASE_KIND as unknown as number,
+		pubkey: 'p'.repeat(64),
+		created_at: params.createdAt,
+		content: '',
+		tags: params.coordinates.map((coordinate) => ['a', coordinate]),
+	} as unknown as NDKEvent
+}
+
+describe('fetchAuctionSettlementsForList', () => {
+	beforeEach(() => {
+		fetchedRequests = []
+		relayEvents = new Set()
+	})
+
+	test('returns empty map and does not hit relay without ids or coordinates', async () => {
+		const result = await fetchAuctionSettlementsForList([], [])
+		expect(result.size).toBe(0)
+		expect(fetchedRequests).toEqual([])
+	})
+
+	test('groups settlements by root id and coordinate with de-duplication and recency ordering', async () => {
+		const rootId = 'root-auction-1'
+		const coordinate = `30408:${'a'.repeat(64)}:auction-1`
+		const newestRootOnly = makeSettlementEvent({ id: 's-new', createdAt: 300, rootIds: [rootId] })
+		const bothRefs = makeSettlementEvent({ id: 's-both', createdAt: 200, rootIds: [rootId], coordinates: [coordinate] })
+		const coordinateOnly = makeSettlementEvent({ id: 's-coord', createdAt: 100, coordinates: [coordinate] })
+		const duplicateNewestRootOnly = makeSettlementEvent({ id: 's-new', createdAt: 300, rootIds: [rootId] })
+		relayEvents = new Set([newestRootOnly, bothRefs, coordinateOnly, duplicateNewestRootOnly])
+
+		const grouped = await fetchAuctionSettlementsForList([rootId], [coordinate])
+
+		expect(grouped.get(rootId)?.map((event) => event.id)).toEqual(['s-new', 's-both'])
+		expect(grouped.get(coordinate)?.map((event) => event.id)).toEqual(['s-both', 's-coord'])
+	})
+
+	test('chunks large root-id and coordinate lists into multiple filters', async () => {
+		const ids = Array.from({ length: 81 }, (_, index) => `root-${index}`)
+		const coordinates = Array.from({ length: 81 }, (_, index) => `30408:${'a'.repeat(64)}:auction-${index}`)
+
+		await fetchAuctionSettlementsForList(ids, coordinates, 77)
+
+		expect(fetchedRequests).toHaveLength(1)
+		const filterBatch = fetchedRequests[0] as NDKFilter[]
+		expect(Array.isArray(filterBatch)).toBe(true)
+		expect(filterBatch).toHaveLength(4)
+		expect(filterBatch.every((filter) => filter.kinds?.includes(AUCTION_SETTLEMENT_KIND as never))).toBe(true)
+		expect(filterBatch.every((filter) => filter.limit === 77)).toBe(true)
+	})
+})
+
+describe('fetchAuctionPathReleasesForList', () => {
+	beforeEach(() => {
+		fetchedRequests = []
+		relayEvents = new Set()
+	})
+
+	test('returns empty map and does not hit relay without coordinates', async () => {
+		const result = await fetchAuctionPathReleasesForList([])
+		expect(result.size).toBe(0)
+		expect(fetchedRequests).toEqual([])
+	})
+
+	test('groups path releases by coordinate, filters exact coordinate matches, and sorts by recency', async () => {
+		const coordinateA = `30408:${'a'.repeat(64)}:auction-a`
+		const coordinateB = `30408:${'a'.repeat(64)}:auction-b`
+
+		const eventAOld = makePathReleaseEvent({ id: 'r-a-old', createdAt: 100, coordinates: [coordinateA] })
+		const eventANew = makePathReleaseEvent({ id: 'r-a-new', createdAt: 300, coordinates: [coordinateA] })
+		const eventShared = makePathReleaseEvent({ id: 'r-shared', createdAt: 200, coordinates: [coordinateA, coordinateB] })
+		const eventBOnly = makePathReleaseEvent({ id: 'r-b-only', createdAt: 250, coordinates: [coordinateB] })
+		const eventOther = makePathReleaseEvent({ id: 'r-other', createdAt: 999, coordinates: [`30408:${'b'.repeat(64)}:other`] })
+		relayEvents = new Set([eventAOld, eventANew, eventShared, eventBOnly, eventOther])
+
+		const grouped = await fetchAuctionPathReleasesForList([coordinateA, coordinateB])
+
+		expect(grouped.get(coordinateA)?.map((event) => event.id)).toEqual(['r-a-new', 'r-shared', 'r-a-old'])
+		expect(grouped.get(coordinateB)?.map((event) => event.id)).toEqual(['r-b-only', 'r-shared'])
+	})
+})
+
+describe('getAuctionTopBidFromBids', () => {
+	test('returns null when no bids are available', () => {
+		expect(getAuctionTopBidFromBids(null, [])).toBeNull()
+	})
+
+	test('returns highest amount when auction context is unavailable', () => {
+		const bids = [
+			makeBidEvent({ id: 'b-low', pubkey: 'x'.repeat(64), rootId: 'ignored', amount: 100, createdAt: 1 }),
+			makeBidEvent({ id: 'b-high', pubkey: 'y'.repeat(64), rootId: 'ignored', amount: 250, createdAt: 2 }),
+		]
+
+		const topBid = getAuctionTopBidFromBids(null, bids)
+
+		expect(topBid?.id).toBe('b-high')
+	})
+
+	test('uses auction-window-valid bids only (root id + start/end window)', () => {
+		const auction = makeAuctionEvent({
+			id: 'auction-event-id',
+			pubkey: 'a'.repeat(64),
+			dTag: 'auction-1',
+			rootId: 'root-auction-1',
+			startAt: 100,
+			endAt: 200,
+		})
+
+		const bids = [
+			makeBidEvent({ id: 'before-start', pubkey: 'b'.repeat(64), rootId: 'root-auction-1', amount: 1000, createdAt: 99 }),
+			makeBidEvent({ id: 'wrong-root', pubkey: 'c'.repeat(64), rootId: 'other-root', amount: 1200, createdAt: 150 }),
+			makeBidEvent({ id: 'after-end', pubkey: 'd'.repeat(64), rootId: 'root-auction-1', amount: 900, createdAt: 201 }),
+			makeBidEvent({ id: 'valid-low', pubkey: 'e'.repeat(64), rootId: 'root-auction-1', amount: 400, createdAt: 110 }),
+			makeBidEvent({ id: 'valid-top', pubkey: 'f'.repeat(64), rootId: 'root-auction-1', amount: 700, createdAt: 150 }),
+		]
+
+		const topBid = getAuctionTopBidFromBids(auction, bids)
+
+		expect(topBid?.id).toBe('valid-top')
+	})
+})

--- a/src/queries/__tests__/auctionListHelpers.test.ts
+++ b/src/queries/__tests__/auctionListHelpers.test.ts
@@ -28,6 +28,16 @@ mock.module('@/lib/stores/blacklist', () => ({
 }))
 
 mock.module('@/lib/stores/ndk', () => ({
+	getWriteRelays: () => [],
+	ndkStore: {
+		state: {
+			ndk: null,
+			zapNdk: null,
+			explicitRelayUrls: [],
+			writeRelayUrls: [],
+			signer: undefined,
+		},
+	},
 	ndkActions: {
 		getNDK: () => ({}),
 		fetchEventsWithTimeout: mock(async (filter: NDKFilter | NDKFilter[]) => {

--- a/src/queries/__tests__/auctionListHelpers.test.ts
+++ b/src/queries/__tests__/auctionListHelpers.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
 import { AUCTION_KIND, AUCTION_PATH_RELEASE_KIND, AUCTION_SETTLEMENT_KIND } from '@/lib/auction/constants'
+import type { NostrFilter } from '@/lib/nostr/io'
 
-let fetchedRequests: Array<NDKFilter | NDKFilter[]> = []
-let relayEvents = new Set<NDKEvent>()
+let fetchedRequests: Array<NostrFilter | NostrFilter[]> = []
+let relayEvents = new Set<RelayEvent>()
 
 if (!('localStorage' in globalThis)) {
 	const items = new Map<string, string>()
@@ -40,7 +40,7 @@ mock.module('@/lib/stores/ndk', () => ({
 	},
 	ndkActions: {
 		getNDK: () => ({}),
-		fetchEventsWithTimeout: mock(async (filter: NDKFilter | NDKFilter[]) => {
+		fetchEventsWithTimeout: mock(async (filter: NostrFilter | NostrFilter[]) => {
 			fetchedRequests.push(filter)
 			return relayEvents
 		}),
@@ -49,7 +49,17 @@ mock.module('@/lib/stores/ndk', () => ({
 
 const { fetchAuctionSettlementsForList, fetchAuctionPathReleasesForList, getAuctionTopBidFromBids } = await import('@/queries/auctions')
 
-function makeAuctionEvent(params: { id: string; pubkey: string; dTag: string; rootId: string; startAt: number; endAt: number }): NDKEvent {
+type AuctionEventLike = NonNullable<Parameters<typeof getAuctionTopBidFromBids>[0]>
+type RelayEvent = AuctionEventLike
+
+function makeAuctionEvent(params: {
+	id: string
+	pubkey: string
+	dTag: string
+	rootId: string
+	startAt: number
+	endAt: number
+}): RelayEvent {
 	return {
 		id: params.id,
 		kind: AUCTION_KIND,
@@ -62,7 +72,7 @@ function makeAuctionEvent(params: { id: string; pubkey: string; dTag: string; ro
 			['start_at', String(params.startAt)],
 			['end_at', String(params.endAt)],
 		],
-	} as unknown as NDKEvent
+	} as RelayEvent
 }
 
 function makeBidEvent(params: {
@@ -72,7 +82,7 @@ function makeBidEvent(params: {
 	amount: number
 	createdAt: number
 	status?: string
-}): NDKEvent {
+}): Parameters<typeof getAuctionTopBidFromBids>[1][number] {
 	return {
 		id: params.id,
 		kind: 1023,
@@ -84,10 +94,10 @@ function makeBidEvent(params: {
 			['amount', String(params.amount)],
 			['status', params.status ?? 'active'],
 		],
-	} as unknown as NDKEvent
+	} as RelayEvent
 }
 
-function makeSettlementEvent(params: { id: string; createdAt: number; rootIds?: string[]; coordinates?: string[] }): NDKEvent {
+function makeSettlementEvent(params: { id: string; createdAt: number; rootIds?: string[]; coordinates?: string[] }): RelayEvent {
 	const tags: string[][] = []
 	for (const rootId of params.rootIds ?? []) tags.push(['e', rootId])
 	for (const coordinate of params.coordinates ?? []) tags.push(['a', coordinate])
@@ -99,10 +109,10 @@ function makeSettlementEvent(params: { id: string; createdAt: number; rootIds?: 
 		created_at: params.createdAt,
 		content: '',
 		tags,
-	} as unknown as NDKEvent
+	} as RelayEvent
 }
 
-function makePathReleaseEvent(params: { id: string; createdAt: number; coordinates: string[] }): NDKEvent {
+function makePathReleaseEvent(params: { id: string; createdAt: number; coordinates: string[] }): RelayEvent {
 	return {
 		id: params.id,
 		kind: AUCTION_PATH_RELEASE_KIND as unknown as number,
@@ -110,7 +120,7 @@ function makePathReleaseEvent(params: { id: string; createdAt: number; coordinat
 		created_at: params.createdAt,
 		content: '',
 		tags: params.coordinates.map((coordinate) => ['a', coordinate]),
-	} as unknown as NDKEvent
+	} as RelayEvent
 }
 
 describe('fetchAuctionSettlementsForList', () => {
@@ -147,7 +157,7 @@ describe('fetchAuctionSettlementsForList', () => {
 		await fetchAuctionSettlementsForList(ids, coordinates, 77)
 
 		expect(fetchedRequests).toHaveLength(1)
-		const filterBatch = fetchedRequests[0] as NDKFilter[]
+		const filterBatch = fetchedRequests[0] as NostrFilter[]
 		expect(Array.isArray(filterBatch)).toBe(true)
 		expect(filterBatch).toHaveLength(4)
 		expect(filterBatch.every((filter) => filter.kinds?.includes(AUCTION_SETTLEMENT_KIND as never))).toBe(true)

--- a/src/queries/__tests__/auctionPathReleases.test.ts
+++ b/src/queries/__tests__/auctionPathReleases.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
-import type { NDKEvent, NDKFilter } from '@nostr-dev-kit/ndk'
 import { AUCTION_PATH_RELEASE_KIND } from '@/lib/auction/constants'
+import type { NostrEvent, NostrFilter } from '@/lib/nostr/io'
 
-let fetchedFilters: NDKFilter[] = []
-let relayEvents = new Set<NDKEvent>()
+type RelayEvent = NostrEvent
+
+let fetchedFilters: NostrFilter[] = []
+let relayEvents = new Set<RelayEvent>()
 
 if (!('localStorage' in globalThis)) {
 	const items = new Map<string, string>()
@@ -40,7 +42,7 @@ mock.module('@/lib/stores/ndk', () => ({
 	},
 	ndkActions: {
 		getNDK: () => ({}),
-		fetchEventsWithTimeout: mock(async (filter: NDKFilter) => {
+		fetchEventsWithTimeout: mock(async (filter: NostrFilter) => {
 			fetchedFilters.push(filter)
 			return relayEvents
 		}),
@@ -54,7 +56,7 @@ const SELLER_PUBKEY = 'a'.repeat(64)
 const AUCTION_COORDINATE = `30408:${SELLER_PUBKEY}:auction-1`
 const OTHER_AUCTION_COORDINATE = `30408:${SELLER_PUBKEY}:auction-2`
 
-function pathReleaseEvent(id: string, coordinate: string, createdAt: number): NDKEvent {
+function pathReleaseEvent(id: string, coordinate: string, createdAt: number): RelayEvent {
 	return {
 		id,
 		kind: AUCTION_PATH_RELEASE_KIND as unknown as number,
@@ -65,7 +67,7 @@ function pathReleaseEvent(id: string, coordinate: string, createdAt: number): ND
 			['e', '2'.repeat(64)],
 			['a', coordinate],
 		],
-	} as unknown as NDKEvent
+	} as RelayEvent
 }
 
 describe('auction path-release queries', () => {

--- a/src/queries/__tests__/auctionPathReleases.test.ts
+++ b/src/queries/__tests__/auctionPathReleases.test.ts
@@ -28,6 +28,16 @@ mock.module('@/lib/stores/blacklist', () => ({
 }))
 
 mock.module('@/lib/stores/ndk', () => ({
+	getWriteRelays: () => [],
+	ndkStore: {
+		state: {
+			ndk: null,
+			zapNdk: null,
+			explicitRelayUrls: [],
+			writeRelayUrls: [],
+			signer: undefined,
+		},
+	},
 	ndkActions: {
 		getNDK: () => ({}),
 		fetchEventsWithTimeout: mock(async (filter: NDKFilter) => {

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -45,6 +45,7 @@ const PRIVATE_AUCTION_CLAIM_GIFT_WRAP_PAGE_LIMIT = 100
 const PRIVATE_AUCTION_CLAIM_GIFT_WRAP_MAX_PAGES = 5
 const PRIVATE_AUCTION_CLAIM_GIFT_WRAP_WINDOW_SECONDS = 60 * 60 * 24
 const PRIVATE_AUCTION_CLAIM_GIFT_WRAP_POST_MARKER_GRACE_SECONDS = 5 * 60
+const AUCTION_LIST_FILTER_CHUNK_SIZE = 80
 
 const loadDeletedAuctionIds = (): Map<string, number> => {
 	if (typeof localStorage === 'undefined') return new Map()
@@ -103,6 +104,16 @@ const dedupeEventsById = (events: NDKEvent[]): NDKEvent[] => {
 		eventsById.set(event.id, event)
 	}
 	return Array.from(eventsById.values())
+}
+
+const toStableUniqueStrings = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean))).sort()
+
+const chunkStrings = (values: string[], size: number): string[][] => {
+	const chunks: string[][] = []
+	for (let index = 0; index < values.length; index += size) {
+		chunks.push(values.slice(index, index + size))
+	}
+	return chunks
 }
 
 const cloneAuctionEventWithRootId = (
@@ -272,6 +283,116 @@ export const fetchAuctionBidsForList = async (auctionRootEventIds: string[], lim
 	return byAuctionId
 }
 
+/**
+ * Batch-fetch settlements for a list of auctions and group results by both
+ * root event id (`#e`) and coordinate (`#a`).
+ */
+export const fetchAuctionSettlementsForList = async (
+	auctionRootEventIds: string[],
+	auctionCoordinates: string[],
+	limit: number = 200,
+): Promise<Map<string, NDKEvent[]>> => {
+	const ids = toStableUniqueStrings(auctionRootEventIds)
+	const coordinates = toStableUniqueStrings(auctionCoordinates)
+	if (ids.length === 0 && coordinates.length === 0) return new Map()
+	const ndk = ndkActions.getNDK()
+	if (!ndk) return new Map()
+
+	const filters: NDKFilter[] = []
+	for (const idChunk of chunkStrings(ids, AUCTION_LIST_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			kinds: [AUCTION_SETTLEMENT_KIND],
+			'#e': idChunk,
+			limit,
+		})
+	}
+	for (const coordinateChunk of chunkStrings(coordinates, AUCTION_LIST_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			kinds: [AUCTION_SETTLEMENT_KIND],
+			'#a': coordinateChunk,
+			limit,
+		})
+	}
+
+	if (filters.length === 0) return new Map()
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	const settlements = filterBlacklistedEvents(dedupeEventsById(Array.from(events))).sort(
+		(a, b) => (b.created_at || 0) - (a.created_at || 0),
+	)
+
+	const byAuction = new Map<string, NDKEvent[]>()
+	for (const id of ids) byAuction.set(id, [])
+	for (const coordinate of coordinates) byAuction.set(coordinate, [])
+
+	for (const settlement of settlements) {
+		const rootIds = settlement.tags.filter((tag) => tag[0] === 'e' && !!tag[1]).map((tag) => tag[1])
+		const coords = settlement.tags.filter((tag) => tag[0] === 'a' && !!tag[1]).map((tag) => tag[1])
+		for (const rootId of rootIds) {
+			const bucket = byAuction.get(rootId)
+			if (bucket) bucket.push(settlement)
+		}
+		for (const coord of coords) {
+			const bucket = byAuction.get(coord)
+			if (bucket) bucket.push(settlement)
+		}
+	}
+
+	byAuction.forEach((bucket, key) => {
+		const dedupedBucket = dedupeEventsById(bucket).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+		byAuction.set(key, dedupedBucket)
+	})
+
+	return byAuction
+}
+
+/**
+ * Batch-fetch path releases for a list of auction coordinates.
+ */
+export const fetchAuctionPathReleasesForList = async (
+	auctionCoordinates: string[],
+	limit: number = 200,
+): Promise<Map<string, NDKEvent[]>> => {
+	const coordinates = toStableUniqueStrings(auctionCoordinates)
+	if (coordinates.length === 0) return new Map()
+	const ndk = ndkActions.getNDK()
+	if (!ndk) return new Map()
+
+	const filters: NDKFilter[] = []
+	for (const coordinateChunk of chunkStrings(coordinates, AUCTION_LIST_FILTER_CHUNK_SIZE)) {
+		filters.push({
+			kinds: [AUCTION_PATH_RELEASE_KIND as unknown as number],
+			'#a': coordinateChunk,
+			limit,
+		})
+	}
+
+	if (filters.length === 0) return new Map()
+
+	const events = await ndkActions.fetchEventsWithTimeout(filters.length === 1 ? filters[0] : filters, { timeoutMs: 8000 })
+	const releases = filterBlacklistedEvents(dedupeEventsById(Array.from(events))).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+
+	const byCoordinate = new Map<string, NDKEvent[]>()
+	for (const coordinate of coordinates) byCoordinate.set(coordinate, [])
+
+	for (const release of releases) {
+		const releaseCoordinates = release.tags.filter((tag) => tag[0] === 'a' && !!tag[1]).map((tag) => tag[1])
+		for (const releaseCoordinate of releaseCoordinates) {
+			const bucket = byCoordinate.get(releaseCoordinate)
+			if (bucket) bucket.push(release)
+		}
+	}
+
+	byCoordinate.forEach((bucket, key) => {
+		const dedupedBucket = dedupeEventsById(bucket)
+			.filter((event) => isAuctionPathReleaseForCoordinate(event, key))
+			.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+		byCoordinate.set(key, dedupedBucket)
+	})
+
+	return byCoordinate
+}
+
 export const fetchAuctionBids = async (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) => {
 	if (!auctionEventId && !auctionCoordinates) return []
 	const ndk = ndkActions.getNDK()
@@ -351,6 +472,8 @@ export const fetchAuctionPathReleases = async (
 ): Promise<NDKEvent[]> => {
 	const filter = buildAuctionPathReleaseFilter(auctionCoordinates, limit)
 	if (!filter) return []
+	const coordinate = filter['#a']?.[0]
+	if (!coordinate) return []
 	const ndk = ndkActions.getNDK()
 	if (!ndk) return []
 
@@ -358,7 +481,7 @@ export const fetchAuctionPathReleases = async (
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	return filterBlacklistedEvents(Array.from(events))
-		.filter((event) => isAuctionPathReleaseForCoordinate(event, filter['#a'][0]))
+		.filter((event) => isAuctionPathReleaseForCoordinate(event, coordinate))
 		.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 }
 
@@ -439,11 +562,34 @@ export const auctionByATagQueryOptions = (pubkey: string, dTag: string) =>
  * — list pages don't need second-level freshness for every card.
  */
 export const auctionBidsForListQueryOptions = (auctionRootEventIds: string[], limit: number = 1000) => {
-	const stableKey = Array.from(new Set(auctionRootEventIds.filter(Boolean))).sort()
+	const stableKey = toStableUniqueStrings(auctionRootEventIds)
 	return queryOptions({
-		queryKey: [...auctionKeys.all, 'bids', 'forList', stableKey],
+		queryKey: auctionKeys.bidsForList(stableKey),
 		queryFn: () => fetchAuctionBidsForList(stableKey, limit),
 		enabled: stableKey.length > 0,
+		staleTime: 15000,
+		refetchInterval: 15000,
+	})
+}
+
+export const auctionSettlementsForListQueryOptions = (auctionRootEventIds: string[], auctionCoordinates: string[], limit: number = 200) => {
+	const stableRootIds = toStableUniqueStrings(auctionRootEventIds)
+	const stableCoordinates = toStableUniqueStrings(auctionCoordinates)
+	return queryOptions({
+		queryKey: auctionKeys.settlementsForList(stableRootIds, stableCoordinates),
+		queryFn: () => fetchAuctionSettlementsForList(stableRootIds, stableCoordinates, limit),
+		enabled: stableRootIds.length > 0 || stableCoordinates.length > 0,
+		staleTime: 15000,
+		refetchInterval: 15000,
+	})
+}
+
+export const auctionPathReleasesForListQueryOptions = (auctionCoordinates: string[], limit: number = 200) => {
+	const stableCoordinates = toStableUniqueStrings(auctionCoordinates)
+	return queryOptions({
+		queryKey: auctionKeys.pathReleasesForList(stableCoordinates),
+		queryFn: () => fetchAuctionPathReleasesForList(stableCoordinates, limit),
+		enabled: stableCoordinates.length > 0,
 		staleTime: 15000,
 		refetchInterval: 15000,
 	})
@@ -456,6 +602,16 @@ export const auctionBidsForListQueryOptions = (auctionRootEventIds: string[], li
 export const useAuctionBidsForList = (auctionRootEventIds: string[], limit: number = 1000) =>
 	useQuery({
 		...auctionBidsForListQueryOptions(auctionRootEventIds, limit),
+	})
+
+export const useAuctionSettlementsForList = (auctionRootEventIds: string[], auctionCoordinates: string[], limit: number = 200) =>
+	useQuery({
+		...auctionSettlementsForListQueryOptions(auctionRootEventIds, auctionCoordinates, limit),
+	})
+
+export const useAuctionPathReleasesForList = (auctionCoordinates: string[], limit: number = 200) =>
+	useQuery({
+		...auctionPathReleasesForListQueryOptions(auctionCoordinates, limit),
 	})
 
 export const auctionBidsQueryOptions = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) =>

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -695,6 +695,12 @@ export const getAuctionCurrentPriceFromBids = (auction: NDKEvent | null, bids: N
 export const getAuctionBidCountFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): number =>
 	auction ? getAuctionWindowValidBids(auction, bids).length : bids.length
 
+export const getAuctionTopBidFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): NDKEvent | null => {
+	const validBids = auction ? getAuctionWindowValidBids(auction, bids) : bids
+	if (validBids.length === 0) return null
+	return validBids.reduce((top, bid) => (getBidAmount(bid) > getBidAmount(top) ? bid : top), validBids[0])
+}
+
 export const getAuctionSettlementStatus = (settlementEvent: NDKEvent | null): AuctionSettlementStatus => {
 	if (!settlementEvent) return 'unknown'
 	const status = settlementEvent.tags.find((tag) => tag[0] === 'status')?.[1]

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -12,9 +12,13 @@ export const auctionKeys = {
 	all: ['auctions'] as const,
 	details: (id: string) => [...auctionKeys.all, id] as const,
 	bids: (auctionId: string) => [...auctionKeys.all, 'bids', auctionId] as const,
+	bidsForList: (auctionIds: string[]) => [...auctionKeys.all, 'bids', 'forList', auctionIds] as const,
 	byBidder: (pubkey: string) => [...auctionKeys.all, 'byBidder', pubkey] as const,
 	settlements: (auctionId: string) => [...auctionKeys.all, 'settlements', auctionId] as const,
+	settlementsForList: (auctionIds: string[], auctionCoordinates: string[]) =>
+		[...auctionKeys.all, 'settlements', 'forList', auctionIds, auctionCoordinates] as const,
 	pathReleases: (auctionId: string) => [...auctionKeys.all, 'pathReleases', auctionId] as const,
+	pathReleasesForList: (auctionCoordinates: string[]) => [...auctionKeys.all, 'pathReleases', 'forList', auctionCoordinates] as const,
 	verdicts: (auctionId: string) => [...auctionKeys.all, 'verdicts', auctionId] as const,
 	byPubkey: (pubkey: string) => [...auctionKeys.all, 'byPubkey', pubkey] as const,
 	byATag: (pubkey: string, dTag: string) => [...auctionKeys.all, 'byATag', pubkey, dTag] as const,

--- a/src/routes/_dashboard-layout.tsx
+++ b/src/routes/_dashboard-layout.tsx
@@ -122,7 +122,10 @@ function getNotificationCount(
 	unseenMessages: number,
 	unseenPurchases: number,
 	unseenAuctionBids: number,
-	unseenAuctionLive: number,
+	unseenAuctionLiveChatComments: number,
+	unseenAuctionThreadComments: number,
+	unseenProductThreadComments: number,
+	unseenScheduledAuctionsNowLive: number,
 	unseenAuctionSettlementBegins: number,
 	unseenBidUpdates: number,
 ): number {
@@ -136,7 +139,16 @@ function getNotificationCount(
 		return unseenPurchases
 	}
 	if (path === '/dashboard/products/auctions') {
-		return unseenAuctionBids + unseenAuctionLive + unseenAuctionSettlementBegins
+		return (
+			unseenAuctionBids +
+			unseenAuctionLiveChatComments +
+			unseenAuctionThreadComments +
+			unseenScheduledAuctionsNowLive +
+			unseenAuctionSettlementBegins
+		)
+	}
+	if (path === '/dashboard/products/products') {
+		return unseenProductThreadComments
 	}
 	if (path === '/dashboard/products/bids') {
 		return unseenBidUpdates
@@ -177,7 +189,10 @@ function DashboardLayout() {
 		unseenMessages,
 		unseenPurchases,
 		unseenAuctionBids,
-		unseenAuctionLive,
+		unseenAuctionComments: unseenAuctionLiveChatComments,
+		unseenAuctionEventComments: unseenAuctionThreadComments,
+		unseenProductComments: unseenProductThreadComments,
+		unseenAuctionLive: unseenScheduledAuctionsNowLive,
 		unseenAuctionSettlementBegins,
 		unseenBidUpdates,
 	} = useStore(notificationStore)
@@ -348,7 +363,10 @@ function DashboardLayout() {
 													unseenMessages,
 													unseenPurchases,
 													unseenAuctionBids,
-													unseenAuctionLive,
+													unseenAuctionLiveChatComments,
+													unseenAuctionThreadComments,
+													unseenProductThreadComments,
+													unseenScheduledAuctionsNowLive,
 													unseenAuctionSettlementBegins,
 													unseenBidUpdates,
 												)

--- a/src/routes/_dashboard-layout.tsx
+++ b/src/routes/_dashboard-layout.tsx
@@ -122,6 +122,8 @@ function getNotificationCount(
 	unseenMessages: number,
 	unseenPurchases: number,
 	unseenAuctionBids: number,
+	unseenAuctionLive: number,
+	unseenAuctionSettlementBegins: number,
 	unseenBidUpdates: number,
 ): number {
 	if (path === '/dashboard/sales/sales') {
@@ -134,7 +136,7 @@ function getNotificationCount(
 		return unseenPurchases
 	}
 	if (path === '/dashboard/products/auctions') {
-		return unseenAuctionBids
+		return unseenAuctionBids + unseenAuctionLive + unseenAuctionSettlementBegins
 	}
 	if (path === '/dashboard/products/bids') {
 		return unseenBidUpdates
@@ -170,7 +172,15 @@ function DashboardLayout() {
 	const [parent] = useAutoAnimate()
 	const { dashboardTitle, dashboardHeaderAction } = useStore(uiStore)
 	const { isAuthenticated } = useStore(authStore)
-	const { unseenOrders, unseenMessages, unseenPurchases, unseenAuctionBids, unseenBidUpdates } = useStore(notificationStore)
+	const {
+		unseenOrders,
+		unseenMessages,
+		unseenPurchases,
+		unseenAuctionBids,
+		unseenAuctionLive,
+		unseenAuctionSettlementBegins,
+		unseenBidUpdates,
+	} = useStore(notificationStore)
 	const isMessageDetailView =
 		location.pathname.startsWith('/dashboard/sales/messages/') && location.pathname !== '/dashboard/sales/messages'
 	// Admin checking
@@ -338,6 +348,8 @@ function DashboardLayout() {
 													unseenMessages,
 													unseenPurchases,
 													unseenAuctionBids,
+													unseenAuctionLive,
+													unseenAuctionSettlementBegins,
 													unseenBidUpdates,
 												)
 												return (

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -1,6 +1,5 @@
 import { cn } from '@/lib/utils'
-import { AuctionCountdown } from '@/components/AuctionCountdown'
-import { DashboardListItem } from '@/components/layout/DashboardListItem'
+import { AvatarUser } from '@/components/AvatarUser'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
@@ -11,27 +10,30 @@ import {
 	auctionsByPubkeyQueryOptions,
 	getAuctionBiddingCutoffAt,
 	getAuctionBidCountFromBids,
-	getAuctionCurrentPriceFromBids,
 	getAuctionId,
 	getAuctionImages,
-	getAuctionReserve,
 	getAuctionRootEventId,
-	getAuctionSettlementStatus,
 	getAuctionStartAt,
-	getAuctionStartingBid,
 	getAuctionSummary,
 	getAuctionTitle,
+	getAuctionTopBidFromBids,
+	getBidAmount,
 	useAuctionBids,
 	useAuctionBidsForList,
+	useAuctionClaimOrders,
 	useAuctionSettlements,
 } from '@/queries/auctions'
+import { useComments } from '@/queries/comments'
+import { useLiveActivity, useLiveChatMessages } from '@/queries/liveChat'
+import { getOrderId } from '@/queries/orders'
+import { useProfileName } from '@/queries/profiles'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { Clock, Eye, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
+import { Clock, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
@@ -40,17 +42,30 @@ import {
 	useFilteredAuctions,
 	type AuctionSortOption,
 } from '@/lib/utils/auctions'
-import { useBreakpoint } from '@/hooks/useBreakpoint'
 
-function formatAuctionStatus(startAt: number, endAt: number, now: number): string {
-	if (endAt > 0 && now >= endAt) return 'Ended'
+type AuctionStatus = 'Scheduled' | 'Live' | 'Settlement' | 'Ended'
+
+function formatAuctionStatus(startAt: number, biddingCutoffAt: number, settlementLocked: boolean, now: number): AuctionStatus {
 	if (startAt > 0 && now < startAt) return 'Scheduled'
+	if (biddingCutoffAt > 0 && now >= biddingCutoffAt) return settlementLocked ? 'Ended' : 'Settlement'
 	return 'Live'
 }
 
 function formatMaybeDate(timestamp: number): string {
 	if (!timestamp) return 'N/A'
-	return new Date(timestamp * 1000).toLocaleString()
+	return new Date(timestamp * 1000).toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+}
+
+function formatTimeAgo(timestamp: number): string {
+	if (!timestamp) return ''
+	const diffSeconds = Math.max(0, Math.floor(Date.now() / 1000) - timestamp)
+	if (diffSeconds < 60) return 'just now'
+	const diffMinutes = Math.floor(diffSeconds / 60)
+	if (diffMinutes < 60) return `${diffMinutes} min${diffMinutes === 1 ? '' : 's'} ago`
+	const diffHours = Math.floor(diffMinutes / 60)
+	if (diffHours < 24) return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`
+	const diffDays = Math.floor(diffHours / 24)
+	return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
 }
 
 const getAuctionCoordinates = (auction: NDKEvent): string => {
@@ -58,117 +73,51 @@ const getAuctionCoordinates = (auction: NDKEvent): string => {
 	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 }
 
-/**
- * Compact body for a seller's auction row. The auction detail route is the
- * one place to look at the full thing; this collapsible deliberately keeps
- * only the "what's the headline state" essentials plus the inline settlement
- * action so a seller can close ended auctions without a navigation hop.
- * Anything that resembles tech-debt (event IDs, mint URLs, settlement-policy
- * strings, etc.) lives on the detail route behind accordions.
- */
-function AuctionListBody({
-	auction,
-	onPublishSettlement,
-	isSettling,
-}: {
-	auction: NDKEvent
-	onPublishSettlement: () => void
-	isSettling: boolean
-}) {
-	const summary = getAuctionSummary(auction) || auction.content || 'No description'
-	const images = getAuctionImages(auction)
-	const startingBid = getAuctionStartingBid(auction)
-	const reserve = getAuctionReserve(auction)
-	const auctionRootEventId = getAuctionRootEventId(auction)
-	const auctionCoordinates = getAuctionCoordinates(auction)
-	const startAt = getAuctionStartAt(auction)
+const STATUS_BADGE_STYLES: Record<AuctionStatus, string> = {
+	Scheduled: 'border-sky-400 text-sky-700 bg-sky-50',
+	Live: 'border-emerald-400 text-emerald-700 bg-emerald-50',
+	Settlement: 'border-sky-400 text-sky-700 bg-sky-50',
+	Ended: 'border-zinc-300 text-zinc-500 bg-zinc-50',
+}
 
-	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
-	const bids = bidsQuery.data ?? []
-	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-	const now = Math.floor(Date.now() / 1000)
-	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
-	const ended = status === 'Ended'
-	const currentBid = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
-	const bidsCount = getAuctionBidCountFromBids(auction, bids)
+function ActivityRow({ header, unit, count, newCount }: { header: string; unit: string; count: number; newCount: number }) {
+	return (
+		<div className="space-y-0.5">
+			<p className="text-xs text-muted-foreground">{header}</p>
+			<p className="text-sm">
+				<span className="font-semibold">
+					{count} {count === 1 ? unit : `${unit}s`}
+				</span>
+				{newCount > 0 && <span className="ml-2 text-pink-600 font-semibold">{newCount} New</span>}
+			</p>
+		</div>
+	)
+}
 
-	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auction.id, 5, auctionCoordinates)
-	const latestSettlement = settlementsQuery.data?.[0] ?? null
-	const settlementStatus = latestSettlement ? getAuctionSettlementStatus(latestSettlement) : 'unknown'
-	const settlementLocked = !!latestSettlement
-	const reserveMet = currentBid >= reserve
+function TopBidBox({ auction, bids }: { auction: NDKEvent; bids: NDKEvent[] }) {
+	const topBid = getAuctionTopBidFromBids(auction, bids)
+	const { data: bidderName } = useProfileName(topBid?.pubkey ?? '')
 
-	const settlementHelper = settlementLocked
-		? `Settlement already published (${settlementStatus.replace(/_/g, ' ')}).`
-		: !ended
-			? 'Settlement unlocks once the auction ends.'
-			: bidsCount === 0
-				? 'No bids — settlement will record reserve_not_met.'
-				: reserveMet
-					? `Settlement will record settled at ${currentBid.toLocaleString()} sats.`
-					: 'Top bid is below reserve — settlement will record reserve_not_met.'
+	if (!topBid) {
+		return (
+			<div className="rounded-xl border px-4 py-3">
+				<p className="text-sm text-muted-foreground">No bids yet</p>
+			</div>
+		)
+	}
 
 	return (
-		<div className="block p-4 bg-gray-50 border-t">
-			<div className="space-y-4">
-				{images.length > 0 && (
-					<div className="w-full h-32 bg-gray-200 rounded-md overflow-hidden">
-						<img src={images[0][1]} alt="Auction image" className="w-full h-full object-cover" />
-					</div>
-				)}
-				<div>
-					<p className="text-sm text-gray-600 mb-1">Summary:</p>
-					<p className="text-sm">{summary}</p>
+		<div className="rounded-xl border px-4 py-3">
+			<div>
+				<div className="flex items-center gap-2 text-xs text-muted-foreground">
+					<span>Top bid:</span>
+					<span>{formatTimeAgo(topBid.created_at ?? 0)}</span>
 				</div>
-				<div className="grid grid-cols-2 gap-2 text-sm">
-					<p className="text-gray-600">
-						Status:{' '}
-						<span
-							className={`font-medium ${status === 'Live' ? 'text-green-600' : status === 'Scheduled' ? 'text-blue-600' : 'text-zinc-600'}`}
-						>
-							{status}
-						</span>
-					</p>
-					<p className="text-gray-600">
-						Bids: <span className="font-medium">{bidsCount}</span>
-					</p>
-					<p className="text-gray-600">
-						Starting bid: <span className="font-medium">{startingBid.toLocaleString()} sats</span>
-					</p>
-					<p className="text-gray-600">
-						Current bid: <span className="font-medium">{currentBid.toLocaleString()} sats</span>
-					</p>
-					<p className="text-gray-600">
-						Reserve: <span className="font-medium">{reserve.toLocaleString()} sats</span>
-					</p>
-					<p className="text-gray-600 col-span-2">
-						Bidding ends: <span className="font-medium">{formatMaybeDate(biddingCutoffAt)}</span>
-					</p>
-				</div>
-
-				<div className="rounded-md border bg-white px-3 py-3 space-y-2">
-					<p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-500">Settlement</p>
-					<p className="text-xs text-gray-600">{settlementHelper}</p>
-					<Button className="w-full" size="sm" onClick={onPublishSettlement} disabled={!ended || settlementLocked || isSettling}>
-						{isSettling ? (
-							<>
-								<Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
-								Publishing…
-							</>
-						) : (
-							'Publish Settlement'
-						)}
-					</Button>
-				</div>
-
-				<div className="flex flex-wrap items-center gap-2 pt-1">
-					<Link to="/dashboard/products/auctions/$auctionId" params={{ auctionId: auction.id }}>
-						<Button variant="outline" size="sm" className="gap-2">
-							<Eye className="w-3.5 h-3.5" />
-							View Auction
-						</Button>
-					</Link>
-				</div>
+				<p className="text-xl font-bold">{getBidAmount(topBid).toLocaleString()} sats</p>
+			</div>
+			<div className="mt-2 flex items-center gap-2">
+				<AvatarUser pubkey={topBid.pubkey} colored deterministicFallbackText className="w-6 h-6" />
+				<span className="text-sm font-medium truncate max-w-32">{bidderName || topBid.pubkey.slice(0, 8)}</span>
 			</div>
 		</div>
 	)
@@ -176,96 +125,113 @@ function AuctionListBody({
 
 function AuctionListItem({
 	auction,
-	isExpanded,
-	onToggleExpanded,
 	onManage,
 	onPublishSettlement,
 	isSettling,
 }: {
 	auction: NDKEvent
-	isExpanded: boolean
-	onToggleExpanded: () => void
 	onManage: () => void
 	onPublishSettlement: () => void
 	isSettling: boolean
 }) {
-	const startAt = getAuctionStartAt(auction)
-	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
-	const now = Math.floor(Date.now() / 1000)
-	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
+	const summary = getAuctionSummary(auction) || auction.content || 'No description'
 	const images = getAuctionImages(auction)
 	const thumbnailUrl = images.length > 0 ? images[0][1] : null
+	const startAt = getAuctionStartAt(auction)
+	const auctionRootEventId = getAuctionRootEventId(auction)
+	const auctionCoordinates = getAuctionCoordinates(auction)
+	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
+	const now = Math.floor(Date.now() / 1000)
 
-	const breakpoint = useBreakpoint()
+	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
+	const bids = bidsQuery.data ?? []
+	const bidsCount = getAuctionBidCountFromBids(auction, bids)
+	const newBidsCount = bids.filter((bid) => (bid.created_at ?? 0) > notificationActions.getLastSeenAuctionBids()).length
 
-	const triggerContent = (
-		<div className="flex items-center gap-3">
-			{thumbnailUrl ? (
-				<img src={thumbnailUrl} alt="" className="w-10 h-10 rounded object-cover shrink-0" />
-			) : (
-				<div className="w-10 h-10 rounded bg-gray-100 flex items-center justify-center shrink-0">
-					<Gavel className="w-5 h-5 text-gray-400" />
+	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auction.id, 5, auctionCoordinates)
+	const latestSettlement = settlementsQuery.data?.[0] ?? null
+	const settlementLocked = !!latestSettlement
+
+	const status = formatAuctionStatus(startAt, biddingCutoffAt, settlementLocked, now)
+
+	const commentsQuery = useComments(auction)
+	const comments = commentsQuery.data ?? []
+	const newCommentsCount = comments.filter((comment) => comment.createdAt > notificationActions.getLastSeenAuctionEventComments()).length
+
+	const liveActivityQuery = useLiveActivity(auction)
+	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
+	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
+	const chatMessages = chatQuery.data ?? []
+	const newChatCount = chatMessages.filter((message) => message.createdAt > notificationActions.getLastSeenAuctionComments()).length
+
+	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)
+	const orderId = claimOrdersQuery.data?.[0] ? getOrderId(claimOrdersQuery.data[0]) : undefined
+
+	return (
+		<div className="rounded-lg border border-zinc-200 bg-background p-6 shadow-md">
+			<div className="flex flex-col gap-6 lg:flex-row">
+				<div className="flex shrink-0 items-start gap-3 lg:flex-col">
+					{thumbnailUrl ? (
+						<img src={thumbnailUrl} alt="" className="h-24 w-24 shrink-0 rounded-xl object-cover lg:h-32 lg:w-32" />
+					) : (
+						<div className="flex h-24 w-24 shrink-0 items-center justify-center rounded-xl bg-zinc-100 lg:h-32 lg:w-32">
+							<Gavel className="h-8 w-8 text-zinc-400" />
+						</div>
+					)}
+					<Link to="/dashboard/products/auctions/$auctionId" params={{ auctionId: auction.id }} className="lg:w-32">
+						<Button variant="outline" size="sm" className="w-full gap-2">
+							<ExternalLink className="h-3.5 w-3.5" />
+							Open Auction
+						</Button>
+					</Link>
+					{status === 'Scheduled' && (
+						<Button variant="ghost" size="sm" className="gap-2" onClick={onManage}>
+							<Pencil className="h-3.5 w-3.5" />
+							Manage
+						</Button>
+					)}
 				</div>
-			)}
-			<div className="min-w-0 flex-1">
-				<div className="flex items-start justify-between gap-3 min-w-0">
-					<p className="font-semibold text-sm truncate text-foreground">{getAuctionTitle(auction)}</p>
+
+				<div className="flex-1 min-w-0 space-y-4">
+					<div className="min-w-0">
+						<h3 className="text-lg font-semibold text-foreground truncate">{getAuctionTitle(auction)}</h3>
+						<p className="text-sm text-muted-foreground truncate">{summary}</p>
+						<p className="mt-1 text-xs text-muted-foreground">Created: {formatMaybeDate(auction.created_at ?? 0)}</p>
+					</div>
+
+					<TopBidBox auction={auction} bids={bids} />
+
+					{status === 'Settlement' && (
+						<Button className="w-full bg-pink-600 hover:bg-pink-700 text-white" onClick={onPublishSettlement} disabled={isSettling}>
+							{isSettling ? (
+								<>
+									<Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
+									Publishing…
+								</>
+							) : (
+								'Publish Settlement'
+							)}
+						</Button>
+					)}
+
+					{status === 'Ended' && orderId && (
+						<Link to="/dashboard/orders/$orderId" params={{ orderId }}>
+							<Button className="w-full bg-neutral-800 hover:bg-neutral-700 text-white">Go to Order Page</Button>
+						</Link>
+					)}
 				</div>
-				<div className="mt-2 flex flex-wrap items-center gap-2">
-					<span
-						className={cn(
-							'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium',
-							status === 'Live'
-								? 'bg-emerald-100 text-emerald-800'
-								: status === 'Scheduled'
-									? 'bg-sky-100 text-sky-800'
-									: 'bg-zinc-100 text-zinc-800',
-						)}
-					>
-						{status}
-					</span>
+
+				<div className="flex w-full shrink-0 flex-col items-end gap-3 lg:w-64">
+					<span className={cn('inline-flex w-fit rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}>{status}</span>
+					<div className="w-full space-y-3 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-5">
+						<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Activity</p>
+						<ActivityRow header="Bids" unit="Bid" count={bidsCount} newCount={newBidsCount} />
+						<ActivityRow header="Comments" unit="Comment" count={comments.length} newCount={newCommentsCount} />
+						<ActivityRow header="Live Chat" unit="Message" count={chatMessages.length} newCount={newChatCount} />
+					</div>
 				</div>
 			</div>
 		</div>
-	)
-
-	const actions = (
-		<>
-			{breakpoint !== 'sm' && (
-				<div className="min-w-64">
-					<AuctionCountdown auction={auction} />
-				</div>
-			)}
-			<Link
-				to="/dashboard/products/auctions/$auctionId"
-				params={{ auctionId: auction.id }}
-				onClick={(e) => e.stopPropagation()}
-				aria-label={`Open auction route for ${getAuctionTitle(auction)}`}
-			>
-				<Button variant="ghost" size="sm">
-					<Eye className="w-4 h-4" />
-				</Button>
-			</Link>
-			{status === 'Scheduled' && (
-				<Button
-					variant="ghost"
-					size="sm"
-					onClick={(e) => {
-						e.stopPropagation()
-						onManage()
-					}}
-					aria-label={`Manage ${getAuctionTitle(auction)}`}
-				>
-					<Pencil className="w-4 h-4" />
-				</Button>
-			)}
-		</>
-	)
-
-	return (
-		<DashboardListItem isOpen={isExpanded} onOpenChange={onToggleExpanded} triggerContent={triggerContent} actions={actions} icon={false}>
-			<AuctionListBody auction={auction} onPublishSettlement={onPublishSettlement} isSettling={isSettling} />
-		</DashboardListItem>
 	)
 }
 
@@ -277,7 +243,6 @@ function AuctionsOverviewComponent() {
 	const { user, isAuthenticated } = useStore(authStore)
 	const navigate = useNavigate()
 	const matchRoute = useMatchRoute()
-	const [expandedAuction, setExpandedAuction] = useState<string | null>(null)
 	const [sort, setSort] = useState<AuctionSortOption>(defaultAuctionFilters.sort ?? 'ending-soon')
 	const settlementMutation = usePublishAuctionSettlementMutation()
 	const [settlingAuctionId, setSettlingAuctionId] = useState<string | null>(null)
@@ -444,8 +409,6 @@ function AuctionsOverviewComponent() {
 								<li key={auction.id}>
 									<AuctionListItem
 										auction={auction}
-										isExpanded={expandedAuction === auction.id}
-										onToggleExpanded={() => setExpandedAuction((prev) => (prev === auction.id ? null : auction.id))}
 										onManage={() => handleManageAuction(auction.id)}
 										onPublishSettlement={() => void handlePublishSettlement(auction)}
 										isSettling={settlingAuctionId === auction.id && settlementMutation.isPending}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -31,9 +31,9 @@ import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
-import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
+import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { Clock, ExternalLink, Gavel, Loader2, Pencil } from 'lucide-react'
+import { Clock, ExternalLink, Gavel, Loader2 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
@@ -125,12 +125,10 @@ function TopBidBox({ auction, bids }: { auction: NDKEvent; bids: NDKEvent[] }) {
 
 function AuctionListItem({
 	auction,
-	onManage,
 	onPublishSettlement,
 	isSettling,
 }: {
 	auction: NDKEvent
-	onManage: () => void
 	onPublishSettlement: () => void
 	isSettling: boolean
 }) {
@@ -184,12 +182,6 @@ function AuctionListItem({
 							Open Auction
 						</Button>
 					</Link>
-					{status === 'Scheduled' && (
-						<Button variant="ghost" size="sm" className="gap-2" onClick={onManage}>
-							<Pencil className="h-3.5 w-3.5" />
-							Manage
-						</Button>
-					)}
 				</div>
 
 				<div className="flex-1 min-w-0 space-y-4">
@@ -241,7 +233,6 @@ export const Route = createFileRoute('/_dashboard-layout/dashboard/products/auct
 
 function AuctionsOverviewComponent() {
 	const { user, isAuthenticated } = useStore(authStore)
-	const navigate = useNavigate()
 	const matchRoute = useMatchRoute()
 	const [sort, setSort] = useState<AuctionSortOption>(defaultAuctionFilters.sort ?? 'ending-soon')
 	const settlementMutation = usePublishAuctionSettlementMutation()
@@ -301,13 +292,6 @@ function AuctionsOverviewComponent() {
 
 	const handleCreateAuction = () => {
 		uiActions.openDrawer('createAuction')
-	}
-
-	const handleManageAuction = (auctionEventId: string) => {
-		navigate({
-			to: '/dashboard/products/auctions/$auctionId',
-			params: { auctionId: auctionEventId },
-		})
 	}
 
 	if (!isAuthenticated || !user) {
@@ -409,7 +393,6 @@ function AuctionsOverviewComponent() {
 								<li key={auction.id}>
 									<AuctionListItem
 										auction={auction}
-										onManage={() => handleManageAuction(auction.id)}
 										onPublishSettlement={() => void handlePublishSettlement(auction)}
 										isSettling={settlingAuctionId === auction.id && settlementMutation.isPending}
 									/>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -117,15 +117,6 @@ function ActivityRow({ header, unit, count, newCount }: { header: string; unit: 
 	)
 }
 
-function TechnicalDataRow({ label, value }: { label: string; value: string }) {
-	return (
-		<div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-3">
-			<p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">{label}</p>
-			<div className="mt-1 break-all text-sm font-medium text-zinc-900">{value}</div>
-		</div>
-	)
-}
-
 function TopBidBox({
 	auction,
 	bids,

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -35,8 +35,8 @@ import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { Clock, ExternalLink, Gavel, Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { CheckCheck, Clock, ExternalLink, Gavel, Loader2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
 	defaultAuctionFilters,
@@ -174,6 +174,15 @@ function AuctionListItem({
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
 	const chatMessages = chatQuery.data ?? []
 	const newChatCount = chatMessages.filter((message) => message.createdAt > notificationActions.getLastSeenAuctionComments()).length
+	const hasNewActivity = newBidsCount + newCommentsCount + newChatCount > 0
+
+	const handleMarkActivitySeen = () => {
+		notificationActions.markAuctionBidsSeen()
+		notificationActions.markAuctionCommentsSeen()
+		notificationActions.markAuctionEventCommentsSeen()
+		notificationActions.markAuctionLiveSeen()
+		notificationActions.markAuctionSettlementBeginsSeen()
+	}
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)
 	const orderId = claimOrdersQuery.data?.[0] ? getOrderId(claimOrdersQuery.data[0]) : undefined
@@ -250,7 +259,20 @@ function AuctionListItem({
 						</span>
 					</div>
 					<div className="w-full space-y-3 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-5">
-						<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Activity</p>
+						<div className="flex items-center justify-between gap-3">
+							<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Activity</p>
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								onClick={handleMarkActivitySeen}
+								disabled={!hasNewActivity}
+								className="h-7 rounded-md border border-zinc-300 bg-white px-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground hover:bg-zinc-100 hover:text-foreground"
+							>
+								<CheckCheck className="h-3.5 w-3.5" aria-hidden="true" />
+								Mark as seen
+							</Button>
+						</div>
 						<ActivityRow header="Bids" unit="Bid" count={bidsCount} newCount={newBidsCount} />
 						<ActivityRow header="Comments" unit="Comment" count={comments.length} newCount={newCommentsCount} />
 						<ActivityRow header="Live Chat" unit="Message" count={chatMessages.length} newCount={newChatCount} />
@@ -279,16 +301,6 @@ function AuctionsOverviewComponent() {
 	})
 
 	useDashboardTitle(isOnChildRoute ? 'Auction Details' : 'Auctions')
-
-	useEffect(() => {
-		if (isAuthenticated && user?.pubkey) {
-			notificationActions.markAuctionBidsSeen()
-			notificationActions.markAuctionCommentsSeen()
-			notificationActions.markAuctionEventCommentsSeen()
-			notificationActions.markAuctionLiveSeen()
-			notificationActions.markAuctionSettlementBeginsSeen()
-		}
-	}, [isAuthenticated, user?.pubkey])
 
 	const {
 		data: auctions,

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -22,7 +22,6 @@ import {
 	getAuctionTitle,
 	getAuctionTopBidFromBids,
 	getBidAmount,
-	getBidMint,
 	useAuctionBids,
 	useAuctionBidsForList,
 	useAuctionClaimOrders,

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -60,7 +60,13 @@ function formatAuctionStatus(startAt: number, biddingCutoffAt: number, settlemen
 
 function formatMaybeDate(timestamp: number): string {
 	if (!timestamp) return 'N/A'
-	return new Date(timestamp * 1000).toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+	return new Date(timestamp * 1000).toLocaleString('en-US', {
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit',
+		month: 'long',
+		year: 'numeric',
+	})
 }
 
 function formatTimeAgo(timestamp: number): string {

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -167,7 +167,7 @@ function AuctionListItem({
 	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
 	const chatMessages = chatQuery.data ?? []
-	const newChatCount = chatMessages.filter((message) => message.createdAt > notificationActions.getLastSeenAuctionComments()).length
+	const newChatCount = chatMessages.filter((message) => message.createdAt > lastSeenTimestamps.auctionComments).length
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)
 	const orderId = claimOrdersQuery.data?.[0] ? getOrderId(claimOrdersQuery.data[0]) : undefined

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -97,7 +97,17 @@ function ActivityRow({ header, unit, count, newCount }: { header: string; unit: 
 	)
 }
 
-function TopBidBox({ auction, bids, className }: { auction: NDKEvent; bids: NDKEvent[]; className?: string }) {
+function TopBidBox({
+	auction,
+	bids,
+	className,
+	isSettlementPhase,
+}: {
+	auction: NDKEvent
+	bids: NDKEvent[]
+	className?: string
+	isSettlementPhase: boolean
+}) {
 	const topBid = getAuctionTopBidFromBids(auction, bids)
 	const { data: bidderName } = useProfileName(topBid?.pubkey ?? '')
 
@@ -115,16 +125,34 @@ function TopBidBox({ auction, bids, className }: { auction: NDKEvent; bids: NDKE
 	}
 
 	return (
-		<div className={cn('h-full min-h-32 rounded-xl border-2 border-emerald-300 bg-emerald-100 px-4 py-4', className)}>
+		<div
+			className={cn(
+				'h-full min-h-32 rounded-xl border-2 px-4 py-4',
+				isSettlementPhase ? 'border-emerald-300 bg-emerald-100' : 'border-zinc-300 bg-zinc-100',
+				className,
+			)}
+		>
 			<div>
-				<div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-800">
+				<div
+					className={cn(
+						'flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em]',
+						isSettlementPhase ? 'text-emerald-800' : 'text-zinc-700',
+					)}
+				>
 					<span>Top bid:</span>
 					<span>{formatTimeAgo(topBid.created_at ?? 0)}</span>
 				</div>
 				<p className="mt-1 text-2xl font-semibold tracking-tight text-zinc-950">{getBidAmount(topBid).toLocaleString()} sats</p>
 			</div>
 			<div className="mt-2 flex items-center justify-between gap-2">
-				<Badge className="border-emerald-300 bg-white text-emerald-800 hover:bg-white">Winning bid</Badge>
+				<Badge
+					className={cn(
+						'bg-white hover:bg-white',
+						isSettlementPhase ? 'border-emerald-300 text-emerald-800' : 'border-zinc-300 text-zinc-700',
+					)}
+				>
+					{isSettlementPhase ? 'Winning bid' : 'Current top bid'}
+				</Badge>
 
 				<div className="flex items-center gap-2">
 					<Link to="/profile/$profileId" params={{ profileId: topBid.pubkey }}>
@@ -165,6 +193,7 @@ function AuctionListItem({
 	const settlementLocked = !!latestSettlement
 
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, settlementLocked, now)
+	const isSettlementPhase = status === 'Settlement' || status === 'Ended'
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
@@ -218,13 +247,13 @@ function AuctionListItem({
 						<p className="mt-1 text-xs text-muted-foreground">Created: {formatMaybeDate(auction.created_at ?? 0)}</p>
 					</div>
 
-					<TopBidBox auction={auction} bids={bids} className="flex-1" />
+					<TopBidBox auction={auction} bids={bids} className="flex-1" isSettlementPhase={isSettlementPhase} />
 
-					{status === 'Settlement' && (
+					{status !== 'Ended' && (
 						<Button
-							className="mt-auto w-full bg-neutral-800 text-white hover:bg-neutral-700"
+							className="mt-auto w-full bg-neutral-800 text-white hover:bg-neutral-700 disabled:border disabled:border-zinc-300 disabled:bg-zinc-200 disabled:text-zinc-500"
 							onClick={onPublishSettlement}
-							disabled={isSettling}
+							disabled={status !== 'Settlement' || isSettling}
 						>
 							{isSettling ? (
 								<>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -293,6 +293,8 @@ function AuctionsOverviewComponent() {
 	useEffect(() => {
 		if (isAuthenticated && user?.pubkey) {
 			notificationActions.markAuctionBidsSeen()
+			notificationActions.markAuctionLiveSeen()
+			notificationActions.markAuctionSettlementBeginsSeen()
 		}
 	}, [isAuthenticated, user?.pubkey])
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
-import { notificationActions } from '@/lib/stores/notifications'
+import { notificationActions, notificationStore } from '@/lib/stores/notifications'
 import { uiActions } from '@/lib/stores/ui'
 import { usePublishAuctionSettlementMutation } from '@/publish/auctions'
 import {
@@ -36,7 +36,7 @@ import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router'
-import { useStore } from '@tanstack/react-store'
+import { useSelector } from '@tanstack/react-store'
 import { CheckCheck, Clock, ExternalLink, Gavel, Hourglass, Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
@@ -264,10 +264,17 @@ function AuctionListItem({
 	const auctionCoordinates = getAuctionCoordinates(auction)
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const now = Math.floor(Date.now() / 1000)
+	const {
+		lastSeenTimestamps: {
+			auctionBids: lastSeenAuctionBids,
+			auctionComments: lastSeenAuctionComments,
+			auctionEventComments: lastSeenAuctionEventComments,
+		},
+	} = useSelector(notificationStore)
 
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const topBid = getAuctionTopBidFromBids(auction, bids)
-	const newBidsCount = bids.filter((bid) => (bid.created_at ?? 0) > notificationActions.getLastSeenAuctionBids()).length
+	const newBidsCount = bids.filter((bid) => (bid.created_at ?? 0) > lastSeenAuctionBids).length
 
 	const settlementLocked = !!latestSettlement
 
@@ -291,12 +298,12 @@ function AuctionListItem({
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
-	const newCommentsCount = comments.filter((comment) => comment.createdAt > notificationActions.getLastSeenAuctionEventComments()).length
+	const newCommentsCount = comments.filter((comment) => comment.createdAt > lastSeenAuctionEventComments).length
 	const liveActivityQuery = useLiveActivity(auction)
 	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
 	const chatMessages = chatQuery.data ?? []
-	const newChatCount = chatMessages.filter((message) => message.createdAt > notificationActions.getLastSeenAuctionComments()).length
+	const newChatCount = chatMessages.filter((message) => message.createdAt > lastSeenAuctionComments).length
 	const hasNewActivity = newBidsCount + newCommentsCount + newChatCount > 0
 
 	const handleMarkActivitySeen = () => {
@@ -439,7 +446,7 @@ export const Route = createFileRoute('/_dashboard-layout/dashboard/products/auct
 })
 
 function AuctionsOverviewComponent() {
-	const { user, isAuthenticated } = useStore(authStore)
+	const { user, isAuthenticated } = useSelector(authStore)
 	const matchRoute = useMatchRoute()
 	const [sort, setSort] = useState<AuctionSortOption>(defaultAuctionFilters.sort ?? 'ending-soon')
 	const settlementMutation = usePublishAuctionSettlementMutation()

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -3,6 +3,7 @@ import { AvatarUser } from '@/components/AvatarUser'
 import { AuctionCountdown } from '@/components/AuctionCountdown'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
 import { notificationActions } from '@/lib/stores/notifications'
@@ -15,14 +16,17 @@ import {
 	getAuctionId,
 	getAuctionImages,
 	getAuctionRootEventId,
+	getAuctionSettlementGrace,
 	getAuctionStartAt,
 	getAuctionSummary,
 	getAuctionTitle,
 	getAuctionTopBidFromBids,
 	getBidAmount,
+	getBidMint,
 	useAuctionBids,
 	useAuctionBidsForList,
 	useAuctionClaimOrders,
+	useAuctionPathReleases,
 	useAuctionSettlements,
 } from '@/queries/auctions'
 import { useComments } from '@/queries/comments'
@@ -71,6 +75,17 @@ function formatTimeAgo(timestamp: number): string {
 	return `${diffDays} day${diffDays === 1 ? '' : 's'} ago`
 }
 
+function formatTimeLeft(seconds: number): string {
+	if (seconds <= 0) return 'Expired'
+	const days = Math.floor(seconds / 86400)
+	if (days > 0) return `${days} day${days === 1 ? '' : 's'}`
+	const hours = Math.floor(seconds / 3600)
+	if (hours > 0) return `${hours} hour${hours === 1 ? '' : 's'}`
+	const minutes = Math.floor(seconds / 60)
+	if (minutes > 0) return `${minutes} min${minutes === 1 ? '' : 's'}`
+	return `${seconds} sec${seconds === 1 ? '' : 's'}`
+}
+
 const getAuctionCoordinates = (auction: NDKEvent): string => {
 	const auctionDTag = getAuctionId(auction)
 	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
@@ -97,16 +112,39 @@ function ActivityRow({ header, unit, count, newCount }: { header: string; unit: 
 	)
 }
 
+function TechnicalDataRow({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-3">
+			<p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-zinc-500">{label}</p>
+			<div className="mt-1 break-all text-sm font-medium text-zinc-900">{value}</div>
+		</div>
+	)
+}
+
 function TopBidBox({
 	auction,
 	bids,
 	className,
 	isSettlementPhase,
+	showReleasePathDetails,
+	showWaitingForReleasePath,
+	showReleasePathReceived,
+	showSettlementGrieved,
+	showSettlementGrievedNoRelease,
+	settlementSecondsLeft,
+	settlementDeadlineAt,
 }: {
 	auction: NDKEvent
 	bids: NDKEvent[]
 	className?: string
 	isSettlementPhase: boolean
+	showReleasePathDetails: boolean
+	showWaitingForReleasePath: boolean
+	showReleasePathReceived: boolean
+	showSettlementGrieved: boolean
+	showSettlementGrievedNoRelease: boolean
+	settlementSecondsLeft: number
+	settlementDeadlineAt: number
 }) {
 	const topBid = getAuctionTopBidFromBids(auction, bids)
 	const { data: bidderName } = useProfileName(topBid?.pubkey ?? '')
@@ -161,6 +199,37 @@ function TopBidBox({
 					<span className="text-sm font-medium truncate max-w-32">{bidderName || topBid.pubkey.slice(0, 8)}</span>
 				</div>
 			</div>
+			{showReleasePathDetails && (
+				<Accordion type="single" collapsible className="mt-3 rounded-xl border border-zinc-200 bg-white px-4">
+					<AccordionItem value={`release-details-${topBid.id}`} className="border-none">
+						<AccordionTrigger className="py-4 text-sm font-semibold text-zinc-900 hover:no-underline">Settlement details</AccordionTrigger>
+						<AccordionContent className="space-y-3 pb-4">
+							{showWaitingForReleasePath && (
+								<div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+									<div className="font-medium">Waiting for release path</div>
+									<div className="mt-1">Bidder must publish the release path before settlement can be published.</div>
+								</div>
+							)}
+							{showReleasePathReceived && (
+								<div className="rounded-lg border border-sky-300 bg-sky-50 px-3 py-2 text-sm text-sky-900">
+									<div className="font-medium">Release path received</div>
+									<div className="mt-1">{formatTimeLeft(settlementSecondsLeft)} to publish settlement</div>
+								</div>
+							)}
+							{showSettlementGrieved && (
+								<div className="rounded-lg border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-900">
+									Bid was not settled. It was grieved after release path.
+								</div>
+							)}
+							{showSettlementGrievedNoRelease && (
+								<div className="rounded-lg border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-900">
+									Bid was not settled. It was grieved because release path was not published.
+								</div>
+							)}
+						</AccordionContent>
+					</AccordionItem>
+				</Accordion>
+			)}
 		</div>
 	)
 }
@@ -186,14 +255,30 @@ function AuctionListItem({
 	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
 	const bids = bidsQuery.data ?? []
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
+	const topBid = getAuctionTopBidFromBids(auction, bids)
 	const newBidsCount = bids.filter((bid) => (bid.created_at ?? 0) > notificationActions.getLastSeenAuctionBids()).length
 
 	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auction.id, 5, auctionCoordinates)
 	const latestSettlement = settlementsQuery.data?.[0] ?? null
 	const settlementLocked = !!latestSettlement
+	const pathReleasesQuery = useAuctionPathReleases(auctionRootEventId || auction.id, 200, auctionCoordinates)
+	const pathReleases = pathReleasesQuery.data ?? []
 
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, settlementLocked, now)
 	const isSettlementPhase = status === 'Settlement' || status === 'Ended'
+	const settlementGraceSeconds = getAuctionSettlementGrace(auction)
+	const settlementDeadlineAt = biddingCutoffAt > 0 ? biddingCutoffAt + settlementGraceSeconds : 0
+	const settlementSecondsLeft = settlementDeadlineAt > 0 ? Math.max(0, settlementDeadlineAt - now) : 0
+	const settlementGraceExpired = settlementDeadlineAt > 0 && now >= settlementDeadlineAt && !latestSettlement
+	const winnerReleasedPath = !!(
+		topBid && pathReleases.some((pathRelease) => pathRelease.tags.find((tag) => tag[0] === 'e')?.[1] === topBid.id)
+	)
+	const waitingForReleasePath = status === 'Settlement' && !!topBid && !winnerReleasedPath && !settlementGraceExpired
+	const releasePathReceived = status === 'Settlement' && winnerReleasedPath && !settlementGraceExpired
+	const settlementGrieved = status === 'Settlement' && settlementGraceExpired && !latestSettlement && winnerReleasedPath
+	const settlementGrievedNoRelease = status === 'Settlement' && settlementGraceExpired && !latestSettlement && !winnerReleasedPath
+	const showReleasePathDetails = waitingForReleasePath || releasePathReceived || settlementGrieved || settlementGrievedNoRelease
+	const canPublishSettlementNow = status === 'Settlement' && !settlementGraceExpired && (!topBid || winnerReleasedPath)
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
@@ -247,13 +332,25 @@ function AuctionListItem({
 						<p className="mt-1 text-xs text-muted-foreground">Created: {formatMaybeDate(auction.created_at ?? 0)}</p>
 					</div>
 
-					<TopBidBox auction={auction} bids={bids} className="flex-1" isSettlementPhase={isSettlementPhase} />
+					<TopBidBox
+						auction={auction}
+						bids={bids}
+						className="flex-1"
+						isSettlementPhase={isSettlementPhase}
+						showReleasePathDetails={showReleasePathDetails}
+						showWaitingForReleasePath={waitingForReleasePath}
+						showReleasePathReceived={releasePathReceived}
+						showSettlementGrieved={settlementGrieved}
+						showSettlementGrievedNoRelease={settlementGrievedNoRelease}
+						settlementSecondsLeft={settlementSecondsLeft}
+						settlementDeadlineAt={settlementDeadlineAt}
+					/>
 
 					{status !== 'Ended' && (
 						<Button
 							className="mt-auto w-full bg-neutral-800 text-white hover:bg-neutral-700 disabled:border disabled:border-zinc-300 disabled:bg-zinc-200 disabled:text-zinc-500"
 							onClick={onPublishSettlement}
-							disabled={status !== 'Settlement' || isSettling}
+							disabled={!canPublishSettlementNow || isSettling}
 						>
 							{isSettling ? (
 								<>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -202,7 +202,7 @@ function AuctionListItem({
 					<TopBidBox auction={auction} bids={bids} />
 
 					{status === 'Settlement' && (
-						<Button className="w-full bg-pink-600 hover:bg-pink-700 text-white" onClick={onPublishSettlement} disabled={isSettling}>
+						<Button className="w-full bg-neutral-800 hover:bg-neutral-700 text-white" onClick={onPublishSettlement} disabled={isSettling}>
 							{isSettling ? (
 								<>
 									<Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
@@ -227,7 +227,10 @@ function AuctionListItem({
 							<AuctionCountdown auction={auction} bids={bids} />
 						</div>
 						<span
-							className={cn('inline-flex w-fit whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}
+							className={cn(
+								'inline-flex w-fit whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium',
+								STATUS_BADGE_STYLES[status],
+							)}
 						>
 							{status}
 						</span>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -48,7 +48,8 @@ type AuctionStatus = 'Scheduled' | 'Live' | 'Settlement' | 'Ended'
 
 function formatAuctionStatus(startAt: number, biddingCutoffAt: number, settlementLocked: boolean, now: number): AuctionStatus {
 	if (startAt > 0 && now < startAt) return 'Scheduled'
-	if (biddingCutoffAt > 0 && now >= biddingCutoffAt) return settlementLocked ? 'Ended' : 'Settlement'
+	if (settlementLocked) return 'Ended'
+	if (biddingCutoffAt > 0 && now >= biddingCutoffAt) return 'Settlement'
 	return 'Live'
 }
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -181,16 +181,21 @@ function AuctionListItem({
 	return (
 		<div className="rounded-lg border border-zinc-200 bg-background p-6 shadow-md">
 			<div className="flex flex-col gap-6 lg:flex-row">
-				<div className="flex shrink-0 items-start gap-3 lg:flex-col">
+				<div className="flex shrink-0 items-center gap-3 lg:flex-col lg:items-center">
 					{thumbnailUrl ? (
-						<img src={thumbnailUrl} alt="" className="h-24 w-24 shrink-0 rounded-xl object-cover lg:h-32 lg:w-32" />
+						<div className="overflow-hidden rounded-xl border border-white/60 bg-zinc-100 p-1 shadow-sm ring-1 ring-zinc-200/70">
+							<img src={thumbnailUrl} alt="" className="h-24 w-24 shrink-0 object-cover lg:h-32 lg:w-32" />
+						</div>
 					) : (
-						<div className="flex h-24 w-24 shrink-0 items-center justify-center rounded-xl bg-zinc-100 lg:h-32 lg:w-32">
+						<div className="flex h-24 w-24 shrink-0 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 shadow-sm ring-1 ring-zinc-200/70 lg:h-32 lg:w-32">
 							<Gavel className="h-8 w-8 text-zinc-400" />
 						</div>
 					)}
-					<Link to="/dashboard/products/auctions/$auctionId" params={{ auctionId: auction.id }} className="lg:w-32">
-						<Button variant="outline" size="sm" className="w-full gap-2">
+					<Link to="/auctions/$auctionId" params={{ auctionId: auction.id }} className="w-24 lg:w-32">
+						<Button
+							size="sm"
+							className="w-full gap-2 rounded-xl border border-zinc-300 bg-neutral-800 text-white shadow-sm hover:bg-neutral-700"
+						>
 							<ExternalLink className="h-3.5 w-3.5" />
 							Open Auction
 						</Button>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -33,6 +33,7 @@ import { getOrderId } from '@/queries/orders'
 import { useProfileName } from '@/queries/profiles'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
+import { parseSettlementEvent } from '@/lib/schemas/auction/settlementEvents'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router'
@@ -93,6 +94,55 @@ function formatTimeLeft(seconds: number): string {
 const getAuctionCoordinates = (auction: NDKEvent): string => {
 	const auctionDTag = getAuctionId(auction)
 	return auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
+}
+
+const compareEventRecencyDescending = (left: NDKEvent, right: NDKEvent): number => {
+	const createdAtDelta = (right.created_at || 0) - (left.created_at || 0)
+	if (createdAtDelta !== 0) return createdAtDelta
+	return right.id.localeCompare(left.id)
+}
+
+const dedupeEventsById = (events: NDKEvent[]): NDKEvent[] => {
+	const byId = new Map<string, NDKEvent>()
+	for (const event of events) {
+		if (!event?.id) continue
+		byId.set(event.id, event)
+	}
+	return Array.from(byId.values())
+}
+
+const isCanonicalSellerSettlementForAuction = (
+	event: NDKEvent,
+	auction: NDKEvent,
+	auctionRootEventId: string,
+	auctionCoordinates: string,
+): boolean => {
+	const parsed = parseSettlementEvent(event)
+	if (!parsed.ok) return false
+
+	const authorMatchesSeller = event.pubkey === auction.pubkey || parsed.value.sellerPubkey === auction.pubkey
+	if (!authorMatchesSeller) return false
+
+	const rootReferenceMatches = parsed.value.auctionRootEventId === auctionRootEventId
+	const coordinateReferenceMatches = parsed.value.auctionCoordinate === auctionCoordinates
+	return rootReferenceMatches || coordinateReferenceMatches
+}
+
+const resolveLatestCanonicalSettlementForAuction = (
+	auction: NDKEvent,
+	auctionRootEventId: string,
+	auctionCoordinates: string,
+	settlementsByAuctionKey?: Map<string, NDKEvent[]>,
+): NDKEvent | null => {
+	const events = dedupeEventsById([
+		...(settlementsByAuctionKey?.get(auctionRootEventId) ?? []),
+		...(settlementsByAuctionKey?.get(auctionCoordinates) ?? []),
+	])
+
+	const matching = events.filter((event) => isCanonicalSellerSettlementForAuction(event, auction, auctionRootEventId, auctionCoordinates))
+	if (matching.length === 0) return null
+
+	return [...matching].sort(compareEventRecencyDescending)[0] ?? null
 }
 
 const STATUS_BADGE_STYLES: Record<AuctionStatus, string> = {
@@ -624,8 +674,12 @@ function AuctionsOverviewComponent() {
 										const auctionRootEventId = getAuctionRootEventId(auction) || auction.id
 										const auctionCoordinates = getAuctionCoordinates(auction)
 										const bids = bidsByAuctionId?.get(auctionRootEventId) ?? []
-										const latestSettlement =
-											settlementsByAuctionKey?.get(auctionRootEventId)?.[0] ?? settlementsByAuctionKey?.get(auctionCoordinates)?.[0] ?? null
+										const latestSettlement = resolveLatestCanonicalSettlementForAuction(
+											auction,
+											auctionRootEventId,
+											auctionCoordinates,
+											settlementsByAuctionKey,
+										)
 										const pathReleases = pathReleasesByAuctionCoordinate?.get(auctionCoordinates) ?? []
 
 										return (

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -162,7 +162,7 @@ function AuctionListItem({
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
-	const newCommentsCount = comments.filter((comment) => comment.createdAt > lastSeenTimestamps.auctionEventComments).length
+	const newCommentsCount = comments.filter((comment) => comment.createdAt > notificationActions.getLastSeenAuctionEventComments()).length
 	const liveActivityQuery = useLiveActivity(auction)
 	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -329,7 +329,7 @@ function AuctionListItem({
 	const hasNewActivity = newBidsCount + newCommentsCount + newChatCount > 0 || hasNewLiveStatus || hasNewSettlementStatus
 
 	const handleMarkActivitySeen = () => {
-		notificationActions.markAuctionBidsSeen(auctionNotificationKey, newBidsCount)
+		notificationActions.markAuctionBidsSeen(auctionNotificationKey)
 		notificationActions.markAuctionCommentsSeen(auctionNotificationKey, newChatCount)
 		notificationActions.markAuctionEventCommentsSeen(auctionNotificationKey, newCommentsCount)
 		notificationActions.markAuctionLiveSeen(auctionNotificationKey, hasNewLiveStatus ? 1 : 0)

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -261,16 +261,36 @@ function AuctionListItem({
 	const images = getAuctionImages(auction)
 	const thumbnailUrl = images.length > 0 ? images[0][1] : null
 	const startAt = getAuctionStartAt(auction)
+	const auctionNotificationKey =
+		getAuctionRootEventId(auction) || (getAuctionId(auction) ? `30408:${auction.pubkey}:${getAuctionId(auction)}` : auction.id)
 	const auctionCoordinates = getAuctionCoordinates(auction)
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const now = Math.floor(Date.now() / 1000)
 	const {
 		lastSeenTimestamps: {
-			auctionBids: lastSeenAuctionBids,
-			auctionComments: lastSeenAuctionComments,
-			auctionEventComments: lastSeenAuctionEventComments,
+			auctionBids: lastSeenAuctionBidsGlobal,
+			auctionBidsByAuction,
+			auctionComments: lastSeenAuctionCommentsGlobal,
+			auctionCommentsByAuction,
+			auctionEventComments: lastSeenAuctionEventCommentsGlobal,
+			auctionEventCommentsByAuction,
+			auctionLive: lastSeenAuctionLiveGlobal,
+			auctionLiveByAuction,
+			auctionSettlementBegins: lastSeenAuctionSettlementBeginsGlobal,
+			auctionSettlementBeginsByAuction,
 		},
 	} = useSelector(notificationStore)
+	const lastSeenAuctionBids = Math.max(lastSeenAuctionBidsGlobal, auctionBidsByAuction[auctionNotificationKey] || 0)
+	const lastSeenAuctionComments = Math.max(lastSeenAuctionCommentsGlobal, auctionCommentsByAuction[auctionNotificationKey] || 0)
+	const lastSeenAuctionEventComments = Math.max(
+		lastSeenAuctionEventCommentsGlobal,
+		auctionEventCommentsByAuction[auctionNotificationKey] || 0,
+	)
+	const lastSeenAuctionLive = Math.max(lastSeenAuctionLiveGlobal, auctionLiveByAuction[auctionNotificationKey] || 0)
+	const lastSeenAuctionSettlementBegins = Math.max(
+		lastSeenAuctionSettlementBeginsGlobal,
+		auctionSettlementBeginsByAuction[auctionNotificationKey] || 0,
+	)
 
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const topBid = getAuctionTopBidFromBids(auction, bids)
@@ -304,14 +324,16 @@ function AuctionListItem({
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
 	const chatMessages = chatQuery.data ?? []
 	const newChatCount = chatMessages.filter((message) => message.createdAt > lastSeenAuctionComments).length
-	const hasNewActivity = newBidsCount + newCommentsCount + newChatCount > 0
+	const hasNewLiveStatus = startAt > 0 && startAt <= now && startAt > lastSeenAuctionLive
+	const hasNewSettlementStatus = biddingCutoffAt > 0 && biddingCutoffAt <= now && biddingCutoffAt > lastSeenAuctionSettlementBegins
+	const hasNewActivity = newBidsCount + newCommentsCount + newChatCount > 0 || hasNewLiveStatus || hasNewSettlementStatus
 
 	const handleMarkActivitySeen = () => {
-		notificationActions.markAuctionBidsSeen()
-		notificationActions.markAuctionCommentsSeen()
-		notificationActions.markAuctionEventCommentsSeen()
-		notificationActions.markAuctionLiveSeen()
-		notificationActions.markAuctionSettlementBeginsSeen()
+		notificationActions.markAuctionBidsSeen(auctionNotificationKey, newBidsCount)
+		notificationActions.markAuctionCommentsSeen(auctionNotificationKey, newChatCount)
+		notificationActions.markAuctionEventCommentsSeen(auctionNotificationKey, newCommentsCount)
+		notificationActions.markAuctionLiveSeen(auctionNotificationKey, hasNewLiveStatus ? 1 : 0)
+		notificationActions.markAuctionSettlementBeginsSeen(auctionNotificationKey, hasNewSettlementStatus ? 1 : 0)
 	}
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -162,8 +162,7 @@ function AuctionListItem({
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
-	const newCommentsCount = comments.filter((comment) => comment.createdAt > notificationActions.getLastSeenAuctionEventComments()).length
-
+	const newCommentsCount = comments.filter((comment) => comment.createdAt > lastSeenTimestamps.auctionEventComments).length
 	const liveActivityQuery = useLiveActivity(auction)
 	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import { AvatarUser } from '@/components/AvatarUser'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
@@ -100,24 +101,30 @@ function TopBidBox({ auction, bids }: { auction: NDKEvent; bids: NDKEvent[] }) {
 
 	if (!topBid) {
 		return (
-			<div className="rounded-xl border px-4 py-3">
-				<p className="text-sm text-muted-foreground">No bids yet</p>
+			<div className="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-5 py-4">
+				<p className="text-sm text-zinc-500">No bids yet. Winning bid will appear here.</p>
 			</div>
 		)
 	}
 
 	return (
-		<div className="rounded-xl border px-4 py-3">
+		<div className="rounded-xl border-2 border-emerald-300 bg-emerald-100 px-4 py-4">
 			<div>
-				<div className="flex items-center gap-2 text-xs text-muted-foreground">
+				<div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-800">
 					<span>Top bid:</span>
 					<span>{formatTimeAgo(topBid.created_at ?? 0)}</span>
 				</div>
-				<p className="text-xl font-bold">{getBidAmount(topBid).toLocaleString()} sats</p>
+				<p className="mt-1 text-2xl font-semibold tracking-tight text-zinc-950">{getBidAmount(topBid).toLocaleString()} sats</p>
 			</div>
-			<div className="mt-2 flex items-center gap-2">
-				<AvatarUser pubkey={topBid.pubkey} colored deterministicFallbackText className="w-6 h-6" />
-				<span className="text-sm font-medium truncate max-w-32">{bidderName || topBid.pubkey.slice(0, 8)}</span>
+			<div className="mt-2 flex items-center justify-between gap-2">
+				<Badge className="border-emerald-300 bg-white text-emerald-800 hover:bg-white">Winning bid</Badge>
+
+				<div className="flex items-center gap-2">
+					<Link to="/profile/$profileId" params={{ profileId: topBid.pubkey }}>
+						<AvatarUser pubkey={topBid.pubkey} colored deterministicFallbackText className="w-6 h-6" />
+					</Link>
+					<span className="text-sm font-medium truncate max-w-32">{bidderName || topBid.pubkey.slice(0, 8)}</span>
+				</div>
 			</div>
 		</div>
 	)
@@ -214,7 +221,9 @@ function AuctionListItem({
 				</div>
 
 				<div className="flex w-full shrink-0 flex-col items-end gap-3 lg:w-64">
-					<span className={cn('inline-flex w-fit rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}>{status}</span>
+					<span className={cn('inline-flex w-fit rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}>
+						{status}
+					</span>
 					<div className="w-full space-y-3 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-5">
 						<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Activity</p>
 						<ActivityRow header="Bids" unit="Bid" count={bidsCount} newCount={newBidsCount} />

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -1,5 +1,6 @@
 import { cn } from '@/lib/utils'
 import { AvatarUser } from '@/components/AvatarUser'
+import { AuctionCountdown } from '@/components/AuctionCountdown'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -167,7 +168,7 @@ function AuctionListItem({
 	const liveActivityCoord = liveActivityQuery.data?.coord ?? ''
 	const chatQuery = useLiveChatMessages(liveActivityCoord, status === 'Live')
 	const chatMessages = chatQuery.data ?? []
-	const newChatCount = chatMessages.filter((message) => message.createdAt > lastSeenTimestamps.auctionComments).length
+	const newChatCount = chatMessages.filter((message) => message.createdAt > notificationActions.getLastSeenAuctionComments()).length
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)
 	const orderId = claimOrdersQuery.data?.[0] ? getOrderId(claimOrdersQuery.data[0]) : undefined
@@ -191,7 +192,7 @@ function AuctionListItem({
 					</Link>
 				</div>
 
-				<div className="flex-1 min-w-0 space-y-4">
+				<div className="flex-1 min-w-0 space-y-4 lg:max-w-[28rem]">
 					<div className="min-w-0">
 						<h3 className="text-lg font-semibold text-foreground truncate">{getAuctionTitle(auction)}</h3>
 						<p className="text-sm text-muted-foreground truncate">{summary}</p>
@@ -220,10 +221,17 @@ function AuctionListItem({
 					)}
 				</div>
 
-				<div className="flex w-full shrink-0 flex-col items-end gap-3 lg:w-64">
-					<span className={cn('inline-flex w-fit rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}>
-						{status}
-					</span>
+				<div className="ml-auto flex w-full shrink-0 flex-col items-end gap-3 lg:w-[22rem]">
+					<div className="flex w-full items-center gap-2">
+						<div className="min-w-0 flex-1">
+							<AuctionCountdown auction={auction} bids={bids} />
+						</div>
+						<span
+							className={cn('inline-flex w-fit whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium', STATUS_BADGE_STYLES[status])}
+						>
+							{status}
+						</span>
+					</div>
 					<div className="w-full space-y-3 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-5">
 						<p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">Activity</p>
 						<ActivityRow header="Bids" unit="Bid" count={bidsCount} newCount={newBidsCount} />

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -22,11 +22,10 @@ import {
 	getAuctionTitle,
 	getAuctionTopBidFromBids,
 	getBidAmount,
-	useAuctionBids,
 	useAuctionBidsForList,
 	useAuctionClaimOrders,
-	useAuctionPathReleases,
-	useAuctionSettlements,
+	useAuctionPathReleasesForList,
+	useAuctionSettlementsForList,
 } from '@/queries/auctions'
 import { useComments } from '@/queries/comments'
 import { useLiveActivity, useLiveChatMessages } from '@/queries/liveChat'
@@ -245,10 +244,16 @@ function TopBidBox({
 
 function AuctionListItem({
 	auction,
+	bids,
+	latestSettlement,
+	pathReleases,
 	onPublishSettlement,
 	isSettling,
 }: {
 	auction: NDKEvent
+	bids: NDKEvent[]
+	latestSettlement: NDKEvent | null
+	pathReleases: NDKEvent[]
 	onPublishSettlement: () => void
 	isSettling: boolean
 }) {
@@ -256,22 +261,15 @@ function AuctionListItem({
 	const images = getAuctionImages(auction)
 	const thumbnailUrl = images.length > 0 ? images[0][1] : null
 	const startAt = getAuctionStartAt(auction)
-	const auctionRootEventId = getAuctionRootEventId(auction)
 	const auctionCoordinates = getAuctionCoordinates(auction)
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const now = Math.floor(Date.now() / 1000)
 
-	const bidsQuery = useAuctionBids(auctionRootEventId || auction.id, 500, auctionCoordinates)
-	const bids = bidsQuery.data ?? []
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const topBid = getAuctionTopBidFromBids(auction, bids)
 	const newBidsCount = bids.filter((bid) => (bid.created_at ?? 0) > notificationActions.getLastSeenAuctionBids()).length
 
-	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auction.id, 5, auctionCoordinates)
-	const latestSettlement = settlementsQuery.data?.[0] ?? null
 	const settlementLocked = !!latestSettlement
-	const pathReleasesQuery = useAuctionPathReleases(auctionRootEventId || auction.id, 200, auctionCoordinates)
-	const pathReleases = pathReleasesQuery.data ?? []
 
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, settlementLocked, now)
 	const hasBids = bidsCount > 0
@@ -468,7 +466,10 @@ function AuctionsOverviewComponent() {
 		() => (auctions ?? []).map((auction) => getAuctionRootEventId(auction) || auction.id),
 		[auctions],
 	)
+	const auctionCoordinatesForList = useMemo(() => (auctions ?? []).map((auction) => getAuctionCoordinates(auction)), [auctions])
 	const { data: bidsByAuctionId } = useAuctionBidsForList(auctionRootEventIdsForBids)
+	const { data: settlementsByAuctionKey } = useAuctionSettlementsForList(auctionRootEventIdsForBids, auctionCoordinatesForList, 5)
+	const { data: pathReleasesByAuctionCoordinate } = useAuctionPathReleasesForList(auctionCoordinatesForList, 200)
 	const sortedAuctions = useFilteredAuctions({ auctions: auctions ?? [], filters: { sort: sort }, bidsByAuctionId, tag: undefined })
 
 	const handlePublishSettlement = async (auction: NDKEvent) => {
@@ -590,11 +591,25 @@ function AuctionsOverviewComponent() {
 						<ul ref={animationParent} className="flex flex-col gap-4 mt-4">
 							{sortedAuctions.map((auction) => (
 								<li key={auction.id}>
-									<AuctionListItem
-										auction={auction}
-										onPublishSettlement={() => void handlePublishSettlement(auction)}
-										isSettling={settlingAuctionId === auction.id && settlementMutation.isPending}
-									/>
+									{(() => {
+										const auctionRootEventId = getAuctionRootEventId(auction) || auction.id
+										const auctionCoordinates = getAuctionCoordinates(auction)
+										const bids = bidsByAuctionId?.get(auctionRootEventId) ?? []
+										const latestSettlement =
+											settlementsByAuctionKey?.get(auctionRootEventId)?.[0] ?? settlementsByAuctionKey?.get(auctionCoordinates)?.[0] ?? null
+										const pathReleases = pathReleasesByAuctionCoordinate?.get(auctionCoordinates) ?? []
+
+										return (
+											<AuctionListItem
+												auction={auction}
+												bids={bids}
+												latestSettlement={latestSettlement}
+												pathReleases={pathReleases}
+												onPublishSettlement={() => void handlePublishSettlement(auction)}
+												isSettling={settlingAuctionId === auction.id && settlementMutation.isPending}
+											/>
+										)
+									})()}
 								</li>
 							))}
 						</ul>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -284,7 +284,9 @@ function AuctionListItem({
 	const pathReleases = pathReleasesQuery.data ?? []
 
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, settlementLocked, now)
-	const isSettlementPhase = status === 'Settlement' || status === 'Ended'
+	const hasBids = bidsCount > 0
+	const badgeStatus: AuctionStatus = status === 'Settlement' && !hasBids ? 'Ended' : status
+	const isSettlementPhase = (status === 'Settlement' || status === 'Ended') && hasBids
 	const settlementGraceSeconds = getAuctionSettlementGrace(auction)
 	const settlementDeadlineAt = biddingCutoffAt > 0 ? biddingCutoffAt + settlementGraceSeconds : 0
 	const settlementSecondsLeft = settlementDeadlineAt > 0 ? Math.max(0, settlementDeadlineAt - now) : 0
@@ -292,11 +294,12 @@ function AuctionListItem({
 	const winnerReleasedPath = !!(
 		topBid && pathReleases.some((pathRelease) => pathRelease.tags.find((tag) => tag[0] === 'e')?.[1] === topBid.id)
 	)
-	const waitingForReleasePath = status === 'Settlement' && !!topBid && !winnerReleasedPath && !settlementGraceExpired
-	const releasePathReceived = status === 'Settlement' && winnerReleasedPath && !settlementGraceExpired
-	const settlementGrieved = status === 'Settlement' && settlementGraceExpired && !latestSettlement && winnerReleasedPath
-	const settlementGrievedNoRelease = status === 'Settlement' && settlementGraceExpired && !latestSettlement && !winnerReleasedPath
-	const canPublishSettlementNow = status === 'Settlement' && !settlementGraceExpired && (!topBid || winnerReleasedPath)
+	const waitingForReleasePath = status === 'Settlement' && hasBids && !!topBid && !winnerReleasedPath && !settlementGraceExpired
+	const releasePathReceived = status === 'Settlement' && hasBids && winnerReleasedPath && !settlementGraceExpired
+	const settlementGrieved = status === 'Settlement' && hasBids && settlementGraceExpired && !latestSettlement && winnerReleasedPath
+	const settlementGrievedNoRelease =
+		status === 'Settlement' && hasBids && settlementGraceExpired && !latestSettlement && !winnerReleasedPath
+	const canPublishSettlementNow = status === 'Settlement' && hasBids && !settlementGraceExpired && (!topBid || winnerReleasedPath)
 
 	const commentsQuery = useComments(auction)
 	const comments = commentsQuery.data ?? []
@@ -368,7 +371,7 @@ function AuctionListItem({
 						settlementDeadlineAt={settlementDeadlineAt}
 					/>
 
-					{status !== 'Ended' && (
+					{status !== 'Ended' && hasBids && (
 						<Button
 							className="mt-auto w-full bg-neutral-800 text-white hover:bg-neutral-700 disabled:border disabled:border-zinc-300 disabled:bg-zinc-200 disabled:text-zinc-500"
 							onClick={onPublishSettlement}
@@ -412,10 +415,10 @@ function AuctionListItem({
 						<span
 							className={cn(
 								'inline-flex w-fit whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium',
-								STATUS_BADGE_STYLES[status],
+								STATUS_BADGE_STYLES[badgeStatus],
 							)}
 						>
-							{status}
+							{badgeStatus}
 						</span>
 					</div>
 					<div className="w-full space-y-3 rounded-xl border border-zinc-200 bg-zinc-50 px-5 py-5">

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -293,6 +293,8 @@ function AuctionsOverviewComponent() {
 	useEffect(() => {
 		if (isAuthenticated && user?.pubkey) {
 			notificationActions.markAuctionBidsSeen()
+			notificationActions.markAuctionCommentsSeen()
+			notificationActions.markAuctionEventCommentsSeen()
 			notificationActions.markAuctionLiveSeen()
 			notificationActions.markAuctionSettlementBeginsSeen()
 		}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -39,7 +39,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
-import { CheckCheck, Clock, ExternalLink, Gavel, Loader2 } from 'lucide-react'
+import { CheckCheck, Clock, ExternalLink, Gavel, Hourglass, Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
 	auctionSortOptionValues,
@@ -131,6 +131,7 @@ function TopBidBox({
 	showReleasePathReceived,
 	showSettlementGrieved,
 	showSettlementGrievedNoRelease,
+	showWaitingForShippingMethod,
 	settlementSecondsLeft,
 	settlementDeadlineAt,
 }: {
@@ -143,6 +144,7 @@ function TopBidBox({
 	showReleasePathReceived: boolean
 	showSettlementGrieved: boolean
 	showSettlementGrievedNoRelease: boolean
+	showWaitingForShippingMethod: boolean
 	settlementSecondsLeft: number
 	settlementDeadlineAt: number
 }) {
@@ -226,6 +228,17 @@ function TopBidBox({
 									Bid was not settled. It was grieved because release path was not published.
 								</div>
 							)}
+							{showWaitingForShippingMethod && (
+								<Button
+									type="button"
+									variant="outline"
+									disabled
+									className="w-full justify-start gap-2 border-sky-300 bg-sky-50 text-sky-900 hover:bg-sky-50"
+								>
+									<Hourglass className="h-4 w-4" aria-hidden="true" />
+									Waiting for bidder shipping method
+								</Button>
+							)}
 						</AccordionContent>
 					</AccordionItem>
 				</Accordion>
@@ -277,7 +290,6 @@ function AuctionListItem({
 	const releasePathReceived = status === 'Settlement' && winnerReleasedPath && !settlementGraceExpired
 	const settlementGrieved = status === 'Settlement' && settlementGraceExpired && !latestSettlement && winnerReleasedPath
 	const settlementGrievedNoRelease = status === 'Settlement' && settlementGraceExpired && !latestSettlement && !winnerReleasedPath
-	const showReleasePathDetails = waitingForReleasePath || releasePathReceived || settlementGrieved || settlementGrievedNoRelease
 	const canPublishSettlementNow = status === 'Settlement' && !settlementGraceExpired && (!topBid || winnerReleasedPath)
 
 	const commentsQuery = useComments(auction)
@@ -300,6 +312,9 @@ function AuctionListItem({
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)
 	const orderId = claimOrdersQuery.data?.[0] ? getOrderId(claimOrdersQuery.data[0]) : undefined
+	const waitingForShippingMethod = status === 'Ended' && !!latestSettlement && winnerReleasedPath && !orderId
+	const showReleasePathDetails =
+		waitingForReleasePath || releasePathReceived || settlementGrieved || settlementGrievedNoRelease || waitingForShippingMethod
 
 	return (
 		<div className="rounded-lg border border-zinc-200 bg-background p-6 shadow-md">
@@ -342,6 +357,7 @@ function AuctionListItem({
 						showReleasePathReceived={releasePathReceived}
 						showSettlementGrieved={settlementGrieved}
 						showSettlementGrievedNoRelease={settlementGrievedNoRelease}
+						showWaitingForShippingMethod={waitingForShippingMethod}
 						settlementSecondsLeft={settlementSecondsLeft}
 						settlementDeadlineAt={settlementDeadlineAt}
 					/>
@@ -367,6 +383,18 @@ function AuctionListItem({
 						<Link to="/dashboard/orders/$orderId" params={{ orderId }} className="mt-auto w-full">
 							<Button className="w-full bg-neutral-800 hover:bg-neutral-700 text-white">Go to Order Page</Button>
 						</Link>
+					)}
+
+					{waitingForShippingMethod && (
+						<Button
+							type="button"
+							variant="outline"
+							disabled
+							className="mt-2 w-full justify-start gap-2 border-sky-300 bg-sky-50 text-sky-900 hover:bg-sky-50"
+						>
+							<Hourglass className="h-4 w-4" aria-hidden="true" />
+							Waiting for shipping method
+						</Button>
 					)}
 				</div>
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -97,20 +97,25 @@ function ActivityRow({ header, unit, count, newCount }: { header: string; unit: 
 	)
 }
 
-function TopBidBox({ auction, bids }: { auction: NDKEvent; bids: NDKEvent[] }) {
+function TopBidBox({ auction, bids, className }: { auction: NDKEvent; bids: NDKEvent[]; className?: string }) {
 	const topBid = getAuctionTopBidFromBids(auction, bids)
 	const { data: bidderName } = useProfileName(topBid?.pubkey ?? '')
 
 	if (!topBid) {
 		return (
-			<div className="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-5 py-4">
-				<p className="text-sm text-zinc-500">No bids yet. Winning bid will appear here.</p>
+			<div
+				className={cn(
+					'flex h-full min-h-32 items-center justify-center rounded-xl border border-dashed border-zinc-300 bg-zinc-50 px-5 py-4',
+					className,
+				)}
+			>
+				<p className="text-center text-sm text-zinc-500">No bids yet. Winning bid will appear here.</p>
 			</div>
 		)
 	}
 
 	return (
-		<div className="rounded-xl border-2 border-emerald-300 bg-emerald-100 px-4 py-4">
+		<div className={cn('h-full min-h-32 rounded-xl border-2 border-emerald-300 bg-emerald-100 px-4 py-4', className)}>
 			<div>
 				<div className="flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-800">
 					<span>Top bid:</span>
@@ -192,17 +197,21 @@ function AuctionListItem({
 					</Link>
 				</div>
 
-				<div className="flex-1 min-w-0 space-y-4 lg:max-w-[28rem]">
+				<div className="flex min-w-0 flex-1 flex-col gap-4 lg:max-w-[28rem]">
 					<div className="min-w-0">
 						<h3 className="text-lg font-semibold text-foreground truncate">{getAuctionTitle(auction)}</h3>
 						<p className="text-sm text-muted-foreground truncate">{summary}</p>
 						<p className="mt-1 text-xs text-muted-foreground">Created: {formatMaybeDate(auction.created_at ?? 0)}</p>
 					</div>
 
-					<TopBidBox auction={auction} bids={bids} />
+					<TopBidBox auction={auction} bids={bids} className="flex-1" />
 
 					{status === 'Settlement' && (
-						<Button className="w-full bg-neutral-800 hover:bg-neutral-700 text-white" onClick={onPublishSettlement} disabled={isSettling}>
+						<Button
+							className="mt-auto w-full bg-neutral-800 text-white hover:bg-neutral-700"
+							onClick={onPublishSettlement}
+							disabled={isSettling}
+						>
 							{isSettling ? (
 								<>
 									<Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
@@ -215,7 +224,7 @@ function AuctionListItem({
 					)}
 
 					{status === 'Ended' && orderId && (
-						<Link to="/dashboard/orders/$orderId" params={{ orderId }}>
+						<Link to="/dashboard/orders/$orderId" params={{ orderId }} className="mt-auto w-full">
 							<Button className="w-full bg-neutral-800 hover:bg-neutral-700 text-white">Go to Order Page</Button>
 						</Link>
 					)}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -380,10 +380,10 @@ function AuctionListItem({
 
 	const handleMarkActivitySeen = () => {
 		notificationActions.markAuctionBidsSeen(auctionNotificationKey)
-		notificationActions.markAuctionCommentsSeen(auctionNotificationKey, newChatCount)
-		notificationActions.markAuctionEventCommentsSeen(auctionNotificationKey, newCommentsCount)
-		notificationActions.markAuctionLiveSeen(auctionNotificationKey, hasNewLiveStatus ? 1 : 0)
-		notificationActions.markAuctionSettlementBeginsSeen(auctionNotificationKey, hasNewSettlementStatus ? 1 : 0)
+		notificationActions.markAuctionCommentsSeen(auctionNotificationKey)
+		notificationActions.markAuctionEventCommentsSeen(auctionNotificationKey)
+		notificationActions.markAuctionLiveSeen(auctionNotificationKey)
+		notificationActions.markAuctionSettlementBeginsSeen(auctionNotificationKey)
 	}
 
 	const claimOrdersQuery = useAuctionClaimOrders(auctionCoordinates)

--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -3,6 +3,7 @@ import { DashboardListItem } from '@/components/layout/DashboardListItem'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { authStore } from '@/lib/stores/auth'
+import { notificationActions } from '@/lib/stores/notifications'
 import { productFormActions } from '@/lib/stores/product'
 import { useDeleteProductMutation } from '@/publish/products'
 import {
@@ -20,7 +21,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { createFileRoute, Link, Outlet, useMatchRoute, useNavigate } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { PackageIcon, Trash, EyeOff, Clock, Eye } from 'lucide-react'
-import { useState, useMemo } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { TooltipButton } from '@/components/shared/TooltipButton'
 
 // Component to show basic product information
@@ -205,6 +206,12 @@ function ProductsOverviewComponent() {
 	const [shareDialogOpen, setShareDialogOpen] = useState(false)
 	const [productToShare, setProductToShare] = useState<NDKEvent | null>(null)
 	useDashboardTitle('Products')
+
+	useEffect(() => {
+		if (isAuthenticated) {
+			notificationActions.markProductCommentsSeen()
+		}
+	}, [isAuthenticated])
 
 	// Auto-animate for smooth list transitions
 	const [animationParent] = (() => {


### PR DESCRIPTION
## Summary

Adds real-time seller-facing notifications for auction activity, surfaced as badges in the dashboard header/sidebar and per-auction "new activity" indicators on the auctions list.

- Tracks unseen counts for: auction bids, auction live-chat comments, auction thread comments, product comments, "auction went live," and "settlement began" — each with its own last-seen timestamp and mark-as-seen action in `notificationStore` (`src/lib/stores/notifications.ts`).
- `useNotificationMonitor` now subscribes to the relevant Nostr event kinds in real time and increments the matching counters as new events arrive, in addition to computing initial unseen counts on load.
- Per-auction badges (`AuctionListItem`) read last-seen state scoped by auction/product key rather than a single global timestamp, so marking one auction's activity as seen no longer clears badges on other auctions.
- Header and dashboard-layout badge totals sum all notification categories into the visible unseen count.
- Batched list-level queries for bids/settlements/path-releases (`src/queries/auctions.tsx`, `queryKeyFactory.ts`) reduce per-row query fan-out on the auctions list.
- Adds unit tests for the notification store's increment/mark-seen/scoping behavior (`src/lib/__tests__/notifications.test.ts`).

## Manual Test Plan

1. Sign in as a seller with at least 2 active auctions.
2. **Bid notifications**
   - From a second browser/session (or another key), place a bid on Auction A.
   - Confirm the header badge count increments and Auction A's list row shows a "new activity" indicator.
   - Click "Mark as seen" on Auction A only.
   - Confirm Auction A's indicator clears, **and Auction B's indicator (if it has unseen activity) is unaffected**.
3. **Live-chat / auction comments**
   - Post a live-chat message and a thread comment on a live auction.
   - Confirm both counters increment independently and clear independently via their respective mark-as-seen actions.
4. **Product comments**
   - Post a comment on a product listing.
   - Confirm the product-comments badge increments.
5. **Auction went live**
   - Schedule an auction to start in ~1 minute, wait for it to go live.
   - Confirm the "auction live" badge increments without needing a page reload.
6. **Settlement began**
   - Let an auction reach its bidding cutoff / enter settlement.
   - Confirm the "settlement begins" badge increments.
7. **Cross-tab / reload sanity**
   - Reload the dashboard mid-session and confirm unseen counts are recomputed correctly from historical events (not reset to 0, not double-counted).
8. **Regression pass**
   - Confirm existing auction list functionality (status filters, countdown timers, settlement/publish flow) still works as before.

## Screenshots / Screen recordings

https://github.com/user-attachments/assets/4af9308c-2ee4-4b57-ab8b-19904e57591a

## Test Coverage

Run the notification store unit tests:

```bash
bun test src/lib/__tests__/notifications.test.ts
```
