### PR TITLE
fix: isolate Zap NDK from external relays in CI/staging

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ on:
     - cron: '0 6 * * 1'
 
 jobs:
-  e2e-pricing:
+  e2e-grep:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -118,8 +118,8 @@ jobs:
           CVM_SERVER_KEY: e2e2222222222222222222222222222222222222222222222222222222222222
           LOCAL_RELAY_ONLY: 'true'
 
-      - name: Run pricing E2E tests
-        run: bun run test:e2e -- --grep 'Product Page - View Only'
+      - name: Run E2E tests
+        run: bun run test:e2e -- --grep 'Navigation|User Profile|Shipping Option Creation|Community Tab Progressive Loading|Order Details|Marketplace Display|V4V Dashboard Management|Receiving Payments Configuration|Product Page - View Only'
 
       - name: Show server logs on failure
         if: failure()
@@ -130,18 +130,20 @@ jobs:
           echo "=== Dev server logs ==="
           cat /tmp/devserver.log 2>/dev/null || echo "(no dev server log)"
 
-      - name: Upload pricing test results
+      - name: Upload test results
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: test-results-pricing
+          name: test-results
           path: test-results/
           retention-days: 7
 
   e2e-full:
-    # Keep the broader inherited-flaky suite off the pricing PR path.
-    # It remains available for scheduled/manual comparison runs while the
-    # separate test-fix branch carries the inherited failure work.
+    # The e2e-grep job runs reliable test families on every PR/push.
+    # Families with pre-existing failures (Authentication, App Settings,
+    # NWC, Cart, PII, Products, Multi-Merchant Cart, Zaps, Buyer Purchase,
+    # Auction Mint State, Auction Shipping, Product Page Interactions)
+    # remain in the scheduled e2e-full job.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -252,7 +254,7 @@ jobs:
           if [ -n "$TEST_GREP" ]; then
             bun run test:e2e -- --grep "$TEST_GREP"
           else
-            bun run test:e2e -- --grep-invert 'Product Page - View Only|Collection Management'
+            bun run test:e2e -- --grep-invert 'Navigation|User Profile|Shipping Option Creation|Community Tab Progressive Loading|Order Details|Marketplace Display|V4V Dashboard Management|Receiving Payments Configuration|Product Page - View Only|Collection Management'
           fi
 
       - name: Show server logs on failure

--- a/docs/adr/ADR-016-zap-ndk-external-relay-isolation.md
+++ b/docs/adr/ADR-016-zap-ndk-external-relay-isolation.md
@@ -1,0 +1,65 @@
+# ADR-016: Zap NDK External Relay Isolation
+
+## Status
+
+Accepted
+
+## Date
+
+2026-08-05
+
+## Related
+
+- Extends ADR-0002 (NDK external relay connections cause e2e flakiness)
+- PR: PlebeianApp/market#1211
+
+## Context
+
+The app creates a second NDK instance ("Zap NDK") to monitor NIP-57 zap
+receipts on public relays. LSPs publish zap receipts to their own public
+relays, not the app relay, so the Zap NDK must subscribe there to detect
+paid invoices.
+
+This was done unconditionally — even in development, staging, and CI/E2E
+tests where the local relay will never receive external zaps. Each page
+load opened 7 WebSocket connections to external relays (relay.damus.io,
+nos.lol, etc.) that take 5-30s to fail. While pending, Playwright's
+`waitForLoadState('networkidle')` in test fixtures never fired, causing
+the entire E2E suite to hang until timeout.
+
+## Decision
+
+Gate external Zap NDK connections via a single server-computed boolean
+(`externalZapRelaysEnabled`) exposed in `/api/config`. The browser
+consumes one decision — no client-side stage checks, no env reads, no
+drift between gating sites.
+
+Policy:
+
+| Stage                       | External zap relays | Rationale                                        |
+| --------------------------- | ------------------- | ------------------------------------------------ |
+| Production                  | ON                  | LSPs publish zap receipts to public relays       |
+| Staging                     | OFF                 | Staging events must not reach public relays      |
+| Dev + `LOCAL_RELAY_ONLY`    | OFF                 | CI/E2E — external connections hang `networkidle` |
+| Dev (no `LOCAL_RELAY_ONLY`) | ON                  | Developers can test zap purchases                |
+
+The server-side `EventHandler.ts` independently applies the same policy
+(`isStaging || isLocalOnly`) since it cannot read the `/api/config`
+response it produces.
+
+When disabled, the Zap NDK is set to `null` instead of creating a
+redundant NDK pointed only at the local relay.
+
+## Consequences
+
+- **Positive:** E2E tests no longer hang on external relay connections.
+  ~45 reliable tests can run on every PR (up from 10).
+- **Positive:** CI server startup ~15s faster (no external relay
+  connection timeouts).
+- **Positive:** Normal development unaffected — developers can still
+  test zap purchases with external relays.
+- **Negative:** Any future feature opening another public relay
+  connection will re-introduce the `networkidle` issue. Fixing the
+  test fixtures to use `domcontentloaded` + explicit locators (instead
+  of `networkidle`) would make the suite robust independently of relay
+  egress. This is tracked as a follow-up.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -63,6 +63,6 @@ export default defineConfig({
 
 	globalSetup: './global-setup.ts',
 	globalTeardown: './global-teardown.ts',
-	timeout: 30_000,
+	timeout: 120_000,
 	expect: { timeout: 5_000 },
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -250,6 +250,7 @@ export const server = serve({
 					cvmServerPubkey: getCvmServerPublicKey(),
 					needsSetup: !appSettings,
 					serverReady: eventHandlerReady,
+					externalZapRelaysEnabled: stage === 'production' || (stage === 'development' && process.env.LOCAL_RELAY_ONLY !== 'true'),
 				})
 			},
 		},

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -308,10 +308,14 @@ export const ndkActions = {
 			},
 		})
 
