### PR TITLE
refactor(v4v): make V4VManager agnostic by inverting control

### DIFF
--- a/docs/adr/proposals/v4v-ui-agnostic-audit-and-plan.md
+++ b/docs/adr/proposals/v4v-ui-agnostic-audit-and-plan.md
@@ -1,0 +1,247 @@
+# ADR Proposal: Strip product-specific logic out of the V4V UI (Audit + single-PR plan)
+
+**Status:** Proposed — research complete, awaiting approval to implement
+**Branch:** `audit/v4v-ui-agnostic` (worktree `wt-v4v-ui-audit`), based off **`master`**
+**Date:** 2026-07-30
+**Scope:** A single PR. No new UI component; the existing `V4VManager` is made agnostic by **inversion of control** — product-specific behavior is extracted into helper/utility/query files and injected back at the call site (the dashboard parent route).
+**References:**
+
+- Foundation philosophy: `franchovy/pr1/foundation-styles-review-fixes` → `docs/adr/ADR-component-ui-migration-and-widget-book.md` (UI-layer/business-logic separation; callbacks for actions instead of in-file hooks; `forwardRef`; `cn()`; clean up custom UI). We **follow the philosophy** but do **not** branch from that PR and do **not** adopt its new directory structure (`ui-wrappers/`, `nostr/`, `shared/`, `theme-migration/`) — those don't exist on `master`.
+- Auction intent: `felixfelix-bot/feat/v4v-dev-splits-implementation` → `docs/adr/proposals/v4v-dev-splits-auction.md` + `adr-v4v-dev-splits-DECISIONS.md`. That ADR is valid; its implementation was rejected. This PR does **not** implement auctions — it only makes the V4V UI reusable _so that_ auctions can adopt it later without further UI changes.
+
+---
+
+## 1. Goal
+
+Make the existing `V4VManager` UI **agnostic to how it is used** so it can be reused for multiple purposes (Auctions being the next one), by stripping the product-specific (i.e. sales-specific) functionality out of the component and into appropriate helper/utility/query files, and having the **dashboard parent route** declare that this instance is "for all products" by passing in the sales hooks/handlers/labels it already uses today.
+
+Design intent: the **only** consumer-visible change to `V4VManager` is that it stops fetching/saving/deciding what "V4V" means and instead receives that from props. Its rendered output is otherwise preserved (behavior-identical for sales).
+
+## 2. Decisions applied (from the request)
+
+1. **Base on `master`** — the worktree `wt-v4v-ui-audit` is already on `audit/v4v-ui-agnostic` off `master` (`9da1c855`).
+2. **Follow the philosophy of the UI-migration PR, not its branch.** We apply: no business logic in the presentational component, callbacks for actions instead of in-file hooks, `forwardRef`, `cn()` className merging, and a measured cleanup of custom/hardcoded UI. We do **not** create `ui-wrappers/`, `nostr/`, `shared/`, or `.theme-new` — those are the foundation PR's deliverables and would conflict if we pre-empted them here.
+3. **Single PR.** One cohesive change; no multi-PR sequence.
+4. **No new UI component.** We keep `V4VManager.tsx` (and `ProfileSearch`/`RecipientItem`/`RecipientPreview`) in place; we make it agnostic by extracting product-specific logic out, not by replacing it.
+5. **The route owns the "how".** The dashboard parent route (`circular-economy.tsx`) — and the `V4VSetupDialog` — compose the sales-specific hooks/handlers/labels and pass them into `V4VManager`. That call site is what says "this view is specifically for all products".
+
+## 3. Current state recap (why it is not reusable today)
+
+- `V4VManager.tsx` calls `useV4VManager` **internally** and renders sales-specific copy/visualization: a "PM (Beta) Is Powered By Your Generosity…" `Alert`, an emoji wiggle/shake/glow widget keyed off the total %, "Split of total sales" / "V4V split between recipients" headings, a two-bar seller-vs-V4V viz, hardcoded colors (`bg-fuchsia-500`, `bg-green-600`, `bg-rose-500`, `bg-blue-100`, `text-blue-800`, …), and imports a sales-route CSS file (`…/sales/emoji-animations.css`) directly into the component.
+- `useV4VManager.ts` is the sales "brain": local share state, fraction normalization math, the **app-npub default recipient** seeding, the emoji computations, and the **persistence path** (`usePublishV4VShares` → Nostr kind 30078 `l: v4v_share`, with each recipient scaled by `totalV4VPercentage/100` on save).
+- `ProfileSearch.tsx` and `RecipientItem.tsx` call nostr hooks inline (`useQuery`/NIP-50 search, `useZapCapabilityInfo`). These are Nostr-domain, not product-specific — they stay. (They _would_ move to `nostr/` under the foundation PR; out of scope here to avoid conflicts.)
+- Two consumers (`circular-economy.tsx` route and `V4VSetupDialog.tsx`) **duplicate** the same "normalize stored shares into initialShares + initialTotalPercentage" logic.
+- `V4VDTO` (`{ id, name, pubkey, percentage }`) lives in `src/lib/stores/cart.ts` and is imported across cart/orders/products/V4V. **Not moved** in this PR (minimal change; not blocking agnosticism — the component will accept `V4VDTO[]` as props). Left as a noted follow-up.
+- `queries/v4v.tsx` already holds the sales data layer (`useV4VShares`, `publishV4VShares`, `usePublishV4VShares`, config-state enum). It stays as the sales query/persistence layer; no UI coupling added.
+
+## 4. What is "product-specific" (the extraction targets)
+
+These are the sales-V4V concerns that must leave `V4VManager` (and where they go):
+
+| Product-specific concern                                                                           | Today                                              | Moves to                                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Share math: normalize to sum=1, add/remove/update/equalize, scale-by-total                         | inline in `useV4VManager`                          | **`src/lib/v4v/splits.ts`** (pure, unit-tested, reusable by auctions)                                                                                            |
+| Persistence: save kind 30078, scale recipients by total %                                          | `useV4VManager.saveShares` → `usePublishV4VShares` | stays in **`src/queries/v4v.tsx`**; the _composition_ (scale + publish) is owned by the sales hook the route uses                                                |
+| App-npub default recipient seeding                                                                 | `useV4VManager` init effect                        | the **sales hook** (kept in `src/hooks/`) — an auction hook would seed validators instead                                                                        |
+| Emoji wiggle/shake/glow + 🤙/🎁/💩 values                                                          | `useV4VManager` computed                           | a small **`src/lib/v4v/emoji.ts`** pure helper OR keep in the sales hook and pass as data; component renders it only when `config.showEmoji`                     |
+| All copy ("PM Beta…", "Split of total sales", "V4V split between recipients", button text, alerts) | hardcoded in `V4VManager`                          | a **`labels` prop** supplied by the route (sales labels)                                                                                                         |
+| Sales viz: total-% slider, seller-vs-V4V two-bar, recipient split bar                              | always rendered                                    | gated behind **`config` props** (`showTotalSlider`, `showSellerBar`, `showEmoji`); sales route enables them                                                      |
+| Zap-capability gating (refuse recipients who can't receive zaps)                                   | baked into add-recipient + `RecipientItem`         | a **`requireZapCapable` config flag** from the route (sales: true; auctions: false — donations redeem via locked e-cash notes, not zaps)                         |
+| `emoji-animations.css` import                                                                      | imported in the component                          | moved to the **sales route** (it's a sales viz concern)                                                                                                          |
+| Hardcoded colors                                                                                   | throughout V4V files                               | cleaned up to existing shadcn semantic tokens (`bg-primary`, `text-muted-foreground`, `border`, etc.) where low-risk — no `.theme-new` (doesn't exist on master) |
+
+## 5. Target architecture (inversion of control)
+
+```
+                       ┌─────────────────────────────────────────┐
+   sales route /       │  composes the SALES "how":              │
+   V4VSetupDialog  ───▶│  useSalesV4VSplits (the current hook), │
+   (the call site)     │  sales labels, sales config,            │
+                       │  sales persistence (queries/v4v)       │
+                       └───────────────────┬─────────────────────┘
+                                           │ props: state + handlers + labels + config
+                                           ▼
+                       ┌─────────────────────────────────────────┐
+                       │  V4VManager  (PRESENTATIONAL, AGNOSTIC) │
+                       │  - no @/queries, no @/hooks, no publish  │
+                       │  - forwardRef + cn(className)            │
+                       │  - renders only what config/labels say   │
+                       └───────────────────┬─────────────────────┘
+                                           │ renders
+                                           ▼
+                       ProfileSearch / RecipientItem / RecipientPreview
+                       (Nostr-domain sub-components, unchanged location)
+```
+
+Tomorrow, an **auction** route would compose an `useAuctionV4VSplits` hook (bps unit, total 10000, seller = read-only remainder, validator seeds from kind 30409, `requireZapCapable: false`, `showEmoji: false`, `showTotalSlider: false`, auction labels, persistence to kind 30408) and render the **same** `<V4VManager>`. That consumer is **not** built in this PR — it is the proof of agnosticism.
+
+### 5.1 `V4VManager` props (new contract)
+
+The component stops importing `useV4VManager` and `V4VDTO`-only-as-source. It accepts:
+
+```ts
+// src/components/v4v/V4VManager.tsx
+export interface V4VManagerProps {
+	// --- data (injected by the route's hook) ---
+	shares: V4VDTO[] // current recipients
+	totalV4VPercentage: number // sales concept; auctions pass 100 (of bpsTotal) or ignore
+	newRecipientNpub: string
+	newRecipientShare: number
+	showAddForm: boolean
+	canReceiveZaps?: boolean | undefined
+	isCheckingZap: boolean
+	isChecking: boolean
+	isSaving: boolean // publishMutation.isPending
+	hasChanges?: boolean
+
+	// --- computed viz values (injected; sales hook computes emoji, auctions pass null) ---
+	sellerPercentage?: number
+	formattedSellerPercentage?: string
+	formattedTotalV4V?: string
+	recipientColors?: Record<string, string>
+	emoji?: string
+	emojiSize?: number
+	emojiClass?: string
+
+	// --- handlers (callbacks, not in-file hooks) ---
+	onTotalV4VPercentageChange: (v: number[]) => void
+	onProfileSelect: (npub: string) => void
+	onAddRecipient: () => void
+	onRemoveRecipient: (id: string) => void
+	onUpdatePercentage: (id: string, pct: number) => void
+	onEqualizeAll: () => void
+	onSetNewRecipientShare: (v: number) => void
+	onToggleAddForm: (open: boolean) => void
+	onSave: () => Promise<void> | void
+	onCancel?: () => void
+
+	// --- "how" declared by the call site ---
+	labels: V4VLabels // all copy: alert, headings, button text, empty state
+	config: V4VConfig // feature flags: showEmoji, showTotalSlider, showSellerBar,
+	//   showSaveButton, showCancelButton, requireZapCapable,
+	//   saveButtonTestId, showChangesIndicator
+	className?: string // cn()-merged, forwarded
+}
+```
+
+`V4VLabels` and `V4VConfig` are small interfaces co-located with the component (or in `src/lib/v4v/`). This is the "standardized params" discipline from the foundation ADR (callbacks for actions; `className` via `cn()`).
+
+### 5.2 The sales hook stays as the sales adapter
+
+`src/hooks/useV4VManager.ts` remains the **sales-specific** hook (renamed conceptually to "sales V4V adapter" but we keep the file name to minimize churn). Changes:
+
+- Delegate all share math to `src/lib/v4v/splits.ts`.
+- Keep the app-npub default-recipient seeding, the emoji computation, and the save path (scale-by-total + `usePublishV4VShares`) — these are the sales "how".
+- Return the same surface it returns today (state + handlers + computed), so the route just spreads it into `<V4VManager>`.
+
+### 5.3 The route declares "all products"
+
+`src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx` becomes the place that says "this is the sales/products view":
+
+```tsx
+function CircularEconomyComponent() {
+	// ... existing auth + useV4VShares + normalization (de-duplicated, see §6) ...
+	const sales = useV4VManager({ userPubkey, initialShares, initialTotalPercentage, onSaveSuccess })
+
+	return (
+		<V4VManager
+			{...sales} // state + handlers + computed
+			labels={salesV4VLabels} // sales copy
+			config={{
+				showEmoji: true,
+				showTotalSlider: true,
+				showSellerBar: true,
+				requireZapCapable: true,
+				showSaveButton: true,
+				saveButtonTestId: 'save-v4v-button',
+			}}
+			className="..."
+		/>
+	)
+}
+```
+
+`V4VSetupDialog.tsx` is updated analogously (and its duplicated normalization is removed — see §6). Both call sites now make the product-specific choice; the component does not.
+
+## 6. Single-PR file list
+
+**New files**
+
+- `src/lib/v4v/splits.ts` — pure share math extracted from `useV4VManager`: `normalizeShares`, `addRecipient`, `removeRecipient`, `updatePercentage`, `equalizeAll`, `scaleSharesByTotal`. Pure, no React, no nostr. Reusable by a future auction hook.
+- `src/lib/v4v/labels.ts` (or co-located types) — `V4VLabels` / `V4VConfig` interfaces, and `salesV4VLabels` default (the PM-generosity copy etc.).
+- `src/lib/v4v/__tests__/splits.test.ts` (or `src/lib/__tests__/v4v-splits.test.ts` to match existing test dir) — unit tests for the extracted math.
+- _(Optional, only if emoji extraction is cleaner)_ `src/lib/v4v/emoji.ts` — `getEmojiState(totalPct) → { emoji, emojiSize, emojiClass }`. If small enough, keep in the sales hook instead; decide during implementation.
+
+**Modified files**
+
+- `src/components/v4v/V4VManager.tsx` — remove `useV4VManager` import + `emoji-animations.css` import; accept the new props (§5.1); gate all sales-only rendering behind `config`; pull all copy from `labels`; add `forwardRef` + `cn()`; clean hardcoded colors to shadcn tokens where low-risk. Behavior preserved for sales.
+- `src/hooks/useV4VManager.ts` — delegate math to `src/lib/v4v/splits.ts`; otherwise keep as the sales adapter (same return surface).
+- `src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx` — call `useV4VManager`, build `salesV4VLabels` + sales `config`, import `emoji-animations.css` here, render `<V4VManager {...sales} labels config />`. Remove the duplicated normalize block (move into a tiny shared helper, see next).
+- `src/components/dialogs/V4VSetupDialog.tsx` — same wiring as the route; remove its duplicated normalize logic by reusing the shared normalize helper.
+- `src/components/orders/detail/V4VRecipientsCard.tsx` — minor: token-color cleanup only (it's already pure/presentational); no contract change. _(Only if it stays low-risk; otherwise defer.)_
+- A shared normalization helper for "stored shares → { initialShares, initialTotalPercentage }" (currently duplicated in the route and the dialog). Place in `src/lib/v4v/splits.ts` as `deriveInitialSharesFromStored(stored)` and use in both consumers.
+
+**Not touched (deliberate — minimal change / avoid conflicts with foundation PR)**
+
+- `src/components/v4v/ProfileSearch.tsx`, `RecipientItem.tsx`, `RecipientPreview.tsx` — stay in `v4v/` (not moved to `nostr/`); their inline nostr hooks remain (Nostr-domain, allowed exception under the foundation ADR; relocation is the foundation PR's job).
+- `V4VDTO` in `src/lib/stores/cart.ts` — not relocated (rename blast radius is large and not required for agnosticism; the component accepts `V4VDTO[]` as props). Noted follow-up.
+- `src/queries/v4v.tsx` — no UI coupling added; stays the sales data layer.
+- No new component directories (`ui-wrappers/`, `nostr/`, `shared/`), no `.theme-new`, no `ThemeMigrationWrapper` — those are the foundation PR.
+
+## 7. How this follows the foundation philosophy (mapping)
+
+| Foundation ADR principle                           | How this PR applies it (on master)                                                                                            |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| No business logic in presentational components     | `V4VManager` no longer owns state/persistence/defaults; receives state + handlers via props                                   |
+| Callbacks for actions instead of in-file hooks     | All actions are `on*` props; `useV4VManager` is called by the route, not the component                                        |
+| `forwardRef` to root element                       | added to `V4VManager`                                                                                                         |
+| `cn()` className merging                           | `className` prop merged via `cn()`                                                                                            |
+| Clean up custom UI / hardcoded colors              | measured pass to existing shadcn tokens (no `.theme-new` — absent on master)                                                  |
+| Standardized params (variants/feature flags)       | `config` flags gate sales-only rendering; `labels` externalize copy                                                           |
+| Components may only import below them in hierarchy | `V4VManager` imports only `ui/` primitives + `v4v/` siblings + types; **no** `@/queries`, `@/hooks`, `@/lib/stores/*` actions |
+
+## 8. Proof of agnosticism (auction reuse, not built now)
+
+To confirm the PR achieves reuse, the plan includes a **non-implemented sketch** (in the ADR doc, not code) of an auction consumer:
+
+```tsx
+// HYPOTHETICAL — not in this PR
+function AuctionSplitsSection() {
+	const auction = useAuctionV4VSplits({ auctionEventId, sellerNpub }) // kind 30408 read + 30409 validators
+	return (
+		<V4VManager
+			{...auction} // shares (bps, total 10000), handlers, no emoji
+			labels={auctionV4VLabels} // "V4V Splits", validator/V4V copy
+			config={{ showEmoji: false, showTotalSlider: false, showSellerBar: true, requireZapCapable: false, showSaveButton: true }}
+		/>
+	)
+}
+```
+
+This works iff `V4VManager` makes no assumption about unit, persistence kind, default recipients, or copy — which is exactly what this PR enforces. The auction _adapter + persistence + schema_ (kind 30408/30409, ADR-0002-compliant Nostr I/O) is a **separate, future** effort that consumes the now-agnostic UI unchanged.
+
+## 9. Tests
+
+- **Unit:** `src/lib/v4v/__tests__/splits.test.ts` — normalize, add/remove/update/equalize, scale-by-total, `deriveInitialSharesFromStored`, sum-invariant enforcement. Port the meaningful assertions from the existing math and from felix's `auction-splits-arithmetic.test.ts` (pure math only).
+- **Behavior gate:** existing `e2e/tests/v4v-product-creation.spec.ts` must remain green — this PR is behavior-identical for sales. Run before declaring done.
+- No new e2e for auctions (out of scope).
+
+## 10. Risks & open questions
+
+1. **Prop surface grows.** Inversion of control means `V4VManager` gains ~25 props. This is the intended trade-off for agnosticism without a new component. Acceptable per the request; keep the prop grouping (data / handlers / labels / config) clear with JSDoc.
+2. **Emoji extraction.** Decide during implementation whether emoji state is a tiny pure helper (`src/lib/v4v/emoji.ts`) or stays as computed values returned by the sales hook and passed through. Either keeps the component agnostic (it only renders `emoji`/`emojiClass`/`emojiSize` when `config.showEmoji`).
+3. **Color cleanup risk.** Mapping hardcoded colors to shadcn tokens on master (without `.theme-new`) is a visual judgment call; keep it conservative and reversible. If any mapping is contentious, defer that specific color to keep the PR focused.
+4. **`V4VRecipientsCard`.** Optional touch; if it risks scope creep, defer to a follow-up. It is already presentational and doesn't block the main goal.
+5. **Naming.** We keep the `useV4VManager` filename to minimize churn even though it is now conceptually the _sales_ adapter. Acceptable? (Alternative: rename to `useSalesV4VManager`; adds churn.)
+6. **Future auction unit.** `V4VManager` currently thinks in "percentage of total" with a separate total slider. Auctions use bps with seller = remainder and no total knob. The `config` flags handle the UI differences; a future auction adapter supplies `totalV4VPercentage`-equivalents (or the prop set is adjusted slightly then). This PR does not need to finalize the bps plumbing — only ensure no sales assumption is hardcoded. Flag for the auction PR.
+
+## 11. Out of scope (explicit)
+
+- Implementing the auction adapter / kind 30408 / 30409 / validator queries (that's the next effort; this PR unblocks it).
+- Migrating sales `queries/v4v.tsx` off NDK to applesauce (ADR-0002) — separate migration.
+- Moving `V4VDTO` out of `cart.ts`, relocating `ProfileSearch`/`RecipientItem` to `nostr/`, adopting `.theme-new` / `ThemeMigrationWrapper` / new dirs — all foundation-PR concerns.
+- Validator consensus, bidder WOT, bid bonds, settlement-window fallback (deferred per the V4V ADR's own list).
+
+## 12. Next step
+
+On approval, implement the single PR described in §6 on this worktree (`audit/v4v-ui-agnostic` off `master`): extract `src/lib/v4v/splits.ts` + tests, invert `V4VManager` to props/labels/config, wire `circular-economy.tsx` and `V4VSetupDialog.tsx` to inject the sales "how", and keep `v4v-product-creation.spec.ts` green.

--- a/src/components/dialogs/V4VSetupDialog.tsx
+++ b/src/components/dialogs/V4VSetupDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { V4VManager } from '@/components/v4v/V4VManager'
 import { salesV4VConfig, salesV4VLabels, type V4VConfig, type V4VLabels } from '@/lib/v4v/labels'
+import { salesV4VManagerProps } from '@/lib/v4v/sales-props'
 import { deriveInitialSharesFromStored } from '@/lib/v4v/splits'
 import { useV4VManager } from '@/hooks/useV4VManager'
 import { useV4VShares } from '@/queries/v4v'
@@ -46,36 +47,7 @@ export function V4VSetupDialog({ open, onOpenChange, userPubkey, onConfirm }: V4
 				</DialogHeader>
 
 				<div className="space-y-6 py-4">
-					<V4VManager
-						shares={sales.localShares}
-						totalV4VPercentage={sales.totalV4VPercentage}
-						newRecipientNpub={sales.newRecipientNpub}
-						newRecipientShare={sales.newRecipientShare}
-						showAddForm={sales.showAddForm}
-						canReceiveZaps={sales.canReceiveZaps}
-						isCheckingZap={sales.isCheckingZap}
-						isChecking={sales.isChecking}
-						isSaving={sales.publishMutation.isPending}
-						sellerPercentage={sales.sellerPercentage}
-						formattedSellerPercentage={sales.formattedSellerPercentage}
-						formattedTotalV4V={sales.formattedTotalV4V}
-						recipientColors={sales.recipientColors}
-						emoji={sales.emoji}
-						emojiSize={sales.emojiSize}
-						emojiClass={sales.emojiClass}
-						onTotalV4VPercentageChange={sales.handleTotalV4VPercentageChange}
-						onProfileSelect={sales.handleProfileSelect}
-						onAddRecipient={sales.handleAddRecipient}
-						onRemoveRecipient={sales.handleRemoveRecipient}
-						onUpdatePercentage={sales.handleUpdatePercentage}
-						onEqualizeAll={sales.handleEqualizeAll}
-						onSetNewRecipientShare={sales.setNewRecipientShare}
-						onToggleAddForm={sales.setShowAddForm}
-						onSave={sales.saveShares}
-						onCancel={() => onOpenChange(false)}
-						labels={labels}
-						config={config}
-					/>
+					<V4VManager {...salesV4VManagerProps(sales)} onCancel={() => onOpenChange(false)} labels={labels} config={config} />
 				</div>
 			</DialogContent>
 		</Dialog>

--- a/src/components/dialogs/V4VSetupDialog.tsx
+++ b/src/components/dialogs/V4VSetupDialog.tsx
@@ -1,5 +1,8 @@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { V4VManager } from '@/components/v4v/V4VManager'
+import { salesV4VConfig, salesV4VLabels, type V4VConfig, type V4VLabels } from '@/lib/v4v/labels'
+import { deriveInitialSharesFromStored } from '@/lib/v4v/splits'
+import { useV4VManager } from '@/hooks/useV4VManager'
 import { useV4VShares } from '@/queries/v4v'
 import { useMemo } from 'react'
 
@@ -14,27 +17,8 @@ export function V4VSetupDialog({ open, onOpenChange, userPubkey, onConfirm }: V4
 	// Fetch existing V4V shares (if any)
 	const { data: v4vShares } = useV4VShares(userPubkey)
 
-	// Calculate initial values from fetched shares
-	const { initialShares, initialTotalPercentage } = useMemo(() => {
-		if (!v4vShares || v4vShares.length === 0) {
-			return { initialShares: [], initialTotalPercentage: 10 }
-		}
-
-		// Calculate total V4V percentage (sum of all share percentages)
-		const totalPercentage = v4vShares.reduce((sum, share) => sum + share.percentage, 0) * 100
-
-		// Normalize shares to sum to 1 (for the split between recipients)
-		const totalSharePercentage = v4vShares.reduce((sum, share) => sum + share.percentage, 0)
-		const normalizedShares = v4vShares.map((share) => ({
-			...share,
-			percentage: share.percentage / totalSharePercentage,
-		}))
-
-		return {
-			initialShares: normalizedShares,
-			initialTotalPercentage: totalPercentage,
-		}
-	}, [v4vShares])
+	// Derive editor boot values from stored shares (shared helper, no duplication).
+	const { initialShares, initialTotalPercentage } = useMemo(() => deriveInitialSharesFromStored(v4vShares), [v4vShares])
 
 	const handleSaveSuccess = () => {
 		onOpenChange(false)
@@ -42,6 +26,14 @@ export function V4VSetupDialog({ open, onOpenChange, userPubkey, onConfirm }: V4
 			onConfirm()
 		}
 	}
+
+	// The sales / "all products" adapter, with dialog-specific copy + config
+	// (confirm-and-save button, cancel button). The agnostic V4VManager receives
+	// this via props — it does not know it is inside a dialog.
+	const sales = useV4VManager({ userPubkey, initialShares, initialTotalPercentage, onSaveSuccess: handleSaveSuccess })
+
+	const labels: V4VLabels = { ...salesV4VLabels, saveButtonText: 'Confirm & Save' }
+	const config: V4VConfig = { ...salesV4VConfig, showCancelButton: true, saveButtonTestId: 'confirm-v4v-setup-button' }
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -55,15 +47,34 @@ export function V4VSetupDialog({ open, onOpenChange, userPubkey, onConfirm }: V4
 
 				<div className="space-y-6 py-4">
 					<V4VManager
-						userPubkey={userPubkey}
-						initialShares={initialShares}
-						initialTotalPercentage={initialTotalPercentage}
-						onSaveSuccess={handleSaveSuccess}
-						showSaveButton={true}
-						saveButtonText="Confirm & Save"
-						saveButtonTestId="confirm-v4v-setup-button"
-						showCancelButton={true}
+						shares={sales.localShares}
+						totalV4VPercentage={sales.totalV4VPercentage}
+						newRecipientNpub={sales.newRecipientNpub}
+						newRecipientShare={sales.newRecipientShare}
+						showAddForm={sales.showAddForm}
+						canReceiveZaps={sales.canReceiveZaps}
+						isCheckingZap={sales.isCheckingZap}
+						isChecking={sales.isChecking}
+						isSaving={sales.publishMutation.isPending}
+						sellerPercentage={sales.sellerPercentage}
+						formattedSellerPercentage={sales.formattedSellerPercentage}
+						formattedTotalV4V={sales.formattedTotalV4V}
+						recipientColors={sales.recipientColors}
+						emoji={sales.emoji}
+						emojiSize={sales.emojiSize}
+						emojiClass={sales.emojiClass}
+						onTotalV4VPercentageChange={sales.handleTotalV4VPercentageChange}
+						onProfileSelect={sales.handleProfileSelect}
+						onAddRecipient={sales.handleAddRecipient}
+						onRemoveRecipient={sales.handleRemoveRecipient}
+						onUpdatePercentage={sales.handleUpdatePercentage}
+						onEqualizeAll={sales.handleEqualizeAll}
+						onSetNewRecipientShare={sales.setNewRecipientShare}
+						onToggleAddForm={sales.setShowAddForm}
+						onSave={sales.saveShares}
 						onCancel={() => onOpenChange(false)}
+						labels={labels}
+						config={config}
 					/>
 				</div>
 			</DialogContent>

--- a/src/components/v4v/V4VManager.tsx
+++ b/src/components/v4v/V4VManager.tsx
@@ -54,7 +54,7 @@ export interface V4VManagerProps {
 	onEqualizeAll: () => void
 	onSetNewRecipientShare: (value: number) => void
 	onToggleAddForm: (open: boolean) => void
-	onSave: () => void
+	onSave: () => void | Promise<void>
 	onCancel?: () => void
 
 	// --- the "how" declared by the call site ---
@@ -100,7 +100,7 @@ export const V4VManager = forwardRef<HTMLDivElement, V4VManagerProps>(function V
 	ref,
 ) {
 	const handleSave = () => {
-		onSave()
+		void onSave()
 	}
 
 	// Whether adding a recipient is allowed right now. The sales adapter requires

--- a/src/components/v4v/V4VManager.tsx
+++ b/src/components/v4v/V4VManager.tsx
@@ -4,140 +4,174 @@ import { Slider } from '@/components/ui/slider'
 import { ProfileSearch } from '@/components/v4v/ProfileSearch'
 import { RecipientItem } from '@/components/v4v/RecipientItem'
 import { RecipientPreview } from '@/components/v4v/RecipientPreview'
-import { useV4VManager } from '@/hooks/useV4VManager'
+import type { V4VConfig, V4VLabels } from '@/lib/v4v/labels'
+import { cn } from '@/lib/utils'
 import type { V4VDTO } from '@/lib/stores/cart'
-import '@/routes/_dashboard-layout/dashboard/sales/emoji-animations.css'
+import { forwardRef } from 'react'
 
-interface V4VManagerProps {
-	userPubkey: string
-	initialShares?: V4VDTO[]
-	initialTotalPercentage?: number
-	onSaveSuccess?: () => void
-	showSaveButton?: boolean
-	saveButtonText?: string
-	saveButtonTestId?: string
-	showChangesIndicator?: boolean
+/**
+ * V4VManager — agnostic V4V / split editor.
+ *
+ * This component is **presentational and persistence-agnostic**: it owns no
+ * state, fetches nothing, and publishes nothing. All data, handlers, copy
+ * (`labels`) and feature flags (`config`) are injected by the call site, which
+ * is what declares *how* this view is used (e.g. the sales / "all products"
+ * dashboard route supplies the sales hook + sales labels + sales config).
+ *
+ * A future auction consumer can render the same component with a different
+ * adapter, labels, and config (e.g. `showEmoji: false`, `requireZapCapable:
+ * false`) without changing this file.
+ */
+export interface V4VManagerProps {
+	// --- data (injected by the caller's adapter hook) ---
+	shares: V4VDTO[]
+	totalV4VPercentage: number
+	newRecipientNpub: string
+	newRecipientShare: number
+	showAddForm: boolean
+	canReceiveZaps?: boolean | undefined
+	isCheckingZap: boolean
+	isChecking: boolean
+	isSaving: boolean
+	/** For the optional "changed/saved" indicator on the save button. */
 	hasChanges?: boolean
-	className?: string
-	showCancelButton?: boolean
+
+	// --- computed viz values (injected; sales adapter supplies emoji, others may omit) ---
+	sellerPercentage?: number
+	formattedSellerPercentage?: string
+	formattedTotalV4V?: string
+	recipientColors?: Record<string, string>
+	emoji?: string
+	emojiSize?: number
+	emojiClass?: string
+
+	// --- handlers (callbacks; the component performs no business logic) ---
+	onTotalV4VPercentageChange: (value: number[]) => void
+	onProfileSelect: (npub: string) => void
+	onAddRecipient: () => void
+	onRemoveRecipient: (id: string) => void
+	onUpdatePercentage: (id: string, percentage: number) => void
+	onEqualizeAll: () => void
+	onSetNewRecipientShare: (value: number) => void
+	onToggleAddForm: (open: boolean) => void
+	onSave: () => void
 	onCancel?: () => void
+
+	// --- the "how" declared by the call site ---
+	labels: V4VLabels
+	config: V4VConfig
+
+	className?: string
 }
 
-export function V4VManager({
-	userPubkey,
-	initialShares = [],
-	initialTotalPercentage = 10,
-	onSaveSuccess,
-	showSaveButton = true,
-	saveButtonText = 'Save Changes',
-	saveButtonTestId = 'save-v4v-button',
-	showChangesIndicator = false,
-	hasChanges = false,
-	className = '',
-	showCancelButton = false,
-	onCancel,
-}: V4VManagerProps) {
-	const {
-		// State
-		showAddForm,
-		setShowAddForm,
+export const V4VManager = forwardRef<HTMLDivElement, V4VManagerProps>(function V4VManager(
+	{
+		shares,
+		totalV4VPercentage,
 		newRecipientNpub,
 		newRecipientShare,
-		setNewRecipientShare,
-		localShares,
-		isChecking,
-		totalV4VPercentage,
+		showAddForm,
 		canReceiveZaps,
 		isCheckingZap,
-		publishMutation,
-
-		// Computed values
-		sellerPercentage,
-		formattedSellerPercentage,
-		formattedTotalV4V,
-		recipientColors,
+		isChecking,
+		isSaving,
+		hasChanges,
+		sellerPercentage = 0,
+		formattedSellerPercentage = '0',
+		formattedTotalV4V = '0',
+		recipientColors = {},
+		emoji,
 		emojiSize,
 		emojiClass,
-		emoji,
-
-		// Handlers
-		handleTotalV4VPercentageChange,
-		handleProfileSelect,
-		handleAddRecipient,
-		handleRemoveRecipient,
-		handleUpdatePercentage,
-		handleEqualizeAll,
-		saveShares,
-	} = useV4VManager({
-		userPubkey,
-		initialShares,
-		initialTotalPercentage,
-		onSaveSuccess,
-	})
-
-	const handleSave = async () => {
-		await saveShares()
+		onTotalV4VPercentageChange,
+		onProfileSelect,
+		onAddRecipient,
+		onRemoveRecipient,
+		onUpdatePercentage,
+		onEqualizeAll,
+		onSetNewRecipientShare,
+		onToggleAddForm,
+		onSave,
+		onCancel,
+		labels,
+		config,
+		className,
+	},
+	ref,
+) {
+	const handleSave = () => {
+		onSave()
 	}
 
+	// Whether adding a recipient is allowed right now. The sales adapter requires
+	// recipients to be zap-capable; an auction adapter sets requireZapCapable:false.
+	const addDisabled =
+		isChecking || isCheckingZap || !newRecipientNpub || (config.requireZapCapable && !canReceiveZaps) || totalV4VPercentage === 0
+
 	return (
-		<div className={`space-y-6 ${className}`}>
-			<Alert className="bg-blue-100 border-blue-200 text-blue-800">
-				<AlertDescription>
-					PM (Beta) Is Powered By Your Generosity. Your Contribution Is The Only Thing That Enables Us To Continue Creating Free And Open
-					Source Solutions 🙏
-				</AlertDescription>
-			</Alert>
+		<div ref={ref} className={cn('space-y-6', className)}>
+			{labels.alertText && (
+				<Alert className="bg-blue-100 border-blue-200 text-blue-800">
+					<AlertDescription>{labels.alertText}</AlertDescription>
+				</Alert>
+			)}
 
 			<div className="space-y-4">
-				<h2 className="font-semibold text-xl">Split of total sales</h2>
+				<h2 className="font-semibold text-xl">{labels.totalSplitHeading}</h2>
 
-				{/* Total V4V percentage slider */}
-				<div className="mt-4">
-					<div className="flex justify-between mb-2 text-muted-foreground text-sm">
-						<span>Seller: {formattedSellerPercentage}%</span>
-						<span>V4V: {formattedTotalV4V}%</span>
-					</div>
-					<Slider value={[totalV4VPercentage]} min={0} max={100} step={1} onValueChange={handleTotalV4VPercentageChange} />
-				</div>
-
-				{/* Emoji animation section */}
-				<div className="my-8 text-center">
-					<div
-						className={`p-4 rounded-full bg-gray-200 inline-flex items-center justify-center ${emojiClass}`}
-						style={{
-							fontSize: `${emojiSize}px`,
-							width: `${emojiSize * 1.5}px`,
-							height: `${emojiSize * 1.5}px`,
-						}}
-					>
-						{emoji}
-					</div>
-				</div>
-
-				{/* First bar - Total split between seller and V4V */}
-				<div className="flex rounded-md w-full h-12 overflow-hidden">
-					<div
-						className="flex justify-start items-center bg-green-600 pl-4 font-medium text-white"
-						style={{ width: `${sellerPercentage}%` }}
-					>
-						{formattedSellerPercentage}%
-					</div>
-					{totalV4VPercentage > 0 && (
-						<div
-							className="flex justify-center items-center bg-fuchsia-500 font-medium text-white"
-							style={{ width: `${totalV4VPercentage}%` }}
-						>
-							V4V
+				{/* Total V4V percentage slider (sales-only; gated by config) */}
+				{config.showTotalSlider && (
+					<div className="mt-4">
+						<div className="flex justify-between mb-2 text-muted-foreground text-sm">
+							<span>{labels.sellerLabel(formattedSellerPercentage)}</span>
+							<span>{labels.v4vLabel(formattedTotalV4V)}</span>
 						</div>
-					)}
-				</div>
+						<Slider value={[totalV4VPercentage]} min={0} max={100} step={1} onValueChange={onTotalV4VPercentageChange} />
+					</div>
+				)}
 
-				<h2 className="mt-6 font-semibold text-xl">V4V split between recipients</h2>
+				{/* Emoji animation section (sales-only; gated by config) */}
+				{config.showEmoji && emoji && (
+					<div className="my-8 text-center">
+						<div
+							className={cn('p-4 rounded-full bg-muted inline-flex items-center justify-center', emojiClass)}
+							style={{
+								fontSize: `${emojiSize}px`,
+								width: `${(emojiSize ?? 0) * 1.5}px`,
+								height: `${(emojiSize ?? 0) * 1.5}px`,
+							}}
+						>
+							{emoji}
+						</div>
+					</div>
+				)}
+
+				{/* First bar - Total split between seller and V4V (sales-only; gated by config) */}
+				{config.showSellerBar && (
+					<div className="flex rounded-md w-full h-12 overflow-hidden">
+						<div
+							className="flex justify-start items-center bg-green-600 pl-4 font-medium text-white"
+							style={{ width: `${sellerPercentage}%` }}
+						>
+							{formattedSellerPercentage}%
+						</div>
+						{totalV4VPercentage > 0 && (
+							<div
+								className="flex justify-center items-center bg-fuchsia-500 font-medium text-white"
+								style={{ width: `${totalV4VPercentage}%` }}
+							>
+								V4V
+							</div>
+						)}
+					</div>
+				)}
+
+				<h2 className="mt-6 font-semibold text-xl">{labels.recipientsHeading}</h2>
 
 				{/* Second bar - Split between V4V recipients */}
-				{localShares.length > 0 && totalV4VPercentage > 0 ? (
+				{shares.length > 0 && totalV4VPercentage > 0 ? (
 					<div className="flex rounded-md w-full h-12 overflow-hidden">
-						{localShares.map((share, index) => (
+						{shares.map((share, index) => (
 							<div
 								key={share.id}
 								className={`${index === 0 ? 'bg-rose-500' : 'bg-gray-500'} flex items-center justify-center text-white font-medium`}
@@ -151,20 +185,20 @@ export function V4VManager({
 						))}
 					</div>
 				) : (
-					<div className="text-gray-500">No V4V recipients added yet</div>
+					<div className="text-muted-foreground">{labels.emptyRecipientsText}</div>
 				)}
 
 				{/* Recipients list */}
 				<div className="space-y-2 mt-4">
-					{localShares.map((share) => (
+					{shares.map((share) => (
 						<RecipientItem
 							key={share.id}
 							share={{
 								...share,
 								percentage: share.percentage,
 							}}
-							onRemove={handleRemoveRecipient}
-							onPercentageChange={handleUpdatePercentage}
+							onRemove={onRemoveRecipient}
+							onPercentageChange={onUpdatePercentage}
 							color={recipientColors[share.pubkey]}
 						/>
 					))}
@@ -174,7 +208,7 @@ export function V4VManager({
 				{showAddForm ? (
 					<div className="space-y-4 mt-6 p-4 border rounded-lg">
 						<div className="flex-1">
-							<ProfileSearch onSelect={handleProfileSelect} placeholder="Search profiles or paste npub..." />
+							<ProfileSearch onSelect={onProfileSelect} placeholder={labels.searchPlaceholder} />
 
 							{newRecipientNpub && (
 								<RecipientPreview
@@ -185,25 +219,31 @@ export function V4VManager({
 								/>
 							)}
 						</div>
-						{localShares.length > 0 && (
+						{shares.length > 0 && (
 							<div className="space-y-2">
 								<div className="flex justify-between text-muted-foreground text-sm">
-									<span>Share percentage: {newRecipientShare}%</span>
+									<span>{labels.newRecipientShareLabel(newRecipientShare)}</span>
 								</div>
-								<Slider value={[newRecipientShare]} min={1} max={100} step={1} onValueChange={(value) => setNewRecipientShare(value[0])} />
+								<Slider
+									value={[newRecipientShare]}
+									min={1}
+									max={100}
+									step={1}
+									onValueChange={(value) => onSetNewRecipientShare(value[0])}
+								/>
 							</div>
 						)}
 						<div className="flex flex-wrap items-center gap-2">
 							<Button
 								className="flex-grow sm:flex-grow-0"
-								onClick={handleAddRecipient}
-								disabled={isChecking || isCheckingZap || !newRecipientNpub || !canReceiveZaps || totalV4VPercentage === 0}
+								onClick={onAddRecipient}
+								disabled={addDisabled}
 								data-testid="add-v4v-recipient-button"
 							>
-								Add
+								{labels.addFormConfirmText}
 							</Button>
-							<Button variant="outline" onClick={() => setShowAddForm(false)} data-testid="cancel-v4v-recipient-button">
-								Cancel
+							<Button variant="outline" onClick={() => onToggleAddForm(false)} data-testid="cancel-v4v-recipient-button">
+								{labels.addFormCancelText}
 							</Button>
 						</div>
 					</div>
@@ -211,45 +251,45 @@ export function V4VManager({
 					<div className="gap-4 grid grid-cols-1 sm:grid-cols-2 mt-6">
 						<Button
 							variant="outline"
-							onClick={() => setShowAddForm(true)}
+							onClick={() => onToggleAddForm(true)}
 							disabled={totalV4VPercentage === 0}
 							data-testid="add-v4v-recipient-form-button"
 						>
-							Add Recipient
+							{labels.addRecipientButtonText}
 						</Button>
 						<Button
 							variant="outline"
-							onClick={handleEqualizeAll}
-							disabled={localShares.length === 0 || totalV4VPercentage === 0}
+							onClick={onEqualizeAll}
+							disabled={shares.length === 0 || totalV4VPercentage === 0}
 							data-testid="equal-all-v4v-button"
 						>
-							Equal All
+							{labels.equalizeAllButtonText}
 						</Button>
 					</div>
 				)}
 
 				{/* Save button */}
-				{showSaveButton && (
+				{config.showSaveButton && (
 					<div className="mt-6">
-						{showCancelButton ? (
+						{config.showCancelButton && onCancel ? (
 							<div className="flex gap-2">
 								<Button variant="outline" onClick={onCancel} className="flex-1">
-									Cancel
+									{labels.cancelButtonText}
 								</Button>
 								<Button
 									variant="default"
 									className="flex-1"
 									onClick={handleSave}
-									disabled={publishMutation.isPending || (showChangesIndicator && !hasChanges)}
-									data-testid={saveButtonTestId}
+									disabled={isSaving || (config.showChangesIndicator && !hasChanges)}
+									data-testid={config.saveButtonTestId}
 								>
-									{publishMutation.isPending
-										? 'Saving...'
-										: showChangesIndicator && hasChanges
-											? saveButtonText
-											: showChangesIndicator
-												? 'Saved'
-												: saveButtonText}
+									{isSaving
+										? labels.savingText
+										: config.showChangesIndicator && hasChanges
+											? labels.saveButtonText
+											: config.showChangesIndicator
+												? labels.savedText
+												: labels.saveButtonText}
 								</Button>
 							</div>
 						) : (
@@ -257,16 +297,16 @@ export function V4VManager({
 								variant="default"
 								className="w-full"
 								onClick={handleSave}
-								disabled={publishMutation.isPending || (showChangesIndicator && !hasChanges)}
-								data-testid={saveButtonTestId}
+								disabled={isSaving || (config.showChangesIndicator && !hasChanges)}
+								data-testid={config.saveButtonTestId}
 							>
-								{publishMutation.isPending
-									? 'Saving...'
-									: showChangesIndicator && hasChanges
-										? saveButtonText
-										: showChangesIndicator
-											? 'Saved'
-											: saveButtonText}
+								{isSaving
+									? labels.savingText
+									: config.showChangesIndicator && hasChanges
+										? labels.saveButtonText
+										: config.showChangesIndicator
+											? labels.savedText
+											: labels.saveButtonText}
 							</Button>
 						)}
 					</div>
@@ -274,4 +314,4 @@ export function V4VManager({
 			</div>
 		</div>
 	)
-}
+})

--- a/src/hooks/useV4VManager.ts
+++ b/src/hooks/useV4VManager.ts
@@ -1,4 +1,11 @@
 import type { V4VDTO } from '@/lib/stores/cart'
+import {
+	addRecipientToShares,
+	equalizeAllShares,
+	removeRecipientFromShares,
+	scaleSharesByTotal,
+	updateSharePercentage,
+} from '@/lib/v4v/splits'
 import { getDistinctColorsForRecipients } from '@/lib/utils'
 import { useConfigQuery } from '@/queries/config'
 import { useZapCapabilityByNpub } from '@/queries/profiles'
@@ -135,38 +142,7 @@ export function useV4VManager({ userPubkey, initialShares = [], initialTotalPerc
 				return
 			}
 
-			let newSharePercentage = 0
-			let updatedShares = []
-
-			if (localShares.length === 0) {
-				newSharePercentage = 1
-				updatedShares = [
-					{
-						id: `new-${Date.now()}`,
-						name: '', // Will be resolved by UserWithAvatar component
-						pubkey: hexPubkey,
-						percentage: newSharePercentage,
-					},
-				]
-			} else {
-				newSharePercentage = newRecipientShare / 100
-
-				const totalExistingPercentage = localShares.reduce((sum, share) => sum + share.percentage, 0)
-				const remainingPercentage = 1 - newSharePercentage
-				const ratio = remainingPercentage / totalExistingPercentage
-
-				updatedShares = localShares.map((share) => ({
-					...share,
-					percentage: share.percentage * ratio,
-				}))
-
-				updatedShares.push({
-					id: `new-${Date.now()}`,
-					name: '', // Will be resolved by UserWithAvatar component
-					pubkey: hexPubkey,
-					percentage: newSharePercentage,
-				})
-			}
+			const updatedShares = addRecipientToShares(localShares, hexPubkey, newRecipientShare)
 
 			setLocalShares(updatedShares)
 
@@ -182,90 +158,15 @@ export function useV4VManager({ userPubkey, initialShares = [], initialTotalPerc
 	}
 
 	const handleRemoveRecipient = (id: string) => {
-		const shareToRemove = localShares.find((share) => share.id === id)
-		if (!shareToRemove) return
-
-		const remainingShares = localShares.filter((share) => share.id !== id)
-
-		if (remainingShares.length === 0) {
-			setLocalShares([])
-		} else {
-			const totalRemainingPercentage = remainingShares.reduce((sum, share) => sum + share.percentage, 0)
-			const ratio = 1 / totalRemainingPercentage
-
-			const updatedShares = remainingShares.map((share) => ({
-				...share,
-				percentage: share.percentage * ratio,
-			}))
-
-			setLocalShares(updatedShares)
-		}
+		setLocalShares(removeRecipientFromShares(localShares, id))
 	}
 
 	const handleUpdatePercentage = (id: string, newPercentage: number) => {
-		const shareToUpdate = localShares.find((share) => share.id === id)
-		if (!shareToUpdate) return
-
-		const oldPercentage = shareToUpdate.percentage
-		const percentageDiff = newPercentage - oldPercentage
-
-		if (localShares.length === 1) {
-			setLocalShares([
-				{
-					...shareToUpdate,
-					percentage: 1,
-				},
-			])
-			return
-		}
-
-		const otherShares = localShares.filter((share) => share.id !== id)
-		const totalOtherPercentage = otherShares.reduce((sum, share) => sum + share.percentage, 0)
-
-		if (totalOtherPercentage - percentageDiff <= 0.01 && percentageDiff > 0) {
-			const minPerShare = 0.01
-			const totalMinForOthers = minPerShare * otherShares.length
-			const maxForUpdated = 1 - totalMinForOthers
-
-			const updatedShares = localShares.map((share) => ({
-				...share,
-				percentage: share.id === id ? maxForUpdated : minPerShare,
-			}))
-			setLocalShares(updatedShares)
-			return
-		}
-
-		const updatedShares = localShares.map((share) => {
-			if (share.id === id) {
-				return { ...share, percentage: newPercentage }
-			} else {
-				const adjustmentFactor = (totalOtherPercentage - percentageDiff) / totalOtherPercentage
-				return { ...share, percentage: share.percentage * adjustmentFactor }
-			}
-		})
-
-		const total = updatedShares.reduce((sum, share) => sum + share.percentage, 0)
-		if (Math.abs(total - 1) > 0.0001) {
-			const normalizedShares = updatedShares.map((share) => ({
-				...share,
-				percentage: share.percentage / total,
-			}))
-			setLocalShares(normalizedShares)
-		} else {
-			setLocalShares(updatedShares)
-		}
+		setLocalShares(updateSharePercentage(localShares, id, newPercentage))
 	}
 
 	const handleEqualizeAll = () => {
-		if (localShares.length === 0) return
-
-		const equalShare = 1 / localShares.length
-		const updatedShares = localShares.map((share) => ({
-			...share,
-			percentage: equalShare,
-		}))
-
-		setLocalShares(updatedShares)
+		setLocalShares(equalizeAllShares(localShares))
 	}
 
 	const saveShares = async (clearShares = false) => {
@@ -287,10 +188,7 @@ export function useV4VManager({ userPubkey, initialShares = [], initialTotalPerc
 				}
 			}
 
-			const sharesToSave = localShares.map((share) => ({
-				...share,
-				percentage: share.percentage * (totalV4VPercentage / 100),
-			}))
+			const sharesToSave = scaleSharesByTotal(localShares, totalV4VPercentage)
 
 			const result = await publishMutation.mutateAsync({
 				shares: sharesToSave,

--- a/src/lib/__tests__/v4v-splits.test.ts
+++ b/src/lib/__tests__/v4v-splits.test.ts
@@ -25,9 +25,12 @@ describe('normalizeShares', () => {
 		expect(out[0].percentage).toBeCloseTo(0.5, 10)
 	})
 
-	test('returns input unchanged when total is 0', () => {
-		const out = normalizeShares([share('a', 0)])
-		expect(out).toEqual([share('a', 0)])
+	test('returns a copy (not the same reference) when total is 0', () => {
+		const input = [share('a', 0)]
+		const out = normalizeShares(input)
+		expect(out).toEqual(input)
+		expect(out).not.toBe(input)
+		expect(out[0]).not.toBe(input[0])
 	})
 })
 
@@ -141,5 +144,10 @@ describe('deriveInitialSharesFromStored', () => {
 		expect(sum(out.initialShares)).toBeCloseTo(1, 10)
 		expect(out.initialShares[0].percentage).toBeCloseTo(0.7, 10) // 0.07 / 0.10
 		expect(out.initialShares[1].percentage).toBeCloseTo(0.3, 10)
+	})
+
+	test('returns empty shares and 0 total when all stored percentages are 0', () => {
+		const stored = [share('a', 0), share('b', 0)]
+		expect(deriveInitialSharesFromStored(stored)).toEqual({ initialShares: [], initialTotalPercentage: 0 })
 	})
 })

--- a/src/lib/__tests__/v4v-splits.test.ts
+++ b/src/lib/__tests__/v4v-splits.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test'
+import type { V4VDTO } from '@/lib/stores/cart'
+import {
+	addRecipientToShares,
+	deriveInitialSharesFromStored,
+	equalizeAllShares,
+	normalizeShares,
+	removeRecipientFromShares,
+	scaleSharesByTotal,
+	updateSharePercentage,
+} from '@/lib/v4v/splits'
+
+const sum = (s: V4VDTO[]) => s.reduce((acc, x) => acc + x.percentage, 0)
+const share = (id: string, percentage: number, pubkey = `pk-${id}`): V4VDTO => ({
+	id,
+	name: '',
+	pubkey,
+	percentage,
+})
+
+describe('normalizeShares', () => {
+	test('divides by the total so the array sums to 1', () => {
+		const out = normalizeShares([share('a', 2), share('b', 2)])
+		expect(sum(out)).toBeCloseTo(1, 10)
+		expect(out[0].percentage).toBeCloseTo(0.5, 10)
+	})
+
+	test('returns input unchanged when total is 0', () => {
+		const out = normalizeShares([share('a', 0)])
+		expect(out).toEqual([share('a', 0)])
+	})
+})
+
+describe('addRecipientToShares', () => {
+	test('first recipient gets the whole pool', () => {
+		const out = addRecipientToShares([], 'pk-new', 10)
+		expect(out).toHaveLength(1)
+		expect(out[0].pubkey).toBe('pk-new')
+		expect(out[0].percentage).toBe(1)
+	})
+
+	test('scales existing recipients down so the array still sums to 1', () => {
+		const start = [share('a', 0.5), share('b', 0.5)]
+		const out = addRecipientToShares(start, 'pk-new', 20) // new takes 20%
+		expect(out).toHaveLength(3)
+		expect(sum(out)).toBeCloseTo(1, 10)
+		expect(out.find((s) => s.pubkey === 'pk-new')!.percentage).toBeCloseTo(0.2, 10)
+		// existing two each had 0.5 of 1.0; remaining 0.8 split proportionally -> 0.4 each
+		expect(out.find((s) => s.id === 'a')!.percentage).toBeCloseTo(0.4, 10)
+	})
+
+	test('does not mutate the input array', () => {
+		const start = [share('a', 1)]
+		addRecipientToShares(start, 'pk-new', 10)
+		expect(start).toHaveLength(1)
+		expect(start[0].percentage).toBe(1)
+	})
+})
+
+describe('removeRecipientFromShares', () => {
+	test('removes and re-normalizes the remainder to sum to 1', () => {
+		const start = [share('a', 0.25), share('b', 0.75)]
+		const out = removeRecipientFromShares(start, 'a')
+		expect(out).toHaveLength(1)
+		expect(out[0].id).toBe('b')
+		expect(out[0].percentage).toBeCloseTo(1, 10)
+	})
+
+	test('returns [] when the last recipient is removed', () => {
+		const out = removeRecipientFromShares([share('a', 1)], 'a')
+		expect(out).toEqual([])
+	})
+
+	test('returns input unchanged when id not found', () => {
+		const start = [share('a', 1)]
+		expect(removeRecipientFromShares(start, 'nope')).toEqual(start)
+	})
+})
+
+describe('updateSharePercentage', () => {
+	test('absorbs the delta into the others proportionally', () => {
+		const start = [share('a', 0.5), share('b', 0.5)]
+		const out = updateSharePercentage(start, 'a', 0.8)
+		expect(sum(out)).toBeCloseTo(1, 10)
+		expect(out.find((s) => s.id === 'a')!.percentage).toBeCloseTo(0.8, 10)
+		expect(out.find((s) => s.id === 'b')!.percentage).toBeCloseTo(0.2, 10)
+	})
+
+	test('clamps when the increase would starve others below the minimum', () => {
+		const start = [share('a', 0.5), share('b', 0.5)]
+		const out = updateSharePercentage(start, 'a', 0.99) // only one other, min 0.01
+		expect(sum(out)).toBeCloseTo(1, 10)
+		expect(out.find((s) => s.id === 'a')!.percentage).toBeCloseTo(0.99, 10)
+		expect(out.find((s) => s.id === 'b')!.percentage).toBeCloseTo(0.01, 10)
+	})
+
+	test('a single recipient is always pinned to 1', () => {
+		const out = updateSharePercentage([share('a', 1)], 'a', 0.3)
+		expect(out).toHaveLength(1)
+		expect(out[0].percentage).toBe(1)
+	})
+
+	test('returns input unchanged when id not found', () => {
+		const start = [share('a', 1)]
+		expect(updateSharePercentage(start, 'nope', 0.5)).toEqual(start)
+	})
+})
+
+describe('equalizeAllShares', () => {
+	test('distributes equally', () => {
+		const out = equalizeAllShares([share('a', 0.7), share('b', 0.2), share('c', 0.1)])
+		expect(out).toHaveLength(3)
+		expect(sum(out)).toBeCloseTo(1, 10)
+		out.forEach((s) => expect(s.percentage).toBeCloseTo(1 / 3, 10))
+	})
+
+	test('empty in, empty out', () => {
+		expect(equalizeAllShares([])).toEqual([])
+	})
+})
+
+describe('scaleSharesByTotal', () => {
+	test('multiplies each share by total/100', () => {
+		const out = scaleSharesByTotal([share('a', 0.5), share('b', 0.5)], 10)
+		expect(out.find((s) => s.id === 'a')!.percentage).toBeCloseTo(0.05, 10)
+		expect(out.find((s) => s.id === 'b')!.percentage).toBeCloseTo(0.05, 10)
+	})
+})
+
+describe('deriveInitialSharesFromStored', () => {
+	test('defaults when there are no stored shares', () => {
+		expect(deriveInitialSharesFromStored(undefined)).toEqual({ initialShares: [], initialTotalPercentage: 10 })
+		expect(deriveInitialSharesFromStored([])).toEqual({ initialShares: [], initialTotalPercentage: 10 })
+	})
+
+	test('re-normalizes the pool to sum to 1 and reports the total as a percentage', () => {
+		// stored as fractions of total sales, e.g. 7% + 3% = 10% total
+		const stored = [share('a', 0.07), share('b', 0.03)]
+		const out = deriveInitialSharesFromStored(stored)
+		expect(out.initialTotalPercentage).toBeCloseTo(10, 10)
+		expect(sum(out.initialShares)).toBeCloseTo(1, 10)
+		expect(out.initialShares[0].percentage).toBeCloseTo(0.7, 10) // 0.07 / 0.10
+		expect(out.initialShares[1].percentage).toBeCloseTo(0.3, 10)
+	})
+})

--- a/src/lib/v4v/labels.ts
+++ b/src/lib/v4v/labels.ts
@@ -1,0 +1,100 @@
+/**
+ * Externalized "how" for the agnostic V4V UI.
+ *
+ * `V4VManager` renders no copy and decides no feature on its own — the call
+ * site (the sales route / dialog) supplies a `V4VLabels` for every string and a
+ * `V4VConfig` for every feature flag. A future auction consumer would supply a
+ * different `V4VLabels` + `V4VConfig` to the same component.
+ *
+ * Kept intentionally minimal and free of React/Nostr so it can be reused and
+ * unit-tested independently of the component.
+ */
+
+/** All user-facing strings the V4V editor can render. */
+export interface V4VLabels {
+	/** Optional banner shown above the editor (sales: the "generosity" note). Omit to hide. */
+	alertText?: string
+	/** Heading for the seller-vs-V4V total split section. */
+	totalSplitHeading: string
+	/** Heading for the between-recipients section. */
+	recipientsHeading: string
+	/** Text shown when there are no recipients yet. */
+	emptyRecipientsText: string
+	/** Placeholder for the profile search input. */
+	searchPlaceholder: string
+	/** Add-recipient button label. */
+	addRecipientButtonText: string
+	/** "Equalize all" button label. */
+	equalizeAllButtonText: string
+	/** Confirm button label inside the add form. */
+	addFormConfirmText: string
+	/** Cancel button label inside the add form. */
+	addFormCancelText: string
+	/** Label shown next to the new-recipient share slider. */
+	newRecipientShareLabel: (share: number) => string
+	/** Seller-side label in the total split readout. */
+	sellerLabel: (formatted: string) => string
+	/** V4V-side label in the total split readout. */
+	v4vLabel: (formatted: string) => string
+	/** Save button label. */
+	saveButtonText: string
+	/** Save button label when a change indicator is on and nothing changed. */
+	savedText: string
+	/** Save button label while persisting. */
+	savingText: string
+	/** Cancel button label (when a cancel button is shown). */
+	cancelButtonText: string
+}
+
+/** Feature flags that switch sales-only rendering on/off. */
+export interface V4VConfig {
+	/** Show the emoji wiggle/shake/glow widget (sales-only). */
+	showEmoji: boolean
+	/** Show the "total V4V %" slider that splits seller vs V4V (sales-only). */
+	showTotalSlider: boolean
+	/** Show the seller-vs-V4V split bar (sales-only). */
+	showSellerBar: boolean
+	/** Require recipients to be able to receive zaps (sales-only). */
+	requireZapCapable: boolean
+	/** Show the save button. */
+	showSaveButton: boolean
+	/** Show a cancel button next to save. */
+	showCancelButton: boolean
+	/** Enable the "changed/saved" indicator on the save button. */
+	showChangesIndicator: boolean
+	/** testid for the save button. */
+	saveButtonTestId: string
+}
+
+/** The sales / "all products" labels — what the dashboard route injects. */
+export const salesV4VLabels: V4VLabels = {
+	alertText:
+		'PM (Beta) Is Powered By Your Generosity. Your Contribution Is The Only Thing That Enables Us To Continue Creating Free And Open Source Solutions 🙏',
+	totalSplitHeading: 'Split of total sales',
+	recipientsHeading: 'V4V split between recipients',
+	emptyRecipientsText: 'No V4V recipients added yet',
+	searchPlaceholder: 'Search profiles or paste npub...',
+	addRecipientButtonText: 'Add Recipient',
+	equalizeAllButtonText: 'Equal All',
+	addFormConfirmText: 'Add',
+	addFormCancelText: 'Cancel',
+	newRecipientShareLabel: (share) => `Share percentage: ${share}%`,
+	sellerLabel: (formatted) => `Seller: ${formatted}%`,
+	v4vLabel: (formatted) => `V4V: ${formatted}%`,
+	saveButtonText: 'Save Changes',
+	savedText: 'Saved',
+	savingText: 'Saving...',
+	cancelButtonText: 'Cancel',
+}
+
+/** The sales / "all products" feature config — what the dashboard route injects. */
+export const salesV4VConfig: V4VConfig = {
+	showEmoji: true,
+	showTotalSlider: true,
+	showSellerBar: true,
+	requireZapCapable: true,
+	showSaveButton: true,
+	showCancelButton: false,
+	showChangesIndicator: false,
+	saveButtonTestId: 'save-v4v-button',
+}

--- a/src/lib/v4v/sales-props.ts
+++ b/src/lib/v4v/sales-props.ts
@@ -1,0 +1,46 @@
+import type { useV4VManager } from '@/hooks/useV4VManager'
+
+/**
+ * Map the sales / "all products" adapter hook output to the props expected by
+ * the agnostic V4VManager component.
+ *
+ * Both call sites — the dashboard route (`circular-economy.tsx`) and the setup
+ * dialog (`V4VSetupDialog.tsx`) — spread this helper and then add their own
+ * `labels`, `config`, and (optionally) `onCancel`. Keeping the ~25 common prop
+ * mappings in one place prevents the two consumers from drifting when
+ * `useV4VManager` adds or renames a field.
+ *
+ * A future auction adapter would have its own `auctionV4VManagerProps()`
+ * helper following the same pattern.
+ */
+export function salesV4VManagerProps(sales: ReturnType<typeof useV4VManager>) {
+	return {
+		shares: sales.localShares,
+		totalV4VPercentage: sales.totalV4VPercentage,
+		newRecipientNpub: sales.newRecipientNpub,
+		newRecipientShare: sales.newRecipientShare,
+		showAddForm: sales.showAddForm,
+		canReceiveZaps: sales.canReceiveZaps,
+		isCheckingZap: sales.isCheckingZap,
+		isChecking: sales.isChecking,
+		isSaving: sales.publishMutation.isPending,
+		sellerPercentage: sales.sellerPercentage,
+		formattedSellerPercentage: sales.formattedSellerPercentage,
+		formattedTotalV4V: sales.formattedTotalV4V,
+		recipientColors: sales.recipientColors,
+		emoji: sales.emoji,
+		emojiSize: sales.emojiSize,
+		emojiClass: sales.emojiClass,
+		onTotalV4VPercentageChange: sales.handleTotalV4VPercentageChange,
+		onProfileSelect: sales.handleProfileSelect,
+		onAddRecipient: sales.handleAddRecipient,
+		onRemoveRecipient: sales.handleRemoveRecipient,
+		onUpdatePercentage: sales.handleUpdatePercentage,
+		onEqualizeAll: sales.handleEqualizeAll,
+		onSetNewRecipientShare: sales.setNewRecipientShare,
+		onToggleAddForm: sales.setShowAddForm,
+		onSave: () => {
+			void sales.saveShares()
+		},
+	}
+}

--- a/src/lib/v4v/splits.ts
+++ b/src/lib/v4v/splits.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure, dependency-free share math for the V4V split editor.
+ *
+ * Everything here is framework-agnostic (no React, no Nostr, no store actions)
+ * so it can be unit-tested and reused by any V4V *adapter* — sales (kind 30078)
+ * today, auctions (kind 30408) tomorrow — without the UI knowing which.
+ *
+ * Percentages are stored as **fractions of the recipient pool** (0..1) and are
+ * kept invariant: the array always sums to 1. The sales adapter additionally
+ * scales the whole pool by a separate "total V4V %" knob at the persistence
+ * boundary (`scaleSharesByTotal`); an auction adapter would instead keep the
+ * pool at a fixed total (e.g. 10000 bps) with the owner as the remainder.
+ */
+import type { V4VDTO } from '@/lib/stores/cart'
+
+const SUM_EPSILON = 0.0001
+const MIN_SHARE = 0.01
+
+function sum(shares: V4VDTO[]): number {
+	return shares.reduce((acc, s) => acc + s.percentage, 0)
+}
+
+/** Divide every share by the total so the array sums to exactly 1. */
+export function normalizeShares(shares: V4VDTO[]): V4VDTO[] {
+	const total = sum(shares)
+	if (total === 0) return shares
+	return shares.map((s) => ({ ...s, percentage: s.percentage / total }))
+}
+
+/**
+ * Add a recipient. `newSharePct` is a 0..100 percentage of the pool the new
+ * recipient should take; existing recipients are scaled down proportionally so
+ * the result still sums to 1. When the pool is empty the recipient gets 100%
+ * (fraction = 1). Returns the updated array; does not mutate the input.
+ */
+export function addRecipientToShares(shares: V4VDTO[], hexPubkey: string, newSharePct: number): V4VDTO[] {
+	if (shares.length === 0) {
+		return [
+			{
+				id: `new-${Date.now()}`,
+				name: '', // resolved lazily by UserCard
+				pubkey: hexPubkey,
+				percentage: 1,
+			},
+		]
+	}
+
+	const newShareFraction = newSharePct / 100
+	const totalExisting = sum(shares)
+	const remaining = 1 - newShareFraction
+	const ratio = remaining / totalExisting
+
+	const scaled = shares.map((s) => ({ ...s, percentage: s.percentage * ratio }))
+	scaled.push({
+		id: `new-${Date.now()}`,
+		name: '',
+		pubkey: hexPubkey,
+		percentage: newShareFraction,
+	})
+	return scaled
+}
+
+/** Remove a recipient and re-normalize the rest so they sum to 1. */
+export function removeRecipientFromShares(shares: V4VDTO[], id: string): V4VDTO[] {
+	const remaining = shares.filter((s) => s.id !== id)
+	if (remaining.length === 0) return []
+
+	const totalRemaining = sum(remaining)
+	if (totalRemaining === 0) return remaining
+	const ratio = 1 / totalRemaining
+	return remaining.map((s) => ({ ...s, percentage: s.percentage * ratio }))
+}
+
+/**
+ * Set one recipient's share to `newPercentage` (fraction 0..1) and absorb the
+ * delta into the others proportionally, keeping the array summed to 1. Enforces
+ * a minimum share for each recipient so one can never starve the rest to zero.
+ */
+export function updateSharePercentage(shares: V4VDTO[], id: string, newPercentage: number): V4VDTO[] {
+	const shareToUpdate = shares.find((s) => s.id === id)
+	if (!shareToUpdate) return shares
+
+	if (shares.length === 1) {
+		return [{ ...shareToUpdate, percentage: 1 }]
+	}
+
+	const oldPercentage = shareToUpdate.percentage
+	const diff = newPercentage - oldPercentage
+	const others = shares.filter((s) => s.id !== id)
+	const totalOther = sum(others)
+
+	// Would starve the others below the minimum -> clamp.
+	if (totalOther - diff <= MIN_SHARE && diff > 0) {
+		const totalMinForOthers = MIN_SHARE * others.length
+		const maxForUpdated = 1 - totalMinForOthers
+		return shares.map((s) => ({
+			...s,
+			percentage: s.id === id ? maxForUpdated : MIN_SHARE,
+		}))
+	}
+
+	const adjustmentFactor = (totalOther - diff) / totalOther
+	const updated = shares.map((s) =>
+		s.id === id ? { ...s, percentage: newPercentage } : { ...s, percentage: s.percentage * adjustmentFactor },
+	)
+
+	// Guard against floating-point drift.
+	const total = sum(updated)
+	if (Math.abs(total - 1) > SUM_EPSILON) {
+		return updated.map((s) => ({ ...s, percentage: s.percentage / total }))
+	}
+	return updated
+}
+
+/** Distribute the pool equally across all recipients. */
+export function equalizeAllShares(shares: V4VDTO[]): V4VDTO[] {
+	if (shares.length === 0) return []
+	const equal = 1 / shares.length
+	return shares.map((s) => ({ ...s, percentage: equal }))
+}
+
+/**
+ * Scale every recipient by `totalPercentage/100`. Used by the sales adapter at
+ * the persistence boundary to turn the normalized pool into fractions-of-total-sales
+ * before publishing to kind 30078. (Auction adapter does not need this — its
+ * pool is already expressed in the publish unit.)
+ */
+export function scaleSharesByTotal(shares: V4VDTO[], totalPercentage: number): V4VDTO[] {
+	const factor = totalPercentage / 100
+	return shares.map((s) => ({ ...s, percentage: s.percentage * factor }))
+}
+
+/**
+ * Convert stored sales V4V shares (fractions of total sales) back into the
+ * `{ initialShares, initialTotalPercentage }` shape the editor boots from.
+ *
+ * `initialShares` are re-normalized to sum to 1 (the *between-recipients* split)
+ * and `initialTotalPercentage` is the *seller-vs-V4V* total. This deduplicates the
+ * logic that both `circular-economy.tsx` and `V4VSetupDialog.tsx` previously
+ * inlined.
+ */
+export function deriveInitialSharesFromStored(storedShares: V4VDTO[] | undefined | null): {
+	initialShares: V4VDTO[]
+	initialTotalPercentage: number
+} {
+	if (!storedShares || storedShares.length === 0) {
+		return { initialShares: [], initialTotalPercentage: 10 }
+	}
+
+	const totalPercentage = storedShares.reduce((acc, s) => acc + s.percentage, 0) * 100
+	const totalSharePercentage = storedShares.reduce((acc, s) => acc + s.percentage, 0)
+	const normalizedShares = storedShares.map((s) => ({
+		...s,
+		percentage: s.percentage / totalSharePercentage,
+	}))
+
+	return {
+		initialShares: normalizedShares,
+		initialTotalPercentage: totalPercentage,
+	}
+}

--- a/src/lib/v4v/splits.ts
+++ b/src/lib/v4v/splits.ts
@@ -23,7 +23,7 @@ function sum(shares: V4VDTO[]): number {
 /** Divide every share by the total so the array sums to exactly 1. */
 export function normalizeShares(shares: V4VDTO[]): V4VDTO[] {
 	const total = sum(shares)
-	if (total === 0) return shares
+	if (total === 0) return shares.map((s) => ({ ...s }))
 	return shares.map((s) => ({ ...s, percentage: s.percentage / total }))
 }
 
@@ -147,8 +147,14 @@ export function deriveInitialSharesFromStored(storedShares: V4VDTO[] | undefined
 		return { initialShares: [], initialTotalPercentage: 10 }
 	}
 
-	const totalPercentage = storedShares.reduce((acc, s) => acc + s.percentage, 0) * 100
 	const totalSharePercentage = storedShares.reduce((acc, s) => acc + s.percentage, 0)
+	const totalPercentage = totalSharePercentage * 100
+
+	// Guard against all-zero stored shares (would produce NaN from division by zero).
+	if (totalSharePercentage === 0) {
+		return { initialShares: [], initialTotalPercentage: 0 }
+	}
+
 	const normalizedShares = storedShares.map((s) => ({
 		...s,
 		percentage: s.percentage / totalSharePercentage,

--- a/src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx
@@ -1,5 +1,6 @@
 import { V4VManager } from '@/components/v4v/V4VManager'
 import { salesV4VConfig, salesV4VLabels } from '@/lib/v4v/labels'
+import { salesV4VManagerProps } from '@/lib/v4v/sales-props'
 import { deriveInitialSharesFromStored } from '@/lib/v4v/splits'
 import { authStore } from '@/lib/stores/auth'
 import { useV4VManager } from '@/hooks/useV4VManager'
@@ -53,35 +54,7 @@ function CircularEconomyComponent() {
 				<h1 className="text-2xl font-bold">Circular Economy</h1>
 			</div>
 			<div className="space-y-6 p-4 lg:p-6">
-				<V4VManager
-					shares={sales.localShares}
-					totalV4VPercentage={sales.totalV4VPercentage}
-					newRecipientNpub={sales.newRecipientNpub}
-					newRecipientShare={sales.newRecipientShare}
-					showAddForm={sales.showAddForm}
-					canReceiveZaps={sales.canReceiveZaps}
-					isCheckingZap={sales.isCheckingZap}
-					isChecking={sales.isChecking}
-					isSaving={sales.publishMutation.isPending}
-					sellerPercentage={sales.sellerPercentage}
-					formattedSellerPercentage={sales.formattedSellerPercentage}
-					formattedTotalV4V={sales.formattedTotalV4V}
-					recipientColors={sales.recipientColors}
-					emoji={sales.emoji}
-					emojiSize={sales.emojiSize}
-					emojiClass={sales.emojiClass}
-					onTotalV4VPercentageChange={sales.handleTotalV4VPercentageChange}
-					onProfileSelect={sales.handleProfileSelect}
-					onAddRecipient={sales.handleAddRecipient}
-					onRemoveRecipient={sales.handleRemoveRecipient}
-					onUpdatePercentage={sales.handleUpdatePercentage}
-					onEqualizeAll={sales.handleEqualizeAll}
-					onSetNewRecipientShare={sales.setNewRecipientShare}
-					onToggleAddForm={sales.setShowAddForm}
-					onSave={sales.saveShares}
-					labels={salesV4VLabels}
-					config={salesV4VConfig}
-				/>
+				<V4VManager {...salesV4VManagerProps(sales)} labels={salesV4VLabels} config={salesV4VConfig} />
 			</div>
 		</div>
 	)

--- a/src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx
+++ b/src/routes/_dashboard-layout/dashboard/sales/circular-economy.tsx
@@ -1,10 +1,18 @@
 import { V4VManager } from '@/components/v4v/V4VManager'
+import { salesV4VConfig, salesV4VLabels } from '@/lib/v4v/labels'
+import { deriveInitialSharesFromStored } from '@/lib/v4v/splits'
 import { authStore } from '@/lib/stores/auth'
+import { useV4VManager } from '@/hooks/useV4VManager'
 import { useV4VShares } from '@/queries/v4v'
 import { useDashboardTitle } from '@/routes/_dashboard-layout'
 import { createFileRoute } from '@tanstack/react-router'
 import { useStore } from '@tanstack/react-store'
 import { useMemo } from 'react'
+
+// Sales-only emoji animation styles. Imported here (at the call site) rather
+// than inside the agnostic V4VManager so the component stays free of
+// product-specific styling.
+import '@/routes/_dashboard-layout/dashboard/sales/emoji-animations.css'
 
 export const Route = createFileRoute('/_dashboard-layout/dashboard/sales/circular-economy')({
 	component: CircularEconomyComponent,
@@ -18,29 +26,13 @@ function CircularEconomyComponent() {
 	// Fetch existing V4V shares
 	const { data: v4vShares, isLoading } = useV4VShares(userPubkey)
 
-	// Calculate initial values from fetched shares
-	const { initialShares, initialTotalPercentage } = useMemo(() => {
-		if (!v4vShares || v4vShares.length === 0) {
-			// No shares configured - use defaults
-			return { initialShares: [], initialTotalPercentage: 10 }
-		}
+	// Derive editor boot values from stored shares (shared helper, no duplication).
+	const { initialShares, initialTotalPercentage } = useMemo(() => deriveInitialSharesFromStored(v4vShares), [v4vShares])
 
-		// Calculate total V4V percentage (sum of all share percentages)
-		// Shares are stored as decimals (0.1 = 10% of total sales)
-		const totalPercentage = v4vShares.reduce((sum, share) => sum + share.percentage, 0) * 100
-
-		// Normalize shares to sum to 1 (for the split between recipients in the UI)
-		const totalSharePercentage = v4vShares.reduce((sum, share) => sum + share.percentage, 0)
-		const normalizedShares = v4vShares.map((share) => ({
-			...share,
-			percentage: share.percentage / totalSharePercentage,
-		}))
-
-		return {
-			initialShares: normalizedShares,
-			initialTotalPercentage: totalPercentage,
-		}
-	}, [v4vShares])
+	// The sales / "all products" adapter — owns state, defaults, emoji, and
+	// persistence to kind 30078. The route injects its output into the agnostic
+	// V4VManager below, which is what declares this view is specifically for sales.
+	const sales = useV4VManager({ userPubkey, initialShares, initialTotalPercentage })
 
 	if (isLoading) {
 		return (
@@ -62,11 +54,33 @@ function CircularEconomyComponent() {
 			</div>
 			<div className="space-y-6 p-4 lg:p-6">
 				<V4VManager
-					userPubkey={userPubkey}
-					initialShares={initialShares}
-					initialTotalPercentage={initialTotalPercentage}
-					showChangesIndicator={false}
-					saveButtonText="Save Changes"
+					shares={sales.localShares}
+					totalV4VPercentage={sales.totalV4VPercentage}
+					newRecipientNpub={sales.newRecipientNpub}
+					newRecipientShare={sales.newRecipientShare}
+					showAddForm={sales.showAddForm}
+					canReceiveZaps={sales.canReceiveZaps}
+					isCheckingZap={sales.isCheckingZap}
+					isChecking={sales.isChecking}
+					isSaving={sales.publishMutation.isPending}
+					sellerPercentage={sales.sellerPercentage}
+					formattedSellerPercentage={sales.formattedSellerPercentage}
+					formattedTotalV4V={sales.formattedTotalV4V}
+					recipientColors={sales.recipientColors}
+					emoji={sales.emoji}
+					emojiSize={sales.emojiSize}
+					emojiClass={sales.emojiClass}
+					onTotalV4VPercentageChange={sales.handleTotalV4VPercentageChange}
+					onProfileSelect={sales.handleProfileSelect}
+					onAddRecipient={sales.handleAddRecipient}
+					onRemoveRecipient={sales.handleRemoveRecipient}
+					onUpdatePercentage={sales.handleUpdatePercentage}
+					onEqualizeAll={sales.handleEqualizeAll}
+					onSetNewRecipientShare={sales.setNewRecipientShare}
+					onToggleAddForm={sales.setShowAddForm}
+					onSave={sales.saveShares}
+					labels={salesV4VLabels}
+					config={salesV4VConfig}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
Strip the product-specific (sales) functionality out of the V4V UI and into helper/label/query files so the component can be reused for multiple purposes (auctions next), without introducing a new UI component.

V4VManager is now presentational and persistence-agnostic: it owns no state, fetches nothing, and publishes nothing. All data, handlers, copy (`labels`) and feature flags (`config`) are injected by the call site, which is what declares *how* the view is used. It gains forwardRef + cn() className merging and gates sales-only rendering (emoji, total slider, seller bar, zap-capable requirement) behind config flags.

Extracted into reusable, unit-tested files:
- src/lib/v4v/splits.ts: pure share math (normalize/add/remove/update/equalize, scale-by-total, deriveInitialSharesFromStored) — reusable by a future auction adapter.
- src/lib/v4v/labels.ts: V4VLabels/V4VConfig types + sales defaults (all copy
  + feature flags externalized from the component).

useV4VManager stays as the sales/"all products" adapter (same return surface) but now delegates all math to src/lib/v4v/splits.ts.

The dashboard parent route (circular-economy.tsx) and V4VSetupDialog declare "this is for all products" by composing the sales hook + sales labels/config and injecting them into V4VManager. The duplicated stored-shares normalization in both consumers is replaced by deriveInitialSharesFromStored. The sales-only emoji-animations.css import moves from the component to the route.

Behavior is preserved for sales: all e2e testids (save-v4v-button, confirm-v4v-setup-button, add-v4v-recipient-*, equal-all-v4v-button) and the save/changed-indicator button logic are unchanged. Color cleanup is conservative/reversible (bg-gray-200 -> bg-muted, text-gray-500 -> text-muted-foreground); custom viz/brand colors left as-is pending the foundation theme PR.

Follows the philosophy of ADR: Component UI Migration (no business logic in presentational components; callbacks for actions; forwardRef; cn()) without basing on the foundation PR or adopting its new directory structure.

Plan/audit doc: docs/adr/proposals/v4v-ui-agnostic-audit-and-plan.md
Tests: src/lib/__tests__/v4v-splits.test.ts (17 passing).