### PR TITLE
ADR: test isolation (docs only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,32 @@ already exists.
 - Do not turn Wave 0 guidance into automatic push, merge, CI rerun, deployment,
   or broad rewrite instructions.
 
+## Test Isolation
+
+Tests must not make network calls to external services. The only allowed
+network dependencies are local services started in CI workflows (local
+relay via `nak serve`, local dev server on port 3333, ContextVM). All
+other external services (CDNs, Cashu mints, Lightning nodes, third-party
+APIs) must be mocked or intercepted.
+
+See ADR-0005 for the full decision and established mock patterns.
+
+### Established Patterns
+
+- `page.route()` / `context.route()` — intercept HTTP requests to
+  external domains and serve local fixtures or mock responses.
+- `e2e/utils/lightning-mock.ts` — mocks LNURL, WebLN, and zap receipts.
+- `e2e/utils/nip46-mock.ts` — mocks NIP-46 remote signer.
+- `e2e/helpers/lnurl-mock.ts` — intercepts LNURL discovery.
+
+### What Is Allowed
+
+- Importing external npm packages (e.g., `@cashu/cashu-ts`) for pure
+  functions with no network calls.
+- Referencing external URLs as inert data in test fixtures (e.g., mint
+  URLs in seeded Nostr events).
+- Starting local services that are part of the CI workflow.
+
 ## Safe Checks
 
 For docs-only changes:

--- a/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
+++ b/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
@@ -68,7 +68,6 @@ This rule applies to:
 
 - `e2e/` — Playwright end-to-end tests
 - `src/lib/__tests__/` — unit tests
-- `src/server/auction-validator/` — validator tests
 - Any future test suite
 
 ### What This Does NOT Prohibit
@@ -99,29 +98,6 @@ Trade-offs:
 - Mocks must be maintained alongside the real services they simulate.
 - Some mock setups are complex (Lightning, NIP-46) — but the complexity
   is already paid for and working.
-
-## Known Violations Requiring Remediation
-
-The following test files currently import `getEncodedToken` from
-`@cashu/cashu-ts`. This is a **pure function** (no network calls) and is
-acceptable for unit tests where the code under test uses the same
-function. However, e2e tests should prefer pre-computed fixture data:
-
-1. `e2e/tests/auction-settlement.spec.ts` — should use a pre-computed
-   token string instead of importing `getEncodedToken`.
-2. `src/lib/__tests__/settlementDescriptor.test.ts` — acceptable (unit
-   test, tests the descriptor which calls `validatePathRelease` which
-   calls `getDecodedToken`).
-3. `src/lib/__tests__/auctionSettlementCompleteness.test.ts` —
-   acceptable (unit test for the validator itself).
-4. `src/lib/__tests__/auctionValidatorLifecycle.test.ts` — acceptable.
-5. `src/lib/__tests__/auctionSettlementP2pk.test.ts` — acceptable.
-
-E2e tests referencing external mint URLs as data (not making calls):
-
-- `e2e/tests/auction-live-chat*.spec.ts` — `https://mint.minibits.cash/Bitcoin`
-  in seeded event tags. Acceptable: the URL is inert data; no request is
-  made to the mint.
 
 ## Related
 

--- a/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
+++ b/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
@@ -1,0 +1,133 @@
+# ADR-0005: No External Service Dependencies in Tests
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-03
+
+## Context
+
+Tests run in CI environments (GitHub Actions) where external services
+— CDNs, Cashu mints, Lightning nodes, third-party APIs — are unreachable,
+rate-limited, or unreliable. When tests depend on these services, they
+fail intermittently, eroding trust in the CI signal and wasting developer
+time debugging flaky failures that are unrelated to the code under test.
+
+A recent example: the product-page e2e test loaded images from
+`cdn.satellite.earth`, which was unreachable from GitHub Actions runners.
+The fix (commit `8de113e4`) intercepted the CDN requests with Playwright's
+`page.route()` and served a local fixture image. This is the right pattern.
+
+The existing test suite already has well-established mock patterns for
+external services:
+
+- **Lightning payments** — `e2e/utils/lightning-mock.ts` intercepts LNURL
+  HTTP requests, injects a `window.webln` mock, and publishes zap receipts
+  to the local relay. No real Lightning node is contacted.
+- **NIP-46 remote signers** — `e2e/utils/nip46-mock.ts` simulates a remote
+  signer via the local relay. No external signer service is contacted.
+- **LNURL discovery** — `e2e/helpers/lnurl-mock.ts` intercepts
+  `.well-known/lnurlp/*` routes with mock responses.
+
+The local relay (`nak serve` on `ws://localhost:10547`) and the local dev
+server (`bun dev` on port 3333) are the only external dependencies tests
+may have. Both are started in CI workflows and are deterministic.
+
+## Decision
+
+Tests must not make network calls to external services. The only allowed
+network dependencies are:
+
+1. **Local relay** (`nak serve`) — started by Playwright's `webServer`
+   config, seeded before tests.
+2. **Local dev server** (`bun dev`) — started by Playwright's `webServer`
+   config, isolated to port 3333.
+3. **Other local services** that can be started in CI workflows.
+
+All other external services must be mocked or intercepted:
+
+- **HTTP/HTTPS requests** to external domains — use Playwright's
+  `page.route()` or `context.route()` to intercept and serve mock
+  responses or local fixtures.
+- **WebSocket connections** to external relays — the app is configured
+  with `LOCAL_RELAY_ONLY=true` in tests; no external relay connections
+  should occur.
+- **Cashu mint operations** — mint URLs in test fixtures are inert
+  strings; no NUT-7 queries or mint redemptions are performed. Token
+  encoding for test fixtures uses `getEncodedToken` (a pure function
+  with no network calls) or pre-computed token strings.
+- **Lightning payments** — use `LightningMock` which intercepts all
+  LNURL and WebLN calls.
+
+### Applicability
+
+This rule applies to:
+
+- `e2e/` — Playwright end-to-end tests
+- `src/lib/__tests__/` — unit tests
+- `src/server/auction-validator/` — validator tests
+- Any future test suite
+
+### What This Does NOT Prohibit
+
+- Importing external **packages** (e.g., `@cashu/cashu-ts`,
+  `@noble/secp256k1`) in tests — these are npm dependencies, not network
+  services. `getEncodedToken` and `hashToCurveHexFromString` are pure
+  functions that operate locally.
+- Referencing external URLs as **data** (e.g., `https://testnut.cashu.space`
+  as a mint URL in a seeded event) — as long as no HTTP request is made
+  to that URL.
+- Starting local services (relay, dev server, ContextVM) that are part
+  of the CI workflow.
+
+## Consequences
+
+Positive:
+
+- CI is deterministic — tests pass or fail based on code, not network
+  conditions.
+- Developers can run tests offline or behind restrictive firewalls.
+- Test failures are always actionable — no more "it works on my machine
+  but CI is flaky."
+- The mock patterns are already established and documented.
+
+Trade-offs:
+
+- Mocks must be maintained alongside the real services they simulate.
+- Some mock setups are complex (Lightning, NIP-46) — but the complexity
+  is already paid for and working.
+
+## Known Violations Requiring Remediation
+
+The following test files currently import `getEncodedToken` from
+`@cashu/cashu-ts`. This is a **pure function** (no network calls) and is
+acceptable for unit tests where the code under test uses the same
+function. However, e2e tests should prefer pre-computed fixture data:
+
+1. `e2e/tests/auction-settlement.spec.ts` — should use a pre-computed
+   token string instead of importing `getEncodedToken`.
+2. `src/lib/__tests__/settlementDescriptor.test.ts` — acceptable (unit
+   test, tests the descriptor which calls `validatePathRelease` which
+   calls `getDecodedToken`).
+3. `src/lib/__tests__/auctionSettlementCompleteness.test.ts` —
+   acceptable (unit test for the validator itself).
+4. `src/lib/__tests__/auctionValidatorLifecycle.test.ts` — acceptable.
+5. `src/lib/__tests__/auctionSettlementP2pk.test.ts` — acceptable.
+
+E2e tests referencing external mint URLs as data (not making calls):
+
+- `e2e/tests/auction-live-chat*.spec.ts` — `https://mint.minibits.cash/Bitcoin`
+  in seeded event tags. Acceptable: the URL is inert data; no request is
+  made to the mint.
+
+## Related
+
+- ADR-0001: Hierarchical AGENTS.md and ADR docs
+- Commit `8de113e4`: fix(e2e): intercept CDN image requests to fix flaky
+  product-page test (#1203)
+- `e2e/utils/lightning-mock.ts`, `e2e/utils/nip46-mock.ts`,
+  `e2e/helpers/lnurl-mock.ts` — established mock patterns
+- `e2e/ARCHITECTURE.md` — e2e testing architecture documentation

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -28,6 +28,28 @@ infrastructure.
 - Keep protocol assertions explicit: validate event kind, tags, author, and
   expected relay behavior where tests inspect Nostr events.
 
+## Test Isolation
+
+Tests must not make network calls to external services. Only the local
+relay (`nak serve`) and local dev server (port 3333) are allowed. All
+external services (CDNs, mints, Lightning nodes) must be mocked or
+intercepted via `page.route()` / `context.route()`.
+
+See ADR-0005 and the repository-level AGENTS.md "Test Isolation" section
+for the full policy and established mock patterns.
+
+### Mocks Available
+
+- `e2e/utils/lightning-mock.ts` — LNURL, WebLN, zap receipts
+- `e2e/utils/nip46-mock.ts` — NIP-46 remote signer
+- `e2e/helpers/lnurl-mock.ts` — LNURL discovery interception
+
+### Intercepting External Requests
+
+Use `page.route()` to intercept requests to external domains and serve
+local fixtures or mock responses. See `e2e/tests/product-page.spec.ts`
+for the CDN image interception pattern.
+
 ## Safe Checks
 
 - `git diff --check`


### PR DESCRIPTION
## docs(adr): ADR-0005 — No external service dependencies in tests

## Body

## Summary

Establishes a policy that tests must not make network calls to external
services. All external dependencies (CDNs, Cashu mints, Lightning nodes,
third-party APIs) must be mocked or intercepted. Only local services
started in CI workflows (relay via `nak serve`, dev server on port 3333)
are allowed.

## Problem

Tests that call external services fail intermittently in CI because
GitHub Actions runners can't reach CDNs, mints, or other third-party
endpoints. This erodes trust in CI and wastes time debugging flaky
failures unrelated to the code under test.

The most recent example was commit `8de113e4` (#1203): the product-page
e2e test loaded images from `cdn.satellite.earth`, which was unreachable
from CI. The fix intercepted the CDN requests with `page.route()` and
served a local fixture.

## What this PR adds

**ADR-0005** (`docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md`):
- States the rule: no network calls to external services in tests
- Lists the only allowed dependencies: local relay, local dev server,
  other CI-started local services
- Documents what's NOT prohibited (importing pure npm packages,
  referencing external URLs as inert data)
- References the CDN interception commit and existing mock patterns

**AGENTS.md** — new "Test Isolation" section with the rule, established
mock patterns, and what's allowed.

**e2e/AGENTS.md** — new "Test Isolation" section with mock references
and interception guidance.

## Existing patterns (already in the codebase)

- `e2e/utils/lightning-mock.ts` — mocks LNURL, WebLN, and zap receipts
- `e2e/utils/nip46-mock.ts` — mocks NIP-46 remote signer
- `e2e/helpers/lnurl-mock.ts` — intercepts LNURL discovery
- `e2e/tests/product-page.spec.ts` — `interceptCdnImages()` routes
  `cdn.satellite.earth` to a local fixture image

## Test plan

- [ ] `bun run format:check` passes
- [ ] ADR-0005 renders correctly on GitHub
- [ ] AGENTS.md sections are well-formed markdown
