### PR TITLE
ci(relay): add bounded staging readiness gate

### DIFF
--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -51,6 +51,9 @@ jobs:
           cd deploy-simple/relay
           go test ./...
 
+      - name: Test staging relay readiness gate
+        run: bash deploy-simple/relay/tests/install-staging-relay-readiness.test.sh
+
       - name: Build relay binary
         env:
           RELAY_VERSION: ${{ steps.version.outputs.relay_version }}

--- a/deploy-simple/relay/install-staging-relay.sh
+++ b/deploy-simple/relay/install-staging-relay.sh
@@ -21,6 +21,10 @@ readonly LISTEN_ADDR="127.0.0.1:10549"
 
 # Emergency one-minute gates, not long-term storage limits.
 readonly MIN_FREE=$((2 * 1024 * 1024 * 1024))
+# The readiness deadline is configurable. Sixty seconds is the initial
+# candidate until measured staging startup behavior establishes a better value.
+readonly READINESS_SECONDS="${RELAY_READINESS_SECONDS:-60}"
+readonly READINESS_TIMEOUT_STATUS=75
 readonly OBSERVE_SECONDS=60
 readonly SAMPLE_SECONDS=5
 readonly MAX_RAW_GROWTH=$((16 * 1024 * 1024))
@@ -40,25 +44,47 @@ PRE_BINARY_SHA=""
 PRE_RUNNING_SHA=""
 PRE_UNIT_SHA=""
 
-for path in "$SOURCE_BIN" "$SOURCE_UNIT"; do
-	[[ -f "$path" && ! -L "$path" ]] || {
-		echo "Missing or unsafe deploy artifact: $path"
-		exit 1
-	}
-done
-
-grep -Fxq "User=${SERVICE_USER}" "$SOURCE_UNIT" &&
-	grep -Fxq "Group=${SERVICE_GROUP}" "$SOURCE_UNIT" &&
-	grep -Fxq "EnvironmentFile=${REMOTE_ENV}" "$SOURCE_UNIT" &&
-	grep -Fxq "ExecStart=${REMOTE_BIN}" "$SOURCE_UNIT" || {
-	echo "Staged systemd unit does not match the staging deployment contract"
-	exit 1
-}
-
 uint() {
 	case "$1" in
 		''|*[!0-9]*) return 1 ;;
 	esac
