### PR TITLE
feat: set custom input as default bid amount input

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -1,6 +1,5 @@
-import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { ToggleGroup } from '@/components/ui/toggle-group'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
 import { usePublishAuctionBidMutation, type AuctionBidFormData } from '@/publish/auctions'
@@ -26,7 +25,7 @@ import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { useAuctionCountdown } from './AuctionCountdown'
-import { Pencil, Plus, Minus, X, CircleX, TheaterIcon } from 'lucide-react'
+import { CircleX } from 'lucide-react'
 import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group'
 import { cn } from '@/lib/utils'
 import { TooltipToggleGroupItem } from './shared/TooltipToggleGroupItem'
@@ -191,7 +190,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
-	const [isEditing, setIsEditing] = useState(false)
 	const [isDepositOpen, setIsDepositOpen] = useState(false)
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
@@ -240,23 +238,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const isDisabledInput = ended || notStarted || isOwnAuction || bidMutation.isPending
 	const isDisabledBid = isDisabledInput || !Number.isFinite(parsedBidAmount) || parsedBidAmount < minBid
 
-	// Determine which toggle is active based on current input
-	const getSelectedValue = () => {
-		// Check for invalid result
-		if (!Number.isFinite(parsedBidAmount)) return ''
-
-		if (parsedBidAmount === minBid) return 'inc1'
-
-		// Only return these values as selected if the options are showing.
-		if (!compact) {
-			if (parsedBidAmount === minBid + bidStep) return 'inc2'
-			if (parsedBidAmount === Math.max(currentPrice * 2, minBid)) return 'mult2'
-		}
-
-		// For custom values, the "edit" is selected (when shown).
-		return 'edit'
-	}
-
 	// Button text logic
 	const buttonText = useMemo(() => {
 		if (isOwnAuction) return 'Your Auction'
@@ -264,8 +245,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		if (notStarted) return 'Bidding not started'
 		if (bidMutation.isPending) return 'Submitting...'
 		if (!hasSignedInBidder) return 'Sign in to bid'
-		const selectedValue = getSelectedValue()
-		if (compact || selectedValue === 'edit' || selectedValue === 'mult2') return 'Bid ' + parsedBidAmount.toLocaleString() + ' sats'
+		if (compact) return 'Bid ' + parsedBidAmount.toLocaleString() + ' sats'
 		return 'Place Bid'
 	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
 
@@ -340,7 +320,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		try {
 			await bidMutation.mutateAsync(bidData)
 			toast.success('Bid placed successfully')
-			setIsEditing(false)
 			onBidSuccess?.()
 		} catch {
 			// Error handled by mutation
@@ -475,90 +454,23 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			)}
 			{/* Main Action Area */}
 			<div className={cn('flex flex-col sm:flex-row gap-2 items-stretch sm:items-center')}>
-				{!compact &&
-					(isEditing ? (
-						// EDIT MODE: Input Field
-						<InputGroup className="grow w-auto">
-							<InputGroupInput
-								type="number"
-								min={minBid}
-								step={bidStep}
-								value={bidAmountInput}
-								onChange={(e) => setBidAmountInput(e.target.value)}
-								placeholder={`Min: ${minBid.toLocaleString()}`}
-								disabled={isDisabledInput}
-								autoFocus
-							/>
-							<InputGroupAddon align="inline-end">
-								<CircleX onClick={() => setIsEditing(false)} className="size-4 cursor-pointer" />
-							</InputGroupAddon>
-						</InputGroup>
-					) : (
-						// QUICK ACTION MODE: Toggle Group
-						<ToggleGroup
-							type="single"
-							value={getSelectedValue()}
-							onValueChange={(val) => {
-								if (!val) return
-								if (val === 'inc1') {
-									setBidAmountInput(String(minBid))
-								} else if (val === 'inc2') {
-									setBidAmountInput(String(minBid + bidStep))
-								} else if (val === 'mult2') {
-									setBidAmountInput(String(Math.max(currentPrice * 2, minBid)))
-								} else if (val === 'edit') {
-									setIsEditing(true)
-								}
-							}}
-							className={cn('flex w-auto')}
-						>
-							<TooltipToggleGroupItem
-								value="inc1"
-								variant="outline"
-								size="sm"
-								tooltip={hasPriorBids ? 'Minimum Raise' : 'Minimum Bid'}
-								disabled={isDisabledInput}
-								className={cn('cursor-pointer flex')}
-							>
-								{minBid.toLocaleString()} sats
-							</TooltipToggleGroupItem>
-
-							<TooltipToggleGroupItem
-								value="inc2"
-								variant="outline"
-								size="sm"
-								tooltip="Minimum bid plus one raise"
-								disabled={isDisabledInput}
-								className="flex cursor-pointer"
-							>
-								{(minBid + bidStep).toLocaleString()} sats
-							</TooltipToggleGroupItem>
-							<TooltipToggleGroupItem
-								value="mult2"
-								variant="outline"
-								size="sm"
-								tooltip="2x Current Bid"
-								disabled={isDisabledInput}
-								className="flex cursor-pointer"
-							>
-								<X className="size-3 mr-1" /> 2
-							</TooltipToggleGroupItem>
-							<TooltipToggleGroupItem
-								value="edit"
-								variant="outline"
-								size="sm"
-								onClick={() => setIsEditing(true) /* Enforce on-click behavior */}
-								tooltip={
-									getSelectedValue() === 'edit' ? 'Custom Bid: ' + bidAmountInput.toLocaleString() + ' SATS' : 'Customize Bid Amount'
-								}
-								disabled={isDisabledInput}
-								className="flex cursor-pointer"
-								title="Customize bid"
-							>
-								<Pencil className="h-3 w-3" />
-							</TooltipToggleGroupItem>
-						</ToggleGroup>
-					))}
+				{!compact && (
+					<InputGroup className="grow w-auto">
+						<InputGroupInput
+							type="number"
+							min={minBid}
+							step={bidStep}
+							value={bidAmountInput}
+							onChange={(e) => setBidAmountInput(e.target.value)}
+							placeholder={`Min: ${minBid.toLocaleString()}`}
+							disabled={isDisabledInput}
+							autoFocus
+						/>
+						<InputGroupAddon align="inline-end">
+							<CircleX onClick={() => setBidAmountInput(String(minBid))} className="size-4 cursor-pointer" />
+						</InputGroupAddon>
+					</InputGroup>
+				)}
 
 				{/* Place Bid Button */}
 				<Button

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -323,7 +323,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			toast.success('Bid placed successfully')
 			// Reset the editing flag so the input re-syncs to the new minBid floor.
 			setHasStartedEditingBidAmount(false)
-			setBidAmountInput('')
 			onBidSuccess?.()
 		} catch {
 			// Error handled by mutation

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -23,7 +23,7 @@ import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auct
 import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
-import { useMemo, useState, useEffect, useCallback, useRef, type ChangeEvent, type KeyboardEvent } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef, type ChangeEvent, type ClipboardEvent, type KeyboardEvent } from 'react'
 import { useAuctionCountdown } from './AuctionCountdown'
 import { InputGroup, InputGroupInput } from './ui/input-group'
 import { cn } from '@/lib/utils'
