### PR TITLE
ops: add read-only relay disk report

### DIFF
--- a/docs/ops/relay-pruning.md
+++ b/docs/ops/relay-pruning.md
@@ -74,6 +74,12 @@ disable host key checking.
 
 Use this before any cleanup:
 
+A helper script is also available for the same read-only inventory:
+
+    scripts/ops/relay-disk-report.sh market-relay-staging
+
+The script requires a local SSH config alias and does not perform cleanup.
+
     ssh market-relay-staging '
     set -u
 

--- a/scripts/ops/relay-disk-report.sh
+++ b/scripts/ops/relay-disk-report.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only reporting helper. Do not add cleanup, pruning, restart, or deploy commands here.
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <ssh-host-alias>" >&2
+  echo "example: $0 market-relay-staging" >&2
+  exit 64
+fi
+
+host="$1"
+
+ssh -- "$host" 'sh -s' <<'REMOTE'
+set -u
+
+has_sudo=0
+if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  has_sudo=1
+else
+  echo "sudo not available non-interactively; privileged checks may be incomplete"
+fi
+
+run_privileged() {
+  if [ "$has_sudo" = "1" ]; then
+    sudo -n "$@"
+  else
+    "$@"
+  fi
+}
+
+deploy_home="${DEPLOY_HOME:-$HOME}"
+
+echo "== host =="
+hostname || true
+date -u || true
+
+echo
+echo "== filesystem usage =="
+df -hT || true
+
+echo
+echo "== inode usage =="
+df -i || true
+
+echo
+echo "== /var/lib top-level usage =="
+run_privileged du -xhd1 /var/lib 2>/dev/null | sort -h | tail -30 || true
+
+echo
+echo "== relay data usage =="
+run_privileged du -sh \
+  /var/lib/market-relay \
+  /var/lib/market-relay/raw \
+  /var/lib/market-relay/search \
+  2>/dev/null || true
+
+echo
+echo "== deploy/temp usage =="
+du -sh /tmp /tmp/deploy-package 2>/dev/null || true
+du -sh "$deploy_home"/deploy-package "$deploy_home"/*.tar.gz "$deploy_home"/Caddyfile.staging 2>/dev/null || true
+du -sh "$deploy_home"/releases/* 2>/dev/null | sort -h || true
+
+echo
+echo "== docker usage =="
+docker system df || true
+
+echo
+echo "== journal usage =="
+run_privileged journalctl --disk-usage || true
+
+echo
+echo "== deleted-open-file check =="
+if command -v lsof >/dev/null 2>&1; then
+  run_privileged lsof +L1 2>/dev/null | sort -k7 -n | tail -20 || true
+else
+  echo "lsof not installed; skipping deleted-open-file check"
+fi
+
+echo
+echo "== relay service status =="
+run_privileged systemctl status market-relay --no-pager || true
+
+echo
+echo "== report complete =="
+REMOTE


### PR DESCRIPTION
## Summary

Adds a read-only relay disk reporting helper script and links it from the relay pruning runbook.

## Context

The relay pruning runbook defines safe cleanup boundaries. This follow-up adds a repeatable way to collect the same disk inventory without performing cleanup.

## Changes

- Adds `scripts/ops/relay-disk-report.sh`
- Requires a local SSH config alias instead of committing host/user/IP/key details
- Uses non-interactive sudo only, avoiding password prompts
- Reports filesystem, inode, relay data, Docker, journal, deleted-open-file, deploy/temp, and relay service status
- Links the helper from `docs/ops/relay-pruning.md`

## Non-goals

- No server cleanup
- No raw event deletion
- No Docker pruning
- No journal vacuum
- No log truncation
- No relay restart
- No deploy rerun
- No `.env` or secret inspection