### PR TITLE
fix: prevent AI_GUARDRAILS crash + profile unload after tab backgrounding

### DIFF
--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -1,0 +1,111 @@
+# ADR-015: Production-safe NDK filter validation and stable kind-0 profile fetching
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-02
+
+## Related
+
+- PR: #1207
+- User-reported crash: `AI_GUARDRAILS ERROR: Filter[0].authors[0] is not a valid 64-char hex pubkey: ""`
+- Symptom: profile pages fail to load / show a false "Could not load user profile" after the browser tab is backgrounded and refocused.
+
+## Context
+
+Two distinct failure modes were producing the same user-visible outcome — a
+profile page that wouldn't load — and both traced back to how NDK filters and
+kind-0 (metadata) fetches were handled.
+
+1. **Filter-validation crash.** NDK AI Guardrails were enabled unconditionally
+   in production via `{ skip: ... }`. The `filter-invalid-hex` guardrail is a
+   fatal, `canDisable: false` throw, so any filter carrying an empty/invalid
+   pubkey — e.g. `{ authors: [''] }` produced by a `pubkey ?? ''` fallback
+   during a transient state — crashed the page. Several query helpers built
+   `authors` / `#p` filters straight from a pubkey parameter with no empty
+   check, so an empty string reached the filter and threw.
+
+   Disabling guardrails alone is **not** sufficient: NDK validates every
+   filter before subscribing regardless of guardrails, and the default
+   `filterValidationMode: 'validate'` _also_ throws (`"Invalid filter(s)
+detected"`) on a bad pubkey — the page would still crash, just with a
+   different message.
+
+2. **Stale-refetch profile clobber.** Kind-0 metadata is a stable,
+   rarely-updated event, yet profile reads used React Query defaults
+   (`refetchOnWindowFocus: true`). On a degraded relay pool after a backgrounded
+   tab, the refetch can EOSE-empty and React Query commits `{ profile: null }`
+   over previously-loaded good data, which trips the `!profile` "Could not
+   load user profile" error even though the profile was fine moments before.
+   This was confirmed by A/B test (revert → bug returns; re-apply → bug gone).
+
+## Decision
+
+Three coupled decisions; each guards a layer the next depends on.
+
+### 1. Disable AI Guardrails in production; set `filterValidationMode: 'fix'`
+
+- AI Guardrails are an NDK **dev-time educational tool** (shipped off by
+  default). Gate them on `stage`: **on** in `development`/`staging` (useful
+  dev tooling), **off** in `production` (graceful degradation, not a fatal
+  throw).
+- Set `filterValidationMode: 'fix'` in production. In `'fix'` mode NDK
+  **strips** invalid entries from a filter instead of throwing; if that
+  empties an `authors`/`#p` array the key is dropped entirely (`void 0`),
+  broadening the filter rather than crashing. Dev/staging keep the default
+  `'validate'` so filter bugs surface loudly during development.
+- The server-side app-settings fetch NDK uses `aiGuardrails: false` +
+  `filterValidationMode: 'fix'` (lenient, never crash).
+
+These two are **inseparable**: guardrails off without `'fix'` still throws in
+`'validate'`; `'fix'` without guardrails off keeps the educational throw.
+
+### 2. Guard empty-string pubkey paths before building Nostr filters
+
+The primary defense. Query helpers that build `authors`/`#p` from a pubkey
+parameter now short-circuit on an empty/blank pubkey (early-return / throw /
+`enabled: !!pubkey`) instead of constructing an invalid filter. No fetching
+logic is changed beyond guarding the error-causing condition:
+
+- `fetchProfileByIdentifier` — bail on empty/blank identifier
+- `useProfileName` / `useProfileNip05` — add `enabled: !!pubkey` (matching
+  the existing `useProfile`)
+- `fetchAuthor` — throw on empty pubkey
+- `fetchShippingOptionsByPubkey`, `fetchProductsByPubkey`,
+  `fetchCollectionsByPubkey`, `fetchOrdersByBuyer`, `fetchOrdersBySeller`,
+  `fetchSellerPrivateOrderGiftWraps`, `resolvePaymentDetailsForProduct` —
+  early-return on empty pubkey
+
+### 3. Do not refetch kind-0 metadata (stable events)
+
+- Stop refetching kind-0 on `refetchOnWindowFocus` / `refetchOnReconnect`.
+- Keep previous data visible during any refetch (`keepPreviousData`).
+- `staleTime: 60_000`.
+
+### Explicit non-goals
+
+- **Do not** return a placeholder profile instead of the "Profile not found"
+  error. The error condition stays `!profile` so genuinely-unfound profiles
+  (valid hex, but no kind-0 metadata anywhere) still show the error.
+- **Do not** change any fetching logic apart from guarding the
+  error-causing condition.
+
+## Consequences
+
+- An empty/invalid pubkey in production can no longer crash a page: the query
+  guards prevent the invalid filter from being built (primary), and
+  `filterValidationMode: 'fix'` strips any that slip through (safety net).
+- Dev/staging retain loud failure on filter bugs (`'validate'` + guardrails
+  on), so regressions are caught before production.
+- Profile metadata is no longer clobbered by a degraded post-refocus refetch;
+  the previously-loaded profile stays visible.
+- New query helpers that build `authors`/`#p` from a pubkey parameter must
+  guard against empty input. The server-side app-settings NDK pattern
+  (`aiGuardrails: false`, `filterValidationMode: 'fix'`) is the template for
+  any future one-off server fetch NDK instance.
+- `'fix'` broadens (does not narrow) a filter when it strips a bad author, so
+  it must remain a safety net, not the primary defense — the empty-pubkey
+  guards are the contract that keeps filters well-formed.

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -75,10 +75,18 @@ the repository-standard checks:
   `resolvePaymentDetailsForProduct`) use `isValidHexKey` — these build
   `authors`/`#p` directly, which NDK's strict validation requires to be 64-hex.
 - **Identifier-accepting** paths (`fetchProfileByIdentifier`, `useProfileName`,
-  `useProfileNip05`) use `validateProfileIdentifier`, because they feed
-  `ndk.fetchUser`, which accepts hex/npub/nprofile/nip05. (The dashboard
-  messages route passes an npub route param to `useProfileName`, so a hex-only
-  gate would break that view.)
+  `useProfileNip05`, `useProfile`) use `validateProfileIdentifier`, because
+  they feed `ndk.fetchUser`, which accepts hex/npub/nprofile/nip05. (The
+  dashboard messages route passes an npub route param to `useProfileName`, so
+  a hex-only gate would break that view.) The validation lives in the shared
+  `profileByIdentifierQueryOptions` factory (`enabled`), not in individual
+  hooks, so every consumer is gated — including route loaders and direct
+  `useQuery` callers. Callers with additional conditions COMBINE (not
+  overwrite) the factory's `enabled`, e.g.
+  `enabled: options.enabled && !validationError`.
+- **Hex-pubkey query factories** (`wotScoreQueryOptions`) use `isValidHexKey`
+  at the factory level, so `useWotScore` and direct callers like `WotScore.tsx`
+  inherit the guard.
 
 This replaces the earlier truthiness (`!!pubkey`) guards, which permitted
 whitespace, truncated keys, and arbitrary malformed non-empty values.

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -18,7 +18,7 @@ Accepted
 ## Context
 
 Two failure modes produced the same user-visible outcome — a profile page
-that wouldn't load — and a third latent risk was surfaced in review.
+that wouldn't load — and two latent risks were surfaced in review.
 
 1. **Filter-validation crash.** NDK AI Guardrails were enabled unconditionally
    in production via `{ skip: ... }`. The `filter-invalid-hex` guardrail is a
@@ -35,7 +35,8 @@ that wouldn't load — and a third latent risk was surfaced in review.
    previously-loaded data, tripping a false "Could not load user profile".
    Compounding this, `fetchProfileByIdentifier` wrapped every path in a
    try/catch that returned `{ profile: null, user: null }`, so timeout, relay
-   error, no connection, and genuine absence were all indistinguishable.
+   error, no connection, and metadata not observed from the configured relays
+   were all indistinguishable.
 
 3. **App-config authority gap.** Not a reported crash, but a latent risk
    surfaced in review: the kind-31990 app-config fetch queried by author +
@@ -43,6 +44,15 @@ that wouldn't load — and a third latent risk was surfaced in review.
    `created_at`. The content schema validates shape, not publisher authority,
    so a malformed `appPubkey` (or a relay returning an event from a different
    publisher) could yield app settings from an unrelated source.
+
+4. **Products caller overwrite + nip19 render crash.** The
+   `productsByPubkeyQueryOptions` factory guard (`enabled: isValidHexKey`)
+   was correct, but consumers overwrote it with truthiness (`!!pubkey`),
+   bypassing validation for malformed truthy input. `fetchProductsByPubkey`
+   constructed `authors: [pubkey]` without a defensive check. And
+   `FeaturedUserCard` called `nip19.npubEncode` synchronously during render —
+   a malformed pubkey crashed the render before React Query evaluated
+   `enabled`.
 
 ## Decision
 
@@ -69,11 +79,17 @@ Query helpers that build `authors`/`#p` from a pubkey parameter reject a
 malformed pubkey (not just an empty one) before constructing the filter, using
 the repository-standard checks:
 
-- **Hex-pubkey fetchers** (`fetchAuthor`, `fetchShippingOptionsByPubkey`,
-  `fetchOrdersByBuyer`/`fetchOrdersBySeller`,
+- **Hex-pubkey fetchers** (`fetchAuthor`, `fetchProductsByPubkey`,
+  `fetchShippingOptionsByPubkey`, `fetchOrdersByBuyer`/`fetchOrdersBySeller`,
   `fetchSellerPrivateOrderGiftWraps`, `fetchCollectionsByPubkey`,
   `resolvePaymentDetailsForProduct`) use `isValidHexKey` — these build
   `authors`/`#p` directly, which NDK's strict validation requires to be 64-hex.
+  `fetchAuthor` and `fetchProductsByPubkey` **throw** on invalid input because a
+  malformed pubkey reaching the fetcher is a programming error, not a data
+  condition — the throw surfaces the bug in React Query's error state rather
+  than silently returning an empty list that conflates "no results" with
+  "invalid input." The sibling fetchers (`fetchShippingOptionsByPubkey`, etc.)
+  return `[]` and may be migrated to the throw pattern in a follow-up.
 - **Identifier-accepting** paths (`fetchProfileByIdentifier`, `useProfileName`,
   `useProfileNip05`, `useProfile`) use `validateProfileIdentifier`, because
   they feed `ndk.fetchUser`, which accepts hex/npub/nprofile/nip05. (The
@@ -84,24 +100,46 @@ the repository-standard checks:
   `useQuery` callers. Callers with additional conditions COMBINE (not
   overwrite) the factory's `enabled`, e.g.
   `enabled: options.enabled && !validationError`.
-- **Hex-pubkey query factories** (`wotScoreQueryOptions`) use `isValidHexKey`
-  at the factory level, so `useWotScore` and direct callers like `WotScore.tsx`
-  inherit the guard.
+- **Hex-pubkey query factories** (`productsByPubkeyQueryOptions`,
+  `wotScoreQueryOptions`) use `isValidHexKey` at the factory level, so
+  `useProductsByPubkey`, `useWotScore`, and direct callers inherit the guard.
+  Consumers with additional conditions COMBINE (not overwrite) the factory's
+  `enabled`, e.g. `enabled: productOptions.enabled && isAuthenticated`.
+  Truthiness checks (`!!pubkey`) are dropped because `isValidHexKey` implies
+  truthiness — only genuine business-logic conditions survive the
+  combination.
 
 This replaces the earlier truthiness (`!!pubkey`) guards, which permitted
 whitespace, truncated keys, and arbitrary malformed non-empty values.
 
-### 3. Distinguish transient fetch failures from genuine absence; don't refetch stable kind-0
+- **`safeNpubEncode`** (`lib/utils.ts`): wraps `nip19.npubEncode` with
+  `isValidHexKey`, returning `null` for invalid input instead of throwing.
+  Components like `FeaturedUserCard` call `nip19.npubEncode` synchronously
+  during render — a malformed pubkey crashes the render before React Query
+  evaluates `enabled`. The helper validates before encoding, preventing the
+  crash. It is reusable for other render-time npub encoding call sites.
 
-- `fetchProfileByIdentifier` throws on transient failures — timeout, relay
-  error, and no relay connection (`ndk.pool.connectedRelays()`, matching the
-  pattern in `publish/profiles.tsx`) — so React Query treats them as `isError`
-  and retains previous profile data. Only genuine absence (relays connected
-  and `fetchProfile()` resolved to null) returns the null-shaped value.
+### 3. Distinguish transient fetch failures from metadata not observed; don't refetch stable kind-0
+
+- `fetchProfileByIdentifier` throws on transient failures — timeout (8s
+  `Promise.race`) and relay errors — so React Query treats them as `isError`
+  and retains previous profile data. No zero-relay preflight check is
+  performed: zero connected relays is a normal transient state during
+  `connect()`, and the 8s timeout determines failure. If a relay connects
+  during the window, the subscription proceeds naturally. Only metadata
+  not observed from the configured relays (relays connected and
+  `fetchProfile()` resolved to null) returns the null-shaped value.
 - ProfilePage keeps previous data visible during refetch
-  (`placeholderData: keepPreviousData`), stops refetching kind-0 on window
-  focus / reconnect, and its not-found condition fires only when there is
-  genuinely no profile to show (`!profile`, not `isError || !profile`).
+  (`placeholderData: keepPreviousData`) and stops refetching kind-0 on
+  window focus (`refetchOnWindowFocus: false`). `refetchOnReconnect` is
+  **preserved** (React Query default `true`) so a failed zero-relay startup
+  query auto-retries once the browser regains connectivity. Recovery uses
+  normal React Query retries, browser-network reconnect handling, and a
+  manual **Try again** button for retryable errors — not an NDK
+  relay-readiness subscription.
+- Three distinct error states: **transport error** (`isError && !profile`,
+  retryable, shows "Try again"), **metadata not observed** (`!isError &&
+!profile`, settled, non-retryable), and **invalid identifier** (non-retryable).
 - Behavior is covered by `profilesFetch.test.ts`.
 
 ### 4. Verify app-settings publisher authority before accepting content
@@ -126,7 +164,8 @@ app actually trusts:
 ### Explicit non-goals
 
 - **Do not** return a placeholder profile instead of the "Profile not found"
-  error; genuinely-unfound profiles still show the error.
+  error; profiles with no metadata observed from configured relays still show
+  the error.
 - **Do not** change fetching logic apart from: input validation guards, the
   transient/absence distinction, and app-config publisher-authority
   verification. No other fetching behavior is altered.
@@ -142,13 +181,18 @@ app actually trusts:
   strict `'validate'` remains the backstop for malformed filters.
 - A transient post-refocus refetch no longer clobbers a loaded profile
   (throws → `isError` + retained data; `keepPreviousData` covers the pending
-  state). Genuine absence still surfaces the "not found" error.
+  state). Metadata not observed from the configured relays still surfaces the
+  "not found" error; transport errors surface a retryable error with a
+  "Try again" button.
 - App-config content is accepted only from events authored by the expected
   `appPubkey` with kind 31990 and the exact d tag; a spoofed event that
   passes the shape schema is refused.
 - New query helpers building `authors`/`#p` from a pubkey must validate it with
   `isValidHexKey` (hex fetchers) or `validateProfileIdentifier` (identifier
-  fetchers) before constructing the filter.
+  fetchers) before constructing the filter. Factory-level `enabled` guards
+  must be combined (not overwritten) by callers; truthiness is insufficient.
+  `safeNpubEncode` should be used instead of bare `nip19.npubEncode` in
+  render-time code paths.
 
 ## Follow-ups (not in this PR, per review)
 

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -1,4 +1,4 @@
-# ADR-015: Production-safe NDK filter validation and stable kind-0 profile fetching
+# ADR-015: Production-safe NDK filter handling and stable kind-0 profile fetching
 
 ## Status
 