@@ -321,6 +321,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		try {
 			await bidMutation.mutateAsync(bidData)
 			toast.success('Bid placed successfully')
+			// Reset the editing flag so the input re-syncs to the new minBid floor.
+			setHasStartedEditingBidAmount(false)
 			onBidSuccess?.()
 		} catch {
 			// Error handled by mutation
@@ -343,10 +345,17 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		if (hasStartedEditingBidAmount) return
 		if (!event.key) return
 		if (String(bidAmountInput) !== String(minBid)) return
-		if (!/^[0-9.]$/.test(event.key)) return
+		if (!/^[0-9]$/.test(event.key)) return
 
 		setHasStartedEditingBidAmount(true)
 		setBidAmountInput('')
+	}
+
+	const handleBidAmountInputPaste = (event: ClipboardEvent<HTMLInputElement>) => {
+		event.preventDefault()
+		const pasted = event.clipboardData?.getData('text') ?? ''
+		setHasStartedEditingBidAmount(true)
+		setBidAmountInput(pasted)
 	}
 
 	const handleBidAmountInputChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -479,6 +488,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							value={bidAmountInput}
 							onChange={handleBidAmountInputChange}
 							onKeyDown={handleBidAmountInputKeyDown}
+							onPaste={handleBidAmountInputPaste}
 							placeholder={`Min: ${minBid.toLocaleString()}`}
 							disabled={isDisabledInput}
 						/>

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -481,7 +481,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							onKeyDown={handleBidAmountInputKeyDown}
 							placeholder={`Min: ${minBid.toLocaleString()}`}
 							disabled={isDisabledInput}
-							autoFocus
 						/>
 					</InputGroup>
 				)}

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -23,7 +23,7 @@ import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auct
 import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
-import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
+import { useMemo, useState, useEffect, useCallback, useRef, type ChangeEvent, type KeyboardEvent } from 'react'
 import { useAuctionCountdown } from './AuctionCountdown'
 import { InputGroup, InputGroupInput } from './ui/input-group'
 import { cn } from '@/lib/utils'
