### PR TITLE
FIX: Digital product detection inconsistency

### DIFF
--- a/src/components/orders/OrderDetailComponent.tsx
+++ b/src/components/orders/OrderDetailComponent.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils'
 import { getCoordsFromATag } from '@/lib/utils/coords'
 import { getStatusMessaging, getStatusStyles } from '@/lib/utils/orderUtils'
 import { type OrderWithRelatedEvents } from '@/queries/orders'
-import { getProductId, productSmartQueryOptions } from '@/queries/products'
+import { getProductId, productSmartQueryOptions, getProductType } from '@/queries/products'
 import {
 	getShippingInfo,
 	getShippingPickupAddressString,
@@ -235,11 +235,14 @@ export function OrderDetailComponent({ order }: OrderDetailComponentProps) {
 	// Extract shipping information
 	const shippingInfo = shippingOption ? getShippingInfo(shippingOption) : null
 	const isPickupService = shippingOption ? getShippingService(shippingOption)?.[1] === 'pickup' : false
-	const isDigitalService = shippingOption ? getShippingService(shippingOption)?.[1] === 'digital' : false
 	const pickupAddress = shippingOption && isPickupService ? getShippingPickupAddressString(shippingOption) : null
 	const shouldShowPrivateDetailsUnavailable = isOrderSeller && Boolean(shippingOption) && !isPickupService && !order.privateOrderDetails
 
 	const products = productQueries.map((query) => query.data).filter(Boolean) as NDKEvent[]
+
+	// Determine if any order item is a digital product according to product metadata
+	const hasDigitalProduct = products.some((p) => getProductType(p)?.[2] === 'digital')
+	const isDigitalService = hasDigitalProduct
 
 	const openPaymentDialog = (invoiceList: PaymentInvoiceData[]) => {
 		if (!invoiceList.length) return

--- a/src/components/orders/StockUpdateDialog.tsx
+++ b/src/components/orders/StockUpdateDialog.tsx
@@ -24,6 +24,7 @@ import {
 	getProductCollection,
 	getProductShippingOptions,
 } from '@/queries/products'
+import { fetchOrderStockItems } from './orderStockHelpers'
 
 interface ProductStockUpdate {
 	productRef: string // Format: 30402:pubkey:dtag
@@ -54,62 +55,24 @@ export function StockUpdateDialog({ open, onOpenChange, order, onComplete }: Sto
 		const fetchProductsData = async () => {
 			setLoading(true)
 			try {
-				// Get all item tags from the order
-				const itemTags = order.order.tags.filter((tag) => tag[0] === 'item')
-
+				const stockItems = await fetchOrderStockItems(order.order)
 				const productUpdates: ProductStockUpdate[] = []
 
-				for (const itemTag of itemTags) {
-					const productRef = itemTag[1] // Format: 30402:pubkey:dtag (or 30402:pubkey:eventId for legacy)
-					const quantity = parseInt(itemTag[2] || '1')
+				for (const item of stockItems) {
+					if (item.isDigital || !item.productEvent) continue
 
-					// Parse the product reference
-					const [kind, pubkey, identifier] = productRef.split(':')
-
-					if (kind !== '30402' || !pubkey || !identifier) {
-						console.warn('Invalid product reference:', productRef)
-						continue
-					}
-
-					let productEvent: NDKEvent | null = null
-
-					// First, try to fetch by d-tag (new format)
-					productEvent = await fetchProductByATag(pubkey, identifier)
-
-					// If not found and identifier looks like an event ID (64 hex chars), try fetching by event ID
-					if (!productEvent && /^[a-f0-9]{64}$/i.test(identifier)) {
-						try {
-							productEvent = await fetchProduct(identifier)
-							// Verify the product belongs to the expected seller
-							if (productEvent && productEvent.pubkey !== pubkey) {
-								console.warn('Product pubkey mismatch, ignoring:', productRef)
-								productEvent = null
-							}
-						} catch (error) {
-							console.warn('Failed to fetch product by event ID:', identifier)
-						}
-					}
-
-					if (!productEvent) {
-						console.warn('Product not found:', productRef)
-						continue
-					}
-
-					const productName = getProductTitle(productEvent)
-					const stockTag = getProductStock(productEvent)
+					const productName = getProductTitle(item.productEvent)
+					const stockTag = getProductStock(item.productEvent)
 					const currentStock = stockTag ? parseInt(stockTag[1]) : 0
-					const newStock = Math.max(0, currentStock - quantity)
-
-					// Get the actual d-tag for updates
-					const actualDTag = getProductId(productEvent)
+					const newStock = Math.max(0, currentStock - item.quantity)
 
 					productUpdates.push({
-						productRef: `30402:${pubkey}:${actualDTag}`, // Use proper d-tag format
+						productRef: item.productRef,
 						productName,
-						quantityOrdered: quantity,
+						quantityOrdered: item.quantity,
 						currentStock,
 						newStock,
-						productEvent,
+						productEvent: item.productEvent,
 					})
 				}
 
@@ -159,6 +122,8 @@ export function StockUpdateDialog({ open, onOpenChange, order, onComplete }: Sto
 				const isNsfw = isNSFWProduct(product.productEvent)
 
 				const formData: ProductFormData = {
+					// Determine delivery from type tag
+					delivery: typeTag?.[2] === 'digital' ? 'digital' : 'physical',
 					name: product.productName,
 					summary: getProductSummary(product.productEvent),
 					description: getProductDescription(product.productEvent),

--- a/src/components/orders/orderStockHelpers.ts
+++ b/src/components/orders/orderStockHelpers.ts
@@ -1,0 +1,39 @@
+import { fetchProductSmart, getProductId, getProductType } from '@/queries/products'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { getOrderItems } from './orderDetailHelpers'
+
+export type OrderStockItem = {
+	productRef: string
+	quantity: number
+	isDigital: boolean
+	productEvent: NDKEvent | null
+}
+
+export async function fetchOrderStockItems(orderEvent: NDKEvent): Promise<OrderStockItem[]> {
+	const items = getOrderItems(orderEvent)
+	const stockItems: OrderStockItem[] = []
+
+	for (const item of items) {
+		const [kind, sellerPubkey, identifier] = item.productRef.split(':')
+		if (kind !== '30402' || !sellerPubkey || !identifier) continue
+
+		let productEvent: NDKEvent | null = null
+		try {
+			productEvent = await fetchProductSmart(identifier, sellerPubkey)
+		} catch {
+			productEvent = null
+		}
+
+		const isDigital = !!productEvent && getProductType(productEvent)?.[2] === 'digital'
+		const canonicalProductRef = productEvent ? `30402:${sellerPubkey}:${getProductId(productEvent)}` : item.productRef
+
+		stockItems.push({
+			productRef: canonicalProductRef,
+			quantity: item.quantity,
+			isDigital,
+			productEvent,
+		})
+	}
+
+	return stockItems
+}

--- a/src/components/orders/orderStockHelpers.ts
+++ b/src/components/orders/orderStockHelpers.ts
@@ -1,5 +1,5 @@
 import { fetchProductSmart, getProductId, getProductType } from '@/queries/products'
-import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import type { NDKEvent } from '@/lib/nostr/ndk-events'
 import { getOrderItems } from './orderDetailHelpers'
 
 export type OrderStockItem = {

--- a/src/components/sheet-contents/products/NameTab.tsx
+++ b/src/components/sheet-contents/products/NameTab.tsx
@@ -8,7 +8,7 @@ import { useForm } from '@tanstack/react-form'
 import { useStore } from '@tanstack/react-store'
 
 export function NameTab() {
-	const { productType, name, summary, description, selectedCollection } = useStore(productFormStore)
+	const { productType, delivery, name, summary, description, selectedCollection } = useStore(productFormStore)
 	const { user } = useStore(authStore)
 
 	// Fetch user's collections
@@ -21,6 +21,7 @@ export function NameTab() {
 			description: description,
 			collection: selectedCollection || '',
 			productType: productType,
+			delivery: delivery,
 		},
 		onSubmit: async ({ value }) => {
 			productFormActions.updateValues({
@@ -28,6 +29,7 @@ export function NameTab() {
 				summary: value.summary,
 				description: value.description,
 				productType: value.productType as 'single' | 'variable',
+				delivery: value.delivery as 'physical' | 'digital',
 			})
 		},
 	})
@@ -77,6 +79,27 @@ export function NameTab() {
 					<SelectContent>
 						<SelectItem value="single">Single Product</SelectItem>
 						<SelectItem value="variable">Product with variants</SelectItem>
+					</SelectContent>
+				</Select>
+			</div>
+
+			<div className="grid w-full gap-1.5">
+				<Select
+					value={delivery}
+					onValueChange={(value) =>
+						productFormActions.updateValues({
+							delivery: value as 'physical' | 'digital',
+							// Clear quantity for digital products
+							...(value === 'digital' ? { quantity: '' } : {}),
+						})
+					}
+				>
+					<SelectTrigger className="border-2">
+						<SelectValue placeholder="Physical or Digital" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="physical">Physical</SelectItem>
+						<SelectItem value="digital">Digital</SelectItem>
 					</SelectContent>
 				</Select>
 			</div>

--- a/src/components/sheet-contents/products/ProductFormContent.tsx
+++ b/src/components/sheet-contents/products/ProductFormContent.tsx
@@ -27,7 +27,7 @@ const PRODUCT_FORM_TAB_LABELS: Record<ProductFormTab, string> = {
 
 type ProductFormWorkflowState = Pick<
 	ProductFormState,
-	'name' | 'description' | 'price' | 'quantity' | 'mainCategory' | 'images' | 'shippings'
+	'name' | 'description' | 'price' | 'quantity' | 'mainCategory' | 'images' | 'shippings' | 'delivery'
 >
 
 function isValidNumberString(value: string): boolean {
@@ -45,7 +45,8 @@ function getTabValidationIssues(state: ProductFormWorkflowState, tab: ProductFor
 		case 'detail': {
 			const issues: string[] = []
 			if (!isValidNumberString(state.price)) issues.push('Valid product price is required')
-			if (!isValidNumberString(state.quantity)) issues.push('Valid product quantity is required')
+			// Quantity not required for digital products
+			if (state.delivery !== 'digital' && !isValidNumberString(state.quantity)) issues.push('Valid product quantity is required')
 			return issues
 		}
 		case 'category':

--- a/src/components/sheet-contents/products/tabs.tsx
+++ b/src/components/sheet-contents/products/tabs.tsx
@@ -27,6 +27,7 @@ export function DetailTab() {
 		price,
 		fiatPrice,
 		quantity,
+		delivery,
 		currency,
 		status,
 		specs,
@@ -327,43 +328,47 @@ export function DetailTab() {
 				</div>
 			)}
 
-			<form.Field
-				name="quantity"
-				validators={{
-					onChange: (field) => {
-						if (!field.value) return 'Quantity is required'
-						if (!/^[0-9]*$/.test(field.value)) return 'Please enter a valid number'
-						return undefined
-					},
-				}}
-			>
-				{(field) => (
-					<div className="grid w-full gap-1.5">
-						<Label htmlFor={field.name}>
-							<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Quantity</span>
-						</Label>
-						<Input
-							id={field.name}
-							name={field.name}
-							value={field.state.value}
-							onBlur={field.handleBlur}
-							onChange={(e) => {
-								field.handleChange(e.target.value)
-								productFormActions.updateValues({ quantity: e.target.value })
-							}}
-							className="border-2"
-							placeholder="e.g. 100"
-							data-testid="product-quantity-input"
-							required
-							pattern="[0-9]*"
-							inputMode="numeric"
-						/>
-						{field.state.meta.errors?.length > 0 && field.state.meta.isTouched && (
-							<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
-						)}
-					</div>
-				)}
-			</form.Field>
+			{delivery !== 'digital' ? (
+				<form.Field
+					name="quantity"
+					validators={{
+						onChange: (field) => {
+							if (!field.value) return 'Quantity is required'
+							if (!/^[0-9]*$/.test(field.value)) return 'Please enter a valid number'
+							return undefined
+						},
+					}}
+				>
+					{(field) => (
+						<div className="grid w-full gap-1.5">
+							<Label htmlFor={field.name}>
+								<span className="after:content-['*'] after:ml-0.5 after:text-red-500">Quantity</span>
+							</Label>
+							<Input
+								id={field.name}
+								name={field.name}
+								value={field.state.value}
+								onBlur={field.handleBlur}
+								onChange={(e) => {
+									field.handleChange(e.target.value)
+									productFormActions.updateValues({ quantity: e.target.value })
+								}}
+								className="border-2"
+								placeholder="e.g. 100"
+								data-testid="product-quantity-input"
+								required
+								pattern="[0-9]*"
+								inputMode="numeric"
+							/>
+							{field.state.meta.errors?.length > 0 && field.state.meta.isTouched ? (
+								<div className="text-red-500 text-sm mt-1">{field.state.meta.errors.join(', ')}</div>
+							) : null}
+						</div>
+					)}
+				</form.Field>
+			) : (
+				<div className="text-sm text-muted-foreground">Digital products do not track stock.</div>
+			)}
 
 			<div className="grid w-full gap-1.5">
 				<Label>

--- a/src/lib/checkout/deliveryRequirements.ts
+++ b/src/lib/checkout/deliveryRequirements.ts
@@ -4,6 +4,8 @@ export type CheckoutDeliveryRequirementInput = {
 	products: Array<{
 		id: string
 		shippingMethodId?: string | null
+		// Optional product-level hint - "digital" | "physical" - when available
+		productType?: 'digital' | 'physical'
 	}>
 	servicesByShippingRef: Record<string, string | null | undefined>
 }
@@ -34,6 +36,18 @@ export function resolveCheckoutDeliveryRequirements(input: CheckoutDeliveryRequi
 	const unresolvedShippingRefs = new Set<string>()
 
 	for (const product of input.products) {
+		// If product explicitly declares its type as digital, treat it as digital delivery
+		if (product.productType === 'digital') {
+			hasDigitalDelivery = true
+			continue
+		}
+
+		// If product type is unknown, delivery requirements cannot be resolved by product type alone.
+		if (!product.productType) {
+			unresolvedShippingRefs.add(`product:${product.id}:missing-product-type`)
+			continue
+		}
+
 		const shippingRef = product.shippingMethodId?.trim()
 
 		if (!shippingRef) {
@@ -48,12 +62,21 @@ export function resolveCheckoutDeliveryRequirements(input: CheckoutDeliveryRequi
 			continue
 		}
 
-		if (mode === 'digital') {
-			hasDigitalDelivery = true
-		} else if (mode === 'pickup') {
-			hasPickupDelivery = true
+		if (product.productType === 'physical') {
+			if (mode === 'pickup') {
+				hasPickupDelivery = true
+			} else {
+				hasPhysicalDelivery = true
+			}
 		} else {
-			hasPhysicalDelivery = true
+			// This should not happen, but keep compatibility if type is unexpectedly set.
+			if (mode === 'digital') {
+				hasDigitalDelivery = true
+			} else if (mode === 'pickup') {
+				hasPickupDelivery = true
+			} else {
+				hasPhysicalDelivery = true
+			}
 		}
 	}
 

--- a/src/lib/stores/product.ts
+++ b/src/lib/stores/product.ts
@@ -72,6 +72,7 @@ export interface ProductFormState {
 	currency: string
 	status: 'hidden' | 'on-sale' | 'pre-order'
 	productType: 'single' | 'variable'
+	delivery: 'physical' | 'digital'
 	mainCategory: string | null
 	selectedCollection: string | null
 	specs: ProductSpec[]
@@ -101,6 +102,7 @@ export const DEFAULT_FORM_STATE: ProductFormState = {
 	currency: 'SATS',
 	status: 'on-sale',
 	productType: 'single',
+	delivery: 'physical',
 	mainCategory: null,
 	selectedCollection: null,
 	specs: [],
@@ -275,6 +277,7 @@ export const productFormActions = {
 					quantity: stockTag?.[1] || '',
 					status: visibilityTag?.[1] || 'hidden',
 					productType: typeTag?.[1] === 'simple' ? 'single' : 'variable',
+					delivery: typeTag?.[2] === 'digital' ? 'digital' : 'physical',
 					mainCategory: mainCategoryFromTags || null,
 					selectedCollection: collection,
 					categories: subCategoriesFromTags || [],
@@ -470,6 +473,7 @@ export const productFormActions = {
 			images: state.images,
 			specs: state.specs,
 			shippings: normalizeProductShippingSelections(state.shippings),
+			delivery: state.delivery,
 			weight: state.weight,
 			dimensions: state.dimensions,
 			isNSFW: state.isNSFW,

--- a/src/publish/migration.tsx
+++ b/src/publish/migration.tsx
@@ -38,8 +38,11 @@ export const publishMigratedProduct = async (
 		throw new Error('Valid product price is required')
 	}
 
-	if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
-		throw new Error('Valid product quantity is required')
+	// Quantity is not required for digital delivery
+	if (formData.delivery !== 'digital') {
+		if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
+			throw new Error('Valid product quantity is required')
+		}
 	}
 
 	if (formData.images.length === 0) {

--- a/src/publish/orders.tsx
+++ b/src/publish/orders.tsx
@@ -15,10 +15,12 @@ import {
 import { createEncryptedPrivateOrderMessageWithSigner, type PrivateOrderDeliveryDetails } from '@/lib/orders/privateOrderMessage'
 import { fetchProfileByIdentifier } from '@/queries/profiles'
 import { getShippingEvent, getShippingService } from '@/queries/shipping'
+import { fetchProductSmart, getProductType } from '@/queries/products'
 import type { Event } from 'nostr-tools'
 // import type { CartProduct, SellerData, V4VShare } from '@/lib/stores/cart'
 
 async function resolveDeliveryRequirementsForProducts(
+	sellerPubkey: string,
 	products: Array<{ id: string; shippingMethodId?: string | null }>,
 ): Promise<CheckoutDeliveryRequirements> {
 	const shippingRefs = Array.from(new Set(products.map((product) => product.shippingMethodId?.trim()).filter(Boolean) as string[]))
@@ -36,8 +38,25 @@ async function resolveDeliveryRequirementsForProducts(
 		}),
 	)
 
+	// Fetch product type metadata when available so digital products can be detected
+	const productsWithType: Array<{ id: string; shippingMethodId?: string | null; productType?: 'digital' | 'physical' }> = []
+
+	await Promise.all(
+		products.map(async (p) => {
+			try {
+				const productEvent = await fetchProductSmart(p.id, sellerPubkey)
+				const typeTag = getProductType(productEvent as any)
+				const productType = typeTag?.[2] === 'digital' ? 'digital' : undefined
+				productsWithType.push({ ...p, productType })
+			} catch (error) {
+				// If product fetch fails, fall back to original product info
+				productsWithType.push({ ...p })
+			}
+		}),
+	)
+
 	return resolveCheckoutDeliveryRequirements({
-		products,
+		products: productsWithType,
 		servicesByShippingRef,
 	})
 }
@@ -832,7 +851,7 @@ export async function publishOrderWithDependencies(params: PublishOrderDependenc
 
 		if (sellerProducts.length === 0 || !data) continue
 
-		const requirements = await resolveDeliveryRequirementsForProducts(sellerProducts)
+		const requirements = await resolveDeliveryRequirementsForProducts(sellerPubkey, sellerProducts)
 		if (!requirements.isResolved) {
 			throw new Error('Delivery requirements could not be verified for one or more selected shipping options')
 		}

--- a/src/publish/products.tsx
+++ b/src/publish/products.tsx
@@ -26,6 +26,7 @@ export interface ProductFormData {
 	weight: { value: string; unit: string } | null
 	dimensions: { value: string; unit: string } | null
 	isNSFW: boolean
+	delivery?: 'physical' | 'digital'
 }
 
 /**
@@ -38,6 +39,7 @@ export const createProductEvent = (
 	productId?: string, // Optional for updates
 	appPubkey?: string, // Optional app pubkey for client tag
 	handlerId?: string, // Optional handler ID for client tag
+	deliveryType: 'digital' | 'physical' = 'physical',
 ): NDKEvent => {
 	const event = new NDKEvent(ndk)
 	event.kind = 30402 // Product listings kind
@@ -87,7 +89,7 @@ export const createProductEvent = (
 		['d', id], // Product identifier - this is the key for updates!
 		['title', formData.name],
 		['price', formData.price, formData.currency],
-		['type', formData.productType === 'single' ? 'simple' : 'variable', 'physical'],
+		['type', formData.productType === 'single' ? 'simple' : 'variable', deliveryType],
 		['visibility', formData.status],
 		['stock', formData.quantity],
 		...(formData.summary ? [['summary', formData.summary] as NDKTag] : []),
@@ -122,8 +124,11 @@ export const publishProduct = async (formData: ProductFormData, signer: NDKSigne
 		throw new Error('Valid product price is required')
 	}
 
-	if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
-		throw new Error('Valid product quantity is required')
+	// Quantity is not required for digital delivery
+	if (formData.delivery !== 'digital') {
+		if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
+			throw new Error('Valid product quantity is required')
+		}
 	}
 
 	if (formData.images.length === 0) {
@@ -134,13 +139,16 @@ export const publishProduct = async (formData: ProductFormData, signer: NDKSigne
 		throw new Error('Main category is required')
 	}
 
-	// Validate shipping options
-	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
-	if (validShippings.length === 0) {
+	// Validate shipping options (not required for digital delivery)
+	const normalizedShippings = normalizeProductShippingSelections(formData.shippings)
+	const validShippings = normalizedShippings.filter((ship) => ship.shippingRef)
+	if (validShippings.length === 0 && formData.delivery !== 'digital') {
 		throw new Error('At least one shipping option is required')
 	}
 
-	const event = createProductEvent(formData, signer, ndk)
+	const deliveryType: 'digital' | 'physical' = formData.delivery ?? 'physical'
+
+	const event = createProductEvent(formData, signer, ndk, undefined, undefined, undefined, deliveryType)
 
 	await event.sign(signer)
 	await ndkActions.publishEvent(event)
@@ -174,8 +182,32 @@ export const updateProduct = async (
 		throw new Error('Valid product price is required')
 	}
 
-	if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
-		throw new Error('Valid product quantity is required')
+	// Determine whether this product should be considered digital for validation
+	let isDigitalForUpdate = formData.delivery === 'digital'
+	if (!isDigitalForUpdate) {
+		const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
+		if (validShippings.length > 0) {
+			for (const ship of validShippings) {
+				try {
+					const shippingId = parseShippingReference(ship.shippingRef)
+					const shippingEvent = await getShippingEvent(shippingId)
+					const serviceTag = shippingEvent ? getShippingService(shippingEvent) : undefined
+					if (serviceTag?.[1] === 'digital') {
+						isDigitalForUpdate = true
+						break
+					}
+				} catch (e) {
+					continue
+				}
+			}
+		}
+	}
+
+	// Quantity is not required for digital products
+	if (!isDigitalForUpdate) {
+		if (!formData.quantity.trim() || isNaN(Number(formData.quantity))) {
+			throw new Error('Valid product quantity is required')
+		}
 	}
 
 	if (formData.images.length === 0) {
@@ -186,14 +218,31 @@ export const updateProduct = async (
 		throw new Error('Main category is required')
 	}
 
-	// Validate shipping options
+	// Validate shipping options (not required for digital delivery)
 	const validShippings = normalizeProductShippingSelections(formData.shippings).filter((ship) => ship.shippingRef)
-	if (validShippings.length === 0) {
+	if (validShippings.length === 0 && formData.delivery !== 'digital') {
 		throw new Error('At least one shipping option is required')
+	}
+	// Determine delivery type for update as well
+	let deliveryType: 'digital' | 'physical' = formData.delivery ?? 'physical'
+	if (!formData.delivery) {
+		for (const ship of validShippings) {
+			try {
+				const shippingId = parseShippingReference(ship.shippingRef)
+				const shippingEvent = await getShippingEvent(shippingId)
+				const serviceTag = shippingEvent ? getShippingService(shippingEvent) : undefined
+				if (serviceTag?.[1] === 'digital') {
+					deliveryType = 'digital'
+					break
+				}
+			} catch (e) {
+				continue
+			}
+		}
 	}
 
 	// Create event with the same d tag to update the existing product
-	const event = createProductEvent(formData, signer, ndk, productDTag)
+	const event = createProductEvent(formData, signer, ndk, productDTag, undefined, undefined, deliveryType)
 
 	await event.sign(signer)
 	await ndkActions.publishEvent(event)

--- a/src/routes/checkout.tsx
+++ b/src/routes/checkout.tsx
@@ -13,6 +13,7 @@ import {
 	resolveCheckoutDeliveryRequirements,
 	type CheckoutDeliveryRequirements,
 } from '@/lib/checkout/deliveryRequirements'
+import { fetchProductSmart, getProductType } from '@/queries/products'
 import { authStore } from '@/lib/stores/auth'
 import { cartActions, cartStore } from '@/lib/stores/cart'
 import { ndkStore } from '@/lib/stores/ndk'
@@ -180,12 +181,38 @@ function RouteComponent() {
 			}
 
 			if (!hasAllShippingMethods) {
-				setDeliveryRequirements(
-					resolveCheckoutDeliveryRequirements({
-						products: cartProducts,
-						servicesByShippingRef: {},
-					}),
-				)
+				// Try to enrich cart products with productType hints before resolving delivery requirements
+				try {
+					const enriched: Array<{ id: string; shippingMethodId?: string | null; productType?: 'digital' | 'physical' }> = []
+					await Promise.all(
+						cartProducts.map(async (prod) => {
+							try {
+								const ev = await fetchProductSmart(prod.id, prod.sellerPubkey)
+								const typeTag = getProductType(ev as any)
+								enriched.push({ ...prod, productType: typeTag?.[2] === 'digital' ? 'digital' : undefined })
+							} catch {
+								enriched.push({ ...prod })
+							}
+						}),
+					)
+
+					setDeliveryRequirements(
+						resolveCheckoutDeliveryRequirements({
+							products: enriched,
+							servicesByShippingRef: {},
+						}),
+					)
+				} catch (e) {
+					setDeliveryRequirements(
+						resolveCheckoutDeliveryRequirements({
+							products: cartProducts.map((prod) => ({
+								...prod,
+								productType: undefined,
+							})),
+							servicesByShippingRef: {},
+						}),
+					)
+				}
 				setIsDeliveryRequirementsLoading(false)
 				setDeliveryRequirementsError(null)
 				return
@@ -208,12 +235,37 @@ function RouteComponent() {
 
 				if (isCancelled) return
 
-				setDeliveryRequirements(
-					resolveCheckoutDeliveryRequirements({
-						products: cartProducts,
-						servicesByShippingRef,
-					}),
-				)
+				try {
+					const enriched: Array<{ id: string; shippingMethodId?: string | null; productType?: 'digital' | 'physical' }> = []
+					await Promise.all(
+						cartProducts.map(async (prod) => {
+							try {
+								const ev = await fetchProductSmart(prod.id, prod.sellerPubkey)
+								const typeTag = getProductType(ev as any)
+								enriched.push({ ...prod, productType: typeTag?.[2] === 'digital' ? 'digital' : undefined })
+							} catch {
+								enriched.push({ ...prod })
+							}
+						}),
+					)
+
+					setDeliveryRequirements(
+						resolveCheckoutDeliveryRequirements({
+							products: enriched,
+							servicesByShippingRef,
+						}),
+					)
+				} catch (e) {
+					setDeliveryRequirements(
+						resolveCheckoutDeliveryRequirements({
+							products: cartProducts.map((prod) => ({
+								...prod,
+								productType: undefined,
+							})),
+							servicesByShippingRef,
+						}),
+					)
+				}
 				setIsDeliveryRequirementsLoading(false)
 			} catch (error) {
 				console.error('Failed to resolve checkout delivery requirements:', error)
@@ -221,7 +273,10 @@ function RouteComponent() {
 
 				setDeliveryRequirements(
 					resolveCheckoutDeliveryRequirements({
-						products: cartProducts,
+						products: cartProducts.map((prod) => ({
+							...prod,
+							productType: undefined,
+						})),
 						servicesByShippingRef,
 					}),
 				)

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -619,7 +619,7 @@ function RouteComponent() {
 								showRootCurrency={true}
 							/>
 
-							{visibility === 'pre-order' ? (
+							{productType?.delivery === 'digital' ? null : visibility === 'pre-order' ? (
 								<Badge className="bg-blue-500">Pre-order</Badge>
 							) : (
 								<Badge>{stock !== undefined ? `${stock} in stock` : 'Out of stock'}</Badge>


### PR DESCRIPTION
The fixes consistently move digital detection from shipping-service inference to explicit product metadata via the product type tag, which is the Gamma Markets spec signal.

1. OrderDetailComponent.tsx
- Switched digital detection from getShippingService(shippingOption)?.[1] === 'digital'
- Now uses getProductType(product)?.[2] === 'digital'
- This makes order detail UI treat products as digital based on the product tag, not the order shipping method
2. StockUpdateDialog.tsx
- Replaced manual item parsing with fetchOrderStockItems(order.order)
- Skips stock update entries when item.isDigital is true
- Builds update payloads using delivery inferred from the product type tag
- Prevents digital products from appearing in stock-update workflows
3. NameTab.tsx
- Adds an explicit delivery selector (physical / digital)
- Clears quantity when digital is selected
- Enables the form to capture the product delivery type directly
4. ProductFormContent.tsx
- Changes validation so quantity is only required when delivery !== 'digital'
- Ensures digital products can be published without stock quantity validation
5. tabs.tsx
- Reads delivery from form state
- Hides the quantity input for digital products
- Shows a helpful message: “Digital products do not track stock.”
- Improves product form UX and avoids physical-stock UI for digital products
6. deliveryRequirements.ts
- Adds optional product-level productType?: 'digital' | 'physical'
- Treats productType === 'digital' as digital delivery
- Uses explicit product metadata instead of shipping service type to decide delivery mode
- Adds handling for unknown productType to avoid silent fallback
7. product.ts
- Adds delivery to product form state and defaults to physical
- Initializes delivery from the type tag when loading a product for edit
- Serializes delivery into publish payload state
- Makes delivery metadata part of product edit/create state
8. migration.tsx
- Removes quantity validation for products whose delivery is digital
- Aligns migrated publish behavior with the new digital product semantics
9. orders.tsx
- Imports fetchProductSmart and getProductType
- When resolving order delivery requirements, fetches each product’s type metadata
- Builds productType hints for checkout resolution
- Ensures order publish validation is based on product metadata rather than shipping fallback
10. products.tsx
- Adds delivery to ProductFormData
- Writes ['type', simple|variable, deliveryType] instead of always physical
- Makes shipping option validation optional for digital products
- Makes quantity validation optional for digital products
- Persists explicit digital/physical delivery into published product tags
11. checkout.tsx
- Imports product metadata helpers
- Enriches cart products with fetched product type metadata before delivery resolution
- Uses resolveCheckoutDeliveryRequirements() with explicit productType
- In fallback branches, clears productType instead of silently continuing with raw cart shipping inference
- Tightens checkout so delivery resolution relies on product metadata
12. src/routes/products.$productId.tsx
- Changes the product detail page display logic so digital products do not show stock/pre-order badge
- Uses productType?.delivery === 'digital' to suppress physical-stock display
13. orderStockHelpers.ts
- Reads the order's item tags using getOrderItems(orderEvent)
- parses the product reference 30402:pubkey:identifier, fetches the actual product event via fetchProductSmart(identifier, sellerPubkey), determines whether that product is digital by checking getProductType(productEvent)?.[2] === 'digital', & builds a canonical productRef using the fetched product’s real d tag if available
- Returns an array of OrderStockItem objects containing productRef, ordered quantity, isDigital, productEvent (or null if fetch failed)