@@ -13,99 +13,95 @@ Accepted
 - PR: #1207
 - User-reported crash: `AI_GUARDRAILS ERROR: Filter[0].authors[0] is not a valid 64-char hex pubkey: ""`
 - Symptom: profile pages fail to load / show a false "Could not load user profile" after the browser tab is backgrounded and refocused.
+- Review feedback: #1206 (products empty-pubkey guard), maximotodev review of #1207.
 
 ## Context
 
-Two distinct failure modes were producing the same user-visible outcome — a
-profile page that wouldn't load — and both traced back to how NDK filters and
-kind-0 (metadata) fetches were handled.
+Two failure modes produced the same user-visible outcome — a profile page
+that wouldn't load.
 
 1. **Filter-validation crash.** NDK AI Guardrails were enabled unconditionally
    in production via `{ skip: ... }`. The `filter-invalid-hex` guardrail is a
    fatal, `canDisable: false` throw, so any filter carrying an empty/invalid
-   pubkey — e.g. `{ authors: [''] }` produced by a `pubkey ?? ''` fallback
-   during a transient state — crashed the page. Several query helpers built
-   `authors` / `#p` filters straight from a pubkey parameter with no empty
-   check, so an empty string reached the filter and threw.
+   pubkey — e.g. `{ authors: [''] }` from a `pubkey ?? ''` fallback during a
+   transient state — crashed the page. Several query helpers built
+   `authors`/`#p` filters straight from a pubkey parameter with no empty
+   check, so an empty string reached the filter.
 
-   Disabling guardrails alone is **not** sufficient: NDK validates every
-   filter before subscribing regardless of guardrails, and the default
-   `filterValidationMode: 'validate'` _also_ throws (`"Invalid filter(s)
-detected"`) on a bad pubkey — the page would still crash, just with a
-   different message.
-
-2. **Stale-refetch profile clobber.** Kind-0 metadata is a stable,
-   rarely-updated event, yet profile reads used React Query defaults
-   (`refetchOnWindowFocus: true`). On a degraded relay pool after a backgrounded
-   tab, the refetch can EOSE-empty and React Query commits `{ profile: null }`
-   over previously-loaded good data, which trips the `!profile` "Could not
-   load user profile" error even though the profile was fine moments before.
-   This was confirmed by A/B test (revert → bug returns; re-apply → bug gone).
+2. **Profile clobber.** Kind-0 metadata is a stable, rarely-updated event,
+   yet profile reads used React Query defaults (`refetchOnWindowFocus: true`).
+   On a degraded relay pool after a backgrounded tab, a refetch could resolve
+   to a null-shaped value and React Query committed `{ profile: null }` over
+   previously-loaded data, tripping a false "Could not load user profile".
+   Compounding this, `fetchProfileByIdentifier` wrapped every path in a
+   try/catch that returned `{ profile: null, user: null }`, so timeout, relay
+   error, no connection, and genuine absence were all indistinguishable.
 
 ## Decision
 
-Three coupled decisions; each guards a layer the next depends on.
-
-### 1. Disable AI Guardrails in production; set `filterValidationMode: 'fix'`
+### 1. Disable AI Guardrails in production; retain strict filter validation
 
 - AI Guardrails are an NDK **dev-time educational tool** (shipped off by
-  default). Gate them on `stage`: **on** in `development`/`staging` (useful
-  dev tooling), **off** in `production` (graceful degradation, not a fatal
-  throw).
-- Set `filterValidationMode: 'fix'` in production. In `'fix'` mode NDK
-  **strips** invalid entries from a filter instead of throwing; if that
-  empties an `authors`/`#p` array the key is dropped entirely (`void 0`),
-  broadening the filter rather than crashing. Dev/staging keep the default
-  `'validate'` so filter bugs surface loudly during development.
-- The server-side app-settings fetch NDK uses `aiGuardrails: false` +
-  `filterValidationMode: 'fix'` (lenient, never crash).
-
-These two are **inseparable**: guardrails off without `'fix'` still throws in
-`'validate'`; `'fix'` without guardrails off keeps the educational throw.
+  default). Gate them on `stage`: **on** in `development`/`staging`,
+  **off** in `production`.
+- **Retain NDK's default strict filter validation** (`'validate'`) in all
+  stages. Do **not** set `filterValidationMode: 'fix'`: in `'fix'` mode NDK
+  strips a bad `authors`/`#p` entry and, if that empties the array, drops the
+  key entirely — broadening an identity-scoped request instead of rejecting
+  it. That is fail-open and unsafe for marketplace identity, order, payment,
+  and private-data boundaries. Invalid/empty pubkeys are rejected at the
+  query layer **before** any filter is built (fail closed); strict validation
+  then never throws because filters are always well-formed.
+- The server-side app-settings fetch NDK uses `aiGuardrails: false` with
+  default strict validation (a malformed appPubkey fails closed rather than
+  broadening the query).
 
 ### 2. Guard empty-string pubkey paths before building Nostr filters
 
-The primary defense. Query helpers that build `authors`/`#p` from a pubkey
-parameter now short-circuit on an empty/blank pubkey (early-return / throw /
-`enabled: !!pubkey`) instead of constructing an invalid filter. No fetching
-logic is changed beyond guarding the error-causing condition:
+Query helpers that build `authors`/`#p` from a pubkey parameter short-circuit
+on an empty/blank pubkey (early-return / throw / `enabled: !!pubkey`) instead
+of constructing an invalid filter. No fetching logic is changed beyond
+guarding the error-causing condition.
 
-- `fetchProfileByIdentifier` — bail on empty/blank identifier
-- `useProfileName` / `useProfileNip05` — add `enabled: !!pubkey` (matching
-  the existing `useProfile`)
-- `fetchAuthor` — throw on empty pubkey
-- `fetchShippingOptionsByPubkey`, `fetchProductsByPubkey`,
-  `fetchCollectionsByPubkey`, `fetchOrdersByBuyer`, `fetchOrdersBySeller`,
-  `fetchSellerPrivateOrderGiftWraps`, `resolvePaymentDetailsForProduct` —
-  early-return on empty pubkey
+### 3. Distinguish transient fetch failures from genuine absence; don't refetch stable kind-0
 
-### 3. Do not refetch kind-0 metadata (stable events)
-
-- Stop refetching kind-0 on `refetchOnWindowFocus` / `refetchOnReconnect`.
-- Keep previous data visible during any refetch (`keepPreviousData`).
-- `staleTime: 60_000`.
+- `fetchProfileByIdentifier` throws on transient failures — timeout, relay
+  error, and no relay connection (`ndk.pool.connectedRelays()`, matching the
+  pattern in `publish/profiles.tsx`) — so React Query treats them as `isError`
+  and retains previous profile data. Only genuine absence (relays connected
+  and `fetchProfile()` resolved to null) returns the null-shaped value.
+- ProfilePage keeps previous data visible during refetch
+  (`placeholderData: keepPreviousData`), stops refetching kind-0 on window
+  focus / reconnect, and its not-found condition fires only when there is
+  genuinely no profile to show (`!profile`, not `isError || !profile`).
+- Behavior is covered by `profilesFetch.test.ts`.
 
 ### Explicit non-goals
 
 - **Do not** return a placeholder profile instead of the "Profile not found"
-  error. The error condition stays `!profile` so genuinely-unfound profiles
-  (valid hex, but no kind-0 metadata anywhere) still show the error.
-- **Do not** change any fetching logic apart from guarding the
-  error-causing condition.
+  error; genuinely-unfound profiles still show the error.
+- **Do not** change fetching logic apart from guarding the error-causing
+  condition and the transient/absence distinction.
 
 ## Consequences
 
-- An empty/invalid pubkey in production can no longer crash a page: the query
-  guards prevent the invalid filter from being built (primary), and
-  `filterValidationMode: 'fix'` strips any that slip through (safety net).
-- Dev/staging retain loud failure on filter bugs (`'validate'` + guardrails
-  on), so regressions are caught before production.
-- Profile metadata is no longer clobbered by a degraded post-refocus refetch;
-  the previously-loaded profile stays visible.
-- New query helpers that build `authors`/`#p` from a pubkey parameter must
-  guard against empty input. The server-side app-settings NDK pattern
-  (`aiGuardrails: false`, `filterValidationMode: 'fix'`) is the template for
-  any future one-off server fetch NDK instance.
-- `'fix'` broadens (does not narrow) a filter when it strips a bad author, so
-  it must remain a safety net, not the primary defense — the empty-pubkey
-  guards are the contract that keeps filters well-formed.
+- An empty/invalid pubkey is rejected at the query layer (fail closed); NDK
+  strict validation is retained, so any filter that slips past the guards
+  fails loudly rather than being silently broadened.
+- Guardrails off in production removes the `AI_GUARDRAILS` educational throw;
+  strict `'validate'` remains the backstop for malformed filters.
+- A transient post-refocus refetch no longer clobbers a loaded profile
+  (throws → `isError` + retained data; `keepPreviousData` covers the pending
+  state). Genuine absence still surfaces the "not found" error.
+- New query helpers building `authors`/`#p` from a pubkey must guard empty
+  input.
+
+## Follow-ups (not in this PR, per review)
+
+- Upgrade the empty-pubkey guards from truthiness (`!!pubkey`) to full
+  repo-standard `isValidHexKey` validation, and validate profile identifiers
+  with `validateProfileIdentifier` before any relay request.
+- Validate `appPubkey` before the app-settings query and verify the returned
+  event's publisher authority (author + kind 31990 + exact `d` tag).
+- Resolve the products-query overlap with #1206 (which uses `isValidHexKey`
+  at the query-activation boundary).

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -152,6 +152,6 @@ app actually trusts:
 
 ## Follow-ups (not in this PR, per review)
 
-- Products-by-pubkey is owned by #1206 (`enabled: isValidHexKey` at the
-  query-activation boundary); this PR does not guard products to avoid two
-  competing contracts. Merge #1206 before this PR and rebase onto the result.
+- None. The products-by-pubkey guard from #1206 (`enabled: isValidHexKey`
+  at the query-activation boundary) has been incorporated into this PR;
+  #1206 is closed as superseded.

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -56,12 +56,25 @@ that wouldn't load.
   default strict validation (a malformed appPubkey fails closed rather than
   broadening the query).
 
-### 2. Guard empty-string pubkey paths before building Nostr filters
+### 2. Validate identity inputs before building Nostr filters
 
-Query helpers that build `authors`/`#p` from a pubkey parameter short-circuit
-on an empty/blank pubkey (early-return / throw / `enabled: !!pubkey`) instead
-of constructing an invalid filter. No fetching logic is changed beyond
-guarding the error-causing condition.
+Query helpers that build `authors`/`#p` from a pubkey parameter reject a
+malformed pubkey (not just an empty one) before constructing the filter, using
+the repository-standard checks:
+
+- **Hex-pubkey fetchers** (`fetchAuthor`, `fetchShippingOptionsByPubkey`,
+  `fetchOrdersByBuyer`/`fetchOrdersBySeller`,
+  `fetchSellerPrivateOrderGiftWraps`, `fetchCollectionsByPubkey`,
+  `resolvePaymentDetailsForProduct`) use `isValidHexKey` — these build
+  `authors`/`#p` directly, which NDK's strict validation requires to be 64-hex.
+- **Identifier-accepting** paths (`fetchProfileByIdentifier`, `useProfileName`,
+  `useProfileNip05`) use `validateProfileIdentifier`, because they feed
+  `ndk.fetchUser`, which accepts hex/npub/nprofile/nip05. (The dashboard
+  messages route passes an npub route param to `useProfileName`, so a hex-only
+  gate would break that view.)
+
+This replaces the earlier truthiness (`!!pubkey`) guards, which permitted
+whitespace, truncated keys, and arbitrary malformed non-empty values.
 
 ### 3. Distinguish transient fetch failures from genuine absence; don't refetch stable kind-0
 
@@ -98,10 +111,8 @@ guarding the error-causing condition.
 
 ## Follow-ups (not in this PR, per review)
 
-- Upgrade the empty-pubkey guards from truthiness (`!!pubkey`) to full
-  repo-standard `isValidHexKey` validation, and validate profile identifiers
-  with `validateProfileIdentifier` before any relay request.
 - Validate `appPubkey` before the app-settings query and verify the returned
   event's publisher authority (author + kind 31990 + exact `d` tag).
-- Resolve the products-query overlap with #1206 (which uses `isValidHexKey`
-  at the query-activation boundary).
+- Products-by-pubkey is owned by #1206 (`enabled: isValidHexKey` at the
+  query-activation boundary); this PR does not guard products to avoid two
+  competing contracts. Merge #1206 before this PR and rebase onto the result.

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -80,7 +80,8 @@ malformed pubkey (not just an empty one) before constructing the filter, using
 the repository-standard checks:
 
 - **Hex-pubkey fetchers** (`fetchAuthor`, `fetchProductsByPubkey`,
-  `fetchShippingOptionsByPubkey`, `fetchOrdersByBuyer`/`fetchOrdersBySeller`,
+  `fetchUserPaymentDetails`, `fetchShippingOptionsByPubkey`,
+  `fetchOrdersByBuyer`/`fetchOrdersBySeller`,
   `fetchSellerPrivateOrderGiftWraps`, `fetchCollectionsByPubkey`,
   `resolvePaymentDetailsForProduct`) use `isValidHexKey` — these build
   `authors`/`#p` directly, which NDK's strict validation requires to be 64-hex.
@@ -88,8 +89,13 @@ the repository-standard checks:
   malformed pubkey reaching the fetcher is a programming error, not a data
   condition — the throw surfaces the bug in React Query's error state rather
   than silently returning an empty list that conflates "no results" with
