### PR TITLE
Fixed broken CI step with nak install by pinning specific commit hash

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,6 @@ jobs:
           git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
-          
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -172,7 +171,7 @@ jobs:
           git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
-          
+
           GOBIN="$(go env GOPATH)/bin"
           mkdir -p "$GOBIN"
           go build -o "$GOBIN/nak" .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,6 +50,10 @@ jobs:
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
 
+          GOBIN="$(go env GOPATH)/bin"
+          mkdir -p "$GOBIN"
+          go build -o "$GOBIN/nak" .
+          echo "nak installed at: $(which nak)"
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -157,8 +157,17 @@ jobs:
 
       - name: Install nak
         run: |
-          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          # NOTE: We pin to commit b6568388 because the upstream 'nak' repository 
+          # (commit 9c35de2 on Jul 16) introduced a breaking 'replace' directive 
+          # in go.mod: `replace fiatjaf.com/nostr => ../nostrlib`.
+          # This local path reference fails in CI where the sibling 'nostrlib' repo 
+          # does not exist, causing build failures.
+          # Pinning to this pre-regression commit ensures the build uses the 
+          # remote module source until the upstream issue is resolved.
+          git clone https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
+          git checkout b65683886b58382890888fbdda90e5c2129df488
+          
           GOBIN="$(go env GOPATH)/bin"
           mkdir -p "$GOBIN"
           go build -o "$GOBIN/nak" .

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,12 +39,17 @@ jobs:
 
       - name: Install nak
         run: |
+          # NOTE: We pin to commit b6568388 because the upstream 'nak' repository 
+          # (commit 9c35de2 on Jul 16) introduced a breaking 'replace' directive 
+          # in go.mod: `replace fiatjaf.com/nostr => ../nostrlib`.
+          # This local path reference fails in CI where the sibling 'nostrlib' repo 
+          # does not exist, causing build failures.
+          # Pinning to this pre-regression commit ensures the build uses the 
+          # remote module source until the upstream issue is resolved.
           git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
-          GOBIN="$(go env GOPATH)/bin"
-          mkdir -p "$GOBIN"
-          go build -o "$GOBIN/nak" .
-          echo "nak installed at: $(which nak)"
+          git checkout b65683886b58382890888fbdda90e5c2129df488
+          
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -164,7 +169,7 @@ jobs:
           # does not exist, causing build failures.
           # Pinning to this pre-regression commit ensures the build uses the 
           # remote module source until the upstream issue is resolved.
-          git clone https://github.com/fiatjaf/nak.git /tmp/nak
+          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
           

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
           # does not exist, causing build failures.
           # Pinning to this pre-regression commit ensures the build uses the 
           # remote module source until the upstream issue is resolved.
-          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          git clone https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
 
@@ -168,7 +168,7 @@ jobs:
           # does not exist, causing build failures.
           # Pinning to this pre-regression commit ensures the build uses the 
           # remote module source until the upstream issue is resolved.
-          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          git clone https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
           git checkout b65683886b58382890888fbdda90e5c2129df488
 


### PR DESCRIPTION
Github actions / CI e2e workflow is currently broken due to a failure to install `nak`. 

Examples here:
https://github.com/PlebeianApp/market/actions/runs/29657492941
https://github.com/PlebeianApp/market/actions/runs/29485596739

The error, which occurs in setup for every run, is the following:
`[e2e-pricing](https://github.com/PlebeianApp/market/actions/runs/29657492941/job/88115190125#step:6:22)
fiatjaf.com/nostr@v0.0.0-20260708142249-c591b5592910: replacement directory ../nostrlib does not exist`

This is due to a breaking change introduced in:

```
commit 9c35de2b0223463782bd39b1eac68eb93c5788f9
Author: fiatjaf <fiatjaf@gmail.com>
Date:   Thu Jul 16 15:23:30 2026 -0300
```

notably the line:

`replace fiatjaf.com/nostr => ../nostrlib`

which breaks our CI due to a local import that doesn't exist.

The simplest solution for now would be to point the CI to use a working version of the `nak` package until 1) the issue is resolved upstream (if it is considered an issue) or 2) we reconfigure the CI to handle the path appropriately. The former is cleaner to implement than the latter but requires identification of this change as an issue.

As a temporary measure, we can pin the commit that occurred before this breaking change. That is the change contained in this PR.