### PR TITLE
[FEAT] Improve loading indicator for user names & avatars

### DIFF
--- a/src/components/AvatarUser.tsx
+++ b/src/components/AvatarUser.tsx
@@ -1,36 +1,57 @@
 import * as React from 'react'
+import { useState } from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
-import { useProfile } from '@/queries/profiles'
+import { cn } from '@/lib/utils'
+import { useProfile, getProfileName } from '@/queries/profiles'
+import { Spinner } from './ui/spinner'
 
 interface AvatarUserProps extends React.ComponentProps<typeof AvatarPrimitive.Root> {
 	pubkey?: string
 }
 
-function AvatarUser({ pubkey, className }: AvatarUserProps) {
-	const { data: profileData } = useProfile(pubkey)
-	const { profile, user } = profileData ?? {}
+type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
+
+function AvatarUser({ pubkey, className = '', ...props }: AvatarUserProps) {
+	const { data: profileData, isLoading: isProfileLoading } = useProfile(pubkey)
+	const { profile } = profileData ?? {}
+
+	const profileName = getProfileName({ profile: profile ?? null })
+	const profilePicture = typeof profile?.picture === 'string' ? profile.picture.trim() : ''
+	const [imageState, setImageState] = useState<{ src: string; status: ImageLoadingStatus }>({ src: '', status: 'idle' })
+	const imageStatus = profilePicture ? (imageState.src === profilePicture ? imageState.status : 'loading') : 'idle'
+	const isImageLoading = imageStatus === 'loading'
 
 	// Determine fallback text
 	const getFallbackText = () => {
-		const title = profile?.displayName ?? profile?.name ?? 'p'
-		return title?.charAt(0).toUpperCase()
+		const title = profileName || 'n'
+		return title.charAt(0).toUpperCase()
 	}
 
+	const showSpinner = isProfileLoading || isImageLoading
+
 	return (
-		<AvatarPrimitive.Root data-slot="avatar" className={'relative flex size-8 shrink-0 overflow-hidden rounded-full w-6 h-6 ' + className}>
-			{profile?.picture ? (
-				// If profile picture is present, return image as avatar
-				<AvatarPrimitive.Image data-slot="avatar-image" className="aspect-square size-full" src={profile?.picture} />
-			) : (
-				// If no profile picture, return fallback avatar
-				<AvatarPrimitive.Fallback
-					data-slot="avatar-fallback"
-					className="bg-neo-purple text-white flex size-full items-center justify-center rounded-full text-center"
-				>
-					{getFallbackText()}
-				</AvatarPrimitive.Fallback>
+		<AvatarPrimitive.Root
+			data-slot="avatar"
+			className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full w-6 h-6', className)}
+			{...props}
+		>
+			{profilePicture && (
+				<AvatarPrimitive.Image
+					data-slot="avatar-image"
+					className="aspect-square size-full"
+					src={profilePicture}
+					alt={profileName || 'User avatar'}
+					onLoadingStatusChange={(status) => setImageState({ src: profilePicture, status })}
+				/>
 			)}
+			<AvatarPrimitive.Fallback
+				data-slot="avatar-fallback"
+				delayMs={200}
+				className="bg-neo-purple text-white flex size-full items-center justify-center rounded-full text-center"
+			>
+				{showSpinner ? <Spinner className="h-1/2 w-1/2 text-white" /> : getFallbackText()}
+			</AvatarPrimitive.Fallback>
 		</AvatarPrimitive.Root>
 	)
 }

--- a/src/components/AvatarUser.tsx
+++ b/src/components/AvatarUser.tsx
@@ -10,10 +10,12 @@ interface AvatarUserProps extends React.ComponentProps<typeof AvatarPrimitive.Ro
 	pubkey?: string
 }
 
-type ImageLoadingStatus = 'idle' | 'loading' | 'loaded' | 'error'
+type ImageLoadingStatus = NonNullable<
+	Parameters<NonNullable<React.ComponentProps<typeof AvatarPrimitive.Image>['onLoadingStatusChange']>>[0]
+>
 
-function AvatarUser({ pubkey, className = '', ...props }: AvatarUserProps) {
-	const { data: profileData, isLoading: isProfileLoading } = useProfile(pubkey)
+function AvatarUser({ pubkey, className, ...props }: AvatarUserProps) {
+	const { data: profileData, isPending, isFetching } = useProfile(pubkey)
 	const { profile } = profileData ?? {}
 
 	const profileName = (profile?.displayName || profile?.name || '').trim()
@@ -22,13 +24,13 @@ function AvatarUser({ pubkey, className = '', ...props }: AvatarUserProps) {
 	const imageStatus = profilePicture ? (imageState.src === profilePicture ? imageState.status : 'loading') : 'idle'
 	const isImageLoading = imageStatus === 'loading'
 
-	// Determine fallback text
+	// Use a simple initial for the fallback when no profile name is available.
 	const getFallbackText = () => {
-		const title = profileName || 'n'
+		const title = profileName || 'N'
 		return title.charAt(0).toUpperCase()
 	}
 
-	const showSpinner = isProfileLoading || isImageLoading
+	const showSpinner = isPending || isFetching || isImageLoading
 
 	return (
 		<AvatarPrimitive.Root
@@ -47,7 +49,6 @@ function AvatarUser({ pubkey, className = '', ...props }: AvatarUserProps) {
 			)}
 			<AvatarPrimitive.Fallback
 				data-slot="avatar-fallback"
-				delayMs={200}
 				className="bg-neo-purple text-white flex size-full items-center justify-center rounded-full text-center"
 			>
 				{showSpinner ? <Spinner className="h-1/2 w-1/2 text-white" /> : getFallbackText()}

--- a/src/components/AvatarUser.tsx
+++ b/src/components/AvatarUser.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
 import { cn } from '@/lib/utils'
-import { useProfile } from '@/queries/profiles'
+import { getNormalizedProfileDisplayName, getNormalizedProfilePicture, useProfile } from '@/queries/profiles'
 import { Spinner } from './ui/spinner'
 
 interface AvatarUserProps extends React.ComponentProps<typeof AvatarPrimitive.Root> {
@@ -15,11 +15,11 @@ type ImageLoadingStatus = NonNullable<
 >
 
 function AvatarUser({ pubkey, className, ...props }: AvatarUserProps) {
-	const { data: profileData, isPending, isFetching } = useProfile(pubkey)
+	const { data: profileData, isLoading } = useProfile(pubkey)
 	const { profile } = profileData ?? {}
 
-	const profileName = (profile?.displayName || profile?.name || '').trim()
-	const profilePicture = typeof profile?.picture === 'string' ? profile.picture.trim() : ''
+	const profileName = getNormalizedProfileDisplayName(profile)
+	const profilePicture = getNormalizedProfilePicture(profile)
 	const [imageState, setImageState] = useState<{ src: string; status: ImageLoadingStatus }>({ src: '', status: 'idle' })
 	const imageStatus = profilePicture ? (imageState.src === profilePicture ? imageState.status : 'loading') : 'idle'
 	const isImageLoading = imageStatus === 'loading'
@@ -30,7 +30,7 @@ function AvatarUser({ pubkey, className, ...props }: AvatarUserProps) {
 		return title.charAt(0).toUpperCase()
 	}
 
-	const showSpinner = isPending || isFetching || isImageLoading
+	const showSpinner = isLoading || isImageLoading
 
 	return (
 		<AvatarPrimitive.Root

--- a/src/components/AvatarUser.tsx
+++ b/src/components/AvatarUser.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import * as AvatarPrimitive from '@radix-ui/react-avatar'
 
 import { cn } from '@/lib/utils'
-import { useProfile, getProfileName } from '@/queries/profiles'
+import { useProfile } from '@/queries/profiles'
 import { Spinner } from './ui/spinner'
 
 interface AvatarUserProps extends React.ComponentProps<typeof AvatarPrimitive.Root> {
@@ -16,7 +16,7 @@ function AvatarUser({ pubkey, className = '', ...props }: AvatarUserProps) {
 	const { data: profileData, isLoading: isProfileLoading } = useProfile(pubkey)
 	const { profile } = profileData ?? {}
 
-	const profileName = getProfileName({ profile: profile ?? null })
+	const profileName = (profile?.displayName || profile?.name || '').trim()
 	const profilePicture = typeof profile?.picture === 'string' ? profile.picture.trim() : ''
 	const [imageState, setImageState] = useState<{ src: string; status: ImageLoadingStatus }>({ src: '', status: 'idle' })
 	const imageStatus = profilePicture ? (imageState.src === profilePicture ? imageState.status : 'loading') : 'idle'

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,4 +1,10 @@
-import { getNormalizedProfileDisplayName, getNormalizedProfileNip05, normalizeOptionalPubkey, normalizeOptionalString, useProfile } from '@/queries/profiles'
+import {
+	getNormalizedProfileDisplayName,
+	getNormalizedProfileNip05,
+	normalizeOptionalPubkey,
+	normalizeOptionalString,
+	useProfile,
+} from '@/queries/profiles'
 import { AvatarUser } from './AvatarUser'
 import { useState } from 'react'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
@@ -208,7 +214,11 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 						<p className={cn(classSizeNIP05, 'text-gray-400 truncate', className)}>{profileNip05}</p>
 					) : (
 						showNpubAsSubtitle &&
-						copyNpubWrapper(<span className={cn(classSizeNpub, 'font-medium text-gray-400 truncate lowercase', classNpub, className)}>{textDisplayNpub}</span>)
+						copyNpubWrapper(
+							<span className={cn(classSizeNpub, 'font-medium text-gray-400 truncate lowercase', classNpub, className)}>
+								{textDisplayNpub}
+							</span>,
+						)
 					))}
 			</div>
 		</div>

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import { useProfile, getProfileName, getProfileNip05 } from '@/queries/profiles'
+import { useProfile, getProfileNip05 } from '@/queries/profiles'
 import { AvatarUser } from './AvatarUser'
 import { useState } from 'react'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
@@ -44,7 +44,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	const breakpoint = useBreakpoint()
 	const compact = breakpoint === 'md' || breakpoint === 'sm'
 
-	const profileDisplayName = getProfileName({ profile: profile ?? null }).trim() || null
+	const profileDisplayName = (profile?.displayName || profile?.name || '').trim() || null
 	const profileNip05 = getProfileNip05({ profile: profile ?? null })?.trim() || null
 	const userNpub = user?.npub?.trim()
 	const npub = userNpub && isValidNpub(userNpub) ? userNpub : encodeIdentifierToNpub(safePubkey)
@@ -136,7 +136,9 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	const copyNpubWrapper = (child: React.ReactNode) =>
 		shouldCopyNpub ? (
 			<Tooltip open={forceShowTooltip == true ? forceShowTooltip : undefined}>
-				<TooltipTrigger className={'w-min ' + className}>{child}</TooltipTrigger>
+				<TooltipTrigger asChild className={'w-min ' + className}>
+					{child}
+				</TooltipTrigger>
 
 				<TooltipContent side="bottom" className="">
 					{textTooltip}

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,13 +1,15 @@
-import { useProfile } from '@/queries/profiles'
+import { useProfile, getProfileName, getProfileNip05 } from '@/queries/profiles'
 import { AvatarUser } from './AvatarUser'
 import { useState } from 'react'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
 import { Nip05Badge } from './Nip05Badge'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Link } from '@tanstack/react-router'
+import { nip19 } from 'nostr-tools'
+import { isValidHexKey, isValidNpub } from '@/lib/utils'
 
 interface UserCardProps {
-	pubkey: string
+	pubkey?: string
 	className?: string
 	/** Small: , Medium: , Large: User Profile */
 	size?: 'xs' | 'sm' | 'md' | 'lg'
@@ -15,23 +17,49 @@ interface UserCardProps {
 	onPress?: 'profile' | 'copy-npub' | 'none'
 }
 
+function encodeIdentifierToNpub(identifier: string | undefined): string | null {
+	const trimmedIdentifier = identifier?.trim()
+	if (!trimmedIdentifier) return null
+
+	if (isValidNpub(trimmedIdentifier)) {
+		return trimmedIdentifier
+	}
+
+	if (!isValidHexKey(trimmedIdentifier)) {
+		return null
+	}
+
+	return nip19.npubEncode(trimmedIdentifier)
+}
+
+function formatNpubForDisplay(npub: string): string {
+	return `${npub.slice(0, 9)}..${npub.slice(-6)}`
+}
+
 export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
-	const { data: profileData } = useProfile(pubkey)
-	const { user } = profileData || {}
+	const safePubkey = pubkey?.trim() || undefined
+	const { data: profileData, isLoading } = useProfile(safePubkey)
+	const { profile, user } = profileData || {}
 
 	const breakpoint = useBreakpoint()
 	const compact = breakpoint === 'md' || breakpoint === 'sm'
 
-	const textDisplayNpub = user?.npub.slice(0, 9) + '..' + user?.npub.slice(-6)
-	const textTitle = user?.profile?.displayName ?? user?.profile?.name ?? textDisplayNpub
+	const profileDisplayName = getProfileName({ profile: profile ?? null }).trim() || null
+	const profileNip05 = getProfileNip05({ profile: profile ?? null })?.trim() || null
+	const userNpub = user?.npub?.trim()
+	const npub = userNpub && isValidNpub(userNpub) ? userNpub : encodeIdentifierToNpub(safePubkey)
+	const textDisplayNpub = npub ? formatNpubForDisplay(npub) : 'Unknown user'
+	const textTitle = isLoading ? 'Loading...' : (profileDisplayName ?? textDisplayNpub)
 
-	const showNip05AddressAfterBadge = user?.profile?.nip05 != null && !(subtitle === 'nip-05' || compact)
-	const showNip05AsSubtitle = user?.profile?.nip05 != null && (subtitle === 'nip-05' || compact)
-	const showNpubAsTitle = textTitle == textDisplayNpub
-	const showNpubAsSubtitle = !showNpubAsTitle && subtitle === 'npub'
+	const showNip05AddressAfterBadge = !isLoading && profileNip05 != null && !(subtitle === 'nip-05' || compact)
+	const showNip05AsSubtitle = !isLoading && profileNip05 != null && (subtitle === 'nip-05' || compact)
+	const showNpubAsTitle = !isLoading && profileDisplayName == null && npub != null
+	const showNpubAsSubtitle = !showNpubAsTitle && !isLoading && profileDisplayName != null && subtitle === 'npub' && npub != null
 	const showSubtitle = size !== 'xs'
 
-	const shouldCopyNpub = onPress !== 'none'
+	const onlyPrimaryTextShows = !showSubtitle || (!showNip05AsSubtitle && !showNpubAsSubtitle)
+	const disableSmallPrimaryCopy = (size === 'xs' || size === 'sm') && onlyPrimaryTextShows
+	const shouldCopyNpub = onPress !== 'none' && !isLoading && npub != null && !disableSmallPrimaryCopy
 
 	const classSizeAvatar = {
 		xs: 'h-6 w-6',
@@ -86,12 +114,12 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 				//event.stopPropagation()
 				event.preventDefault()
 
-				if (user?.npub == null) {
+				if (npub == null) {
 					return
 				}
 
 				// Copy npub to clipboard
-				navigator.clipboard.writeText(user?.npub)
+				navigator.clipboard.writeText(npub)
 
 				// Update tooltip to show copied state
 				setTextTooltip('Copied!')
@@ -121,7 +149,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	// Note: We pass in min-w-0 to ensure text (name, npub) truncates
 	const content = (
 		<div className={'flex flex-row items-center min-w-0 font-sans font-normal tracking-normal text-nowrap ' + classGapHorizontal}>
-			<AvatarUser pubkey={user?.pubkey} className={classSizeAvatar + ' min-w-0 ' + className} />
+			<AvatarUser pubkey={safePubkey} className={classSizeAvatar + ' min-w-0 ' + className} />
 			<div className={'flex flex-col min-w-0 ' + classGapVertical + ' ' + className}>
 				<div className={'flex items-center gap-1 min-w-0 overflow-hidden ' + className}>
 					{showNpubAsTitle ? (
@@ -133,14 +161,14 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 					) : (
 						<h2 className={classSizeName + ' truncate min-w-0 ' + className}>{textTitle}</h2>
 					)}
-					{user?.pubkey && (
-						<Nip05Badge pubkey={user.pubkey} className={classSizeNIP05 + ' ' + className} showAddress={showNip05AddressAfterBadge} />
+					{safePubkey && profileNip05 && (
+						<Nip05Badge pubkey={safePubkey} className={classSizeNIP05 + ' ' + className} showAddress={showNip05AddressAfterBadge} />
 					)}
 				</div>
 
 				{showSubtitle &&
 					(showNip05AsSubtitle ? (
-						<p className={classSizeNIP05 + ' text-gray-400 truncate ' + className}>{user?.profile?.nip05}</p>
+						<p className={classSizeNIP05 + ' text-gray-400 truncate ' + className}>{profileNip05}</p>
 					) : (
 						showNpubAsSubtitle &&
 						copyNpubWrapper(
@@ -156,8 +184,12 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 		</div>
 	)
 
-	if (onPress === 'profile') {
-		return <Link to={`/profile/${pubkey}`}>{content}</Link>
+	if (onPress === 'profile' && safePubkey) {
+		return (
+			<Link to="/profile/$profileId" params={{ profileId: safePubkey }}>
+				{content}
+			</Link>
+		)
 	} else {
 		return content
 	}

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -36,9 +36,9 @@ function formatNpubForDisplay(npub: string): string {
 	return `${npub.slice(0, 9)}..${npub.slice(-6)}`
 }
 
-export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
+export function UserCard({ pubkey, className, size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
 	const safePubkey = pubkey?.trim() || undefined
-	const { data: profileData, isLoading } = useProfile(safePubkey)
+	const { data: profileData, isPending, isFetching } = useProfile(safePubkey)
 	const { profile, user } = profileData || {}
 
 	const breakpoint = useBreakpoint()
@@ -49,17 +49,19 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	const userNpub = user?.npub?.trim()
 	const npub = userNpub && isValidNpub(userNpub) ? userNpub : encodeIdentifierToNpub(safePubkey)
 	const textDisplayNpub = npub ? formatNpubForDisplay(npub) : 'Unknown user'
-	const textTitle = isLoading ? 'Loading...' : (profileDisplayName ?? textDisplayNpub)
+	const isProfileLoading = isPending || isFetching
+	const textTitle = isProfileLoading ? 'Loading...' : (profileDisplayName ?? textDisplayNpub)
 
-	const showNip05AddressAfterBadge = !isLoading && profileNip05 != null && !(subtitle === 'nip-05' || compact)
-	const showNip05AsSubtitle = !isLoading && profileNip05 != null && (subtitle === 'nip-05' || compact)
-	const showNpubAsTitle = !isLoading && profileDisplayName == null && npub != null
-	const showNpubAsSubtitle = !showNpubAsTitle && !isLoading && profileDisplayName != null && subtitle === 'npub' && npub != null
+	const showNip05AddressAfterBadge = !isProfileLoading && profileNip05 != null && !(subtitle === 'nip-05' || compact)
+	const showNip05AsSubtitle = !isProfileLoading && profileNip05 != null && (subtitle === 'nip-05' || compact)
+	const showNpubAsTitle = !isProfileLoading && profileDisplayName == null && npub != null
+	const showNpubAsSubtitle = !showNpubAsTitle && !isProfileLoading && profileDisplayName != null && subtitle === 'npub' && npub != null
 	const showSubtitle = size !== 'xs'
 
+	// Avoid turning an already-compact card into a copy target when it only shows one text line.
 	const onlyPrimaryTextShows = !showSubtitle || (!showNip05AsSubtitle && !showNpubAsSubtitle)
 	const disableSmallPrimaryCopy = (size === 'xs' || size === 'sm') && onlyPrimaryTextShows
-	const shouldCopyNpub = onPress !== 'none' && !isLoading && npub != null && !disableSmallPrimaryCopy
+	const shouldCopyNpub = onPress !== 'none' && !isProfileLoading && npub != null && !disableSmallPrimaryCopy
 
 	const classSizeAvatar = {
 		xs: 'h-6 w-6',
@@ -111,7 +113,6 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 
 	const onClickNpub = shouldCopyNpub
 		? (event: React.MouseEvent) => {
-				//event.stopPropagation()
 				event.preventDefault()
 
 				if (npub == null) {
@@ -135,7 +136,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 
 	const copyNpubWrapper = (child: React.ReactNode) =>
 		shouldCopyNpub ? (
-			<Tooltip open={forceShowTooltip == true ? forceShowTooltip : undefined}>
+			<Tooltip open={forceShowTooltip === true ? forceShowTooltip : undefined}>
 				<TooltipTrigger asChild className={'w-min ' + className}>
 					{child}
 				</TooltipTrigger>

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -6,7 +6,7 @@ import { Nip05Badge } from './Nip05Badge'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Link } from '@tanstack/react-router'
 import { nip19 } from 'nostr-tools'
-import { isValidHexKey, isValidNpub } from '@/lib/utils'
+import { cn, isValidHexKey, isValidNpub } from '@/lib/utils'
 
 interface UserCardProps {
 	pubkey?: string
@@ -137,7 +137,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	const copyNpubWrapper = (child: React.ReactNode) =>
 		shouldCopyNpub ? (
 			<Tooltip open={forceShowTooltip === true ? forceShowTooltip : undefined}>
-				<TooltipTrigger asChild className={'w-min ' + className}>
+				<TooltipTrigger asChild className={cn('w-min', className)}>
 					{child}
 				</TooltipTrigger>
 
@@ -151,34 +151,31 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 
 	// Note: We pass in min-w-0 to ensure text (name, npub) truncates
 	const content = (
-		<div className={'flex flex-row items-center min-w-0 font-sans font-normal tracking-normal text-nowrap ' + classGapHorizontal}>
-			<AvatarUser pubkey={safePubkey} className={classSizeAvatar + ' min-w-0 ' + className} />
-			<div className={'flex flex-col min-w-0 ' + classGapVertical + ' ' + className}>
-				<div className={'flex items-center gap-1 min-w-0 overflow-hidden ' + className}>
+		<div className={cn('flex flex-row items-center min-w-0 font-sans font-normal tracking-normal text-nowrap', classGapHorizontal)}>
+			<AvatarUser pubkey={safePubkey} className={cn(classSizeAvatar, 'min-w-0', className)} />
+			<div className={cn('flex flex-col min-w-0', classGapVertical, className)}>
+				<div className={cn('flex items-center gap-1 min-w-0 overflow-hidden', className)}>
 					{showNpubAsTitle ? (
 						copyNpubWrapper(
-							<h2 className={classSizeName + ' truncate lowercase min-w-0 ' + classNpub + ' ' + className} onClick={onClickNpub}>
+							<h2 className={cn(classSizeName, 'truncate lowercase min-w-0', classNpub, className)} onClick={onClickNpub}>
 								{textTitle}
 							</h2>,
 						)
 					) : (
-						<h2 className={classSizeName + ' truncate min-w-0 ' + className}>{textTitle}</h2>
+						<h2 className={cn(classSizeName, 'truncate min-w-0', className)}>{textTitle}</h2>
 					)}
 					{safePubkey && profileNip05 && (
-						<Nip05Badge pubkey={safePubkey} className={classSizeNIP05 + ' ' + className} showAddress={showNip05AddressAfterBadge} />
+						<Nip05Badge pubkey={safePubkey} className={cn(classSizeNIP05, className)} showAddress={showNip05AddressAfterBadge} />
 					)}
 				</div>
 
 				{showSubtitle &&
 					(showNip05AsSubtitle ? (
-						<p className={classSizeNIP05 + ' text-gray-400 truncate ' + className}>{profileNip05}</p>
+						<p className={cn(classSizeNIP05, 'text-gray-400 truncate', className)}>{profileNip05}</p>
 					) : (
 						showNpubAsSubtitle &&
 						copyNpubWrapper(
-							<p
-								className={classSizeNpub + ' font-medium text-gray-400 truncate lowercase ' + classNpub + ' ' + className}
-								onClick={onClickNpub}
-							>
+							<p className={cn(classSizeNpub, 'font-medium text-gray-400 truncate lowercase', classNpub, className)} onClick={onClickNpub}>
 								{textDisplayNpub}
 							</p>,
 						)

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-import { useProfile, getProfileNip05 } from '@/queries/profiles'
+import { getNormalizedProfileDisplayName, getNormalizedProfileNip05, normalizeOptionalPubkey, normalizeOptionalString, useProfile } from '@/queries/profiles'
 import { AvatarUser } from './AvatarUser'
 import { useState } from 'react'
 import { useBreakpoint } from '@/hooks/useBreakpoint'
@@ -36,21 +36,41 @@ function formatNpubForDisplay(npub: string): string {
 	return `${npub.slice(0, 9)}..${npub.slice(-6)}`
 }
 
+export function getUserCardTitle({
+	isProfileLoading,
+	profileDisplayName,
+	textDisplayNpub,
+}: {
+	isProfileLoading: boolean
+	profileDisplayName: string | null
+	textDisplayNpub: string
+}): string {
+	if (isProfileLoading) {
+		return 'Loading...'
+	}
+
+	return profileDisplayName ?? textDisplayNpub
+}
+
+export function isKeyboardCopyActivationKey(event: KeyboardEvent): boolean {
+	return event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'
+}
+
 export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
-	const safePubkey = pubkey?.trim() || undefined
-	const { data: profileData, isPending, isFetching } = useProfile(safePubkey)
+	const safePubkey = normalizeOptionalPubkey(pubkey)
+	const { data: profileData, isLoading } = useProfile(safePubkey)
 	const { profile, user } = profileData || {}
 
 	const breakpoint = useBreakpoint()
 	const compact = breakpoint === 'md' || breakpoint === 'sm'
 
-	const profileDisplayName = (profile?.displayName || profile?.name || '').trim() || null
-	const profileNip05 = getProfileNip05({ profile: profile ?? null })?.trim() || null
-	const userNpub = user?.npub?.trim()
+	const profileDisplayName = getNormalizedProfileDisplayName(profile)
+	const profileNip05 = getNormalizedProfileNip05(profile)
+	const userNpub = normalizeOptionalString(user?.npub)
 	const npub = userNpub && isValidNpub(userNpub) ? userNpub : encodeIdentifierToNpub(safePubkey)
 	const textDisplayNpub = npub ? formatNpubForDisplay(npub) : 'Unknown user'
-	const isProfileLoading = isPending || isFetching
-	const textTitle = isProfileLoading ? 'Loading...' : (profileDisplayName ?? textDisplayNpub)
+	const isProfileLoading = isLoading
+	const textTitle = getUserCardTitle({ isProfileLoading, profileDisplayName, textDisplayNpub })
 
 	const showNip05AddressAfterBadge = !isProfileLoading && profileNip05 != null && !(subtitle === 'nip-05' || compact)
 	const showNip05AsSubtitle = !isProfileLoading && profileNip05 != null && (subtitle === 'nip-05' || compact)
@@ -111,34 +131,52 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 	const [textTooltip, setTextTooltip] = useState(textTooltipDefault)
 	const [forceShowTooltip, setForceShowTooltip] = useState(false)
 
-	const onClickNpub = shouldCopyNpub
-		? (event: React.MouseEvent) => {
-				event.preventDefault()
+	const handleCopyNpub = (event?: React.SyntheticEvent) => {
+		event?.preventDefault()
 
-				if (npub == null) {
+		if (npub == null) {
+			return
+		}
+
+		navigator.clipboard.writeText(npub)
+		setTextTooltip('Copied!')
+		setForceShowTooltip(true)
+
+		setTimeout(() => {
+			setTextTooltip(textTooltipDefault)
+			setForceShowTooltip(false)
+		}, 2000)
+	}
+
+	const onClickNpub = shouldCopyNpub
+		? (event: React.MouseEvent<HTMLButtonElement>) => {
+				handleCopyNpub(event)
+			}
+		: undefined
+
+	const onKeyDownNpub = shouldCopyNpub
+		? (event: React.KeyboardEvent<HTMLButtonElement>) => {
+				if (!isKeyboardCopyActivationKey(event.nativeEvent)) {
 					return
 				}
 
-				// Copy npub to clipboard
-				navigator.clipboard.writeText(npub)
-
-				// Update tooltip to show copied state
-				setTextTooltip('Copied!')
-				setForceShowTooltip(true)
-
-				// After delay, reset tooltip
-				setTimeout(() => {
-					setTextTooltip(textTooltipDefault)
-					setForceShowTooltip(false)
-				}, 2000)
+				handleCopyNpub(event)
 			}
-		: () => {}
+		: undefined
 
 	const copyNpubWrapper = (child: React.ReactNode) =>
 		shouldCopyNpub ? (
 			<Tooltip open={forceShowTooltip === true ? forceShowTooltip : undefined}>
-				<TooltipTrigger asChild className={cn('w-min', className)}>
-					{child}
+				<TooltipTrigger asChild>
+					<button
+						type="button"
+						aria-label={textTooltipDefault}
+						className={cn('w-min min-w-0 border-0 bg-transparent p-0 text-left', classNpub)}
+						onClick={onClickNpub}
+						onKeyDown={onKeyDownNpub}
+					>
+						{child}
+					</button>
 				</TooltipTrigger>
 
 				<TooltipContent side="bottom" className="">
@@ -156,11 +194,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 			<div className={cn('flex flex-col min-w-0', classGapVertical, className)}>
 				<div className={cn('flex items-center gap-1 min-w-0 overflow-hidden', className)}>
 					{showNpubAsTitle ? (
-						copyNpubWrapper(
-							<h2 className={cn(classSizeName, 'truncate lowercase min-w-0', classNpub, className)} onClick={onClickNpub}>
-								{textTitle}
-							</h2>,
-						)
+						copyNpubWrapper(<span className={cn(classSizeName, 'truncate lowercase min-w-0', classNpub, className)}>{textTitle}</span>)
 					) : (
 						<h2 className={cn(classSizeName, 'truncate min-w-0', className)}>{textTitle}</h2>
 					)}
@@ -174,11 +208,7 @@ export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-
 						<p className={cn(classSizeNIP05, 'text-gray-400 truncate', className)}>{profileNip05}</p>
 					) : (
 						showNpubAsSubtitle &&
-						copyNpubWrapper(
-							<p className={cn(classSizeNpub, 'font-medium text-gray-400 truncate lowercase', classNpub, className)} onClick={onClickNpub}>
-								{textDisplayNpub}
-							</p>,
-						)
+						copyNpubWrapper(<span className={cn(classSizeNpub, 'font-medium text-gray-400 truncate lowercase', classNpub, className)}>{textDisplayNpub}</span>)
 					))}
 			</div>
 		</div>

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -36,7 +36,7 @@ function formatNpubForDisplay(npub: string): string {
 	return `${npub.slice(0, 9)}..${npub.slice(-6)}`
 }
 
-export function UserCard({ pubkey, className, size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
+export function UserCard({ pubkey, className = '', size = 'md', subtitle = 'nip-05', onPress = 'profile' }: UserCardProps) {
 	const safePubkey = pubkey?.trim() || undefined
 	const { data: profileData, isPending, isFetching } = useProfile(safePubkey)
 	const { profile, user } = profileData || {}

--- a/src/queries/__tests__/profile-validation.test.ts
+++ b/src/queries/__tests__/profile-validation.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test'
 import { nip19 } from 'nostr-tools'
 
 import { isValidHexKey } from '../../lib/utils'
-import { getProfileIdentifierValidationError, validateProfileIdentifier } from '../../lib/utils/profileValidation'
+import { getProfileIdentifierValidationError, validateProfileIdentifier } from '@/lib/utils/profileValidation'
+import { getNormalizedProfileDisplayName, getNormalizedProfileNip05, normalizeOptionalPubkey } from '@/queries/profiles'
+import { getUserCardTitle, isKeyboardCopyActivationKey } from '@/components/UserCard'
 
 const VALID_HEX = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
 const VALID_NPUB = nip19.npubEncode(VALID_HEX)
@@ -25,6 +27,55 @@ describe('nostr pubkey validation', () => {
 		expect(isValidHexKey('npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq')).toBe(false)
 		expect(isValidHexKey('01234')).toBe(false)
 		expect(isValidHexKey('g'.repeat(64))).toBe(false)
+	})
+})
+
+describe('profile metadata normalization', () => {
+	test('falls back to a valid name when displayName is whitespace-only', () => {
+		const profile = {
+			displayName: '   ',
+			name: 'Alice',
+			picture: 123 as unknown as string,
+			nip05: 456 as unknown as string,
+		}
+
+		expect(getNormalizedProfileDisplayName(profile as never)).toBe('Alice')
+		expect(getNormalizedProfileNip05(profile as never)).toBeNull()
+	})
+
+	test('treats non-string kind-0 fields as absent instead of throwing', () => {
+		const profile = {
+			displayName: 42,
+			name: 999,
+			picture: false,
+			nip05: 123,
+		}
+
+		expect(() => getNormalizedProfileDisplayName(profile as never)).not.toThrow()
+		expect(() => getNormalizedProfileNip05(profile as never)).not.toThrow()
+		expect(getNormalizedProfileDisplayName(profile as never)).toBeNull()
+		expect(getNormalizedProfileNip05(profile as never)).toBeNull()
+	})
+
+	test('guards empty-string callers by normalizing optional pubkeys to undefined', () => {
+		expect(normalizeOptionalPubkey('   ')).toBeUndefined()
+		expect(normalizeOptionalPubkey(undefined)).toBeUndefined()
+		expect(normalizeOptionalPubkey(VALID_HEX)).toBe(VALID_HEX)
+	})
+
+	test('keeps cached identity visible during background refresh', () => {
+		expect(getUserCardTitle({ isProfileLoading: false, profileDisplayName: 'Alice', textDisplayNpub: 'npub1...' })).toBe('Alice')
+		expect(getUserCardTitle({ isProfileLoading: false, profileDisplayName: null, textDisplayNpub: 'npub1...' })).toBe('npub1...')
+	})
+
+	test('treats Enter and Space as keyboard activation for copy mode', () => {
+		const enterEvent = { key: 'Enter' } as KeyboardEvent
+		const spaceEvent = { key: ' ' } as KeyboardEvent
+		const otherEvent = { key: 'Tab' } as KeyboardEvent
+
+		expect(isKeyboardCopyActivationKey(enterEvent)).toBe(true)
+		expect(isKeyboardCopyActivationKey(spaceEvent)).toBe(true)
+		expect(isKeyboardCopyActivationKey(otherEvent)).toBe(false)
 	})
 })
 

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -4,6 +4,36 @@ import { NDKWoT } from '@nostr-dev-kit/wot'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { profileKeys } from './queryKeyFactory'
 
+export function normalizeOptionalString(value: unknown): string | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	const trimmed = value.trim()
+	return trimmed.length > 0 ? trimmed : null
+}
+
+export function getNormalizedProfileDisplayName(profile: Partial<NDKUserProfile> | null | undefined): string | null {
+	return normalizeOptionalString(profile?.displayName) ?? normalizeOptionalString(profile?.name)
+}
+
+export function getNormalizedProfileNip05(profile: Partial<NDKUserProfile> | null | undefined): string | null {
+	return normalizeOptionalString(profile?.nip05)
+}
+
+export function getNormalizedProfilePicture(profile: Partial<NDKUserProfile> | null | undefined): string {
+	return normalizeOptionalString(profile?.picture) ?? ''
+}
+
+export function normalizeOptionalPubkey(identifier: string | undefined): string | undefined {
+	if (typeof identifier !== 'string') {
+		return undefined
+	}
+
+	const trimmed = identifier.trim()
+	return trimmed.length > 0 ? trimmed : undefined
+}
+
 export const fetchProfileByNpub = async (npub: string): Promise<NDKUserProfile | null> => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
@@ -99,13 +129,11 @@ export const nip05ValidationQueryOptions = (pubkey: string) =>
 // --- DATA EXTRACTION FUNCTIONS ---
 
 export const getProfileName = ({ profile }: { profile: NDKUserProfile | null }): string => {
-	if (!profile) return ''
-	return profile.name || profile.displayName || ''
+	return getNormalizedProfileDisplayName(profile) ?? ''
 }
 
 export const getProfileNip05 = ({ profile }: { profile: NDKUserProfile | null }): string | undefined => {
-	if (!profile) return undefined
-	return profile.nip05
+	return getNormalizedProfileNip05(profile) ?? undefined
 }
 
 // --- REACT QUERY HOOKS ---


### PR DESCRIPTION
UserCard was building the fallback from user?.npub.slice(...) before user existed, so JS concatenated undefined..undefined. It also passed user?.pubkey down to the avatar, meaning the avatar had no stable pubkey while profile data loaded. 

What changed
Loading now renders Loading... plus an avatar spinner. 
Name/display-name fallbacks treat blank strings as missing and fall back to a derived npub from the input pubkey. 
Profile links and avatar loading now use the primary pubkey prop, not loaded profile/user fields. copy npub is disabled while loading, and disabled for compact primary-only displays. 
No duplicate user-card/avatar component path was added.

fixes #864 
<img width="495" height="275" alt="Screenshot from 2026-07-16 10-53-30" src="https://github.com/user-attachments/assets/c65d7534-a7ce-4df1-9ffa-f10a0f7a7128" />