-  "invalid input." The sibling fetchers (`fetchShippingOptionsByPubkey`, etc.)
-  return `[]` and may be migrated to the throw pattern in a follow-up.
+  "invalid input." The sibling fetchers (`fetchShippingOptionsByPubkey`,
+  `fetchUserPaymentDetails`, etc.) return `[]` because their try-catch blocks
+  swallow throws; they may be migrated to the throw pattern in a follow-up.
+  `fetchProductPaymentDetails` guards its optional-author path: if a pubkey is
+  provided but malformed, it returns `[]` (fail closed); if no pubkey is
+  provided, it proceeds with a broad query (no `authors` filter) — that
+  broadening is intentional.
 - **Identifier-accepting** paths (`fetchProfileByIdentifier`, `useProfileName`,
   `useProfileNip05`, `useProfile`) use `validateProfileIdentifier`, because
   they feed `ndk.fetchUser`, which accepts hex/npub/nprofile/nip05. (The
@@ -100,9 +106,15 @@ the repository-standard checks:
   `useQuery` callers. Callers with additional conditions COMBINE (not
   overwrite) the factory's `enabled`, e.g.
   `enabled: options.enabled && !validationError`.
-- **Hex-pubkey query factories** (`productsByPubkeyQueryOptions`,
-  `wotScoreQueryOptions`) use `isValidHexKey` at the factory level, so
-  `useProductsByPubkey`, `useWotScore`, and direct callers inherit the guard.
+- **Hex-pubkey query factories** (`authorQueryOptions`,
+  `productsByPubkeyQueryOptions`, `collectionsByPubkeyQueryOptions`,
+  `shippingOptionsByPubkeyQueryOptions`, `wotScoreQueryOptions`) use
+  `isValidHexKey` at the factory level, so `useProductsByPubkey`,
+  `useCollectionsByPubkey`, `useShippingOptionsByPubkey`, `useWotScore`, and
+  direct callers inherit the guard. Hooks that build queries inline
+  (`useOrdersByBuyer`, `useOrdersBySeller`, `useUserPaymentDetails`,
+  `useRichUserPaymentDetails`, `useWalletDetail`, `useAvailablePaymentOptions`)
+  also use `isValidHexKey` at the `enabled` boundary.
   Consumers with additional conditions COMBINE (not overwrite) the factory's
   `enabled`, e.g. `enabled: productOptions.enabled && isAuthenticated`.
   Truthiness checks (`!!pubkey`) are dropped because `isValidHexKey` implies

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -89,6 +89,25 @@ whitespace, truncated keys, and arbitrary malformed non-empty values.
   genuinely no profile to show (`!profile`, not `isError || !profile`).
 - Behavior is covered by `profilesFetch.test.ts`.
 
+### 4. Verify app-settings publisher authority before accepting content
+
+The kind-31990 app-config fetch (`fetchAppSettings` in `lib/appSettings.ts`)
+queries `{ kinds: [31990], authors: [appPubkey], '#d': ['plebeian-market-handler'] }`.
+Two hardenings close the gap between the requested filter and the content the
+app actually trusts:
+
+- **Validate before the query**: `appPubkey` is checked with `isValidHexKey`
+  before an NDK instance is created or any relay request is issued. A malformed
+  key is rejected early (fail closed) rather than relying solely on NDK's
+  strict filter validation to refuse the filter.
+- **Verify after the fetch**: the returned events are filtered to only those
+  authored by `appPubkey`, with kind 31990 and the exact `d` tag
+  `plebeian-market-handler` (`selectAuthoritativeAppSettingsEvent`). The
+  content schema validates shape, not authority, so a spoofed event from a
+  different publisher that happens to pass `AppSettingsSchema` is refused.
+  A higher-timestamp spoofed event is ignored in favor of the legitimate one.
+- Behavior is covered by `appSettings.test.ts`.
+
 ### Explicit non-goals
 
 - **Do not** return a placeholder profile instead of the "Profile not found"
@@ -111,8 +130,6 @@ whitespace, truncated keys, and arbitrary malformed non-empty values.
 
 ## Follow-ups (not in this PR, per review)
 
-- Validate `appPubkey` before the app-settings query and verify the returned
-  event's publisher authority (author + kind 31990 + exact `d` tag).
 - Products-by-pubkey is owned by #1206 (`enabled: isValidHexKey` at the
   query-activation boundary); this PR does not guard products to avoid two
   competing contracts. Merge #1206 before this PR and rebase onto the result.

--- a/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
+++ b/docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md
@@ -18,7 +18,7 @@ Accepted
 ## Context
 
 Two failure modes produced the same user-visible outcome — a profile page
-that wouldn't load.
+that wouldn't load — and a third latent risk was surfaced in review.
 
 1. **Filter-validation crash.** NDK AI Guardrails were enabled unconditionally
    in production via `{ skip: ... }`. The `filter-invalid-hex` guardrail is a
@@ -37,6 +37,13 @@ that wouldn't load.
    try/catch that returned `{ profile: null, user: null }`, so timeout, relay
    error, no connection, and genuine absence were all indistinguishable.
 
+3. **App-config authority gap.** Not a reported crash, but a latent risk
+   surfaced in review: the kind-31990 app-config fetch queried by author +
+   kind + d tag yet trusted whichever returned event had the highest
+   `created_at`. The content schema validates shape, not publisher authority,
+   so a malformed `appPubkey` (or a relay returning an event from a different
+   publisher) could yield app settings from an unrelated source.
+
 ## Decision
 
 ### 1. Disable AI Guardrails in production; retain strict filter validation
@@ -53,8 +60,8 @@ that wouldn't load.
   query layer **before** any filter is built (fail closed); strict validation
   then never throws because filters are always well-formed.
 - The server-side app-settings fetch NDK uses `aiGuardrails: false` with
-  default strict validation (a malformed appPubkey fails closed rather than
-  broadening the query).
+  default strict validation. App-config publisher authority is verified
+  separately (see decision 4).
 
 ### 2. Validate identity inputs before building Nostr filters
 
@@ -112,21 +119,28 @@ app actually trusts:
 
 - **Do not** return a placeholder profile instead of the "Profile not found"
   error; genuinely-unfound profiles still show the error.
-- **Do not** change fetching logic apart from guarding the error-causing
-  condition and the transient/absence distinction.
+- **Do not** change fetching logic apart from: input validation guards, the
+  transient/absence distinction, and app-config publisher-authority
+  verification. No other fetching behavior is altered.
 
 ## Consequences
 
-- An empty/invalid pubkey is rejected at the query layer (fail closed); NDK
-  strict validation is retained, so any filter that slips past the guards
-  fails loudly rather than being silently broadened.
+- A malformed pubkey (empty, whitespace, truncated, or non-hex) is rejected
+  at the query layer with `isValidHexKey` / `validateProfileIdentifier`
+  before any filter is built (fail closed). NDK strict validation is retained
+  as the backstop, so any filter that slips past the guards fails loudly
+  rather than being silently broadened.
 - Guardrails off in production removes the `AI_GUARDRAILS` educational throw;
   strict `'validate'` remains the backstop for malformed filters.
 - A transient post-refocus refetch no longer clobbers a loaded profile
   (throws → `isError` + retained data; `keepPreviousData` covers the pending
   state). Genuine absence still surfaces the "not found" error.
-- New query helpers building `authors`/`#p` from a pubkey must guard empty
-  input.
+- App-config content is accepted only from events authored by the expected
+  `appPubkey` with kind 31990 and the exact d tag; a spoofed event that
+  passes the shape schema is refused.
+- New query helpers building `authors`/`#p` from a pubkey must validate it with
+  `isValidHexKey` (hex fetchers) or `validateProfileIdentifier` (identifier
+  fetchers) before constructing the filter.
 
 ## Follow-ups (not in this PR, per review)
 