+}
+
+validate_config() {
+	uint "$READINESS_SECONDS" && ((10#$READINESS_SECONDS > 0)) || {
+		echo "Relay readiness deadline must be a positive integer"
+		return 1
+	}
+}
+
+validate_payload() {
+	local path
+	for path in "$SOURCE_BIN" "$SOURCE_UNIT"; do
+		[[ -f "$path" && ! -L "$path" ]] || {
+			echo "Missing or unsafe deploy artifact: $path"
+			return 1
+		}
+	done
+
+	grep -Fxq "User=${SERVICE_USER}" "$SOURCE_UNIT" &&
+		grep -Fxq "Group=${SERVICE_GROUP}" "$SOURCE_UNIT" &&
+		grep -Fxq "EnvironmentFile=${REMOTE_ENV}" "$SOURCE_UNIT" &&
+		grep -Fxq "ExecStart=${REMOTE_BIN}" "$SOURCE_UNIT" || {
+		echo "Staged systemd unit does not match the staging deployment contract"
+		return 1
+	}
+}
+
+boot_id() {
+	cat /proc/sys/kernel/random/boot_id
+}
+
+readiness_now() {
+	awk '{print int($1)}' /proc/uptime
+}
+
+readiness_sleep() {
+	sleep "$1"
 }
 
 property() {
@@ -118,7 +144,7 @@ preflight() {
 	PRE_PID="$(property MainPID)"
 	restarts="$(property NRestarts)"
 	PRE_INVOCATION="$(property InvocationID)"
-	PRE_BOOT_ID="$(cat /proc/sys/kernel/random/boot_id)"
+	PRE_BOOT_ID="$(boot_id)"
 
 	[[ "$active" == "active" && "$substate" == "running" ]] || {
 		echo "Staging relay must be active/running before activation"
@@ -266,7 +292,8 @@ make_backup() {
 }
 
 rollback() {
-	local pid invocation restarts active substate
+	local pid invocation restarts active substate readiness_status rollback_epoch
+	local raw_before search_before free_before
 
 	sudo systemctl stop "$SERVICE_NAME" || {
 		echo "Unable to stop failed staging relay"
@@ -302,8 +329,24 @@ rollback() {
 		echo "Rollback unit has unexpected systemd drop-ins"
 		return 1
 	}
+
+	raw_before="$(allocated "$RAW_DIR")"
+	search_before="$(allocated "$SEARCH_DIR")"
+	free_before="$(free_bytes)"
+	uint "$raw_before" && uint "$search_before" && uint "$free_before" || {
+		echo "Unable to read numeric rollback-readiness storage metrics"
+		return 1
+	}
+	((free_before >= MIN_FREE)) || {
+		echo "Staging relay data filesystem is below the rollback free-space gate"
+		return 1
+	}
+
+	rollback_epoch="$(date +%s)" || {
+		echo "Unable to capture rollback journal epoch"
+		return 1
+	}
 	sudo systemctl restart "$SERVICE_NAME" || return 1
-	sleep 5
 	active="$(property ActiveState)" || return 1
 	substate="$(property SubState)" || return 1
 	[[ "$active" == "active" && "$substate" == "running" ]] || {
@@ -329,20 +372,46 @@ rollback() {
 		echo "Rollback running process does not match the previous binary"
 		return 1
 	}
-	local_health || {
-		echo "Rollback relay local NIP-11 check failed"
-		return 1
-	}
 
-	printf 'rollback_main_pid=%s\n' "$pid"
-	printf 'rollback_invocation_id=%s\n' "$invocation"
-	printf 'rollback_nrestarts=%s\n' "$restarts"
-	echo "Previous staging relay binary and unit restored"
+	if wait_for_readiness "Rollback" "$pid" "$invocation" "$PRE_BINARY_SHA" \
+		"$raw_before" "$search_before" "$free_before"; then
+		readiness_status=0
+	else
+		readiness_status=$?
+	fi
+
+	case "$readiness_status" in
+		0|"$READINESS_TIMEOUT_STATUS")
+			check_journal_window "Rollback" "$rollback_epoch" || return 1
+			check_runtime_sample "Rollback post-journal check" "$pid" "$invocation" "$PRE_BINARY_SHA" \
+				"$raw_before" "$search_before" "$free_before" || return 1
+			;;
+	esac
+
+	case "$readiness_status" in
+		0)
+			printf 'rollback_main_pid=%s\n' "$pid"
+			printf 'rollback_invocation_id=%s\n' "$invocation"
+			printf 'rollback_nrestarts=%s\n' "$restarts"
+			echo "Rollback restoration and readiness succeeded"
+			return 0
+			;;
+		"$READINESS_TIMEOUT_STATUS")
+			echo "Rollback files and process were restored, but local NIP-11 readiness was not confirmed before the deadline"
+			echo "The restored process remains running with verified identity; operator review is required"
+			return "$READINESS_TIMEOUT_STATUS"
+			;;
+		*)
+			echo "Rollback readiness structural verification failed"
+			return 1
+			;;
+	esac
 }
 
 on_exit() {
 	local status=$?
-	local rollback_ok=1
+	local rollback_status=0
+	local retain_backup=0
 
 	trap - EXIT
 	set +e
@@ -350,14 +419,30 @@ on_exit() {
 		echo "Staging relay deployment failed; beginning guarded rollback"
 		sudo systemctl status "$SERVICE_NAME" --no-pager || true
 		sudo journalctl -u "$SERVICE_NAME" -n 100 --no-pager || true
-		if ! rollback; then
-			rollback_ok=0
-			status=70
-			echo "Guarded rollback failed; manual intervention is required"
+		if rollback; then
+			rollback_status=0
+		else
+			rollback_status=$?
 		fi
+
+		case "$rollback_status" in
+			0)
+				;;
+			"$READINESS_TIMEOUT_STATUS")
+				retain_backup=1
+				status="$READINESS_TIMEOUT_STATUS"
+				echo "Guarded rollback restored the files and process, but health was not confirmed"
+				echo "Workflow remains failed; operator review is required"
+				;;
+			*)
+				retain_backup=1
+				status=70
+				echo "Guarded rollback structurally failed; manual intervention is required"
+				;;
+		esac
 	fi
 	if [[ -n "$BACKUP_DIR" ]]; then
-		if ((rollback_ok == 1)); then
+		if ((retain_backup == 0)); then
 			rm -rf "$BACKUP_DIR"
 		else
 			echo "Rollback backup retained at $BACKUP_DIR"
@@ -374,7 +459,7 @@ check_growth() {
 	search_now="$(allocated "$SEARCH_DIR")"
 	free_now="$(free_bytes)"
 	uint "$raw_now" && uint "$search_now" && uint "$free_now" || {
-		echo "Unable to read numeric observation storage metrics"
+		echo "Unable to read numeric relay storage metrics"
 		return 1
 	}
 
@@ -383,15 +468,15 @@ check_growth() {
 	free_loss="$(positive_delta "$free_before" "$free_now")"
 
 	((raw_growth <= MAX_RAW_GROWTH)) || {
-		echo "Staging raw allocation exceeded the observation gate"
+		echo "Staging raw allocation exceeded the emergency growth gate"
 		return 1
 	}
 	((search_growth <= MAX_SEARCH_GROWTH)) || {
-		echo "Staging search allocation exceeded the observation gate"
+		echo "Staging search allocation exceeded the emergency growth gate"
 		return 1
 	}
 	((free_loss <= MAX_FREE_LOSS)) || {
-		echo "Staging filesystem free-space loss exceeded the observation gate"
+		echo "Staging filesystem free-space loss exceeded the emergency growth gate"
 		return 1
 	}
 	((free_now >= MIN_FREE)) || {
@@ -406,28 +491,145 @@ check_growth() {
 }
 
 check_runtime_sample() {
-	local pid="$1" invocation="$2" binary_sha="$3"
-	local raw_before="$4" search_before="$5" free_before="$6"
+	local context="$1" pid="$2" invocation="$3" binary_sha="$4"
+	local raw_before="$5" search_before="$6" free_before="$7"
 
-	[[ "$(cat /proc/sys/kernel/random/boot_id)" == "$PRE_BOOT_ID" ]] || { echo "Runtime sample failed: boot_id changed during observation"; return 1; }
-	[[ "$(property ActiveState)" == "active" && "$(property SubState)" == "running" ]] || { echo "Runtime sample failed: service is not active/running"; return 1; }
-	[[ "$(property MainPID)" == "$pid" ]] || { echo "Runtime sample failed: MainPID changed during observation"; return 1; }
-	[[ "$(property InvocationID)" == "$invocation" ]] || { echo "Runtime sample failed: InvocationID changed during observation"; return 1; }
-	[[ "$(property NRestarts)" == "0" ]] || { echo "Runtime sample failed: NRestarts is nonzero during observation"; return 1; }
-	[[ "$(hash_file "/proc/${pid}/exe")" == "$binary_sha" ]] || { echo "Runtime sample failed: running binary hash does not match expected"; return 1; }
+	[[ "$(boot_id)" == "$PRE_BOOT_ID" ]] || { echo "${context}: boot ID changed"; return 1; }
+	[[ "$(property ActiveState)" == "active" && "$(property SubState)" == "running" ]] || { echo "${context}: service is not active/running"; return 1; }
+	[[ "$(property MainPID)" == "$pid" ]] || { echo "${context}: MainPID changed"; return 1; }
+	[[ "$(property InvocationID)" == "$invocation" ]] || { echo "${context}: InvocationID changed"; return 1; }
+	[[ "$(property NRestarts)" == "0" ]] || { echo "${context}: NRestarts is nonzero"; return 1; }
+	[[ "$(hash_file "/proc/${pid}/exe")" == "$binary_sha" ]] || { echo "${context}: running binary hash does not match expected"; return 1; }
 	check_growth "$raw_before" "$search_before" "$free_before"
+}
+
+wait_for_readiness() {
+	local context="$1" pid="$2" invocation="$3" binary_sha="$4"
+	local raw_before="$5" search_before="$6" free_before="$7"
+	local start deadline now elapsed remaining sleep_for attempts=0
+
+	start="$(readiness_now)"
+	uint "$start" || {
+		echo "${context} readiness could not read a monotonic start time"
+		return 1
+	}
+	deadline=$((start + 10#$READINESS_SECONDS))
+
+	while :; do
+		now="$(readiness_now)"
+		uint "$now" || {
+			echo "${context} readiness could not read a monotonic sample time"
+			return 1
+		}
+		((attempts == 0 || now < deadline)) || break
+
+		attempts=$((attempts + 1))
+		check_runtime_sample "${context} readiness check" "$pid" "$invocation" "$binary_sha" \
+			"$raw_before" "$search_before" "$free_before" || return 1
+
+		if local_health; then
+			# The request can race with a process restart or storage spike. Recheck
+			# all structural and emergency gates after the successful response.
+			check_runtime_sample "${context} post-health readiness check" "$pid" "$invocation" "$binary_sha" \
+				"$raw_before" "$search_before" "$free_before" || return 1
+			now="$(readiness_now)"
+			uint "$now" || {
+				echo "${context} readiness could not read a monotonic completion time"
+				return 1
+			}
+			if ((now <= deadline)); then
+				elapsed=$((now - start))
+				printf 'readiness_context=%s\n' "$context"
+				printf 'readiness_attempts=%s\n' "$attempts"
+				printf 'readiness_elapsed_seconds=%s\n' "$elapsed"
+				echo "${context} local NIP-11 readiness confirmed"
+				return 0
+			fi
+			break
+		fi
+
+		now="$(readiness_now)"
+		uint "$now" || {
+			echo "${context} readiness could not read a monotonic sample time"
+			return 1
+		}
+		((now < deadline)) || break
+
+		printf '%s local NIP-11 is not ready yet (attempt %s); retrying\n' "$context" "$attempts"
+		remaining=$((deadline - now))
+		sleep_for="$SAMPLE_SECONDS"
+		((sleep_for <= remaining)) || sleep_for="$remaining"
+		readiness_sleep "$sleep_for" || {
+			echo "${context} readiness retry sleep failed"
+			return 1
+		}
+	done
+
+	# Timeout is a distinct state only while process identity and storage remain
+	# valid. Any drift at the deadline is a structural failure instead.
+	check_runtime_sample "${context} readiness deadline check" "$pid" "$invocation" "$binary_sha" \
+		"$raw_before" "$search_before" "$free_before" || return 1
+	elapsed=$((now - start))
+	printf 'readiness_context=%s\n' "$context"
+	printf 'readiness_elapsed_seconds=%s\n' "$elapsed"
+	echo "${context} local NIP-11 readiness was not confirmed within ${READINESS_SECONDS} seconds"
+	return "$READINESS_TIMEOUT_STATUS"
+}
+
+check_journal_window() {
+	local context="$1" epoch="$2"
+	local service_journal kernel_journal grep_status
+
+	if service_journal="$(sudo journalctl -u "$SERVICE_NAME" -n 1000 --since "@${epoch}" --no-pager 2>&1)"; then
+		:
+	else
+		echo "${context}: unable to read relay service journal"
+		return 1
+	fi
+	if kernel_journal="$(sudo journalctl -k -n 1000 --since "@${epoch}" --no-pager 2>&1)"; then
+		:
+	else
+		echo "${context}: unable to read kernel journal"
+		return 1
+	fi
+
+	if grep -Eiq \
+		'scheduled restart job|automatic restarting|restart counter is at' \
+		<<<"$service_journal"; then
+		echo "${context}: automatic relay restart evidence found"
+		return 1
+	else
+		grep_status=$?
+		if ((grep_status != 1)); then
+			echo "${context}: unable to inspect relay restart evidence"
+			return 1
+		fi
+	fi
+
+	if grep -Eiq \
+		'out of memory|oom-kill|killed process' \
+		<<<"$kernel_journal"; then
+		echo "${context}: kernel OOM evidence found"
+		return 1
+	else
+		grep_status=$?
+		if ((grep_status != 1)); then
+			echo "${context}: unable to inspect kernel OOM evidence"
+			return 1
+		fi
+	fi
 }
 
 observe() {
 	local epoch="$1" pid="$2" invocation="$3" binary_sha="$4"
 	local raw_before="$5" search_before="$6" free_before="$7"
-	local deadline service_journal kernel_journal grep_status
+	local deadline
 	local health_failures=0
 
 	deadline=$((SECONDS + OBSERVE_SECONDS))
 	while ((SECONDS < deadline)); do
 		sleep "$SAMPLE_SECONDS"
-		check_runtime_sample "$pid" "$invocation" "$binary_sha" \
+		check_runtime_sample "Steady-state observation sample" "$pid" "$invocation" "$binary_sha" \
 			"$raw_before" "$search_before" "$free_before"
 
 		if local_health; then
@@ -447,7 +649,7 @@ observe() {
 	# cannot pass if runtime identity or growth drifts during the health retry.
 	if ((health_failures == 1)); then
 		sleep "$SAMPLE_SECONDS"
-		check_runtime_sample "$pid" "$invocation" "$binary_sha" \
+		check_runtime_sample "Steady-state observation sample" "$pid" "$invocation" "$binary_sha" \
 			"$raw_before" "$search_before" "$free_before"
 		if local_health; then
 			health_failures=0
@@ -459,36 +661,10 @@ observe() {
 		fi
 	fi
 
-	service_journal="$(sudo journalctl -u "$SERVICE_NAME" -n 1000 --since "@${epoch}" --no-pager 2>&1)"
-	kernel_journal="$(sudo journalctl -k -n 1000 --since "@${epoch}" --no-pager 2>&1)"
-	if grep -Eiq \
-		'scheduled restart job|automatic restarting|restart counter is at' \
-		<<<"$service_journal"; then
-		echo "Automatic relay restart evidence found during observation"
-		return 1
-	else
-		grep_status=$?
-		if ((grep_status != 1)); then
-			echo "Unable to inspect relay restart evidence"
-			return 1
-		fi
-	fi
-
-	if grep -Eiq \
-		'out of memory|oom-kill|killed process' \
-		<<<"$kernel_journal"; then
-		echo "Kernel OOM evidence found during observation"
-		return 1
-	else
-		grep_status=$?
-		if ((grep_status != 1)); then
-			echo "Unable to inspect kernel OOM evidence"
-			return 1
-		fi
-	fi
+	check_journal_window "Activation observation" "$epoch"
 
 	# Reconfirm the terminal runtime/storage state after journal collection.
-	check_runtime_sample "$pid" "$invocation" "$binary_sha" \
+	check_runtime_sample "Steady-state terminal sample" "$pid" "$invocation" "$binary_sha" \
 		"$raw_before" "$search_before" "$free_before"
 
 	printf 'post_main_pid=%s\n' "$pid"
@@ -500,8 +676,11 @@ observe() {
 
 main() {
 	local expected_bin expected_unit installed_bin installed_unit running_bin
-	local raw_before search_before free_before epoch pid invocation restarts
+	local raw_before search_before free_before activation_epoch pid invocation restarts
+	local observe_raw_before observe_search_before observe_free_before
 
+	validate_config
+	validate_payload
 	preflight
 	trap on_exit EXIT
 	make_backup
@@ -535,13 +714,15 @@ main() {
 		return 1
 	}
 
-	epoch="$(date +%s)"
 	sudo systemctl daemon-reload
 	[[ "$(property FragmentPath)" == "$REMOTE_SERVICE" ]] || { echo "Post-install unit fragment path is not from expected location"; return 1; }
 	[[ "$(property NeedDaemonReload)" == "no" ]] || { echo "Post-install unit still requires daemon-reload"; return 1; }
 	[[ -z "$(property DropInPaths)" ]] || { echo "Post-install unit has unexpected systemd drop-ins"; return 1; }
+	activation_epoch="$(date +%s)" || {
+		echo "Unable to capture activation journal epoch"
+		return 1
+	}
 	sudo systemctl restart "$SERVICE_NAME"
-	sleep 5
 
 	[[ "$(property ActiveState)" == "active" && "$(property SubState)" == "running" ]] || { echo "Staging relay is not active/running after activation"; return 1; }
 	pid="$(property MainPID)"
@@ -562,13 +743,30 @@ main() {
 	running_bin="$(hash_file "/proc/${pid}/exe")"
 	printf 'running_binary_sha256=%s\n' "$running_bin"
 	[[ "$running_bin" == "$expected_bin" ]] || { echo "Running binary hash does not match expected artifact hash"; return 1; }
-	local_health
-	check_growth "$raw_before" "$search_before" "$free_before"
-	observe "$epoch" "$pid" "$invocation" "$expected_bin" \
+
+	wait_for_readiness "Activation" "$pid" "$invocation" "$expected_bin" \
 		"$raw_before" "$search_before" "$free_before"
+
+	# The steady-state emergency window starts only after readiness and uses a
+	# fresh baseline so one-minute gates are not stretched across both phases.
+	observe_raw_before="$(allocated "$RAW_DIR")"
+	observe_search_before="$(allocated "$SEARCH_DIR")"
+	observe_free_before="$(free_bytes)"
+	uint "$observe_raw_before" && uint "$observe_search_before" && uint "$observe_free_before" || {
+		echo "Unable to read numeric post-readiness storage metrics"
+		return 1
+	}
+	((observe_free_before >= MIN_FREE)) || {
+		echo "Staging relay data filesystem is below the post-readiness free-space gate"
+		return 1
+	}
+	observe "$activation_epoch" "$pid" "$invocation" "$expected_bin" \
+		"$observe_raw_before" "$observe_search_before" "$observe_free_before"
 
 	DEPLOY_COMPLETE=1
 	echo "Staging relay deployed successfully"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/deploy-simple/relay/tests/install-staging-relay-readiness.test.sh
+++ b/deploy-simple/relay/tests/install-staging-relay-readiness.test.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly TEST_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly INSTALLER="${TEST_DIR}/../install-staging-relay.sh"
+
+export RELAY_READINESS_SECONDS=10
+# shellcheck source=../install-staging-relay.sh
+source "$INSTALLER"
+
+TESTS_RUN=0
+OUTPUT=""
+STATUS=0
+
+reset_state() {
+	FAKE_NOW=0
+	HEALTH_CALLS=0
+	HEALTH_SUCCEEDS_AT=2
+	HEALTH_ADVANCE_SECONDS=0
+	PID_VALUE=200
+	INVOCATION_VALUE="invocation-a"
+	EXPECTED_SHA="expected-sha"
+	BOOT_VALUE="boot-a"
+	PRE_BOOT_ID="$BOOT_VALUE"
+	PRE_BINARY_SHA="$EXPECTED_SHA"
+	PRE_UNIT_SHA="unit-sha"
+	PID_DRIFT_AT=999999
+	INVOCATION_DRIFT_AT=999999
+	HASH_MISMATCH_AT=999999
+	RESTARTS_NONZERO_AT=999999
+	BOOT_DRIFT_AT=999999
+	RAW_BASE=1000
+	SEARCH_BASE=2000
+	FREE_BASE=$((MIN_FREE + MAX_FREE_LOSS + 1024))
+	RAW_GROWTH_AT=999999
+	RAW_GROWTH=0
+	SEARCH_GROWTH_AT=999999
+	SEARCH_GROWTH=0
+	FREE_DROP_AT=999999
+	FREE_DROP=0
+	SERVICE_STOPPED=0
+	STOP_FAIL=0
+	INSTALL_FAIL=0
+	RESTART_FAIL=0
+	SERVICE_JOURNAL=""
+	KERNEL_JOURNAL=""
+	SERVICE_JOURNAL_FAIL=0
+	KERNEL_JOURNAL_FAIL=0
+}
+
+boot_id() {
+	((FAKE_NOW >= BOOT_DRIFT_AT)) && printf '%s\n' "boot-b" || printf '%s\n' "$BOOT_VALUE"
+}
+
+readiness_now() {
+	printf '%s\n' "$FAKE_NOW"
+}
+
+readiness_sleep() {
+	FAKE_NOW=$((FAKE_NOW + $1))
+}
+
+property() {
+	case "$1" in
+		ActiveState) ((SERVICE_STOPPED == 1)) && printf '%s\n' "inactive" || printf '%s\n' "active" ;;
+		SubState) ((SERVICE_STOPPED == 1)) && printf '%s\n' "dead" || printf '%s\n' "running" ;;
+		MainPID) ((FAKE_NOW >= PID_DRIFT_AT)) && printf '%s\n' "$((PID_VALUE + 1))" || printf '%s\n' "$PID_VALUE" ;;
+		InvocationID) ((FAKE_NOW >= INVOCATION_DRIFT_AT)) && printf '%s\n' "invocation-b" || printf '%s\n' "$INVOCATION_VALUE" ;;
+		NRestarts) ((FAKE_NOW >= RESTARTS_NONZERO_AT)) && printf '%s\n' "1" || printf '%s\n' "0" ;;
+		FragmentPath) printf '%s\n' "$REMOTE_SERVICE" ;;
+		NeedDaemonReload) printf '%s\n' "no" ;;
+		DropInPaths) printf '%s' "" ;;
+		*) echo "Unexpected property in test: $1" >&2; return 1 ;;
+	esac
+}
+
+hash_file() {
+	if [[ "$1" == "$REMOTE_SERVICE" ]]; then
+		printf '%s\n' "$PRE_UNIT_SHA"
+	elif ((FAKE_NOW >= HASH_MISMATCH_AT)); then
+		printf '%s\n' "wrong-sha"
+	else
+		printf '%s\n' "$EXPECTED_SHA"
+	fi
+}
+
+allocated() {
+	case "$1" in
+		"$RAW_DIR")
+			((FAKE_NOW >= RAW_GROWTH_AT)) && printf '%s\n' "$((RAW_BASE + RAW_GROWTH))" || printf '%s\n' "$RAW_BASE"
+			;;
+		"$SEARCH_DIR")
+			((FAKE_NOW >= SEARCH_GROWTH_AT)) && printf '%s\n' "$((SEARCH_BASE + SEARCH_GROWTH))" || printf '%s\n' "$SEARCH_BASE"
+			;;
+		*) echo "Unexpected allocation path in test: $1" >&2; return 1 ;;
+	esac
+}
+
+free_bytes() {
+	((FAKE_NOW >= FREE_DROP_AT)) && printf '%s\n' "$((FREE_BASE - FREE_DROP))" || printf '%s\n' "$FREE_BASE"
+}
+
+local_health() {
+	HEALTH_CALLS=$((HEALTH_CALLS + 1))
+	FAKE_NOW=$((FAKE_NOW + HEALTH_ADVANCE_SECONDS))
+	((HEALTH_CALLS >= HEALTH_SUCCEEDS_AT))
+}
+
+sudo() {
+	case "$1:$2" in
+		systemctl:stop) ((STOP_FAIL == 0)) || return 1; SERVICE_STOPPED=1 ;;
+		systemctl:restart) ((RESTART_FAIL == 0)) || return 1; SERVICE_STOPPED=0 ;;
+		systemctl:daemon-reload|systemctl:status) ;;
+		journalctl:-u)
+			((SERVICE_JOURNAL_FAIL == 0)) || return 1
+			printf '%s' "$SERVICE_JOURNAL"
+			;;
+		journalctl:-k)
+			((KERNEL_JOURNAL_FAIL == 0)) || return 1
+			printf '%s' "$KERNEL_JOURNAL"
+			;;
+		install:*) ((INSTALL_FAIL == 0)) || return 1 ;;
+		*) echo "Unexpected sudo command in test: $*" >&2; return 1 ;;
+	esac
+}
+
+capture() {
+	set +e
+	OUTPUT="$("$@" 2>&1)"
+	STATUS=$?
+	set -e
+}
+
+assert_result() {
+	local expected_status="$1" expected_output="$2"
+	[[ "$STATUS" == "$expected_status" ]] || {
+		printf 'Expected status %s, got %s\nOutput:\n%s\n' "$expected_status" "$STATUS" "$OUTPUT" >&2
+		return 1
+	}
+	[[ -z "$expected_output" || "$OUTPUT" == *"$expected_output"* ]] || {
+		printf 'Expected output containing: %s\nActual output:\n%s\n' "$expected_output" "$OUTPUT" >&2
+		return 1
+	}
+}
+
+run_test() {
+	local name="$1"
+	shift
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if "$@"; then
+		printf 'ok %s - %s\n' "$TESTS_RUN" "$name"
+	else
+		printf 'not ok %s - %s\n' "$TESTS_RUN" "$name" >&2
+		return 1
+	fi
+}
+
+run_wait() {
+	wait_for_readiness "Test" "$PID_VALUE" "$INVOCATION_VALUE" "$EXPECTED_SHA" \
+		"$RAW_BASE" "$SEARCH_BASE" "$FREE_BASE"
+}
+
+readiness_case() {
+	local setup="$1" expected_status="$2" expected_output="$3"
+	reset_state
+	"$setup"
+	capture run_wait
+	assert_result "$expected_status" "$expected_output"
+}
+
+setup_delayed_success() { HEALTH_SUCCEEDS_AT=2; }
+setup_timeout() { HEALTH_SUCCEEDS_AT=999999; }
+setup_pid_drift() { setup_timeout; PID_DRIFT_AT=5; }
+setup_invocation_drift() { setup_timeout; INVOCATION_DRIFT_AT=5; }
+setup_hash_mismatch() { setup_timeout; HASH_MISMATCH_AT=5; }
+setup_restart_drift() { setup_timeout; RESTARTS_NONZERO_AT=5; }
+setup_boot_drift() { setup_timeout; BOOT_DRIFT_AT=5; }
+setup_growth_failure() { setup_timeout; RAW_GROWTH_AT=5; RAW_GROWTH=$((MAX_RAW_GROWTH + 1)); }
+setup_search_growth_failure() { setup_timeout; SEARCH_GROWTH_AT=5; SEARCH_GROWTH=$((MAX_SEARCH_GROWTH + 1)); }
+setup_free_loss_failure() { setup_timeout; FREE_DROP_AT=5; FREE_DROP=$((MAX_FREE_LOSS + 1)); }
+setup_free_failure() { setup_timeout; FREE_BASE=$((MIN_FREE + 1)); FREE_DROP_AT=5; FREE_DROP=2; }
+setup_late_health_success() { HEALTH_SUCCEEDS_AT=1; HEALTH_ADVANCE_SECONDS=11; }
+setup_post_health_pid_drift() { HEALTH_SUCCEEDS_AT=1; HEALTH_ADVANCE_SECONDS=5; PID_DRIFT_AT=5; }
+setup_post_health_growth() { HEALTH_SUCCEEDS_AT=1; HEALTH_ADVANCE_SECONDS=5; RAW_GROWTH_AT=5; RAW_GROWTH=$((MAX_RAW_GROWTH + 1)); }
+
+rollback_case() {
+	local setup="$1" expected_status="$2" expected_output="$3"
+	reset_state
+	"$setup"
+	capture rollback
+	assert_result "$expected_status" "$expected_output"
+}
+
+setup_rollback_success() { HEALTH_SUCCEEDS_AT=2; }
+setup_rollback_timeout() { HEALTH_SUCCEEDS_AT=999999; }
+setup_rollback_structural_failure() { STOP_FAIL=1; }
+setup_rollback_restart_evidence() { setup_rollback_success; SERVICE_JOURNAL="automatic restarting"; }
+setup_rollback_oom_evidence() { setup_rollback_success; KERNEL_JOURNAL="oom-kill"; }
+setup_rollback_journal_failure() { setup_rollback_success; SERVICE_JOURNAL_FAIL=1; }
+setup_rollback_timeout_with_restart_evidence() { setup_rollback_timeout; SERVICE_JOURNAL="restart counter is at 1"; }
+
+journal_case() {
+	local setup="$1" expected_status="$2" expected_output="$3"
+	reset_state
+	"$setup"
+	capture check_journal_window "Test journal" 123
+	assert_result "$expected_status" "$expected_output"
+}
+
+setup_clean_journal() { :; }
+setup_restart_journal() { SERVICE_JOURNAL="Scheduled restart job, restart counter is at 1"; }
+setup_oom_journal() { KERNEL_JOURNAL="Out of memory: Killed process 123"; }
+setup_service_journal_failure() { SERVICE_JOURNAL_FAIL=1; }
+setup_kernel_journal_failure() { KERNEL_JOURNAL_FAIL=1; }
+
+test_readiness_configuration_validation() {
+	capture env RELAY_READINESS_SECONDS=invalid bash "$INSTALLER" /nonexistent
+	assert_result 1 "readiness deadline must be a positive integer"
+}
+
+test_readiness_wiring() {
+	local activation_epoch_line activation_restart_line activation_readiness_line
+	local observe_baseline_line observe_line rollback_epoch_line rollback_restart_line
+	local rollback_readiness_line rollback_journal_line
+
+	! grep -Eq '^[[:space:]]*sleep[[:space:]]+5([[:space:]]|$)' "$INSTALLER" || {
+		echo "installer still contains a fixed five-second readiness sleep" >&2
+		return 1
+	}
+	grep -Fq 'if wait_for_readiness "Rollback"' "$INSTALLER" || {
+		echo "rollback does not use the shared readiness gate" >&2
+		return 1
+	}
+
+	activation_epoch_line="$(grep -nF 'activation_epoch="$(date +%s)"' "$INSTALLER" | cut -d: -f1)"
+	activation_restart_line="$(grep -nF 'sudo systemctl restart "$SERVICE_NAME"' "$INSTALLER" | tail -n 1 | cut -d: -f1)"
+	activation_readiness_line="$(grep -nF 'wait_for_readiness "Activation"' "$INSTALLER" | cut -d: -f1)"
+	observe_baseline_line="$(grep -nF 'observe_raw_before="$(allocated "$RAW_DIR")"' "$INSTALLER" | cut -d: -f1)"
+	observe_line="$(grep -nF 'observe "$activation_epoch"' "$INSTALLER" | cut -d: -f1)"
+	uint "$activation_epoch_line" && uint "$activation_restart_line" && uint "$activation_readiness_line" && \
+		uint "$observe_baseline_line" && uint "$observe_line" && \
+		((activation_epoch_line < activation_restart_line && \
+			activation_restart_line < activation_readiness_line && \
+			activation_readiness_line < observe_baseline_line && \
+			observe_baseline_line < observe_line)) || {
+		echo "activation journal epoch, readiness, storage reset, and observation ordering is invalid" >&2
+		return 1
+	}
+
+	rollback_epoch_line="$(grep -nF 'rollback_epoch="$(date +%s)"' "$INSTALLER" | cut -d: -f1)"
+	rollback_restart_line="$(grep -nF 'sudo systemctl restart "$SERVICE_NAME"' "$INSTALLER" | head -n 1 | cut -d: -f1)"
+	rollback_readiness_line="$(grep -nF 'if wait_for_readiness "Rollback"' "$INSTALLER" | cut -d: -f1)"
+	rollback_journal_line="$(grep -nF 'check_journal_window "Rollback" "$rollback_epoch"' "$INSTALLER" | cut -d: -f1)"
+	uint "$rollback_epoch_line" && uint "$rollback_restart_line" && uint "$rollback_readiness_line" && \
+		uint "$rollback_journal_line" && \
+		((rollback_epoch_line < rollback_restart_line && \
+			rollback_restart_line < rollback_readiness_line && \
+			rollback_readiness_line < rollback_journal_line)) || {
+		echo "rollback journal epoch, restart, readiness, and journal ordering is invalid" >&2
+		return 1
+	}
+}
+
+test_rollback_status_not_negated() {
+	! grep -Fq 'if ! rollback' "$INSTALLER" || {
+		echo "rollback status is destroyed by logical negation" >&2
+		return 1
+	}
+}
+
+invoke_failed_exit() {
+	return "$ORIGINAL_STATUS"
+}
+
+invoke_failed_exit_and_handle() {
+	invoke_failed_exit
+	on_exit
+}
+
+install_rollback_stub() {
+	rollback() { return "$ROLLBACK_STUB_STATUS"; }
+}
+
+on_exit_case() {
+	local original_status="$1" rollback_status="$2" expected_status="$3" retain="$4" expected_output="$5"
+	reset_state
+	install_rollback_stub
+	ORIGINAL_STATUS="$original_status"
+	ROLLBACK_STUB_STATUS="$rollback_status"
+	BACKUP_DIR="$(mktemp -d)"
+	FILES_CHANGED=1
+	DEPLOY_COMPLETE=0
+	capture invoke_failed_exit_and_handle
+	assert_result "$expected_status" "$expected_output" || return 1
+	if ((retain == 1)); then
+		[[ -d "$BACKUP_DIR" ]] || { echo "expected rollback backup retention" >&2; return 1; }
+		rm -rf "$BACKUP_DIR"
+	else
+		[[ ! -e "$BACKUP_DIR" ]] || { echo "expected rollback backup cleanup" >&2; return 1; }
+	fi
+}
+
+run_test "delayed readiness then success" readiness_case setup_delayed_success 0 "readiness confirmed"
+run_test "permanent readiness timeout" readiness_case setup_timeout "$READINESS_TIMEOUT_STATUS" "not confirmed within 10 seconds"
+run_test "PID drift" readiness_case setup_pid_drift 1 "MainPID changed"
+run_test "InvocationID drift" readiness_case setup_invocation_drift 1 "InvocationID changed"
+run_test "executable hash mismatch" readiness_case setup_hash_mismatch 1 "running binary hash does not match expected"
+run_test "NRestarts becoming nonzero" readiness_case setup_restart_drift 1 "NRestarts is nonzero"
+run_test "boot ID drift" readiness_case setup_boot_drift 1 "boot ID changed"
+run_test "raw storage-growth failure" readiness_case setup_growth_failure 1 "raw allocation exceeded the emergency growth gate"
+run_test "search storage-growth failure" readiness_case setup_search_growth_failure 1 "search allocation exceeded the emergency growth gate"
+run_test "free-space-loss failure above minimum" readiness_case setup_free_loss_failure 1 "free-space loss exceeded the emergency growth gate"
+run_test "minimum free-space failure" readiness_case setup_free_failure 1 "fell below the minimum free-space gate"
+run_test "health success after deadline" readiness_case setup_late_health_success "$READINESS_TIMEOUT_STATUS" "not confirmed within 10 seconds"
+run_test "post-health identity recheck" readiness_case setup_post_health_pid_drift 1 "MainPID changed"
+run_test "post-health storage recheck" readiness_case setup_post_health_growth 1 "raw allocation exceeded the emergency growth gate"
+run_test "clean journal window" journal_case setup_clean_journal 0 ""
+run_test "startup restart evidence" journal_case setup_restart_journal 1 "automatic relay restart evidence found"
+run_test "startup kernel OOM evidence" journal_case setup_oom_journal 1 "kernel OOM evidence found"
+run_test "service journal failure is closed" journal_case setup_service_journal_failure 1 "unable to read relay service journal"
+run_test "kernel journal failure is closed" journal_case setup_kernel_journal_failure 1 "unable to read kernel journal"
+run_test "successful rollback readiness" rollback_case setup_rollback_success 0 "restoration and readiness succeeded"
+run_test "restored process with rollback-readiness timeout" rollback_case setup_rollback_timeout "$READINESS_TIMEOUT_STATUS" "files and process were restored"
+run_test "structural rollback failure" rollback_case setup_rollback_structural_failure 1 "Unable to stop failed staging relay"
+run_test "rollback restart evidence is structural" rollback_case setup_rollback_restart_evidence 1 "automatic relay restart evidence found"
+run_test "rollback OOM evidence is structural" rollback_case setup_rollback_oom_evidence 1 "kernel OOM evidence found"
+run_test "rollback journal failure is structural" rollback_case setup_rollback_journal_failure 1 "unable to read relay service journal"
+run_test "rollback timeout with restart evidence is structural" rollback_case setup_rollback_timeout_with_restart_evidence 1 "automatic relay restart evidence found"
+run_test "readiness configuration validation" test_readiness_configuration_validation
+run_test "readiness and journal wiring" test_readiness_wiring
+run_test "rollback status is preserved" test_rollback_status_not_negated
+run_test "successful rollback cleanup classification" on_exit_case 1 0 1 0 ""
+run_test "successful rollback preserves arbitrary original status" on_exit_case 42 0 42 0 ""
+run_test "rollback timeout retention classification" on_exit_case 1 "$READINESS_TIMEOUT_STATUS" "$READINESS_TIMEOUT_STATUS" 1 "health was not confirmed"
+run_test "structural rollback retention classification" on_exit_case 1 1 70 1 "structurally failed"
+
+printf '1..%s\n' "$TESTS_RUN"