@@ -189,6 +189,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
+	const [hasStartedEditingBidAmount, setHasStartedEditingBidAmount] = useState(false)
 	const [isDepositOpen, setIsDepositOpen] = useState(false)
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
@@ -218,6 +219,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// Initialize input to min bid on mount or when min changes
 	useEffect(() => {
 		setBidAmountInput(String(minBid))
+		setHasStartedEditingBidAmount(false)
 	}, [minBid])
 
 	useEffect(() => {
@@ -335,6 +337,21 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		}
 
 		await submitPreparedBid(bidData)
+	}
+
+	const handleBidAmountInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (hasStartedEditingBidAmount) return
+		if (!event.key) return
+		if (String(bidAmountInput) !== String(minBid)) return
+		if (!/^[0-9.]$/.test(event.key)) return
+
+		setHasStartedEditingBidAmount(true)
+		setBidAmountInput('')
+	}
+
+	const handleBidAmountInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+		setHasStartedEditingBidAmount(true)
+		setBidAmountInput(event.target.value)
 	}
 
 	const handleRulesDialogOpenChange = (open: boolean) => {
@@ -460,7 +477,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							min={minBid}
 							step={bidStep}
 							value={bidAmountInput}
-							onChange={(e) => setBidAmountInput(e.target.value)}
+							onChange={handleBidAmountInputChange}
+							onKeyDown={handleBidAmountInputKeyDown}
 							placeholder={`Min: ${minBid.toLocaleString()}`}
 							disabled={isDisabledInput}
 							autoFocus

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -25,8 +25,7 @@ import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { useAuctionCountdown } from './AuctionCountdown'
-import { CircleX } from 'lucide-react'
-import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group'
+import { InputGroup, InputGroupInput } from './ui/input-group'
 import { cn } from '@/lib/utils'
 import { TooltipToggleGroupItem } from './shared/TooltipToggleGroupItem'
 import { useStore } from '@tanstack/react-store'
@@ -466,9 +465,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							disabled={isDisabledInput}
 							autoFocus
 						/>
-						<InputGroupAddon align="inline-end">
-							<CircleX onClick={() => setBidAmountInput(String(minBid))} className="size-4 cursor-pointer" />
-						</InputGroupAddon>
 					</InputGroup>
 				)}
 

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -323,6 +323,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			toast.success('Bid placed successfully')
 			// Reset the editing flag so the input re-syncs to the new minBid floor.
 			setHasStartedEditingBidAmount(false)
+			setBidAmountInput('')
 			onBidSuccess?.()
 		} catch {
 			// Error handled by mutation
@@ -341,15 +342,10 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		await submitPreparedBid(bidData)
 	}
 
-	const handleBidAmountInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-		if (hasStartedEditingBidAmount) return
-		if (!event.key) return
-		if (String(bidAmountInput) !== String(minBid)) return
-		if (!/^[0-9]$/.test(event.key)) return
-
-		setHasStartedEditingBidAmount(true)
-		setBidAmountInput('')
-	}
+	// ---------- Bid amount input handlers ----------
+	// Paste is intercepted with preventDefault so the pasted value is set
+	// directly; onChange handles all other input methods (typing, IME,
+	// drag-drop, step buttons, autocomplete) via first-edit-clear.
 
 	const handleBidAmountInputPaste = (event: ClipboardEvent<HTMLInputElement>) => {
 		event.preventDefault()
@@ -359,8 +355,17 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	}
 
 	const handleBidAmountInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+		const rawValue = event.target.value
+		if (!hasStartedEditingBidAmount && String(bidAmountInput) === String(minBid)) {
+			setHasStartedEditingBidAmount(true)
+			// Strip the minBid prefix when the user appends digits to the
+			// default value (e.g. "10000" + "5" -> "100005" -> "5").
+			const stripped = rawValue.startsWith(String(minBid)) ? rawValue.slice(String(minBid).length) : rawValue
+			setBidAmountInput(stripped || rawValue)
+			return
+		}
 		setHasStartedEditingBidAmount(true)
-		setBidAmountInput(event.target.value)
+		setBidAmountInput(rawValue)
 	}
 
 	const handleRulesDialogOpenChange = (open: boolean) => {
@@ -487,7 +492,6 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 							step={bidStep}
 							value={bidAmountInput}
 							onChange={handleBidAmountInputChange}
-							onKeyDown={handleBidAmountInputKeyDown}
 							onPaste={handleBidAmountInputPaste}
 							placeholder={`Min: ${minBid.toLocaleString()}`}
 							disabled={isDisabledInput}

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -218,9 +218,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	// Initialize input to min bid on mount or when min changes
 	useEffect(() => {
+		if (hasStartedEditingBidAmount) return
 		setBidAmountInput(String(minBid))
-		setHasStartedEditingBidAmount(false)
-	}, [minBid])
+	}, [minBid, hasStartedEditingBidAmount])
 
 	useEffect(() => {
 		if (!auctionRulesAckKey || typeof window === 'undefined') {


### PR DESCRIPTION
# Summary

This change makes the custom numeric bid input the default UI.

It removes the quick preset actions for minimum raise and 2x bids, to give one clear, consistent way to set bid amounts.

## Changes

- Removed the quick action toggle controls for preset bid options in `AuctionBidder.tsx:454`
- Always render the custom bid amount input for non-compact mode in `AuctionBidder.tsx:458`
- Replaced the input clear/cancel behavior with reset-to-minimum behavior via the trailing icon in `AuctionBidder.tsx:470`
- Removed now-unused editing state and selection logic in `AuctionBidder.tsx:190`
Cleaned up unused imports after removing preset actions in `AuctionBidder.tsx:1`

## Screenshots

https://github.com/user-attachments/assets/04ecca86-4e69-4008-9963-193ab24a1d05

closes #1125