--- a/src/components/FeaturedUserCard.tsx
+++ b/src/components/FeaturedUserCard.tsx
@@ -9,7 +9,7 @@ import {
 import { profileQueryOptions } from '@/queries/profiles'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
-import { nip19 } from 'nostr-tools'
+import { safeNpubEncode } from '@/lib/utils'
 
 interface FeaturedUserCardProps extends React.HTMLAttributes<'div'> {
 	userPubkey: string
@@ -18,24 +18,27 @@ interface FeaturedUserCardProps extends React.HTMLAttributes<'div'> {
 export function FeaturedUserCard({ userPubkey }: FeaturedUserCardProps) {
 	// Ensure userPubkey is a string
 	const pubkeyString = userPubkey.toString()
+	const npub = safeNpubEncode(pubkeyString)
+	const isValidPubkey = npub !== null
 
 	// Query user's profile
 	const { data: profile } = useQuery({
-		...profileQueryOptions(nip19.npubEncode(pubkeyString)),
-		enabled: !!userPubkey,
+		...profileQueryOptions(npub ?? ''),
+		enabled: isValidPubkey,
 	})
 
 	// Query user's products
+	const productOptions = productsByPubkeyQueryOptions(pubkeyString)
 	const { data: userProductsData, isLoading: isLoadingProducts } = useQuery({
-		...productsByPubkeyQueryOptions(pubkeyString),
-		enabled: !!userPubkey,
+		...productOptions,
+		enabled: productOptions.enabled,
 	})
 
 	// Get first 4 products for display
 	const userProducts = userProductsData?.slice(0, 4) || []
 
 	// Get user display info
-	const displayName = profile?.name || profile?.display_name || nip19.npubEncode(pubkeyString).slice(0, 12) + '...'
+	const displayName = profile?.name || profile?.display_name || (isValidPubkey ? npub!.slice(0, 12) + '...' : 'Unknown')
 	const about = profile?.about
 	const picture = profile?.picture
 

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -24,7 +24,7 @@ import { useShippingOptionsByPubkey, getShippingService, getShippingPickupAddres
 import { getProfileIdentifierValidationError } from '@/lib/utils/profileValidation'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { Edit, MapPin, MessageCircle, Minus, Plus, Share2, Timer } from 'lucide-react'
 import { useState, useEffect, useMemo } from 'react'
@@ -49,6 +49,17 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	} = useQuery({
 		...profileByIdentifierQueryOptions(profileId),
 		enabled: !validationError,
+		// Profile metadata (kind 0) is slow-changing and is invalidated
+		// explicitly when the user edits their profile. Don't let a
+		// backgrounded tab's degraded relay pool clobber a loaded profile:
+		// a refocus/reconnect refetch that EOSE-empties would otherwise
+		// commit { profile: null, user } over good data and flip the page
+		// to a false "Could not load user profile". keepPreviousData keeps
+		// the good profile visible during any in-flight refetch.
+		placeholderData: keepPreviousData,
+		staleTime: 60_000,
+		refetchOnWindowFocus: false,
+		refetchOnReconnect: false,
 	})
 	const { profile, user } = profileData || {}
 
@@ -210,6 +221,11 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		validateBanner()
 	}, [profile?.banner])
 
+	// A profile is "not found" when we resolved no kind-0 metadata for it.
+	// The refocus/reconnect clobber that used to false-fire here is prevented
+	// at the query level (refetchOnWindowFocus/refetchOnReconnect: false +
+	// keepPreviousData above), so this condition now only fires for profiles
+	// that genuinely have no metadata, which is the correct "not found" case.
 	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && (profileIsError || !profile)
 	const invalidResolvedPubkeyError = !validationError && !profileIsLoading && !profileIsFetching && !!user && !profilePubkey
 	const errorMessage =

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -26,7 +26,7 @@ import { useAutoAnimate } from '@formkit/auto-animate/react'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
-import { Edit, MapPin, MessageCircle, Minus, Plus, Share2, Timer } from 'lucide-react'
+import { Edit, MapPin, MessageCircle, Minus, Plus, RotateCcw, Share2, Timer } from 'lucide-react'
 import { useState, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 import { UserCard } from '../UserCard'
@@ -45,21 +45,26 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		data: profileData,
 		isFetching: profileIsFetching,
 		isLoading: profileIsLoading,
+		refetch: refetchProfile,
 	} = useQuery({
 		...profileByIdentifierQueryOptions(profileId),
 		enabled: !validationError,
 		// Profile metadata (kind 0) is slow-changing and is invalidated
-		// explicitly on edit. A refocus/reconnect refetch that fails
-		// transiently (timeout/disconnect) now throws from
-		// fetchProfileByIdentifier, so React Query retains the previous
-		// profile (isError + retained data) instead of committing null.
-		// keepPreviousData keeps it visible during the in-flight refetch,
-		// and the error condition below only fires when there is genuinely
-		// no profile to show. See profilesFetch.test.ts.
+		// explicitly on edit. A refocus refetch that fails transiently
+		// (timeout/disconnect) now throws from fetchProfileByIdentifier,
+		// so React Query retains the previous profile (isError + retained
+		// data) instead of committing null. keepPreviousData keeps it
+		// visible during the in-flight refetch, and the error condition
+		// below only fires when there is genuinely no profile to show.
+		//
+		// refetchOnReconnect is preserved (RQ default) so that an initial
+		// profile query that failed during zero-relay startup is retried
+		// automatically once the relay connects. A failed reconnect refetch
+		// throws (transient), so RQ retains the previous profile via
+		// keepPreviousData — it does not clobber. See profilesFetch.test.ts.
 		placeholderData: keepPreviousData,
 		staleTime: 60_000,
 		refetchOnWindowFocus: false,
-		refetchOnReconnect: false,
 	})
 	const { profile, user } = profileData || {}
 
@@ -233,12 +238,15 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		(invalidResolvedPubkeyError ? 'This profile resolved to an invalid pubkey.' : null) ??
 		(profileNotFoundError ? 'This profile is unavailable or could not be loaded. Please try again later or check the URL.' : null)
 
+	const canRetry = !validationError && !invalidResolvedPubkeyError
+
 	if (errorMessage) {
 		return (
 			<ProfileErrorState
 				title={validationError ? 'Invalid profile identifier' : 'Could not load user profile'}
 				message={errorMessage}
 				gradientColor={profilePubkey ? getHexColorFingerprintFromHexPubkey(profilePubkey) : undefined}
+				onRetry={canRetry ? () => refetchProfile() : undefined}
 			/>
 		)
 	}
@@ -406,9 +414,10 @@ interface ProfileErrorStateProps {
 	title: string
 	message: string
 	gradientColor?: string
+	onRetry?: () => void
 }
 
-function ProfileErrorState({ title, message, gradientColor = 'hsl(0, 0%, 30%)' }: ProfileErrorStateProps) {
+function ProfileErrorState({ title, message, gradientColor = 'hsl(0, 0%, 30%)', onRetry }: ProfileErrorStateProps) {
 	return (
 		<div className="relative flex flex-col min-h-screen">
 			<div className="top-0 right-0 left-0 z-0 absolute bg-hero-image-margin h-[40vh] sm:h-[40vh] md:h-[50vh] overflow-hidden">
@@ -424,6 +433,12 @@ function ProfileErrorState({ title, message, gradientColor = 'hsl(0, 0%, 30%)' }
 				<div className="mx-auto w-full max-w-3xl rounded-3xl border border-border bg-background/90 p-8 text-center shadow-xl backdrop-blur">
 					<h1 className="text-3xl font-semibold text-foreground">{title}</h1>
 					<p className="mt-4 text-sm text-muted-foreground">{message}</p>
+					{onRetry && (
+						<Button onClick={onRetry} className="mt-6" variant="secondary">
+							<RotateCcw className="w-4 h-4 mr-2" />
+							Try again
+						</Button>
+					)}
 				</div>
 			</div>
 		</div>

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -41,6 +41,7 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	const [animationParent] = useAutoAnimate()
 	const validationError = getProfileIdentifierValidationError(profileId)
 
+	const profileOptions = profileByIdentifierQueryOptions(profileId)
 	const {
 		data: profileData,
 		isFetching: profileIsFetching,
@@ -49,8 +50,8 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		error: profileError,
 		refetch: refetchProfile,
 	} = useQuery({
-		...profileByIdentifierQueryOptions(profileId),
-		enabled: !validationError,
+		...profileOptions,
+		enabled: profileOptions.enabled && !validationError,
 		// Profile metadata (kind 0) is slow-changing and is invalidated
 		// explicitly on edit. A refocus refetch that fails transiently
 		// (timeout/disconnect) now throws from fetchProfileByIdentifier,

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -45,6 +45,8 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		data: profileData,
 		isFetching: profileIsFetching,
 		isLoading: profileIsLoading,
+		isError: profileIsError,
+		error: profileError,
 		refetch: refetchProfile,
 	} = useQuery({
 		...profileByIdentifierQueryOptions(profileId),
@@ -226,24 +228,43 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		validateBanner()
 	}, [profile?.banner])
 
-	// "Not found" = settled with no kind-0 metadata to show. Transient failures
-	// (timeout/disconnect/relay error) throw from fetchProfileByIdentifier, so
-	// React Query keeps the previous profile data and `profile` stays non-null
-	// — this no longer false-fires on a failed backgrounded-tab refetch. It
-	// fires only for genuine absence (settled, profile is null).
-	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && !profile
-	const invalidResolvedPubkeyError = !validationError && !profileIsLoading && !profileIsFetching && !!user && !profilePubkey
+	// Transport error: the query failed (timeout, disconnect, relay
+	// exception) on initial load with no cached profile to show. This is
+	// distinct from genuine absence (below) — it is retryable. When a
+	// background refetch fails after a successful load, keepPreviousData
+	// retains the profile and `profile` stays non-null, so this does not
+	// fire and the profile remains visible (covered by profilesFetch.test.ts
+	// QueryClient test).
+	const profileTransportError = !validationError && !profileIsLoading && !profileIsFetching && profileIsError && !profile
+	// Genuine absence: the query succeeded (no error) but no kind-0 metadata
+	// was observed from the configured relays for this user.
+	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && !profileIsError && !profile
+	const invalidResolvedPubkeyError =
+		!validationError && !profileIsLoading && !profileIsFetching && !profileIsError && !!user && !profilePubkey
 	const errorMessage =
 		validationError ??
+		(profileTransportError
+			? `Could not load this profile: ${profileError instanceof Error ? profileError.message : 'the relay may be unreachable or still connecting'}. Please try again.`
+			: null) ??
 		(invalidResolvedPubkeyError ? 'This profile resolved to an invalid pubkey.' : null) ??
-		(profileNotFoundError ? 'This profile is unavailable or could not be loaded. Please try again later or check the URL.' : null)
+		(profileNotFoundError ? 'No profile metadata was observed from the configured relays for this user.' : null)
 
-	const canRetry = !validationError && !invalidResolvedPubkeyError
+	// Only transport errors are retryable; genuine absence and invalid
+	// identifiers are settled states.
+	const canRetry = profileTransportError
+
+	const errorTitle = validationError
+		? 'Invalid profile identifier'
+		: profileTransportError
+			? 'Could not load user profile'
+			: invalidResolvedPubkeyError
+				? 'Invalid profile'
+				: 'Profile not found'
 
 	if (errorMessage) {
 		return (
 			<ProfileErrorState
-				title={validationError ? 'Invalid profile identifier' : 'Could not load user profile'}
+				title={errorTitle}
 				message={errorMessage}
 				gradientColor={profilePubkey ? getHexColorFingerprintFromHexPubkey(profilePubkey) : undefined}
 				onRetry={canRetry ? () => refetchProfile() : undefined}

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -52,19 +52,15 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 	} = useQuery({
 		...profileOptions,
 		enabled: profileOptions.enabled && !validationError,
-		// Profile metadata (kind 0) is slow-changing and is invalidated
-		// explicitly on edit. A refocus refetch that fails transiently
-		// (timeout/disconnect) now throws from fetchProfileByIdentifier,
-		// so React Query retains the previous profile (isError + retained
-		// data) instead of committing null. keepPreviousData keeps it
-		// visible during the in-flight refetch, and the error condition
-		// below only fires when there is genuinely no profile to show.
+		// Profile metadata is slow-changing. Transient fetch failures reject,
+		// so React Query retains previously cached data rather than committing
+		// a null-shaped success. keepPreviousData preserves observer data while
+		// switching query keys.
 		//
-		// refetchOnReconnect is preserved (RQ default) so that an initial
-		// profile query that failed during zero-relay startup is retried
-		// automatically once the relay connects. A failed reconnect refetch
-		// throws (transient), so RQ retains the previous profile via
-		// keepPreviousData — it does not clobber. See profilesFetch.test.ts.
+		// Window-focus refetching is disabled. The default reconnect policy
+		// covers browser online/offline recovery only; it does not observe NDK
+		// relay readiness. Initial failures remain recoverable through normal
+		// retries and the manual Try again action below.
 		placeholderData: keepPreviousData,
 		staleTime: 60_000,
 		refetchOnWindowFocus: false,
@@ -232,13 +228,13 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 
 	// Transport error: the query failed (timeout, disconnect, relay
 	// exception) on initial load with no cached profile to show. This is
-	// distinct from genuine absence (below) — it is retryable. When a
+	// distinct from metadata not observed (below) — it is retryable. When a
 	// background refetch fails after a successful load, keepPreviousData
 	// retains the profile and `profile` stays non-null, so this does not
 	// fire and the profile remains visible (covered by profilesFetch.test.ts
 	// QueryClient test).
 	const profileTransportError = !validationError && !profileIsLoading && !profileIsFetching && profileIsError && !profile
-	// Genuine absence: the query succeeded (no error) but no kind-0 metadata
+	// Metadata not observed: the query succeeded (no error) but no kind-0 metadata
 	// was observed from the configured relays for this user.
 	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && !profileIsError && !profile
 	const invalidResolvedPubkeyError =
@@ -251,7 +247,7 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		(invalidResolvedPubkeyError ? 'This profile resolved to an invalid pubkey.' : null) ??
 		(profileNotFoundError ? 'No profile metadata was observed from the configured relays for this user.' : null)
 
-	// Only transport errors are retryable; genuine absence and invalid
+	// Only transport errors are retryable; metadata not observed and invalid
 	// identifiers are settled states.
 	const canRetry = profileTransportError
 

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -43,19 +43,19 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 
 	const {
 		data: profileData,
-		isLoading: profileIsLoading,
 		isFetching: profileIsFetching,
-		isError: profileIsError,
+		isLoading: profileIsLoading,
 	} = useQuery({
 		...profileByIdentifierQueryOptions(profileId),
 		enabled: !validationError,
 		// Profile metadata (kind 0) is slow-changing and is invalidated
-		// explicitly when the user edits their profile. Don't let a
-		// backgrounded tab's degraded relay pool clobber a loaded profile:
-		// a refocus/reconnect refetch that EOSE-empties would otherwise
-		// commit { profile: null, user } over good data and flip the page
-		// to a false "Could not load user profile". keepPreviousData keeps
-		// the good profile visible during any in-flight refetch.
+		// explicitly on edit. A refocus/reconnect refetch that fails
+		// transiently (timeout/disconnect) now throws from
+		// fetchProfileByIdentifier, so React Query retains the previous
+		// profile (isError + retained data) instead of committing null.
+		// keepPreviousData keeps it visible during the in-flight refetch,
+		// and the error condition below only fires when there is genuinely
+		// no profile to show. See profilesFetch.test.ts.
 		placeholderData: keepPreviousData,
 		staleTime: 60_000,
 		refetchOnWindowFocus: false,
@@ -221,12 +221,12 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		validateBanner()
 	}, [profile?.banner])
 
-	// A profile is "not found" when we resolved no kind-0 metadata for it.
-	// The refocus/reconnect clobber that used to false-fire here is prevented
-	// at the query level (refetchOnWindowFocus/refetchOnReconnect: false +
-	// keepPreviousData above), so this condition now only fires for profiles
-	// that genuinely have no metadata, which is the correct "not found" case.
-	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && (profileIsError || !profile)
+	// "Not found" = settled with no kind-0 metadata to show. Transient failures
+	// (timeout/disconnect/relay error) throw from fetchProfileByIdentifier, so
+	// React Query keeps the previous profile data and `profile` stays non-null
+	// — this no longer false-fires on a failed backgrounded-tab refetch. It
+	// fires only for genuine absence (settled, profile is null).
+	const profileNotFoundError = !validationError && !profileIsLoading && !profileIsFetching && !profile
 	const invalidResolvedPubkeyError = !validationError && !profileIsLoading && !profileIsFetching && !!user && !profilePubkey
 	const errorMessage =
 		validationError ??

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -80,9 +80,10 @@ export function ProfilePage({ profileId }: ProfilePageProps) {
 		}
 	}, [user])
 
+	const sellerProductOptions = productsByPubkeyQueryOptions(profilePubkey ?? '')
 	const { data: sellerProducts = [], isLoading: sellerProductsIsLoading } = useQuery({
-		...productsByPubkeyQueryOptions(profilePubkey ?? ''),
-		enabled: !!profilePubkey,
+		...sellerProductOptions,
+		enabled: sellerProductOptions.enabled,
 	})
 
 	const [showFullAbout, setShowFullAbout] = useState(false)

--- a/src/lib/__tests__/appSettings.test.ts
+++ b/src/lib/__tests__/appSettings.test.ts
@@ -1,0 +1,89 @@
+import { selectAuthoritativeAppSettingsEvent, APP_SETTINGS_KIND, APP_SETTINGS_D_TAG, type AppSettingsEventLike } from '../appSettings'
+import { describe, expect, test } from 'bun:test'
+
+const APP_PUBKEY = 'a'.repeat(64)
+const SPOOF_PUBKEY = 'b'.repeat(64)
+
+/** Minimal event factory satisfying the AppSettingsEventLike structural type. */
+function mockEvent(opts: Partial<AppSettingsEventLike> & { pubkey?: string }): AppSettingsEventLike {
+	return {
+		kind: opts.kind ?? APP_SETTINGS_KIND,
+		pubkey: opts.pubkey ?? APP_PUBKEY,
+		tags: opts.tags ?? [['d', APP_SETTINGS_D_TAG]],
+		created_at: opts.created_at ?? 100,
+		content: opts.content ?? '{}',
+	}
+}
+
+describe('selectAuthoritativeAppSettingsEvent', () => {
+	test('returns the latest event matching the expected author, kind, and d tag', () => {
+		const events = [mockEvent({ created_at: 50 }), mockEvent({ created_at: 100 })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeDefined()
+		expect(result?.pubkey).toBe(APP_PUBKEY)
+		expect(result?.kind).toBe(APP_SETTINGS_KIND)
+		expect(result?.created_at).toBe(100)
+	})
+
+	test('rejects an event from a different publisher (spoofed author)', () => {
+		const events = [mockEvent({ pubkey: SPOOF_PUBKEY, created_at: 999, content: '{"name":"evil"}' })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeUndefined()
+	})
+
+	test('rejects an event with the wrong kind', () => {
+		const events = [mockEvent({ kind: 30000 })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeUndefined()
+	})
+
+	test('rejects an event with a different d tag', () => {
+		const events = [mockEvent({ tags: [['d', 'some-other-handler']] })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeUndefined()
+	})
+
+	test('rejects an event with no d tag at all', () => {
+		const events = [mockEvent({ tags: [] })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeUndefined()
+	})
+
+	test('returns undefined for an empty event list', () => {
+		const result = selectAuthoritativeAppSettingsEvent([], APP_PUBKEY)
+
+		expect(result).toBeUndefined()
+	})
+
+	test('ignores a higher-timestamp spoofed event and selects the legitimate one', () => {
+		const events = [
+			mockEvent({ pubkey: SPOOF_PUBKEY, created_at: 999, content: '{"name":"evil"}' }),
+			mockEvent({ created_at: 50, content: '{"name":"real"}' }),
+		]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result).toBeDefined()
+		expect(result?.pubkey).toBe(APP_PUBKEY)
+		expect(result?.created_at).toBe(50)
+		expect(result?.content).toBe('{"name":"real"}')
+	})
+
+	test('selects the newest among multiple valid events from the same publisher', () => {
+		const events = [mockEvent({ created_at: 10 }), mockEvent({ created_at: 200 }), mockEvent({ created_at: 100 })]
+
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+
+		expect(result?.created_at).toBe(200)
+	})
+})

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -9,14 +9,11 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 		// to avoid shared store issues with ndkActions
 		const ndk = new NDK({
 			explicitRelayUrls: [relayUrl],
-			// This is a server-side, one-off fetch of app-config events with a
-			// known-valid app pubkey. AI guardrails are a dev-time educational
-			// tool and have no place here; leaving them on risks a fatal throw
-			// if the pubkey were ever malformed.
+			// Server-side, one-off fetch of app-config events. AI guardrails are a
+			// dev-time educational tool and have no place here. NDK's default strict
+			// filter validation is retained (a malformed appPubkey fails closed
+			// rather than broadening the query).
 			aiGuardrails: false,
-			// Strip (don't throw on) any invalid filter values — server fetches
-			// should degrade gracefully, never crash.
-			filterValidationMode: 'fix',
 		})
 
 		// Connect with timeout

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -9,10 +9,14 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 		// to avoid shared store issues with ndkActions
 		const ndk = new NDK({
 			explicitRelayUrls: [relayUrl],
-			// Skip AI guardrails that might filter out events during fetch
-			aiGuardrails: {
-				skip: new Set(['ndk-no-cache', 'fetch-events-usage']),
-			},
+			// This is a server-side, one-off fetch of app-config events with a
+			// known-valid app pubkey. AI guardrails are a dev-time educational
+			// tool and have no place here; leaving them on risks a fatal throw
+			// if the pubkey were ever malformed.
+			aiGuardrails: false,
+			// Strip (don't throw on) any invalid filter values — server fetches
+			// should degrade gracefully, never crash.
+			filterValidationMode: 'fix',
 		})
 
 		// Connect with timeout

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -1,8 +1,55 @@
-import NDK, { type NDKFilter, type NostrEvent } from '@nostr-dev-kit/ndk'
+import NDK, { type NDKFilter, type NDKEvent, type NostrEvent } from '@nostr-dev-kit/ndk'
 import { AppSettingsSchema, type AppSettings } from './schemas/app'
+import { isValidHexKey } from './utils'
+
+/** Kind for NIP-89 handler information / app-config events. */
+export const APP_SETTINGS_KIND = 31990
+/** Exact d tag that identifies the Plebeian Market app-settings event. */
+export const APP_SETTINGS_D_TAG = 'plebeian-market-handler'
+
+/**
+ * Structural shape needed to verify app-settings publisher authority. Kept
+ * minimal (and independent of the NDKEvent class) so it is easy to construct
+ * in tests.
+ */
+export interface AppSettingsEventLike {
+	kind?: number
+	pubkey: string
+	tags: Array<string[]>
+	created_at?: number
+	content: string
+}
+
+/**
+ * Select the latest app-settings event that matches the expected publisher
+ * authority: the event must be kind 31990, authored by `appPubkey`, and carry
+ * the exact d tag 'plebeian-market-handler'. Events from any other publisher
+ * (or with a different kind / d tag) are rejected — the content schema
+ * validates shape, not authority, so a spoofed event that passes the schema
+ * must still be refused here.
+ */
+export function selectAuthoritativeAppSettingsEvent(
+	events: ReadonlyArray<AppSettingsEventLike>,
+	appPubkey: string,
+): AppSettingsEventLike | undefined {
+	return events
+		.filter(
+			(e) => e.kind === APP_SETTINGS_KIND && e.pubkey === appPubkey && e.tags.some((t) => t[0] === 'd' && t[1] === APP_SETTINGS_D_TAG),
+		)
+		.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
+}
 
 export async function fetchAppSettings(relayUrl: string, appPubkey: string): Promise<AppSettings | null> {
 	console.log(`Fetching app settings from relay: ${relayUrl} for pubkey: ${appPubkey}`)
+
+	// Reject a malformed app pubkey before creating an NDK instance or issuing
+	// any relay request. NDK's strict filter validation would also fail closed,
+	// but validating here gives a clear, early failure and guarantees the
+	// authors constraint is never satisfied by an unrelated publisher.
+	if (!isValidHexKey(appPubkey)) {
+		console.error('Invalid app pubkey provided:', appPubkey)
+		return null
+	}
 
 	try {
 		// Create a fresh NDK instance for server-side initialization
@@ -57,7 +104,7 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 				})
 			})
 
-		const events = (await fetchWithTimeout(ndk.fetchEvents(filter), 10000)) as Set<any>
+		const events = (await fetchWithTimeout(ndk.fetchEvents(filter), 10000)) as Set<NDKEvent>
 		const eventArray = Array.from(events)
 		console.log(`Fetch returned ${eventArray.length} events`)
 
@@ -67,10 +114,20 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 		}
 
 		console.log(`Found ${eventArray.length} app settings events`)
-		const latestEvent = eventArray.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
+
+		// Verify publisher authority before accepting content: select only the
+		// event authored by the expected app pubkey, with kind 31990 and the exact
+		// d tag 'plebeian-market-handler'. A relay could return an event from a
+		// different publisher whose content passes the shape schema; reject it
+		// here (see selectAuthoritativeAppSettingsEvent).
+		const authoritativeEvent = selectAuthoritativeAppSettingsEvent(eventArray, appPubkey)
+		if (!authoritativeEvent) {
+			console.warn(`No app settings event from expected publisher: ${appPubkey}`)
+			return null
+		}
 
 		try {
-			const parsedContent = JSON.parse(latestEvent.content)
+			const parsedContent = JSON.parse(authoritativeEvent.content)
 			const validatedSettings = AppSettingsSchema.parse(parsedContent)
 
 			return validatedSettings

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -304,19 +304,18 @@ export const ndkActions = {
 		// default). Enabling them in production turns a single malformed pubkey
 		// in any filter into a fatal throw ("AI_GUARDRAILS ERROR") that crashes
 		// the page. Keep them on only in dev/staging where they're useful.
+		//
+		// NDK's default filter validation ('validate', strict) is intentionally
+		// retained in all stages: invalid/empty pubkeys are rejected at the query
+		// layer before any filter is built (fail closed) — never by loosening NDK
+		// validation. 'fix' mode would strip a bad author and broaden an
+		// identity-scoped request instead of rejecting it, which is unsafe for
+		// marketplace identity/order/payment boundaries.
 		const enableGuardrails = stage === 'development' || stage === 'staging'
 		const ndk = new NDK({
 			explicitRelayUrls: explicitRelays,
 			enableOutboxModel: enableOutbox,
 			aiGuardrails: enableGuardrails ? { skip: new Set(['ndk-no-cache', 'fetch-events-usage']) } : false,
-			// NDK validates every filter before subscribing. The default mode
-			// ('validate') *throws* on an invalid pubkey (e.g. an empty string
-			// from a `?? ''` fallback during a transient state) — which would
-			// crash the page even with guardrails off. In production we want
-			// graceful degradation: 'fix' strips invalid entries from the
-			// filter instead of throwing. In dev/staging we keep 'validate' so
-			// filter bugs surface loudly during development.
-			filterValidationMode: enableGuardrails ? 'validate' : 'fix',
 		})
 
 		// Always monitor zap receipts on public ZAP_RELAYS (plus the app relay).

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -300,12 +300,23 @@ export const ndkActions = {
 		// This prevents NDK from discovering and connecting to additional relays
 		const enableOutbox = stage !== 'staging' && stage !== 'development' && !localRelayOnly
 
+		// AI Guardrails are an NDK dev-time educational tool (shipped off by
+		// default). Enabling them in production turns a single malformed pubkey
+		// in any filter into a fatal throw ("AI_GUARDRAILS ERROR") that crashes
+		// the page. Keep them on only in dev/staging where they're useful.
+		const enableGuardrails = stage === 'development' || stage === 'staging'
 		const ndk = new NDK({
 			explicitRelayUrls: explicitRelays,
 			enableOutboxModel: enableOutbox,
-			aiGuardrails: {
-				skip: new Set(['ndk-no-cache', 'fetch-events-usage']),
-			},
+			aiGuardrails: enableGuardrails ? { skip: new Set(['ndk-no-cache', 'fetch-events-usage']) } : false,
+			// NDK validates every filter before subscribing. The default mode
+			// ('validate') *throws* on an invalid pubkey (e.g. an empty string
+			// from a `?? ''` fallback during a transient state) — which would
+			// crash the page even with guardrails off. In production we want
+			// graceful degradation: 'fix' strips invalid entries from the
+			// filter instead of throwing. In dev/staging we keep 'validate' so
+			// filter bugs surface loudly during development.
+			filterValidationMode: enableGuardrails ? 'validate' : 'fix',
 		})
 
 		// Always monitor zap receipts on public ZAP_RELAYS (plus the app relay).

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ import type { NDKUser } from '@nostr-dev-kit/ndk'
 import { toast } from 'sonner'
 import { HEX_KEYS_REGEX } from './constants'
 import { EMAIL_REGEX } from './constants'
-import { decode } from 'nostr-tools/nip19'
+import { decode, npubEncode } from 'nostr-tools/nip19'
 
 export function cn(...inputs: ClassValue[]) {
 	return twMerge(clsx(inputs))
@@ -48,6 +48,14 @@ export function isValidNip05(input: string): boolean {
 
 export function isValidHexKey(input: string): boolean {
 	return HEX_KEYS_REGEX.test(input)
+}
+
+/**
+ * Encodes a hex pubkey to npub, returning null if the input is not a valid
+ * 64-char hex key. Prevents nip19.npubEncode from throwing during render.
+ */
+export function safeNpubEncode(pubkey: string): string | null {
+	return isValidHexKey(pubkey) ? npubEncode(pubkey) : null
 }
 
 export function isValidNpub(input: string): boolean {

--- a/src/queries/__tests__/identityBoundaries.test.ts
+++ b/src/queries/__tests__/identityBoundaries.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+import { fetchUserPaymentDetails, fetchProductPaymentDetails } from '../payment'
+import { authorQueryOptions } from '../authors'
+import { collectionsByPubkeyQueryOptions } from '../collections'
+import { shippingOptionsByPubkeyQueryOptions } from '../shipping'
+
+const VALID_PUBKEY = 'a'.repeat(64)
+
+describe('payment fetcher guards (zero relay I/O for invalid identity)', () => {
+	test('fetchUserPaymentDetails returns [] for empty pubkey without touching NDK', async () => {
+		const result = await fetchUserPaymentDetails('')
+		expect(result).toEqual([])
+	})
+
+	test('fetchUserPaymentDetails returns [] for malformed pubkey without touching NDK', async () => {
+		const result = await fetchUserPaymentDetails('not-hex')
+		expect(result).toEqual([])
+	})
+
+	test('fetchUserPaymentDetails returns [] for whitespace pubkey without touching NDK', async () => {
+		const result = await fetchUserPaymentDetails('   ')
+		expect(result).toEqual([])
+	})
+
+	test('fetchProductPaymentDetails returns [] for malformed optional pubkey without touching NDK', async () => {
+		const result = await fetchProductPaymentDetails('30402:abc:not-hex', 'not-hex')
+		expect(result).toEqual([])
+	})
+
+	test('fetchProductPaymentDetails returns [] for empty optional pubkey without touching NDK', async () => {
+		const result = await fetchProductPaymentDetails('30402:abc:test', '')
+		expect(result).toEqual([])
+	})
+})
+
+describe('identity-scoped query options disable for invalid input', () => {
+	test('authorQueryOptions disables for malformed pubkey', () => {
+		expect(authorQueryOptions('').enabled).toBe(false)
+		expect(authorQueryOptions('not-hex').enabled).toBe(false)
+		expect(authorQueryOptions('abc').enabled).toBe(false)
+	})
+
+	test('authorQueryOptions enables for valid hex pubkey', () => {
+		expect(authorQueryOptions(VALID_PUBKEY).enabled).toBe(true)
+	})
+
+	test('collectionsByPubkeyQueryOptions disables for malformed pubkey', () => {
+		expect(collectionsByPubkeyQueryOptions('').enabled).toBe(false)
+		expect(collectionsByPubkeyQueryOptions('not-hex').enabled).toBe(false)
+	})
+
+	test('collectionsByPubkeyQueryOptions enables for valid hex pubkey', () => {
+		expect(collectionsByPubkeyQueryOptions(VALID_PUBKEY).enabled).toBe(true)
+	})
+
+	test('shippingOptionsByPubkeyQueryOptions disables for malformed pubkey', () => {
+		expect(shippingOptionsByPubkeyQueryOptions('').enabled).toBe(false)
+		expect(shippingOptionsByPubkeyQueryOptions('not-hex').enabled).toBe(false)
+	})
+
+	test('shippingOptionsByPubkeyQueryOptions enables for valid hex pubkey', () => {
+		expect(shippingOptionsByPubkeyQueryOptions(VALID_PUBKEY).enabled).toBe(true)
+	})
+})

--- a/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
+++ b/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test'
+import { productsByPubkeyQueryOptions } from '../products'
+
+const VALID_PUBKEY = 'a'.repeat(64)
+
+describe('productsByPubkeyQueryOptions', () => {
+	test('disables the query while the pubkey is empty', () => {
+		const options = productsByPubkeyQueryOptions('', true)
+
+		expect(options.enabled).toBe(false)
+	})
+
+	test('disables the query for a malformed pubkey', () => {
+		const options = productsByPubkeyQueryOptions('not-a-valid-pubkey')
+
+		expect(options.enabled).toBe(false)
+	})
+
+	test('enables the query for a valid hex pubkey', () => {
+		const options = productsByPubkeyQueryOptions(VALID_PUBKEY)
+
+		expect(options.enabled).toBe(true)
+	})
+})

--- a/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
+++ b/src/queries/__tests__/productsByPubkeyQueryOptions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { productsByPubkeyQueryOptions } from '../products'
+import { fetchProductsByPubkey, productsByPubkeyQueryOptions } from '../products'
+import { safeNpubEncode } from '@/lib/utils'
 
 const VALID_PUBKEY = 'a'.repeat(64)
 
@@ -20,5 +21,63 @@ describe('productsByPubkeyQueryOptions', () => {
 		const options = productsByPubkeyQueryOptions(VALID_PUBKEY)
 
 		expect(options.enabled).toBe(true)
+	})
+
+	test('caller composition: options.enabled && isAuthenticated stays false for malformed truthy input', () => {
+		// Simulates the dashboard products route combining the factory guard
+		// with its own isAuthenticated condition. A truthy-but-malformed pubkey
+		// must still disable the query even when isAuthenticated is true.
+		const options = productsByPubkeyQueryOptions('not-hex-but-truthy')
+		const combinedEnabled = options.enabled && true // isAuthenticated = true
+
+		expect(combinedEnabled).toBe(false)
+	})
+
+	test('caller composition: options.enabled && isAuthenticated is true for valid pubkey + auth', () => {
+		const options = productsByPubkeyQueryOptions(VALID_PUBKEY)
+		const combinedEnabled = options.enabled && true
+
+		expect(combinedEnabled).toBe(true)
+	})
+})
+
+describe('fetchProductsByPubkey direct-call guard', () => {
+	test('throws on malformed pubkey without touching NDK (zero relay I/O)', () => {
+		// isValidHexKey check fires before ndkActions.getNDK() is called,
+		// so no NDK instance is created and no relay request is issued.
+		expect(() => fetchProductsByPubkey('not-hex')).toThrow('invalid seller pubkey')
+	})
+
+	test('throws on empty pubkey without touching NDK', () => {
+		expect(() => fetchProductsByPubkey('')).toThrow('invalid seller pubkey')
+	})
+
+	test('throws on whitespace pubkey without touching NDK', () => {
+		expect(() => fetchProductsByPubkey('   ')).toThrow('invalid seller pubkey')
+	})
+})
+
+describe('safeNpubEncode', () => {
+	test('returns null for empty input', () => {
+		expect(safeNpubEncode('')).toBeNull()
+	})
+
+	test('returns null for whitespace input', () => {
+		expect(safeNpubEncode('   ')).toBeNull()
+	})
+
+	test('returns null for truncated hex', () => {
+		expect(safeNpubEncode('abc123')).toBeNull()
+	})
+
+	test('returns null for non-hex string', () => {
+		expect(safeNpubEncode('not-a-valid-pubkey')).toBeNull()
+	})
+
+	test('returns npub string for valid 64-char hex pubkey', () => {
+		const result = safeNpubEncode(VALID_PUBKEY)
+
+		expect(result).not.toBeNull()
+		expect(result!.startsWith('npub1')).toBe(true)
 	})
 })

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -90,10 +90,17 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('fetchUser boom')
 	})
 
-	test('throws on no relay connection instead of returning null', async () => {
-		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 0, fetchUser: async () => stubUser(null) })
+	test('does not preflight-throw on zero connected relays; proceeds to fetchProfile', async () => {
+		// Zero connected relays is a normal transient state while connect()
+		// completes; the fetcher must not throw a preflight error but instead
+		// proceed and let the timeout/operation determine the outcome.
+		const user = stubUser(null)
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 0, fetchUser: async () => user })
 
-		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('No relay connection')
+		const result = await fetchProfileByIdentifier(VALID_HEX)
+
+		expect(result.profile).toBeNull()
+		expect(result.user).toBe(user)
 	})
 
 	test('throws when NDK is not initialized', async () => {

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -91,4 +91,14 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 
 		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('NDK not initialized')
 	})
+
+	test('returns { profile: null, user: null } for a malformed identifier without a relay request', async () => {
+		const fetchUser = mock(async () => stubUser(null))
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser })
+
+		const result = await fetchProfileByIdentifier('not-a-valid-identifier')
+
+		expect(result).toEqual({ profile: null, user: null })
+		expect(fetchUser).toHaveBeenCalledTimes(0)
+	})
 })

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { QueryClient } from '@tanstack/react-query'
 
 import { ndkActions } from '@/lib/stores/ndk'
 import { fetchProfileByIdentifier } from '../profiles'
@@ -146,5 +147,49 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 
 		expect(result.profile).toBe(profile)
 		expect(result.user).toBe(readyUser)
+	})
+})
+
+describe('QueryClient retains cached profile data after a rejected same-key refetch', () => {
+	test('previous profile survives a failed refetch (RQ v5 fetchFailed reducer spreads state)', async () => {
+		// Prove that keepPreviousData + the throw-on-transient contract work
+		// together: after a successful fetch, a rejected refetch of the same
+		// query key does NOT evict the cached data. RQ v5's fetchFailed reducer
+		// does `...state` (preserving data) before setting status: "error".
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		})
+		const queryKey = ['profile', 'test']
+
+		// First fetch: succeeds with a profile.
+		const profile = { name: 'alice', about: 'hi' } as NDKUserProfileLike
+		const goodUser = stubUser(profile)
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => goodUser })
+
+		const result1 = await queryClient.fetchQuery({
+			queryKey,
+			queryFn: () => fetchProfileByIdentifier(VALID_HEX),
+			staleTime: 0,
+		})
+		expect(result1.profile).toEqual(profile)
+
+		// Second fetch: the relay now rejects. staleTime: 0 forces a re-run.
+		const failingUser = {
+			pubkey: VALID_HEX,
+			fetchProfile: async () => Promise.reject(new Error('relay boom')),
+		} as unknown as NDKUserLike
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => failingUser })
+
+		await expect(
+			queryClient.fetchQuery({
+				queryKey,
+				queryFn: () => fetchProfileByIdentifier(VALID_HEX),
+				staleTime: 0,
+			}),
+		).rejects.toThrow('relay boom')
+
+		// The cache must still retain the previous profile data.
+		const cached = queryClient.getQueryData<{ profile: NDKUserProfileLike | null; user: unknown }>(queryKey)
+		expect(cached?.profile).toEqual(profile)
 	})
 })

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test'
-import type { NDKUser, NDKUserProfile } from '@nostr-dev-kit/ndk'
 
 import { ndkActions } from '@/lib/stores/ndk'
 import { fetchProfileByIdentifier } from '../profiles'
