### PR TITLE
fix(products): disable seller query for invalid pubkeys

### DIFF
--- a/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
+++ b/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { productsByPubkeyQueryOptions } from '../products'
+
+const VALID_PUBKEY = 'a'.repeat(64)
+
+describe('productsByPubkeyQueryOptions', () => {
+	test('disables the query while the pubkey is empty', () => {
+		const options = productsByPubkeyQueryOptions('', true)
+
+		expect(options.enabled).toBe(false)
+	})
+
+	test('disables the query for a malformed pubkey', () => {
+		const options = productsByPubkeyQueryOptions('not-a-valid-pubkey')
+
+		expect(options.enabled).toBe(false)
+	})
+
+	test('enables the query for a valid hex pubkey', () => {
+		const options = productsByPubkeyQueryOptions(VALID_PUBKEY)
+
+		expect(options.enabled).toBe(true)
+	})
+})

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -22,6 +22,7 @@ import { getCoordsFromATag, getATagFromCoords } from '@/lib/utils/coords.ts'
 import { discoverNip50Relays } from '@/lib/relays'
 import { filterBlacklistedEvents, filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
+import { isValidHexKey } from '@/lib/utils'
 
 // Re-export productKeys for use in other query files
 export { productKeys }
@@ -372,6 +373,7 @@ export const productsByPubkeyQueryOptions = (pubkey: string, includeHidden: bool
 	queryOptions({
 		queryKey: includeHidden ? [...productKeys.byPubkey(pubkey), 'includeHidden'] : productKeys.byPubkey(pubkey),
 		queryFn: () => fetchProductsByPubkey(pubkey, includeHidden),
+		enabled: isValidHexKey(pubkey),
 	})
 
 /**


### PR DESCRIPTION
## Problem

One application path can construct an invalid Nostr author filter when
authenticated user state is unavailable:

    ProductsTab
      → useProductsByPubkey(user?.pubkey || '', true)
      → productsByPubkeyQueryOptions('')
      → fetchProductsByPubkey('')
      → authors: ['']

NDK rejects the empty author before making the relay request.

## Change

Add `enabled: isValidHexKey(pubkey)` to the shared
`productsByPubkeyQueryOptions()` configuration.

This keeps consumers using these options as-is, including
`useProductsByPubkey()`, inactive until the seller identity is a valid
64-character hexadecimal pubkey.

The lower-level `fetchProductsByPubkey()` semantics remain unchanged.

## Tests

Added focused coverage verifying that the query is:

- disabled for an empty pubkey;
- disabled for a malformed nonempty pubkey;
- enabled for a valid hexadecimal pubkey.

Validation:

- Prettier: passed
- focused test: 3 passed, 0 failed

## Scope

This fixes one confirmed application path capable of producing an empty
`authors` filter. It does not establish this path as the Telegram
reporter's exact runtime failure or as the sole cause of the broader
profile-loading behavior.

Related to #970.
