### PR TITLE
refactor: strip validation logic from settlement-steps, defer to #1170

### DIFF
--- a/docs/adr/ADR-0015-settlement-validation-split.md
+++ b/docs/adr/ADR-0015-settlement-validation-split.md
@@ -1,0 +1,79 @@
+# ADR-0015: Settlement Steps — Validation Logic Split
+
+**Status:** Proposed
+**Date:** 2026-07-28
+**Supersedes:** None
+**Superseded by:** None
+**Related PRs:** #1144 (feat/settlement-steps), #1170 (feat/1151-auction-validation)
+
+## Context
+
+PR #1144 (`feat/settlement-steps`) introduces auction settlement-step UI and
+order-detail UX. During development, WIP validation logic was prototyped
+directly on this branch in two commits:
+
+- `885fdfb2` — "WIP: Local Validation"
+- `a6fe339f` — "WIP: Auction validation"
+
+These commits added client-side validation helpers (`validateAuctionImmutableTags`,
+`validateBidLocalOnly`, `validateSettlementEventLocalOnly`,
+`validatePathReleaseLocalOnly`) and related query functions
+(`fetchAndValidateAuctionEvent`, `fetchAuctionRelatedEvents`,
+`useAuctionWithRelatedEvents`) to `src/lib/auction/validation.ts` and
+`src/queries/auctions.tsx`.
+
+Concurrently, PR #1170 (`feat/1151-auction-validation`) was developed as the
+dedicated, comprehensive auction validation branch. That PR has undergone
+detailed review (see maximotodev review on #1170) and addresses blocking
+concerns that the WIP validation in #1144 does not:
+
+1. Event authentication before parsing or buffering
+2. Requiring every expected proof to be spent (not just any)
+3. Validator-observed release timing (not seller-controlled `created_at`)
+4. Post-grace redemption observability
+5. Per-mint availability scoping (not gating the entire auction)
+6. Close-role assignment wiring into the production lifecycle
+7. Pinned auction identity (seller, `d` tag, coordinate, root lineage)
+
+## Decision
+
+**Strip all validation logic from `feat/settlement-steps` and treat
+`feat/1151-auction-validation` (#1170) as the parent branch for all auction
+validation work.**
+
+This branch (`feat/settlement-steps-no-validation`) is created from
+`feat/settlement-steps` with the two WIP validation commits reverted. Clear
+placeholders have been added in the stripped files pointing to #1170 and this
+ADR.
+
+### Merge strategy
+
+1. `feat/settlement-steps-no-validation` should be merged into `feat/settlement-steps`
+   (or replace it) to produce a clean settlement-UI-only branch.
+2. The clean settlement branch should then be merged **into** `feat/1151-auction-validation`
+   (#1170), which is the parent branch for validation.
+3. When merging, re-introduce the validation functions from #1170's
+   implementation, which is more complete and addresses all blocking review
+   findings.
+4. Do **not** re-introduce the stripped WIP validation code — it is superseded
+   by #1170.
+
+## Consequences
+
+- `feat/settlement-steps` (or its successor) becomes a pure UI/UX branch with
+  no validation logic, making it easier to review and merge independently.
+- All validation concerns are centralized in #1170, avoiding duplication and
+  divergent implementations.
+- Placeholder comments in `src/lib/auction/validation.ts` and
+  `src/queries/auctions.tsx` document what was removed and where it should
+  come from.
+- The merge order is: settlement-UI → #1170 (validation parent) → `auctions`.
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `src/lib/auction/validation.ts` | Stripped `validateAuctionImmutableTags`, `validateBidLocalOnly`, `validateSettlementEventLocalOnly`, `validatePathReleaseLocalOnly`; added placeholder |
+| `src/queries/auctions.tsx` | Stripped `fetchAndValidateAuctionEvent`, `fetchAndValidateRelatedAuctionEvent`, `fetchAuctionRelatedEvents`, `auctionWithRelatedEventsQueryOptions`, `useAuctionWithRelatedEvents`; added placeholder |
+| `src/components/AuctionSettlement.tsx` | Reverted validation-related imports and `useAuctionWithRelatedEvents` usage; restored pre-validation state |
+| `docs/adr/ADR-0015-settlement-validation-split.md` | This ADR |

--- a/src/components/AuctionSettlement.tsx
+++ b/src/components/AuctionSettlement.tsx
@@ -22,9 +22,9 @@ import {
 	getBidAmount,
 	getAuctionRootEventId,
 	getAuctionTopBidValid,
-	useAuctionWithRelatedEvents,
 } from '@/queries/auctions'
-import { Clock, CheckCircle, Ban, Truck, Gavel, Trophy } from 'lucide-react'
+import { getAuctionWindowValidBids } from '@/lib/auctionSettlement'
+import { Clock, CheckCircle, Ban, Truck, Package, Gavel, Trophy } from 'lucide-react'
 import { AuctionClaimDialog } from './AuctionClaimDialog'
 import { useNavigate } from '@tanstack/react-router'
 import type { NDKEvent } from '@/lib/nostr/ndk-events'
@@ -46,8 +46,6 @@ export function AuctionSettlement({ auction, bids, className }: AuctionSettlemen
 	const auctionCoordinates = auctionDTag ? `30408:${auction.pubkey}:${auctionDTag}` : ''
 	const auctionRootEventId = getAuctionRootEventId(auction) || auction.id
 
-	const auctionWithRelatedEvents = useAuctionWithRelatedEvents(auctionRootEventId, auctionCoordinates)
-
 	// Fetch settlement-related data
 	const settlementsQuery = useAuctionSettlements(auctionRootEventId, 10, auctionCoordinates)
 	const pathReleasesQuery = useAuctionPathReleases(auctionRootEventId, 200, auctionCoordinates)
@@ -64,7 +62,9 @@ export function AuctionSettlement({ auction, bids, className }: AuctionSettlemen
 
 	const isSeller = currentUserPubkey === auction.pubkey
 	const isWinner = currentUserPubkey && settlementWinner === currentUserPubkey
+	const hasClaimOrder = claimOrders.some((order) => order.pubkey === (isSeller ? settlementWinner : currentUserPubkey))
 
+	// Task 1: Replace boolean hasClaimOrder check with matchedClaimOrder constant
 	const matchedClaimOrder = useMemo(() => {
 		if (isSeller && settlementWinner) {
 			// Seller view - look for order from the winner
@@ -206,16 +206,12 @@ export function AuctionSettlement({ auction, bids, className }: AuctionSettlemen
 			bidAmount: 0,
 		}
 	}
-
 	// Winner banner - shown to the auction winner after settlement
 	else if (isWinner && settlementStatus === 'settled') {
 		// Task 1: Update navigation logic to use matchedClaimOrder?.id for the route
 		if (matchedClaimOrder) {
 			const action = () => {
 				if (matchedClaimOrder.id) {
-					const orderId = matchedClaimOrder.tags.find((t) => t[0] === 'order')?.[1]
-					console.log('Test: ', orderId === matchedClaimOrder.id)
-
 					navigate({ to: `/dashboard/orders/${matchedClaimOrder.id}` })
 				} else {
 					toast.error('Issue with order id. Go to Dashboard -> Your Purchases to find the order.')
@@ -251,9 +247,6 @@ export function AuctionSettlement({ auction, bids, className }: AuctionSettlemen
 		if (matchedClaimOrder) {
 			const action = () => {
 				if (matchedClaimOrder.id) {
-					const orderId = matchedClaimOrder.tags.find((t) => t[0] === 'order')?.[1]
-					console.log('Test: ', orderId === matchedClaimOrder.id)
-
 					navigate({ to: `/dashboard/orders/${matchedClaimOrder.id}` })
 				} else {
 					toast.error('Issue with order id. Go to Dashboard -> Sales to find the order.')

--- a/src/lib/auction/validation.ts
+++ b/src/lib/auction/validation.ts
@@ -34,9 +34,8 @@ import {
 	type ValidatorClaim,
 	type ValidatorReason,
 } from './constants'
-import type { ParsedAuctionEvent, ParsedBidEvent, ParsedPathReleaseEvent, ParsedSettlementEvent } from './events'
+import type { ParsedAuctionEvent, ParsedBidEvent } from './events'
 import { parseAuctionLockSecret } from '../cashu/p2pkSecret'
-import { checkProofStateBatch } from '../cashu/nut7'
 
 // ============================================================================
 // Public API
@@ -329,134 +328,25 @@ const clamp = (value: number, min: number, max: number): number => {
 export const VALIDATE_BID_CLAIMS: readonly ValidatorClaim[] = ['valid_bid_placed', 'bid_invalid', 'bid_pending_review']
 
 // ============================================================================
-// Auction Validation
+// PLACEHOLDER — Validation logic moved to #1170 (feat/1151-auction-validation)
 // ============================================================================
-
-export const validateAuctionImmutableTags = (rootAuctionEvent: ParsedAuctionEvent, latestAuctionEvent: ParsedAuctionEvent): boolean => {
-	const hasExactImmutableTagValues =
-		rootAuctionEvent.auctionType === latestAuctionEvent.auctionType &&
-		rootAuctionEvent.startAt === latestAuctionEvent.startAt &&
-		rootAuctionEvent.endAt === latestAuctionEvent.endAt &&
-		rootAuctionEvent.currency === latestAuctionEvent.currency &&
-		rootAuctionEvent.p2pkXpub === latestAuctionEvent.p2pkXpub &&
-		rootAuctionEvent.auditorQuorum === latestAuctionEvent.auditorQuorum &&
-		rootAuctionEvent.maxEndAt === latestAuctionEvent.maxEndAt &&
-		rootAuctionEvent.settlementGrace === latestAuctionEvent.settlementGrace &&
-		rootAuctionEvent.minBidCurve === latestAuctionEvent.minBidCurve &&
-		rootAuctionEvent.settlementPolicy === latestAuctionEvent.settlementPolicy &&
-		rootAuctionEvent.keyScheme === latestAuctionEvent.keyScheme &&
-		rootAuctionEvent.reserve === latestAuctionEvent.reserve &&
-		rootAuctionEvent.bidIncrement === latestAuctionEvent.bidIncrement &&
-		rootAuctionEvent.maxSkewSec === latestAuctionEvent.maxSkewSec &&
-		rootAuctionEvent.mints.sort().join() === latestAuctionEvent.mints.sort().join() &&
-		rootAuctionEvent.auditors.sort().join() === latestAuctionEvent.auditors.sort().join()
-
-	return hasExactImmutableTagValues
-}
-
-// ============================================================================
-// Bid Validation - Client Side
-// ============================================================================
-
-/**
- * Smaller client-side check to verify validity of bid events. Currently does not provide a full guarantee of bid
- * validity as bids contain false `created_at` values and be placed after the auction end.
- * This should eventually be expanded to use validator checks and quorum to mitigate this vulnerability.
- * No checks against the max bid amount are present locally as a bid can be valid but not the highest bid.
- */
-export const validateBidLocalOnly = (auction: ParsedAuctionEvent, bid: ParsedBidEvent): boolean => {
-	// --- Step 1: cross-event reference integrity -----------------------------
-
-	if (bid.auctionRootEventId !== auction.rootEventId) {
-		return false
-	}
-	if (bid.auctionCoordinate !== auction.coordinate) {
-		return false
-	}
-	if (bid.sellerPubkey.toLowerCase() !== auction.sellerPubkey.toLowerCase()) {
-		return false
-	}
-
-	// --- Step 2: time-window checks ------------------------------------------
-
-	if (bid.createdAt < auction.startAt) {
-		return false
-	}
-	if (bid.createdAt > auction.maxEndAt) {
-		return false
-	}
-
-	// --- Step 3: mint allowlist ---------------------------------------------
-
-	if (!auction.mints.includes(bid.mint)) {
-		return false
-	}
-
-	// --- Step 4: lock secret structure --------------------------------------
-
-	const expectedLocktime = auction.maxEndAt + auction.settlementGrace
-	if (bid.locktime !== expectedLocktime) {
-		return false
-	}
-	if (bid.lockSecrets.length !== bid.proofYs.length) {
-		return false
-	}
-
-	// Validate every proof's secret independently. All MUST share the same
-	// lock parameters — the bidder split their input across multiple
-	// denominations but each output proof is its own P2PK lock with its
-	// own nonce. Reject the bid if any proof is malformed; we don't want
-	// validators to selectively trust subsets of a lock set.
-	for (let i = 0; i < bid.lockSecrets.length; i++) {
-		const lockParse = parseAuctionLockSecret(bid.lockSecrets[i], {
-			expectedLocktime,
-			expectedChildPubkey: bid.childPubkey,
-			expectedRefundPubkey: bid.refundPubkey,
-		})
-		if (!lockParse.ok) {
-			return false
-		}
-	}
-
-	// TODO: Get Validator approval of bid
-
-	// TODO: NUT-7 proof state
-
-	// --- Step 8: success ----------------------------------------------------
-
-	return true
-}
-
-export const validateSettlementEventLocalOnly = (auction: ParsedAuctionEvent, settlement: ParsedSettlementEvent): boolean => {
-	const isValidSettlementTarget =
-		settlement.auctionRootEventId === auction.rootEventId &&
-		settlement.auctionCoordinate === auction.coordinate &&
-		settlement.sellerPubkey === auction.sellerPubkey
-
-	if (!isValidSettlementTarget) return false
-
-	switch (settlement.status) {
-		case 'settled':
-			return !!settlement.finalAmount && !!settlement.winnerPubkey
-		case 'cancelled':
-		case 'griefed_no_fallback':
-		case 'reserve_not_met':
-			return false
-	}
-}
-
-export const validatePathReleaseLocalOnly = (
-	auction: ParsedAuctionEvent,
-	pathRelease: ParsedPathReleaseEvent,
-	winningBid: ParsedBidEvent,
-): boolean => {
-	const isValidPathReleaseTarget =
-		pathRelease.auctionCoordinate === auction.coordinate &&
-		pathRelease.sellerPubkey === auction.sellerPubkey &&
-		pathRelease.bidEventId === winningBid.id &&
-		pathRelease.bidderPubkey === winningBid.bidderPubkey
-
-	if (!isValidPathReleaseTarget) return false
-
-	return true
-}
+//
+// The following client-side validation helpers were previously prototyped in
+// this branch but have been stripped to avoid duplication with the dedicated
+// auction-validation work in PR #1170 (branch: feat/1151-auction-validation).
+//
+// Any validation work — including but not limited to — must be treated as a
+// child of #1170, which is the parent branch for all auction validation:
+//
+//   - validateAuctionImmutableTags(rootAuctionEvent, latestAuctionEvent)
+//   - validateBidLocalOnly(auction, bid)
+//   - validateSettlementEventLocalOnly(auction, settlement)
+//   - validatePathReleaseLocalOnly(auction, pathRelease, winningBid)
+//
+// When merging this branch into #1170, re-introduce these functions from the
+// #1170 implementation, which is more complete and addresses the blocking
+// review findings (event authentication, proof-spent completeness, validator-
+// observed release timing, post-grace redemption observability, per-mint
+// scoping, close-role wiring, and pinned auction identity).
+//
+// See: docs/adr/ADR-0015-settlement-validation-split.md

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -32,25 +32,6 @@ import { queryOptions, useQuery } from '@tanstack/react-query'
 import { auctionKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
-import { getCoordsFromATag } from '@/lib/utils/coords'
-import type { ParsedAuctionEvent, ParsedBidEvent, ParsedPathReleaseEvent, ParsedSettlementEvent } from '@/lib/auction/events'
-import {
-	validateAuctionImmutableTags,
-	validateBid,
-	validateBidLocalOnly,
-	validatePathReleaseLocalOnly,
-	validateSettlementEventLocalOnly,
-} from '@/lib/auction/validation'
-import { parseAuctionEvent } from '@/lib/schemas/auction/auctionEvent'
-import { checkProofStateBatch } from '@/lib/cashu/nut7'
-import { parseBidEvent, type ParseBidEventResult } from '@/lib/schemas/auction/bidEvent'
-import {
-	parsePathReleaseEvent,
-	parseSettlementEvent,
-	type ParsePathReleaseEventResult,
-	type ParseSettlementEventResult,
-} from '@/lib/schemas/auction/settlementEvents'
-import type z from 'zod'
 
 export type AuctionSettlementStatus = 'settled' | 'reserve_not_met' | 'cancelled' | 'unknown'
 
@@ -1009,138 +990,26 @@ export const usePrivateAuctionClaimForOrder = (publicMarker: NDKEvent | null | u
 		...privateAuctionClaimQueryOptions(publicMarker, enabled),
 	})
 
+// ============================================================================
+// PLACEHOLDER — Validation query logic moved to #1170 (feat/1151-auction-validation)
+// ============================================================================
 //
-
-export type AuctionWithRelatedEvents = {
-	bids?: ParsedBidEvent[]
-	settlements?: ParsedSettlementEvent[]
-	pathReleases?: ParsedPathReleaseEvent[]
-	claimOrders?: NDKEvent[]
-
-	latestAuction: ParsedAuctionEvent // Latest auction event
-	topBid?: ParsedBidEvent
-	settlement?: ParsedSettlementEvent
-	pathRelease?: ParsedPathReleaseEvent
-	claimOrder?: NDKEvent
-}
-
-const fetchAndValidateAuctionEvent = async (rootAuctionId: string, auctionCoordinates: string): Promise<ParsedAuctionEvent | null> => {
-	const auctionCoords = getCoordsFromATag(auctionCoordinates)
-	const [rootAuctionEvent, latestAuctionEvent] = await Promise.all([
-		fetchAuction(rootAuctionId),
-		fetchAuctionByATag(auctionCoords.pubkey, auctionCoords.identifier),
-	])
-
-	if (!rootAuctionEvent || !latestAuctionEvent) return null
-
-	const rootAuctionEventParsedResult = parseAuctionEvent(rootAuctionEvent)
-	const latestAuctionEventParsedResult = parseAuctionEvent(latestAuctionEvent)
-
-	if (!rootAuctionEventParsedResult.ok || !latestAuctionEventParsedResult.ok) return null
-
-	const rootAuctionEventParsed = rootAuctionEventParsedResult.value
-	const latestAuctionEventParsed = latestAuctionEventParsedResult.value
-
-	const isValidAuctionEvent = validateAuctionImmutableTags(rootAuctionEventParsed, latestAuctionEventParsed)
-
-	if (!isValidAuctionEvent) return null
-
-	return latestAuctionEventParsed
-}
-
-type ParsedAuctionRelatedEvent = ParsedBidEvent | ParsedPathReleaseEvent | ParsedSettlementEvent
-type ParseResult<T> = { ok: true; value: T } | { ok: false; error: z.ZodError | { message: string; code: string } }
-
-const fetchAndValidateRelatedAuctionEvent = async <T extends ParsedAuctionRelatedEvent>(
-	auctionEvent: ParsedAuctionEvent,
-	fetch: (auctionEvent: ParsedAuctionEvent) => Promise<NDKEvent[]>,
-	parse: (event: NDKEvent) => ParseResult<T>,
-	validate: (auctionEvent: ParsedAuctionEvent, event: T) => boolean,
-) => {
-	const relatedEvents = await fetch(auctionEvent)
-
-	return relatedEvents
-		.map((event) => {
-			const result = parse(event)
-			if (!result.ok) return
-
-			return result.value as T
-		})
-		.filter((event): event is T => event !== undefined && validate(auctionEvent, event))
-}
-
-export const fetchAuctionRelatedEvents = async (
-	rootAuctionId: string,
-	limit: number = 500,
-	auctionCoordinates: string,
-): Promise<AuctionWithRelatedEvents | null> => {
-	if (!rootAuctionId || !auctionCoordinates) return null
-	const ndk = ndkActions.getNDK()
-	if (!ndk) return null
-
-	const auctionEvent = await fetchAndValidateAuctionEvent(rootAuctionId, auctionCoordinates)
-
-	if (!auctionEvent) return null
-
-	// Bid Events
-	const bids = await fetchAndValidateRelatedAuctionEvent(
-		auctionEvent,
-		() => fetchAuctionBids('', limit, auctionEvent.coordinate),
-		parseBidEvent,
-		validateBidLocalOnly,
-	)
-
-	const highestBid = bids
-		.sort((a, b) => {
-			const amountDelta = b.amount - a.amount
-			if (amountDelta !== 0) return amountDelta
-			const timeDelta = (a.createdAt || 0) - (b.createdAt || 0)
-			if (timeDelta !== 0) return timeDelta
-			return a.id.localeCompare(b.id)
-		})
-		.at(0)
-
-	if (!bids || !highestBid)
-		return {
-			latestAuction: auctionEvent,
-		}
-
-	const [settlements, pathReleases] = await Promise.all([
-		// Settlement Events
-		fetchAndValidateRelatedAuctionEvent(
-			auctionEvent,
-			() => fetchAuctionSettlements('', limit, auctionEvent.coordinate),
-			parseSettlementEvent,
-			validateSettlementEventLocalOnly,
-		),
-		// Path Release Events
-		fetchAndValidateRelatedAuctionEvent(
-			auctionEvent,
-			() => fetchAuctionPathReleases('', limit, auctionEvent.coordinate),
-			parsePathReleaseEvent,
-			(auctionEvent, pathReleaseEvent) => validatePathReleaseLocalOnly(auctionEvent, pathReleaseEvent, highestBid),
-		),
-	])
-
-	return {
-		latestAuction: auctionEvent,
-		bids: bids,
-		topBid: highestBid,
-		settlements: settlements,
-		// settlement: settlements
-		pathReleases: pathReleases,
-		// pathRelease: pathReleases,
-	}
-}
-
-export const auctionWithRelatedEventsQueryOptions = (auctionRootId: string, auctionCoordinates: string, limit: number = 100) =>
-	queryOptions({
-		queryKey: [...auctionKeys.details(auctionRootId || auctionCoordinates || ''), auctionCoordinates || ''],
-		queryFn: () => fetchAuctionRelatedEvents(auctionRootId, limit, auctionCoordinates),
-		enabled: !!(auctionRootId || auctionCoordinates),
-		staleTime: 5000,
-		refetchInterval: 5000,
-	})
-
-export const useAuctionWithRelatedEvents = (auctionRootId: string, auctionCoordinates: string) =>
-	useQuery({ ...auctionWithRelatedEventsQueryOptions(auctionRootId, auctionCoordinates) })
+// The following query/validation helpers were previously prototyped in this
+// branch but have been stripped to avoid duplication with the dedicated
+// auction-validation work in PR #1170 (branch: feat/1151-auction-validation).
+//
+// Removed functions (to be re-introduced from #1170 when merging):
+//
+//   - fetchAndValidateAuctionEvent(rootAuctionId, auctionCoordinates)
+//   - fetchAndValidateRelatedAuctionEvent(auctionEvent, fetch, parse, validate)
+//   - fetchAuctionRelatedEvents(rootAuctionId, limit, auctionCoordinates)
+//   - auctionWithRelatedEventsQueryOptions(auctionRootId, auctionCoordinates, limit)
+//   - useAuctionWithRelatedEvents(auctionRootId, auctionCoordinates)
+//
+// PR #1170 is the parent branch for all auction validation. Its implementation
+// is more complete and addresses blocking review findings around event
+// authentication, proof-spent completeness, validator-observed timing,
+// post-grace redemption observability, per-mint availability scoping,
+// close-role assignment wiring, and pinned auction identity checks.
+//
+// See: docs/adr/ADR-0015-settlement-validation-split.md


### PR DESCRIPTION
## Summary

Strips the WIP validation logic prototyped in `feat/settlement-steps` (#1144) and defers all auction validation work to `feat/1151-auction-validation` (#1170), which is the parent branch for all auction validation.

## What was removed

The two WIP validation commits were reverted:

- `885fdfb2` — "WIP: Local Validation"
- `a6fe339f` — "WIP: Auction validation"

**Removed functions:**
- `validateAuctionImmutableTags` — immutable tag comparison (superseded by #1170 pinned-identity checks)
- `validateBidLocalOnly` — client-side bid validation (superseded by #1170 authenticated event validation)
- `validateSettlementEventLocalOnly` — settlement event validation (superseded by #1170 completeness checks)
- `validatePathReleaseLocalOnly` — path release validation (superseded by #1170 validator-observed timing)
- `fetchAndValidateAuctionEvent` — auction event fetch + validate (superseded by #1170)
- `fetchAndValidateRelatedAuctionEvent` — generic related-event validation fetch (superseded by #1170)
- `fetchAuctionRelatedEvents` — batch fetch + validate all related auction events (superseded by #1170)
- `auctionWithRelatedEventsQueryOptions` / `useAuctionWithRelatedEvents` — React Query hooks (superseded by #1170)

## What was preserved

- `getAuctionTopBidValid` helper (non-validation, settlement-UI sorting logic)
- All settlement-step UI components (`AuctionSettlement.tsx`, order detail changes)
- All e2e test coverage
- `src/lib/schemas/auction/common.ts` BIP-32 path validation message improvement

## What was added

- **`docs/adr/ADR-0015-settlement-validation-split.md`** — ADR documenting the split decision, merge strategy, and consequences
- **Placeholder comments** in `src/lib/auction/validation.ts` and `src/queries/auctions.tsx` listing removed functions and pointing to #1170

## Merge strategy

1. This branch merges into `feat/settlement-steps` (#1144) to produce a clean settlement-UI-only branch
2. The clean settlement branch then merges **into** `feat/1151-auction-validation` (#1170), which is the parent for all validation
3. Final merge order: settlement-UI → #1170 (validation parent) → `auctions`

## Why

PR #1170 has undergone detailed review and addresses 7 blocking concerns that the WIP validation in #1144 does not cover:
1. Event authentication before parsing/buffering
2. Requiring every expected proof to be spent
3. Validator-observed release timing
4. Post-grace redemption observability
5. Per-mint availability scoping
6. Close-role assignment wiring
7. Pinned auction identity (seller, `d` tag, coordinate, root lineage)