+
+// Infer NDK return types from the function under test instead of importing
+// the NDK package directly — the NDK-footprint CI guard counts any src/ file
+// containing the NDK package import path, and this test file must not
+// increase the 127-file baseline.
+type FetchResult = Awaited<ReturnType<typeof fetchProfileByIdentifier>>
+type NDKUserLike = NonNullable<FetchResult['user']>
+type NDKUserProfileLike = NonNullable<FetchResult['profile']>
 
 // `fetchProfileByIdentifier` reads NDK from the `ndkActions` store, so we stub
 // `getNDK` (the orders-seam.test.ts pattern) to drive each behavioral case.
@@ -17,12 +24,12 @@ afterEach(() => {
 const VALID_HEX = 'a'.repeat(64)
 
 /** A minimal NDKUser stub: just enough (pubkey + fetchProfile) for the fetcher. */
-function stubUser(profile: NDKUserProfile | null): NDKUser {
-	return { pubkey: VALID_HEX, fetchProfile: async () => profile } as unknown as NDKUser
+function stubUser(profile: NDKUserProfileLike | null): NDKUserLike {
+	return { pubkey: VALID_HEX, fetchProfile: async () => profile } as unknown as NDKUserLike
 }
 
 /** Minimal NDK stub: a relay pool that reports `connected` live relays + a fetchUser. */
-function stubNdk(opts: { connectedRelays: number; fetchUser: (identifier: string) => Promise<NDKUser | null> }) {
+function stubNdk(opts: { connectedRelays: number; fetchUser: (identifier: string) => Promise<NDKUserLike | null> }) {
 	return {
 		pool: { connectedRelays: () => Array.from({ length: opts.connectedRelays }, () => ({})) },
 		fetchUser: opts.fetchUser,
@@ -31,7 +38,7 @@ function stubNdk(opts: { connectedRelays: number; fetchUser: (identifier: string
 
 describe('fetchProfileByIdentifier distinguishes genuine absence from transient failures', () => {
 	test('returns the profile when relays are connected and fetchProfile resolves data', async () => {
-		const profile = { name: 'alice', about: 'hi' } as NDKUserProfile
+		const profile = { name: 'alice', about: 'hi' } as NDKUserProfileLike
 		const user = stubUser(profile)
 		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => user })
 
@@ -55,7 +62,10 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 
 	test('throws on timeout instead of returning a null-shaped success', async () => {
 		// fetchProfile never settles; the timeout must win the race and throw.
-		const hangingUser = { pubkey: VALID_HEX, fetchProfile: () => new Promise<NDKUserProfile | null>(() => {}) } as unknown as NDKUser
+		const hangingUser = {
+			pubkey: VALID_HEX,
+			fetchProfile: () => new Promise<NDKUserProfileLike | null>(() => {}),
+		} as unknown as NDKUserLike
 		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => hangingUser })
 		// Fire the timeout reject immediately so the test doesn't wait 8s.
 		globalThis.setTimeout = ((cb: () => void) => {
@@ -67,7 +77,7 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 	})
 
 	test('throws when fetchProfile rejects (relay error) instead of returning null', async () => {
-		const user = { pubkey: VALID_HEX, fetchProfile: async () => Promise.reject(new Error('relay boom')) } as unknown as NDKUser
+		const user = { pubkey: VALID_HEX, fetchProfile: async () => Promise.reject(new Error('relay boom')) } as unknown as NDKUserLike
 		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => user })
 
 		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('relay boom')

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test'
 import { QueryClient } from '@tanstack/react-query'
 
 import { ndkActions } from '@/lib/stores/ndk'
-import { fetchProfileByIdentifier } from '../profiles'
+import { fetchProfileByIdentifier, profileByIdentifierQueryOptions, wotScoreQueryOptions } from '../profiles'
 
 // Infer NDK return types from the function under test instead of importing
 // the NDK package directly — the NDK-footprint CI guard counts any src/ file
@@ -191,5 +191,29 @@ describe('QueryClient retains cached profile data after a rejected same-key refe
 		// The cache must still retain the previous profile data.
 		const cached = queryClient.getQueryData<{ profile: NDKUserProfileLike | null; user: unknown }>(queryKey)
 		expect(cached?.profile).toEqual(profile)
+	})
+})
+
+describe('identity-scoped query options disable for invalid input (zero relay I/O)', () => {
+	test('profileByIdentifierQueryOptions disables for empty / whitespace / malformed identifiers', () => {
+		expect(profileByIdentifierQueryOptions('').enabled).toBe(false)
+		expect(profileByIdentifierQueryOptions('   ').enabled).toBe(false)
+		expect(profileByIdentifierQueryOptions('not-a-valid-identifier').enabled).toBe(false)
+		expect(profileByIdentifierQueryOptions('abc').enabled).toBe(false)
+	})
+
+	test('profileByIdentifierQueryOptions enables for valid hex pubkeys', () => {
+		expect(profileByIdentifierQueryOptions(VALID_HEX).enabled).toBe(true)
+	})
+
+	test('wotScoreQueryOptions disables for invalid hex pubkeys', () => {
+		expect(wotScoreQueryOptions('').enabled).toBe(false)
+		expect(wotScoreQueryOptions('   ').enabled).toBe(false)
+		expect(wotScoreQueryOptions('not-hex').enabled).toBe(false)
+		expect(wotScoreQueryOptions('abc'.repeat(10)).enabled).toBe(false)
+	})
+
+	test('wotScoreQueryOptions enables for valid 64-char hex pubkeys', () => {
+		expect(wotScoreQueryOptions(VALID_HEX).enabled).toBe(true)
 	})
 })

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { NDKUser, NDKUserProfile } from '@nostr-dev-kit/ndk'
+
+import { ndkActions } from '@/lib/stores/ndk'
+import { fetchProfileByIdentifier } from '../profiles'
+
+// `fetchProfileByIdentifier` reads NDK from the `ndkActions` store, so we stub
+// `getNDK` (the orders-seam.test.ts pattern) to drive each behavioral case.
+const realGetNDK = ndkActions.getNDK
+const realSetTimeout = globalThis.setTimeout
+
+afterEach(() => {
+	;(ndkActions as { getNDK: () => unknown }).getNDK = realGetNDK as () => unknown
+	globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+})
+
+const VALID_HEX = 'a'.repeat(64)
+
+/** A minimal NDKUser stub: just enough (pubkey + fetchProfile) for the fetcher. */
+function stubUser(profile: NDKUserProfile | null): NDKUser {
+	return { pubkey: VALID_HEX, fetchProfile: async () => profile } as unknown as NDKUser
+}
+
+/** Minimal NDK stub: a relay pool that reports `connected` live relays + a fetchUser. */
+function stubNdk(opts: { connectedRelays: number; fetchUser: (identifier: string) => Promise<NDKUser | null> }) {
+	return {
+		pool: { connectedRelays: () => Array.from({ length: opts.connectedRelays }, () => ({})) },
+		fetchUser: opts.fetchUser,
+	}
+}
+
+describe('fetchProfileByIdentifier distinguishes genuine absence from transient failures', () => {
+	test('returns the profile when relays are connected and fetchProfile resolves data', async () => {
+		const profile = { name: 'alice', about: 'hi' } as NDKUserProfile
+		const user = stubUser(profile)
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => user })
+
+		const result = await fetchProfileByIdentifier(VALID_HEX)
+
+		expect(result.profile).toBe(profile)
+		expect(result.user).toBe(user)
+	})
+
+	test('returns { profile: null, user } for genuine absence (connected, fetchProfile resolved null)', async () => {
+		const user = stubUser(null)
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => user })
+
+		const result = await fetchProfileByIdentifier(VALID_HEX)
+
+		// A successful null — NOT a transient failure. React Query commits this as
+		// a successful result, which is what lets ProfilePage show "not found".
+		expect(result.profile).toBeNull()
+		expect(result.user).toBe(user)
+	})
+
+	test('throws on timeout instead of returning a null-shaped success', async () => {
+		// fetchProfile never settles; the timeout must win the race and throw.
+		const hangingUser = { pubkey: VALID_HEX, fetchProfile: () => new Promise<NDKUserProfile | null>(() => {}) } as unknown as NDKUser
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => hangingUser })
+		// Fire the timeout reject immediately so the test doesn't wait 8s.
+		globalThis.setTimeout = ((cb: () => void) => {
+			cb()
+			return 0 as unknown as ReturnType<typeof globalThis.setTimeout>
+		}) as typeof globalThis.setTimeout
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('Profile fetch timed out')
+	})
+
+	test('throws when fetchProfile rejects (relay error) instead of returning null', async () => {
+		const user = { pubkey: VALID_HEX, fetchProfile: async () => Promise.reject(new Error('relay boom')) } as unknown as NDKUser
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => user })
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('relay boom')
+	})
+
+	test('throws when ndk.fetchUser rejects instead of returning null', async () => {
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () =>
+			stubNdk({ connectedRelays: 1, fetchUser: async () => Promise.reject(new Error('fetchUser boom')) })
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('fetchUser boom')
+	})
+
+	test('throws on no relay connection instead of returning null', async () => {
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 0, fetchUser: async () => stubUser(null) })
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('No relay connection')
+	})
+
+	test('throws when NDK is not initialized', async () => {
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => null
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('NDK not initialized')
+	})
+})

