### PR TITLE
fix: restore ending-soon as default sort in explore auctions view

### DIFF
--- a/src/lib/utils/auctions.ts
+++ b/src/lib/utils/auctions.ts
@@ -44,7 +44,7 @@ export interface UseFilteredAuctionsProps {
 
 export const defaultAuctionFilters: AuctionFilterState = {
 	hideEnded: false,
-	sort: 'newest',
+	sort: 'ending-soon',
 }
 
 /**

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -40,13 +40,7 @@ import { createFileRoute, Link, Outlet, useMatchRoute } from '@tanstack/react-ro
 import { useSelector } from '@tanstack/react-store'
 import { CheckCheck, Clock, ExternalLink, Gavel, Hourglass, Loader2 } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import {
-	auctionSortOptionValues,
-	defaultAuctionFilters,
-	getAuctionSortOptionTitle,
-	useFilteredAuctions,
-	type AuctionSortOption,
-} from '@/lib/utils/auctions'
+import { auctionSortOptionValues, getAuctionSortOptionTitle, useFilteredAuctions, type AuctionSortOption } from '@/lib/utils/auctions'
 
 type AuctionStatus = 'Scheduled' | 'Live' | 'Settlement' | 'Ended'
 
@@ -520,7 +514,7 @@ export const Route = createFileRoute('/_dashboard-layout/dashboard/products/auct
 function AuctionsOverviewComponent() {
 	const { user, isAuthenticated } = useSelector(authStore)
 	const matchRoute = useMatchRoute()
-	const [sort, setSort] = useState<AuctionSortOption>(defaultAuctionFilters.sort ?? 'ending-soon')
+	const [sort, setSort] = useState<AuctionSortOption>('newest')
 	const settlementMutation = usePublishAuctionSettlementMutation()
 	const [settlingAuctionId, setSettlingAuctionId] = useState<string | null>(null)
 	const [animationParent] = useAutoAnimate()


### PR DESCRIPTION
## Problem

PR #1059 (by hkarani, merged Jun 29) explicitly changed the default auction sort from `'ending-soon'` to `'newest'` for all views. This was a regression for the buyer-facing explore view, where ending-soon is the correct default — buyers want to see auctions closing soonest.

## Fix

- `src/lib/utils/auctions.ts`: Changed `defaultAuctionFilters.sort` back from `'newest'` to `'ending-soon'`. This default is used by the explore view (`/auctions`) and the `AuctionFilters` reset button.
- `src/routes/_dashboard-layout/dashboard/products/auctions.tsx`: Dashboard now explicitly uses `'newest'` as its initial sort state instead of inheriting from `defaultAuctionFilters`, so the two views have independent defaults.

## Rationale

The explore view is a **buyer-first** experience — buyers want to see auctions ending soonest. The dashboard view is a **seller-first** experience — sellers want to see their newest auctions first. The defaults should reflect these different perspectives.

## Verification

- 643 unit tests pass
- Prettier clean
- No new TypeScript errors