### PR TITLE
Fix/auctions fix broken ci

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,13 +39,21 @@ jobs:
 
       - name: Install nak
         run: |
-          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          # NOTE: We pin to commit b6568388 because the upstream 'nak' repository 
+          # (commit 9c35de2 on Jul 16) introduced a breaking 'replace' directive 
+          # in go.mod: `replace fiatjaf.com/nostr => ../nostrlib`.
+          # This local path reference fails in CI where the sibling 'nostrlib' repo 
+          # does not exist, causing build failures.
+          # Pinning to this pre-regression commit ensures the build uses the 
+          # remote module source until the upstream issue is resolved.
+          git clone https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
+          git checkout b65683886b58382890888fbdda90e5c2129df488
+
           GOBIN="$(go env GOPATH)/bin"
           mkdir -p "$GOBIN"
           go build -o "$GOBIN/nak" .
           echo "nak installed at: $(which nak)"
-
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
@@ -157,8 +165,17 @@ jobs:
 
       - name: Install nak
         run: |
-          git clone --depth 1 https://github.com/fiatjaf/nak.git /tmp/nak
+          # NOTE: We pin to commit b6568388 because the upstream 'nak' repository 
+          # (commit 9c35de2 on Jul 16) introduced a breaking 'replace' directive 
+          # in go.mod: `replace fiatjaf.com/nostr => ../nostrlib`.
+          # This local path reference fails in CI where the sibling 'nostrlib' repo 
+          # does not exist, causing build failures.
+          # Pinning to this pre-regression commit ensures the build uses the 
+          # remote module source until the upstream issue is resolved.
+          git clone https://github.com/fiatjaf/nak.git /tmp/nak
           cd /tmp/nak
+          git checkout b65683886b58382890888fbdda90e5c2129df488
+
           GOBIN="$(go env GOPATH)/bin"
           mkdir -p "$GOBIN"
           go build -o "$GOBIN/nak" .


### PR DESCRIPTION
Same as #1163, cherry picking the fix onto the auctions branch. Context is the same (failing CI due to upstream dependency). No other changes.