--- a/src/queries/__tests__/profilesFetch.test.ts
+++ b/src/queries/__tests__/profilesFetch.test.ts
@@ -118,4 +118,33 @@ describe('fetchProfileByIdentifier distinguishes genuine absence from transient 
 		expect(result).toEqual({ profile: null, user: null })
 		expect(fetchUser).toHaveBeenCalledTimes(0)
 	})
+
+	test('can be retried after a transient failure: second call succeeds once the relay is ready', async () => {
+		// Simulate the zero-relay startup scenario: the first call times out
+		// (no relay connected), then the relay connects and the retry succeeds.
+		// This proves that refetchOnReconnect / the retry button recover the
+		// query — the fetcher is stateless and a second invocation works.
+		const hangingUser = {
+			pubkey: VALID_HEX,
+			fetchProfile: () => new Promise<NDKUserProfileLike | null>(() => {}),
+		} as unknown as NDKUserLike
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 0, fetchUser: async () => hangingUser })
+		globalThis.setTimeout = ((cb: () => void) => {
+			cb()
+			return 0 as unknown as ReturnType<typeof globalThis.setTimeout>
+		}) as typeof globalThis.setTimeout
+
+		await expect(fetchProfileByIdentifier(VALID_HEX)).rejects.toThrow('Profile fetch timed out')
+
+		// Restore real setTimeout and simulate relay now being ready.
+		globalThis.setTimeout = realSetTimeout as typeof globalThis.setTimeout
+		const profile = { name: 'alice', about: 'hi' } as NDKUserProfileLike
+		const readyUser = stubUser(profile)
+		;(ndkActions as { getNDK: () => unknown }).getNDK = () => stubNdk({ connectedRelays: 1, fetchUser: async () => readyUser })
+
+		const result = await fetchProfileByIdentifier(VALID_HEX)
+
+		expect(result.profile).toBe(profile)
+		expect(result.user).toBe(readyUser)
+	})
 })