### PR DESCRIPTION
## Summary

- replace the fixed five-second staging relay readiness assumption with a bounded, configurable readiness gate
- preserve runtime identity and emergency storage checks throughout readiness and steady-state observation
- inspect service and kernel journals for restart and OOM evidence during activation and rollback
- distinguish successful rollback, restored-but-not-ready timeout, and structural rollback failure
- add a focused Bash harness and run it in the relay deployment workflow

## Why

The staging activation path previously waited a fixed five seconds before a single local NIP-11 health check. That could reject a healthy relay that starts more slowly, while also leaving startup and rollback journal evidence outside equivalent validation paths.

This change makes readiness explicit and bounded while preserving the existing deployment, rollback, service identity, storage, and backup-retention boundaries.

The default readiness deadline is 60 seconds and remains configurable through `RELAY_READINESS_SECONDS`. Sixty seconds is an initial candidate pending measured staging startup data, not a proven operational requirement.

## Validation

- `bash -n deploy-simple/relay/install-staging-relay.sh`
- `bash -n deploy-simple/relay/tests/install-staging-relay-readiness.test.sh`
- `bash deploy-simple/relay/tests/install-staging-relay-readiness.test.sh`
  - 33 passed
  - 0 failed
  - TAP plan `1..33`
- `git diff --check`

The harness covers delayed readiness, timeout classification, PID/InvocationID/hash/restart/boot drift, raw/search/free-space gates, post-health rechecks, journal read failures, restart/OOM evidence, rollback readiness outcomes, backup retention, arbitrary original status preservation, and activation/rollback ordering.

## Scope and operational safety

This PR changes only:

- `.github/workflows/deploy-relay.yml`
- `deploy-simple/relay/install-staging-relay.sh`
- `deploy-simple/relay/tests/install-staging-relay-readiness.test.sh`

It does not deploy or restart the staging relay, inspect environment-file contents, delete the retained rollback backup, or change production deployment behavior.