-		// Always monitor zap receipts on public ZAP_RELAYS (plus the app relay).
-		// LSPs publish zap receipts to their own public relays, not the local/app relay,
-		// so we must subscribe there to detect paid invoices.
-		const zapNdk = new NDK({ explicitRelayUrls: [...new Set([...ZAP_RELAYS, ...explicitRelays])] })
+		// Monitor zap receipts on public ZAP_RELAYS (plus the app relay) in
+		// production. LSPs publish zap receipts to their own public relays,
+		// not the local/app relay, so we must subscribe there to detect paid
+		// invoices. The server computes externalZapRelaysEnabled in /api/config
+		// and sends it to the browser — one decision point, no client/server
+		// drift. When disabled (staging, CI/E2E), don't create a zap NDK at all.
+		const externalZapRelaysEnabled = configStore.state.config.externalZapRelaysEnabled !== false
+		const zapNdk = externalZapRelaysEnabled ? new NDK({ explicitRelayUrls: [...new Set([...ZAP_RELAYS, ...explicitRelays])] }) : null
 
 		// Determine write relays - staging only writes to main relay, others write to all
 		const mainRelay = getMainRelay()
@@ -354,7 +358,9 @@ export const ndkActions = {
 				ndkStore.setState((s) => ({ ...s, isConnected: connected }))
 				if (connected) console.log('✅ NDK connected to relays')
 
-				// Also connect zap NDK in background (if available - skipped in local-relay-only mode)
+				// Connect zap NDK in background — it's null when external
+				// zap relays are disabled (staging/CI), so the guard inside
+				// connectZapNdk handles that automatically.
 				if (state.zapNdk) {
 					void ndkActions.connectZapNdk(5000)
 				}

--- a/src/server/EventHandler.ts
+++ b/src/server/EventHandler.ts
@@ -126,8 +126,17 @@ export class EventHandler {
 				console.warn('⚠️ App relay NDK setup failed, continuing anyway:', e)
 			}
 
-			// Also subscribe on dedicated zap relays; some LSPs do not publish receipts to the app relay.
-			const zapRelayUrls = Array.from(new Set([config.relayUrl, ...ZAP_RELAYS].filter(Boolean)))
+			// Subscribe on dedicated zap relays in production; some LSPs do not
+			// publish receipts to the app relay. Skip external relays in
+			// staging (must not leak events to public relays) and in CI/E2E
+			// (LOCAL_RELAY_ONLY — they waste 15s waiting for connections that
+			// will never succeed and aren't needed locally).
+			const isStaging = process.env.APP_STAGE === 'staging' || process.env.NODE_ENV === 'staging'
+			const isLocalOnly = process.env.LOCAL_RELAY_ONLY === 'true'
+			const skipExternalZapRelays = isStaging || isLocalOnly
+			const zapRelayUrls = skipExternalZapRelays
+				? [config.relayUrl].filter(Boolean)
+				: Array.from(new Set([config.relayUrl, ...ZAP_RELAYS].filter(Boolean)))
 			console.log(`Connecting to zap relays: ${zapRelayUrls.join(', ')}`)
 			this.zapNdk = new NDK({ explicitRelayUrls: zapRelayUrls })
 			try {


### PR DESCRIPTION
## Problem

E2E tests are flaky because every browser page load opens 7 WebSocket connections to external Nostr relays (relay.damus.io, nos.lol, etc.). These connections take 5-30s to fail. While pending, Playwright's `waitForLoadState('networkidle')` in test fixtures never fires, causing tests to hang until timeout.

The CI was reduced to running only "Product Page - View Only" (10 tests) on PRs because the full suite was too flaky.

## Root Cause

The Zap NDK — a second NDK instance for monitoring zap receipts on public relays — was connecting to external relays unconditionally, even in CI and E2E tests where the local relay will never receive external zaps.

## Decision

Documented in [ADR-016](docs/adr/ADR-016-zap-ndk-external-relay-isolation.md).

The server computes `externalZapRelaysEnabled` in `/api/config` — one boolean that encodes the full policy:

| Environment | External zap relays | Why |
|---|---|---|
| Production | ON | LSPs publish zap receipts to public relays |
| Staging | OFF | Staging events must not reach public relays |
| Dev + `LOCAL_RELAY_ONLY` (CI) | OFF | External WebSocket connections hang `networkidle` |
| Dev without `LOCAL_RELAY_ONLY` | ON | Developers can test zap purchases (NIP-57 receipts) |

Both client (`ndk.ts`) and server (`EventHandler.ts`) use the same policy — no drift between gating sites.

## Files changed (6)

### `src/index.tsx` — expose `externalZapRelaysEnabled` in `/api/config`
One line added to the config response. Non-sensitive boolean — no secret exposure.

### `src/lib/stores/ndk.ts` — null zap NDK when disabled
When `externalZapRelaysEnabled` is `false`, the zap NDK is set to `null` instead of creating a redundant NDK instance. The `connectZapNdk()` method already returns early when `zapNdk` is null.

### `src/server/EventHandler.ts` — gate server-side zap relays
Gates on `isStaging || isLocalOnly`. Staging previously still connected to external relays — now both client and server are consistent.

### `e2e/playwright.config.ts` — global timeout
30s → 120s to accommodate cold starts.

### `.github/workflows/e2e.yml` — expand PR E2E coverage

**Workflow changes** (per `.github/AGENTS.md` requirements):
- **Trigger:** Unchanged — runs on push/PR to master.
- **Permissions:** Unchanged — no new permissions.
- **Environment:** `LOCAL_RELAY_ONLY` is now consumed by the browser via `/api/config` (`externalZapRelaysEnabled` boolean). `LOCAL_RELAY_ONLY` was already set in CI env — no new env vars.
- **Secrets:** No secrets exposed. `externalZapRelaysEnabled` is a non-sensitive boolean.
- **Job rename:** `e2e-pricing` → `e2e-grep`. The job now runs grep-selected reliable test families, not just pricing tests. Branch protection rules keyed on the old job name may need updating.

Expands from 10 to ~45 tests across 9 reliable families (0 failures in CI):

| Family | Tests |
|---|---|
| Navigation | 6 |
| User Profile | 5 |
| Shipping Option Creation | 3 |
| Community Tab Progressive Loading | 8 |
| Order Details | 7 |
| Marketplace Display | 1 |
| V4V Dashboard Management | 2 |
| Receiving Payments Configuration | 3 |
| Product Page - View Only | ~10 |
| **Total** | **~45** |

**Authentication** was excluded because `auth.spec.ts:280` fails on clean master. It can be re-enabled when that test is fixed.

Families with pre-existing failures (Cart, PII, Products, NWC, App Settings, Multi-Merchant Cart, Buyer Purchase, Auction Shipping, Auction Mint State, Product Page Interactions) remain in the scheduled `e2e-full` weekly cron job.

### `docs/adr/ADR-016-zap-ndk-external-relay-isolation.md` — new ADR
Documents the decision, policy table, and consequences.

## Impact

- **No production behavior change** — only affects staging/CI/test environments
- **Normal development unaffected** — zap purchases can be tested as before
- **~45 tests run on every PR** (up from 10), all reliable — CI should be green
- **Server startup ~15s faster** in CI (no external relay connection timeouts)
- **Follow-up:** Fix test fixtures to use `domcontentloaded` instead of `networkidle` (see ADR-0016 consequences)