--- a/src/queries/authors.tsx
+++ b/src/queries/authors.tsx
@@ -29,6 +29,10 @@ export const fetchAuthor = async (pubkey: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
+	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
+	// filter guardrail. Fail fast instead of constructing an invalid filter.
+	if (!pubkey) throw new Error('Author pubkey is required')
+
 	const events = await ndk.fetchEvents(filter)
 	const eventArray = Array.from(events)
 

--- a/src/queries/authors.tsx
+++ b/src/queries/authors.tsx
@@ -50,4 +50,5 @@ export const authorQueryOptions = (pubkey: string) =>
 	queryOptions({
 		queryKey: authorKeys.details(pubkey),
 		queryFn: () => fetchAuthor(pubkey),
+		enabled: isValidHexKey(pubkey),
 	})

--- a/src/queries/authors.tsx
+++ b/src/queries/authors.tsx
@@ -3,6 +3,7 @@ import type { NDKFilter } from '@nostr-dev-kit/ndk'
 import { authorKeys } from './queryKeyFactory'
 import { queryOptions } from '@tanstack/react-query'
 import { ndkActions } from '@/lib/stores/ndk'
+import { isValidHexKey } from '@/lib/utils'
 
 export type NostrAuthor = {
 	id: string
@@ -21,6 +22,10 @@ const transformEvent = (event: NDKEvent): NostrAuthor => ({
 })
 
 export const fetchAuthor = async (pubkey: string) => {
+	// Reject an invalid pubkey before constructing the filter — a malformed
+	// value in { authors: [...] } trips NDK's strict filter validation.
+	if (!isValidHexKey(pubkey)) throw new Error('Author pubkey is required')
+
 	const filter: NDKFilter = {
 		kinds: [0], // kind 0 is metadata
 		authors: [pubkey],
@@ -28,10 +33,6 @@ export const fetchAuthor = async (pubkey: string) => {
 
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
-
-	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
-	// filter guardrail. Fail fast instead of constructing an invalid filter.
-	if (!pubkey) throw new Error('Author pubkey is required')
 
 	const events = await ndk.fetchEvents(filter)
 	const eventArray = Array.from(events)

--- a/src/queries/collections.tsx
+++ b/src/queries/collections.tsx
@@ -346,7 +346,7 @@ export const collectionsByPubkeyQueryOptions = (pubkey: string) =>
 	queryOptions({
 		queryKey: collectionsKeys.byPubkey(pubkey),
 		queryFn: () => fetchCollectionsByPubkey(pubkey),
-		enabled: !!pubkey,
+		enabled: isValidHexKey(pubkey),
 	})
 
 // --- HOOKS ---

--- a/src/queries/collections.tsx
+++ b/src/queries/collections.tsx
@@ -128,6 +128,10 @@ export const fetchCollectionsByPubkey = async (pubkey: string) => {
 		return []
 	}
 
+	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
+	// filter guardrail.
+	if (!pubkey) return []
+
 	const filter: NDKFilter = {
 		kinds: [30405 as NDKKind], // Collections
 		authors: [pubkey],

--- a/src/queries/collections.tsx
+++ b/src/queries/collections.tsx
@@ -1,5 +1,6 @@
 import { CollectionImageTagSchema, CollectionSummaryTagSchema, CollectionTitleTagSchema } from '@/lib/schemas/productCollection.ts'
 import { ndkActions } from '@/lib/stores/ndk'
+import { isValidHexKey } from '@/lib/utils'
 import type { NDKFilter, NDKKind } from '@nostr-dev-kit/ndk'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -128,9 +129,9 @@ export const fetchCollectionsByPubkey = async (pubkey: string) => {
 		return []
 	}
 
-	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
-	// filter guardrail.
-	if (!pubkey) return []
+	// A malformed (not just empty) pubkey would build { authors: [...] } that
+	// trips NDK's strict filter validation. Reject before constructing it.
+	if (!isValidHexKey(pubkey)) return []
 
 	const filter: NDKFilter = {
 		kinds: [30405 as NDKKind], // Collections

--- a/src/queries/orders.tsx
+++ b/src/queries/orders.tsx
@@ -611,7 +611,7 @@ export const useOrdersByBuyer = (buyerPubkey: string) => {
 	return useQuery({
 		queryKey: orderKeys.byBuyer(buyerPubkey),
 		queryFn: () => fetchOrdersByBuyer(buyerPubkey),
-		enabled: !!buyerPubkey,
+		enabled: isValidHexKey(buyerPubkey),
 	})
 }
 
@@ -825,7 +825,7 @@ export const useOrdersBySeller = (sellerPubkey: string, options: UseOrdersBySell
 						}
 					: undefined,
 			),
-		enabled: !!sellerPubkey,
+		enabled: isValidHexKey(sellerPubkey),
 	})
 }
 

--- a/src/queries/orders.tsx
+++ b/src/queries/orders.tsx
@@ -20,6 +20,7 @@ import {
 	type NDKSigner,
 } from '@/lib/nostr/ndk-events'
 import { ndkActions } from '@/lib/stores/ndk'
+import { isValidHexKey } from '@/lib/utils'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type { Event } from 'nostr-tools'
 import { useEffect, useMemo } from 'react'
@@ -87,9 +88,9 @@ export const fetchSellerPrivateOrderGiftWraps = async (sellerPubkey: string): Pr
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	// An empty seller pubkey would build { '#p': [''] } and trip NDK's (fatal)
-	// filter guardrail (#p is validated as 64-hex too).
-	if (!sellerPubkey) return []
+	// A malformed (not just empty) seller pubkey would build { '#p': [...] }
+	// that trips NDK's strict filter validation (#p must be 64-hex too).
+	if (!isValidHexKey(sellerPubkey)) return []
 
 	const giftWrapFilter: NDKFilter = {
 		kinds: [NIP59_GIFT_WRAP_KIND],
@@ -433,9 +434,9 @@ export const fetchOrdersByBuyer = async (buyerPubkey: string): Promise<OrderWith
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	// An empty buyer pubkey would build { authors: [''] } (and later
-	// allAuthors = ['', ...]) and trip NDK's (fatal) filter guardrail.
-	if (!buyerPubkey) return []
+	// A malformed (not just empty) buyer pubkey would build { authors: [...] }
+	// (and later contaminate allAuthors) that trips NDK's strict validation.
+	if (!isValidHexKey(buyerPubkey)) return []
 
 	// Orders where the specified user is the author (buyer sending order to merchant)
 	const orderCreationFilter: NDKFilter = {
@@ -624,9 +625,9 @@ export const fetchOrdersBySeller = async (
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	// An empty seller pubkey would build { '#p': [''] } and trip NDK's
-	// (fatal) filter guardrail (#p is validated as 64-hex too).
-	if (!sellerPubkey) return []
+	// A malformed (not just empty) seller pubkey would build { '#p': [...] }
+	// that trips NDK's strict filter validation (#p must be 64-hex too).
+	if (!isValidHexKey(sellerPubkey)) return []
 
 	// Orders where the specified user is the recipient (merchant receiving orders)
 	const orderReceivedFilter: NDKFilter = {

--- a/src/queries/orders.tsx
+++ b/src/queries/orders.tsx
@@ -87,6 +87,10 @@ export const fetchSellerPrivateOrderGiftWraps = async (sellerPubkey: string): Pr
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
+	// An empty seller pubkey would build { '#p': [''] } and trip NDK's (fatal)
+	// filter guardrail (#p is validated as 64-hex too).
+	if (!sellerPubkey) return []
+
 	const giftWrapFilter: NDKFilter = {
 		kinds: [NIP59_GIFT_WRAP_KIND],
 		'#p': [sellerPubkey],
@@ -429,6 +433,10 @@ export const fetchOrdersByBuyer = async (buyerPubkey: string): Promise<OrderWith
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
+	// An empty buyer pubkey would build { authors: [''] } (and later
+	// allAuthors = ['', ...]) and trip NDK's (fatal) filter guardrail.
+	if (!buyerPubkey) return []
+
 	// Orders where the specified user is the author (buyer sending order to merchant)
 	const orderCreationFilter: NDKFilter = {
 		kinds: [ORDER_PROCESS_KIND],
@@ -615,6 +623,10 @@ export const fetchOrdersBySeller = async (
 ): Promise<OrderWithRelatedEvents[]> => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
+
+	// An empty seller pubkey would build { '#p': [''] } and trip NDK's
+	// (fatal) filter guardrail (#p is validated as 64-hex too).
+	if (!sellerPubkey) return []
 
 	// Orders where the specified user is the recipient (merchant receiving orders)
 	const orderReceivedFilter: NDKFilter = {

--- a/src/queries/payment.tsx
+++ b/src/queries/payment.tsx
@@ -189,6 +189,7 @@ export const usePaymentDetail = (id: string) => {
  * Fetches all payment details for a user
  */
 export const fetchUserPaymentDetails = async (userPubkey: string): Promise<PaymentDetail[]> => {
+	if (!isValidHexKey(userPubkey)) return []
 	try {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
@@ -247,7 +248,7 @@ export const useUserPaymentDetails = (userPubkey: string) => {
 	return useQuery({
 		queryKey: paymentDetailsKeys.byPubkey(userPubkey),
 		queryFn: () => fetchUserPaymentDetails(userPubkey),
-		enabled: !!userPubkey,
+		enabled: isValidHexKey(userPubkey),
 	})
 }
 
@@ -255,6 +256,7 @@ export const useUserPaymentDetails = (userPubkey: string) => {
  * Fetches payment details for a specific product or collection
  */
 export const fetchProductPaymentDetails = async (coordinates: string, userPubkey?: string): Promise<PaymentDetail[]> => {
+	if (userPubkey !== undefined && !isValidHexKey(userPubkey)) return []
 	try {
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
@@ -553,7 +555,7 @@ export const useRichUserPaymentDetails = (userPubkey: string | undefined) => {
 	return useQuery({
 		queryKey: paymentDetailsKeys.byPubkey(userPubkey),
 		queryFn: () => fetchRichUserPaymentDetails(userPubkey!),
-		enabled: !!userPubkey,
+		enabled: isValidHexKey(userPubkey ?? ''),
 	})
 }
 
@@ -837,7 +839,7 @@ export const useWalletDetail = (userPubkey: string, paymentDetailId: string) => 
 	return useQuery({
 		queryKey: walletDetailsKeys.onChainIndex(userPubkey, paymentDetailId),
 		queryFn: () => fetchWalletDetail(userPubkey, paymentDetailId),
-		enabled: !!userPubkey && !!paymentDetailId,
+		enabled: isValidHexKey(userPubkey) && !!paymentDetailId,
 	})
 }
 
@@ -1127,7 +1129,7 @@ export const useAvailablePaymentOptions = (productIds: string[], sellerPubkey: s
 	return useQuery({
 		queryKey: paymentDetailsKeys.availableOptions(sellerPubkey, productIds),
 		queryFn: () => getAvailablePaymentOptions(productIds, sellerPubkey),
-		enabled: enabled && productIds.length > 0 && !!sellerPubkey,
+		enabled: enabled && productIds.length > 0 && isValidHexKey(sellerPubkey),
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	})
 }

--- a/src/queries/payment.tsx
+++ b/src/queries/payment.tsx
@@ -1148,6 +1148,10 @@ export const resolvePaymentDetailsForProduct = async (productId: string, sellerP
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
 
+		// An empty seller pubkey would build { authors: [''] } (and a malformed
+		// coordinate) and trip NDK's (fatal) filter guardrail.
+		if (!sellerPubkey) return []
+
 		// 1. Check for product-specific payment details
 		const productCoordinates = `30402:${sellerPubkey}:${productId}`
 		const productPaymentDetails = await fetchProductPaymentDetails(productCoordinates, sellerPubkey)

--- a/src/queries/payment.tsx
+++ b/src/queries/payment.tsx
@@ -1,6 +1,7 @@
 import { PAYMENT_DETAILS_METHOD, ZAP_RELAYS, type PaymentDetailsMethod } from '@/lib/constants'
 import { configStore } from '@/lib/stores/config'
 import { ndkActions } from '@/lib/stores/ndk'
+import { isValidHexKey } from '@/lib/utils'
 import type { PayWithNwcParams } from '@/publish/payment'
 import { payInvoiceWithNwc, payInvoiceWithWebln } from '@/publish/payment'
 import { LightningAddress, type Invoice, type NostrProvider } from '@getalby/lightning-tools'
@@ -1148,9 +1149,9 @@ export const resolvePaymentDetailsForProduct = async (productId: string, sellerP
 		const ndk = ndkActions.getNDK()
 		if (!ndk) throw new Error('NDK not initialized')
 
-		// An empty seller pubkey would build { authors: [''] } (and a malformed
-		// coordinate) and trip NDK's (fatal) filter guardrail.
-		if (!sellerPubkey) return []
+		// A malformed (not just empty) seller pubkey would build { authors: [...] }
+		// (and a malformed coordinate) that trips NDK's strict filter validation.
+		if (!isValidHexKey(sellerPubkey)) return []
 
 		// 1. Check for product-specific payment details
 		const productCoordinates = `30402:${sellerPubkey}:${productId}`

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -241,6 +241,8 @@ export const fetchProduct = async (id: string) => {
  * @returns Array of product events sorted by creation date (blacklist filtered, optionally hidden products excluded)
  */
 export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boolean = false, limit: number = 50) => {
+	if (!isValidHexKey(pubkey)) throw new Error('fetchProductsByPubkey: invalid seller pubkey')
+
 	const ndk = ndkActions.getNDK()
 	if (!ndk) {
 		console.warn('NDK not ready, returning empty products by pubkey list')

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -22,6 +22,7 @@ import { getCoordsFromATag, getATagFromCoords } from '@/lib/utils/coords.ts'
 import { discoverNip50Relays } from '@/lib/relays'
 import { filterBlacklistedEvents, filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
+import { isValidHexKey } from '@/lib/utils'
 
 // Re-export productKeys for use in other query files
 export { productKeys }
@@ -372,6 +373,7 @@ export const productsByPubkeyQueryOptions = (pubkey: string, includeHidden: bool
 	queryOptions({
 		queryKey: includeHidden ? [...productKeys.byPubkey(pubkey), 'includeHidden'] : productKeys.byPubkey(pubkey),
 		queryFn: () => fetchProductsByPubkey(pubkey, includeHidden),
+		enabled: isValidHexKey(pubkey),
 	})
 
 /**

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -246,6 +246,10 @@ export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boole
 		return []
 	}
 
+	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
+	// filter guardrail.
+	if (!pubkey) return []
+
 	const filter: NDKFilter = {
 		kinds: [30402],
 		authors: [pubkey],

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -246,10 +246,6 @@ export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boole
 		return []
 	}
 
-	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
-	// filter guardrail.
-	if (!pubkey) return []
-
 	const filter: NDKFilter = {
 		kinds: [30402],
 		authors: [pubkey],

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -66,6 +66,14 @@ export const fetchProfileByIdentifier = async (identifier: string): Promise<{ pr
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
+	// An empty/blank identifier would make ndk.fetchUser('') construct an
+	// NDKUser with an empty pubkey, and user.fetchProfile() would then build
+	// { kinds: [0], authors: [''] } — an empty-string author that trips NDK's
+	// (fatal) filter guardrail. Bail out early instead.
+	if (!identifier || !identifier.trim()) {
+		return { profile: null, user: null }
+	}
+
 	const timeoutMs = 8000
 	try {
 		const result = await Promise.race([
@@ -141,6 +149,7 @@ export const getProfileNip05 = ({ profile }: { profile: NDKUserProfile | null })
 export const useProfileName = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
+		enabled: !!pubkey,
 		select: getProfileName,
 	})
 }
@@ -148,6 +157,7 @@ export const useProfileName = (pubkey: string) => {
 export const useProfileNip05 = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
+		enabled: !!pubkey,
 		select: getProfileNip05,
 	})
 }

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -74,22 +74,32 @@ export const fetchProfileByIdentifier = async (identifier: string): Promise<{ pr
 		return { profile: null, user: null }
 	}
 
-	const timeoutMs = 8000
-	try {
-		const result = await Promise.race([
-			(async () => {
-				const user = await ndk.fetchUser(identifier)
-				if (!user) return { profile: null, user: null }
-				const profile = await user.fetchProfile()
-				return { profile, user }
-			})(),
-			new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Profile fetch timed out')), timeoutMs)),
-		])
-		return result
-	} catch (e) {
-		console.error('Failed to fetch profile with identifier:', e)
-		return { profile: null, user: null }
+	// Distinguish transient failures (no connection, timeout, relay errors)
+	// from genuine profile absence. Transient failures must THROW so React
+	// Query treats them as `isError` and retains any previously-loaded profile
+	// (see `placeholderData: keepPreviousData` in ProfilePage) instead of
+	// committing a null-shaped "success" that clobbers a loaded profile. Only
+	// genuine absence — relays connected and fetchProfile() resolved to null —
+	// returns the null-shaped value. (Behavioral cases covered in
+	// profilesFetch.test.ts.)
+	const connectedRelays = ndk.pool?.connectedRelays() ?? []
+	if (connectedRelays.length === 0) {
+		throw new Error('No relay connection available to fetch profile')
 	}
+
+	const timeoutMs = 8000
+	// No try/catch: let the timeout and fetchUser/fetchProfile rejections
+	// propagate as query errors. Only fetchProfile() resolving to null
+	// (genuine absence) produces the null-shaped success below.
+	return await Promise.race([
+		(async () => {
+			const user = await ndk.fetchUser(identifier)
+			if (!user) return { profile: null, user: null }
+			const profile = await user.fetchProfile()
+			return { profile, user }
+		})(),
+		new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Profile fetch timed out')), timeoutMs)),
+	])
 }
 
 export const profileQueryOptions = (npub: string) =>

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -76,19 +76,20 @@ export const fetchProfileByIdentifier = async (identifier: string): Promise<{ pr
 		return { profile: null, user: null }
 	}
 
-	// Distinguish transient failures (no connection, timeout, relay errors)
-	// from genuine profile absence. Transient failures must THROW so React
-	// Query treats them as `isError` and retains any previously-loaded profile
-	// (see `placeholderData: keepPreviousData` in ProfilePage) instead of
+	// Distinguish transient failures (timeout, relay errors) from genuine
+	// profile absence. Transient failures must THROW so React Query treats
+	// them as `isError` and retains any previously-loaded profile (see
+	// `placeholderData: keepPreviousData` in ProfilePage) instead of
 	// committing a null-shaped "success" that clobbers a loaded profile. Only
-	// genuine absence — relays connected and fetchProfile() resolved to null —
-	// returns the null-shaped value. (Behavioral cases covered in
-	// profilesFetch.test.ts.)
-	const connectedRelays = ndk.pool?.connectedRelays() ?? []
-	if (connectedRelays.length === 0) {
-		throw new Error('No relay connection available to fetch profile')
-	}
-
+	// genuine absence — fetchProfile() resolved to null — returns the
+	// null-shaped value.
+	//
+	// No preflight relay-connection check: zero connected relays is a normal
+	// transient state while the app's background connect() completes. A
+	// preflight throw would fail an otherwise-valid initial query before the
+	// relay is ready. Instead, let the timeout below determine failure — if no
+	// relay connects within the timeout window, the race rejects (transient,
+	// retryable). (Behavioral cases covered in profilesFetch.test.ts.)
 	const timeoutMs = 8000
 	// No try/catch: let the timeout and fetchUser/fetchProfile rejections
 	// propagate as query errors. Only fetchProfile() resolving to null

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -3,6 +3,7 @@ import { type NDKUserProfile, NDKEvent, NDKUser } from '@nostr-dev-kit/ndk'
 import { NDKWoT } from '@nostr-dev-kit/wot'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { validateProfileIdentifier } from '@/lib/utils/profileValidation'
+import { isValidHexKey } from '@/lib/utils'
 import { profileKeys } from './queryKeyFactory'
 
 export function normalizeOptionalString(value: unknown): string | null {
@@ -121,6 +122,11 @@ export const profileByIdentifierQueryOptions = (identifier: string) =>
 	queryOptions({
 		queryKey: profileKeys.details(identifier),
 		queryFn: () => fetchProfileByIdentifier(identifier),
+		// Gate at the shared factory so every consumer — hooks, route loaders,
+		// and direct useQuery callers — gets the same validation. Callers that
+		// need additional conditions must COMBINE (not overwrite) this base,
+		// e.g. `enabled: options.enabled && myCondition`.
+		enabled: validateProfileIdentifier(identifier).isValid,
 	})
 
 export const validateNip05 = async (pubkey: string): Promise<boolean | null> => {
@@ -162,10 +168,6 @@ export const getProfileNip05 = ({ profile }: { profile: NDKUserProfile | null })
 export const useProfileName = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
-		// The pubkey feeds ndk.fetchUser, which accepts hex/npub/nprofile/nip05;
-		// gate on a valid identifier (not just truthiness) so whitespace,
-		// truncated, or malformed values don't activate a relay request.
-		enabled: validateProfileIdentifier(pubkey).isValid,
 		select: getProfileName,
 	})
 }
@@ -173,16 +175,15 @@ export const useProfileName = (pubkey: string) => {
 export const useProfileNip05 = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
-		enabled: validateProfileIdentifier(pubkey).isValid,
 		select: getProfileNip05,
 	})
 }
 
 export const useProfile = (pubkey: string | undefined) => {
+	const options = profileByIdentifierQueryOptions(pubkey ?? '')
 	return useQuery({
-		queryKey: profileKeys.details(pubkey ?? ''),
-		queryFn: () => fetchProfileByIdentifier(pubkey!),
-		enabled: !!pubkey,
+		...options,
+		enabled: options.enabled,
 		staleTime: 5 * 60 * 1000,
 		retry: 2,
 	})
@@ -353,7 +354,7 @@ export const wotScoreQueryOptions = (pubkey: string) =>
 	queryOptions({
 		queryKey: profileKeys.wot(pubkey),
 		queryFn: () => getWotScore(pubkey),
-		enabled: !!pubkey,
+		enabled: isValidHexKey(pubkey),
 		retry: 2,
 		retryDelay: 1000,
 	})
@@ -361,6 +362,5 @@ export const wotScoreQueryOptions = (pubkey: string) =>
 export const useWotScore = (pubkey: string) => {
 	return useQuery({
 		...wotScoreQueryOptions(pubkey),
-		enabled: !!pubkey,
 	})
 }

--- a/src/queries/profiles.tsx
+++ b/src/queries/profiles.tsx
@@ -2,6 +2,7 @@ import { ndkActions } from '@/lib/stores/ndk'
 import { type NDKUserProfile, NDKEvent, NDKUser } from '@nostr-dev-kit/ndk'
 import { NDKWoT } from '@nostr-dev-kit/wot'
 import { queryOptions, useQuery } from '@tanstack/react-query'
+import { validateProfileIdentifier } from '@/lib/utils/profileValidation'
 import { profileKeys } from './queryKeyFactory'
 
 export function normalizeOptionalString(value: unknown): string | null {
@@ -66,11 +67,12 @@ export const fetchProfileByIdentifier = async (identifier: string): Promise<{ pr
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	// An empty/blank identifier would make ndk.fetchUser('') construct an
-	// NDKUser with an empty pubkey, and user.fetchProfile() would then build
-	// { kinds: [0], authors: [''] } — an empty-string author that trips NDK's
-	// (fatal) filter guardrail. Bail out early instead.
-	if (!identifier || !identifier.trim()) {
+	// Reject invalid identifiers (empty, whitespace, truncated, or otherwise
+	// malformed) before any relay request — ndk.fetchUser builds an NDKUser
+	// whose pubkey ends up in a { kinds: [0], authors: [...] } filter, and an
+	// invalid value trips NDK's strict filter validation. This accepts hex,
+	// npub, nprofile, and nip05 (everything ndk.fetchUser accepts).
+	if (!validateProfileIdentifier(identifier).isValid) {
 		return { profile: null, user: null }
 	}
 
@@ -159,7 +161,10 @@ export const getProfileNip05 = ({ profile }: { profile: NDKUserProfile | null })
 export const useProfileName = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
-		enabled: !!pubkey,
+		// The pubkey feeds ndk.fetchUser, which accepts hex/npub/nprofile/nip05;
+		// gate on a valid identifier (not just truthiness) so whitespace,
+		// truncated, or malformed values don't activate a relay request.
+		enabled: validateProfileIdentifier(pubkey).isValid,
 		select: getProfileName,
 	})
 }
@@ -167,7 +172,7 @@ export const useProfileName = (pubkey: string) => {
 export const useProfileNip05 = (pubkey: string) => {
 	return useQuery({
 		...profileByIdentifierQueryOptions(pubkey),
-		enabled: !!pubkey,
+		enabled: validateProfileIdentifier(pubkey).isValid,
 		select: getProfileNip05,
 	})
 }

--- a/src/queries/shipping.tsx
+++ b/src/queries/shipping.tsx
@@ -201,6 +201,7 @@ export const shippingOptionsByPubkeyQueryOptions = (pubkey: string) =>
 	queryOptions({
 		queryKey: shippingKeys.byPubkey(pubkey),
 		queryFn: () => fetchShippingOptionsByPubkey(pubkey),
+		enabled: isValidHexKey(pubkey),
 		staleTime: 300000, // Added staleTime of 5 minutes (300,000 ms)
 	})
 
@@ -696,7 +697,6 @@ export const useShippingService = (id: string) => {
 export const useShippingOptionsByPubkey = (pubkey: string) => {
 	return useQuery({
 		...shippingOptionsByPubkeyQueryOptions(pubkey),
-		enabled: !!pubkey,
 	})
 }
 

--- a/src/queries/shipping.tsx
+++ b/src/queries/shipping.tsx
@@ -145,6 +145,10 @@ export const fetchShippingOptionsByPubkey = async (pubkey: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
+	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
+	// filter guardrail.
+	if (!pubkey) return []
+
 	const filter: NDKFilter = {
 		kinds: [SHIPPING_KIND],
 		authors: [pubkey],

--- a/src/queries/shipping.tsx
+++ b/src/queries/shipping.tsx
@@ -1,6 +1,7 @@
 import { ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND, SHIPPING_STATUS } from '@/lib/schemas/order'
 import { SHIPPING_KIND } from '@/lib/schemas/shippingOption'
 import { ndkActions } from '@/lib/stores/ndk'
+import { isValidHexKey } from '@/lib/utils'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
 import type { NDKFilter } from '@nostr-dev-kit/ndk'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -145,9 +146,9 @@ export const fetchShippingOptionsByPubkey = async (pubkey: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 
-	// An empty pubkey would build { authors: [''] } and trip NDK's (fatal)
-	// filter guardrail.
-	if (!pubkey) return []
+	// A malformed (not just empty) pubkey would build { authors: [...] } that
+	// trips NDK's strict filter validation. Reject before constructing it.
+	if (!isValidHexKey(pubkey)) return []
 
 	const filter: NDKFilter = {
 		kinds: [SHIPPING_KIND],

--- a/src/routes/_dashboard-layout/dashboard/account/profile.tsx
+++ b/src/routes/_dashboard-layout/dashboard/account/profile.tsx
@@ -26,9 +26,10 @@ function ProfileComponent() {
 	const pubkey = ndk?.activeUser?.pubkey
 
 	// Fetch profile data with Tanstack Query
+	const profileOptions = profileByIdentifierQueryOptions(pubkey || '')
 	const { data: fetchedData, isLoading: isLoadingProfile } = useQuery({
-		...profileByIdentifierQueryOptions(pubkey || ''),
-		enabled: !!pubkey,
+		...profileOptions,
+		enabled: profileOptions.enabled && !!pubkey,
 	})
 
 	// Extract profile from the query result

--- a/src/routes/_dashboard-layout/dashboard/products/products.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products.tsx
@@ -226,13 +226,14 @@ function ProductsOverviewComponent() {
 			fuzzy: true,
 		})
 
+	const dashboardProductOptions = productsByPubkeyQueryOptions(user?.pubkey ?? '', true) // Include hidden products for own dashboard
 	const {
 		data: products,
 		isLoading,
 		error,
 	} = useQuery({
-		...productsByPubkeyQueryOptions(user?.pubkey ?? '', true), // Include hidden products for own dashboard
-		enabled: !!user?.pubkey && isAuthenticated,
+		...dashboardProductOptions,
+		enabled: dashboardProductOptions.enabled && isAuthenticated,
 	})
 
 	// Sort products based on orderBy

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -29,9 +29,10 @@ function EditProductComponent() {
 	useDashboardTitle('Edit Product')
 
 	// Fetch user's products to find the one being edited (including hidden products)
+	const editProductOptions = productsByPubkeyQueryOptions(user?.pubkey ?? '', true)
 	const { data: products = [], isLoading: isLoadingProducts } = useQuery({
-		...productsByPubkeyQueryOptions(user?.pubkey ?? '', true),
-		enabled: !!user?.pubkey,
+		...editProductOptions,
+		enabled: editProductOptions.enabled,
 	})
 
 	// Find the product being edited (productId is the event.id from the URL)

--- a/src/routes/products.$productId.tsx
+++ b/src/routes/products.$productId.tsx
@@ -341,9 +341,10 @@ function RouteComponent() {
 		}
 	}
 
+	const sellerProductOptions = productsByPubkeyQueryOptions(pubkey)
 	const sellerProductsQuery = useQuery({
-		...productsByPubkeyQueryOptions(pubkey),
-		enabled: !!pubkey,
+		...sellerProductOptions,
+		enabled: sellerProductOptions.enabled,
 	})
 	const sellerProducts = sellerProductsQuery.data ?? []
 


### PR DESCRIPTION
## Summary

Fixes the **`AI_GUARDRAILS ERROR: Filter[0].authors[0] is not a valid 64-char hex pubkey: ""`** crash that made profile pages fail to load — and hardens every identity-scoped query path that could produce an invalid Nostr filter.

Root cause was three-fold: AI Guardrails were enabled unconditionally in production (fatal throw on any malformed filter); several query helpers built `authors`/`#p` filters from unguarded pubkey parameters (empty strings during transient states); and profile reads used React Query defaults that clobbered loaded profiles on a failed background refetch.

Full design rationale: **ADR-015** (`docs/adr/ADR-015-production-safe-ndk-filters-and-stable-kind-0-fetching.md`).

## Decisions

### 1. Disable AI Guardrails in production; retain strict filter validation

- Gate `aiGuardrails` on `stage`: **on** in dev/staging, **off** in production. Removes the fatal `AI_GUARDRAILS` educational throw.
- **Retain** NDK's default strict `'validate'` mode in all stages. Do **not** set `filterValidationMode: 'fix'` — it strips a bad `authors` entry and drops the key if empty, broadening an identity-scoped request (fail-open). Invalid/empty pubkeys are rejected at the query layer **before** any filter is built (fail closed).

### 2. Validate identity inputs before building Nostr filters

**Fetchers** that build `authors`/`#p` directly validate with `isValidHexKey` before constructing the filter:
- `fetchAuthor`, `fetchProductsByPubkey` — **throw** on invalid input (programming error; throw surfaces in RQ error state, not silent `[]`)
- `fetchShippingOptionsByPubkey`, `fetchCollectionsByPubkey`, `fetchOrdersByBuyer`/`fetchOrdersBySeller`, `fetchSellerPrivateOrderGiftWraps`, `resolvePaymentDetailsForProduct`, `fetchUserPaymentDetails` — **early-return `[]`** (these have try-catch blocks that swallow throws)
- `fetchProductPaymentDetails` — guards its optional-author path: if a pubkey is provided but malformed, returns `[]` (fail closed); if no pubkey is provided, proceeds with a broad query (no `authors` filter — intentional)

**Query-option factories** set `enabled: isValidHexKey(pubkey)` at the factory level, so all consumers inherit the guard:
- `profileByIdentifierQueryOptions` (uses `validateProfileIdentifier` — accepts hex/npub/nprofile/nip05)
- `authorQueryOptions`, `productsByPubkeyQueryOptions`, `collectionsByPubkeyQueryOptions`, `shippingOptionsByPubkeyQueryOptions`, `wotScoreQueryOptions`

**Inline hooks** that build queries without a factory also use `isValidHexKey` at the `enabled` boundary:
- `useOrdersByBuyer`, `useOrdersBySeller`, `useUserPaymentDetails`, `useRichUserPaymentDetails`, `useWalletDetail`, `useAvailablePaymentOptions`

**Caller composition**: consumers with additional conditions COMBINE (not overwrite) the factory's `enabled`, e.g. `enabled: productOptions.enabled && isAuthenticated`. Truthiness checks (`!!pubkey`) are dropped — `isValidHexKey` implies truthiness, so only genuine business-logic conditions survive the combination.

**`safeNpubEncode`** (`lib/utils.ts`): wraps `nip19.npubEncode` with `isValidHexKey`, returning `null` for invalid input. Components like `FeaturedUserCard` call `nip19.npubEncode` synchronously during render — a malformed pubkey crashes the render before React Query evaluates `enabled`. The helper validates before encoding, preventing the crash.

Replaces the earlier truthiness (`!!pubkey`) guards, which permitted whitespace, truncated keys, and arbitrary malformed non-empty values.

### 3. Distinguish transient fetch failures from metadata not observed; don't refetch stable kind-0

- `fetchProfileByIdentifier` throws on transient failures (timeout, relay error) so React Query treats them as `isError` and retains previous data. No preflight relay-connection check — zero connected relays is a normal transient state; the 8s timeout determines failure.
- `ProfilePage` keeps previous data visible (`keepPreviousData`), stops refetching kind-0 on window focus, and **preserves reconnect recovery** (`refetchOnReconnect` default) so a failed zero-relay startup query auto-retries once the browser regains connectivity. Recovery uses normal React Query retries, browser-network reconnect handling, and a manual **Try again** button — not an NDK relay-readiness subscription.
- Three distinct error states: **transport error** (retryable, with "Try again" button), **metadata not observed from the configured relays** (settled, non-retryable), and **invalid identifier** (non-retryable).

### 4. Verify app-settings publisher authority before accepting content

- The kind-31990 app-config fetch validates `appPubkey` with `isValidHexKey` before issuing the query, then verifies the returned event's author, kind 31990, and exact `d` tag (`selectAuthoritativeAppSettingsEvent`) — the content schema validates shape, not authority.

## PR #1206 — incorporated

PR #1206 (`fix/products-empty-pubkey-guard`) was closed as superseded. Its guard (`enabled: isValidHexKey(pubkey)` in `productsByPubkeyQueryOptions`) and tests are incorporated here, along with the fetcher-level throw, caller composition, and `safeNpubEncode` for `FeaturedUserCard`.

## Validation

- `tsc` clean (no new errors; pre-existing errors in `publish/payment.tsx`, `search.products.tsx`, `orders.tsx` are untouched).
- `prettier` clean.
- NDK footprint: 127 (baseline unchanged — test files use inferred types, no direct NDK import).
- 103 tests pass across 8 files, including:
  - `profilesFetch.test.ts` (14): transient vs absence, timeout, relay error, retry-after-failure, QueryClient cache retention, invalid-input zero-relay-I/O for both factories.
  - `appSettings.test.ts` (8): publisher-authority verification (wrong author, wrong kind, wrong/missing d tag, spoofed-higher-than-legit).
  - `productsByPubkeyQueryOptions.test.ts` (13): enabled flags, caller composition, direct-fetcher throw zero-I/O, `safeNpubEncode`.
  - `identityBoundaries.test.ts` (11): payment fetcher zero-I/O, `authorQueryOptions`/`collectionsByPubkeyQueryOptions`/`shippingOptionsByPubkeyQueryOptions` enabled flags.

## Commits

1. `fix(profile)` — stop refocus clobbering loaded profiles (keepPreviousData, staleTime, refetchOnWindowFocus off)
2. `fix(ndk)` — disable AI guardrails in production (gate on stage)
3. `fix(queries)` — guard empty pubkeys before building Nostr filters
4. `docs(adr)` — ADR-015
5. `fix(profile)` — distinguish transient fetch failures from metadata not observed + tests
6. `revert(ndk)` — drop production filterValidationMode:'fix'; keep strict 'validate'
7. `fix(queries)` — validate identity inputs with isValidHexKey / validateProfileIdentifier
8. `fix(appSettings)` — verify publisher authority before accepting kind-31990 content + tests
9. `docs(adr)` — reconcile ADR-015 with all four decisions
10. `fix(test)` — remove direct NDK import from test (NDK footprint CI)
11. `fix(profile)` — remove zero-relay preflight throw
12. `fix(profile)` — preserve reconnect recovery + add retry to error UI
13. `fix(profile)` — distinguish transport errors from metadata not observed in ProfilePage
14. `fix(queries)` — move identity validation into shared query-option factories
15. `fix(products)` — incorporate #1206 guard + tests
16. `fix(products)` — compose factory enabled, throw in fetcher, safeNpubEncode, ADR sync
17. `fix(queries)` — complete isValidHexKey at all identity-scoped boundaries (payment, authors, collections, shipping, orders)
