### PR TITLE
fix(server): default-deny public bootstrap

### DIFF
--- a/src/lib/__tests__/appSettings.test.ts
+++ b/src/lib/__tests__/appSettings.test.ts
@@ -1,8 +1,26 @@
-import { selectAuthoritativeAppSettingsEvent, APP_SETTINGS_KIND, APP_SETTINGS_D_TAG, type AppSettingsEventLike } from '../appSettings'
+import {
+	APP_SETTINGS_D_TAG,
+	APP_SETTINGS_KIND,
+	fetchAppSettings,
+	resolveFetchedAppSettings,
+	selectAuthoritativeAppSettingsEvent,
+	type AppSettingsEventLike,
+} from '../appSettings'
 import { describe, expect, test } from 'bun:test'
 
 const APP_PUBKEY = 'a'.repeat(64)
 const SPOOF_PUBKEY = 'b'.repeat(64)
+
+const VALID_SETTINGS = {
+	name: 'Demo Market',
+	displayName: 'Demo Market',
+	picture: 'https://example.com/picture.png',
+	banner: 'https://example.com/banner.png',
+	ownerPk: 'c'.repeat(64),
+	allowRegister: false,
+	defaultCurrency: 'sat',
+	showNostrLink: false,
+}
 
 /** Minimal event factory satisfying the AppSettingsEventLike structural type. */
 function mockEvent(opts: Partial<AppSettingsEventLike> & { pubkey?: string }): AppSettingsEventLike {
@@ -85,5 +103,44 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
 
 		expect(result?.created_at).toBe(200)
+	})
+})
+
+describe('resolveFetchedAppSettings', () => {
+	test('returns null only when a completed query returned no candidate events', () => {
+		expect(resolveFetchedAppSettings([], APP_PUBKEY)).toBeNull()
+	})
+
+	test('returns validated settings from the authoritative event', () => {
+		const event = mockEvent({ content: JSON.stringify(VALID_SETTINGS) })
+
+		expect(resolveFetchedAppSettings([event], APP_PUBKEY)).toEqual(VALID_SETTINGS)
+	})
+
+	test('fails closed when returned candidates contain no authoritative event', () => {
+		const spoofed = mockEvent({
+			pubkey: SPOOF_PUBKEY,
+			content: JSON.stringify(VALID_SETTINGS),
+		})
+
+		expect(() => resolveFetchedAppSettings([spoofed], APP_PUBKEY)).toThrow(/No authoritative app settings event/)
+	})
+
+	test('fails closed on malformed authoritative JSON', () => {
+		const event = mockEvent({ content: '{not-json' })
+
+		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY)).toThrow(/invalid JSON/)
+	})
+
+	test('fails closed when authoritative settings fail schema validation', () => {
+		const event = mockEvent({ content: JSON.stringify({ name: 'incomplete' }) })
+
+		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY)).toThrow(/schema validation/)
+	})
+})
+
+describe('fetchAppSettings fail-closed preflight', () => {
+	test('rejects malformed app pubkeys before relay I/O', async () => {
+		await expect(fetchAppSettings('wss://relay.invalid', 'not-a-pubkey')).rejects.toThrow(/Invalid app pubkey/)
 	})
 })

--- a/src/lib/__tests__/server-bootstrap-persistence.test.ts
+++ b/src/lib/__tests__/server-bootstrap-persistence.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test'
+import { getPublicKey } from 'nostr-tools/pure'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import { AdminManagerImpl } from '@/server/AdminManager'
+import { BootstrapManagerImpl } from '@/server/BootstrapManager'
+import { EditorManagerImpl } from '@/server/EditorManager'
+import { EventValidator } from '@/server/EventValidator'
+
+const APP_PRIVATE_KEY = 'a'.repeat(64)
+const OUTSIDER_PUBKEY = getPublicKey(hexToBytes('b'.repeat(64)))
+const ADMIN_PUBKEY = getPublicKey(hexToBytes('c'.repeat(64)))
+
+type ValidatorEvent = Parameters<EventValidator['validateEvent']>[0]
+
+function setupEvent(pubkey: string): ValidatorEvent {
+	return {
+		kind: 31990,
+		pubkey,
+		created_at: 1,
+		tags: [['d', 'plebeian-market-handler']],
+		content: '{"name":"demo"}',
+	} as ValidatorEvent
+}
+
+function adminListEvent(pubkey: string): ValidatorEvent {
+	return {
+		kind: 30000,
+		pubkey,
+		created_at: 1,
+		tags: [
+			['d', 'admins'],
+			['p', ADMIN_PUBKEY],
+		],
+		content: '',
+	} as ValidatorEvent
+}
+
+function validatorFor(adminManager: AdminManagerImpl, bootstrapManager: BootstrapManagerImpl) {
+	return new EventValidator(APP_PRIVATE_KEY, adminManager, new EditorManagerImpl(), bootstrapManager)
+}
+
+describe('server bootstrap persistence boundary', () => {
+	test('fresh instance stays closed unless public bootstrap is explicitly allowed', () => {
+		const adminManager = new AdminManagerImpl()
+		const bootstrapManager = new BootstrapManagerImpl(adminManager)
+		const validator = validatorFor(adminManager, bootstrapManager)
+
+		expect(bootstrapManager.isBootstrapMode()).toBe(false)
+		expect(validator.validateEvent(setupEvent(OUTSIDER_PUBKEY))).toEqual({
+			isValid: false,
+			reason: 'Setup event rejected: not in bootstrap mode and not signed by app or admin',
+		})
+		expect(validator.validateEvent(adminListEvent(OUTSIDER_PUBKEY))).toEqual({
+			isValid: false,
+			reason: 'Role list event rejected: not in bootstrap mode and not from admin',
+		})
+	})
+
+	test('fresh instance permits first setup and role-list events', () => {
+		const adminManager = new AdminManagerImpl()
+		const bootstrapManager = new BootstrapManagerImpl(adminManager, 0, false, true)
+		const validator = validatorFor(adminManager, bootstrapManager)
+
+		expect(bootstrapManager.isBootstrapMode()).toBe(true)
+		expect(validator.validateEvent(setupEvent(OUTSIDER_PUBKEY)).isValid).toBe(true)
+		expect(validator.validateEvent(adminListEvent(OUTSIDER_PUBKEY)).isValid).toBe(true)
+	})
+
+	test('persisted setup closes bootstrap before admins are loaded', () => {
+		const adminManager = new AdminManagerImpl()
+		const bootstrapManager = new BootstrapManagerImpl(adminManager, 0, true, true)
+		const validator = validatorFor(adminManager, bootstrapManager)
+
+		expect(bootstrapManager.isBootstrapMode()).toBe(false)
+
+		expect(validator.validateEvent(setupEvent(OUTSIDER_PUBKEY))).toEqual({
+			isValid: false,
+			reason: 'Setup event rejected: not in bootstrap mode and not signed by app or admin',
+		})
+
+		expect(validator.validateEvent(adminListEvent(OUTSIDER_PUBKEY))).toEqual({
+			isValid: false,
+			reason: 'Role list event rejected: not in bootstrap mode and not from admin',
+		})
+	})
+
+	test('persisted admin remains authorized after bootstrap is closed', () => {
+		const adminManager = new AdminManagerImpl([ADMIN_PUBKEY])
+		const bootstrapManager = new BootstrapManagerImpl(adminManager, 1, true, true)
+		const validator = validatorFor(adminManager, bootstrapManager)
+
+		expect(bootstrapManager.isBootstrapMode()).toBe(false)
+		expect(validator.validateEvent(setupEvent(ADMIN_PUBKEY)).isValid).toBe(true)
+		expect(validator.validateEvent(adminListEvent(ADMIN_PUBKEY)).isValid).toBe(true)
+	})
+
+	test('existing initial admins still close bootstrap without persisted setup', () => {
+		const adminManager = new AdminManagerImpl([ADMIN_PUBKEY])
+		const bootstrapManager = new BootstrapManagerImpl(adminManager, 1, false, true)
+
+		expect(bootstrapManager.isBootstrapMode()).toBe(false)
+	})
+})

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -39,6 +39,35 @@ export function selectAuthoritativeAppSettingsEvent(
 		.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
 }
 
+/**
+ * Resolve the result of a completed app-settings relay query.
+ *
+ * `null` means the authoritative query completed and returned no candidate
+ * events. Returned-but-unusable state is indeterminate and fails closed.
+ */
+export function resolveFetchedAppSettings(events: ReadonlyArray<AppSettingsEventLike>, appPubkey: string): AppSettings | null {
+	if (events.length === 0) return null
+
+	const authoritativeEvent = selectAuthoritativeAppSettingsEvent(events, appPubkey)
+	if (!authoritativeEvent) {
+		throw new Error(`No authoritative app settings event from expected publisher: ${appPubkey}`)
+	}
+
+	let parsedContent: unknown
+	try {
+		parsedContent = JSON.parse(authoritativeEvent.content)
+	} catch {
+		throw new Error('Authoritative app settings contain invalid JSON')
+	}
+
+	const result = AppSettingsSchema.safeParse(parsedContent)
+	if (!result.success) {
+		throw new Error('Authoritative app settings failed schema validation')
+	}
+
+	return result.data
+}
+
 export async function fetchAppSettings(relayUrl: string, appPubkey: string): Promise<AppSettings | null> {
 	console.log(`Fetching app settings from relay: ${relayUrl} for pubkey: ${appPubkey}`)
 
@@ -47,8 +76,7 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 	// but validating here gives a clear, early failure and guarantees the
 	// authors constraint is never satisfied by an unrelated publisher.
 	if (!isValidHexKey(appPubkey)) {
-		console.error('Invalid app pubkey provided:', appPubkey)
-		return null
+		throw new Error(`Invalid app pubkey provided: ${appPubkey}`)
 	}
 
 	try {
@@ -74,8 +102,7 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 			// Check if we have any connected relays despite the timeout
 			const connected = ndk.pool?.connectedRelays() || []
 			if (connected.length === 0) {
-				console.error('No relays connected, cannot fetch app settings')
-				return null
+				throw new Error('No relays connected, cannot fetch app settings')
 			}
 			console.log(`Connected to ${connected.length} relays despite timeout`)
 		}
@@ -110,34 +137,12 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 
 		if (eventArray.length === 0) {
 			console.log(`No app settings events found for pubkey: ${appPubkey}`)
-			return null
 		}
 
-		console.log(`Found ${eventArray.length} app settings events`)
-
-		// Verify publisher authority before accepting content: select only the
-		// event authored by the expected app pubkey, with kind 31990 and the exact
-		// d tag 'plebeian-market-handler'. A relay could return an event from a
-		// different publisher whose content passes the shape schema; reject it
-		// here (see selectAuthoritativeAppSettingsEvent).
-		const authoritativeEvent = selectAuthoritativeAppSettingsEvent(eventArray, appPubkey)
-		if (!authoritativeEvent) {
-			console.warn(`No app settings event from expected publisher: ${appPubkey}`)
-			return null
-		}
-
-		try {
-			const parsedContent = JSON.parse(authoritativeEvent.content)
-			const validatedSettings = AppSettingsSchema.parse(parsedContent)
-
-			return validatedSettings
-		} catch (error) {
-			console.error('Failed to parse or validate app settings:', error)
-			return null
-		}
+		return resolveFetchedAppSettings(eventArray, appPubkey)
 	} catch (err) {
-		console.error('Failed to fetch app settings due to connection or relay error:', err)
-		return null
+		console.error('Failed to fetch app settings:', err)
+		throw err
 	}
 }
 

--- a/src/server/BootstrapManager.ts
+++ b/src/server/BootstrapManager.ts
@@ -7,9 +7,14 @@ export class BootstrapManagerImpl implements BootstrapManager {
 	private hasSetupEvent: boolean = false
 	private adminManager: AdminManager
 
-	constructor(adminManager: AdminManager, initialAdminCount: number = 0) {
+	constructor(
+		adminManager: AdminManager,
+		initialAdminCount: number = 0,
+		hasExistingSetup: boolean = false,
+		allowPublicBootstrap: boolean = false,
+	) {
 		this.adminManager = adminManager
-		this.bootstrapMode = initialAdminCount === 0
+		this.bootstrapMode = allowPublicBootstrap && initialAdminCount === 0 && !hasExistingSetup
 
 		if (this.bootstrapMode) {
 			console.log('Bootstrap manager initialized in bootstrap mode')

--- a/src/server/EventHandler.ts
+++ b/src/server/EventHandler.ts
@@ -63,7 +63,12 @@ export class EventHandler {
 		// Initialize core components
 		this.adminManager = new AdminManagerImpl(config.adminPubkeys)
 		this.editorManager = new EditorManagerImpl()
-		this.bootstrapManager = new BootstrapManagerImpl(this.adminManager, config.adminPubkeys.length)
+		this.bootstrapManager = new BootstrapManagerImpl(
+			this.adminManager,
+			config.adminPubkeys.length,
+			config.hasExistingSetup,
+			config.allowPublicBootstrap,
+		)
 		this.eventSigner = new EventSigner(config.appPrivateKey)
 		this.eventValidator = new EventValidator(config.appPrivateKey, this.adminManager, this.editorManager, this.bootstrapManager)
 		this.ndkService = new NDKService(this.eventSigner.getAppPubkey(), this.adminManager, this.editorManager, this.bootstrapManager)

--- a/src/server/startup.ts
+++ b/src/server/startup.ts
@@ -1,7 +1,7 @@
 import { getPublicKey } from 'nostr-tools/pure'
 import { fetchAppSettings } from '../lib/appSettings'
 import { getEventHandler } from './EventHandler'
-import { APP_PRIVATE_KEY, RELAY_URL, setAppPublicKey, setAppSettings, setEventHandlerReady } from './runtime'
+import { APP_PRIVATE_KEY, RELAY_URL, getAppSettings, setAppPublicKey, setAppSettings, setEventHandlerReady } from './runtime'
 
 /**
  * Initialise process-level state required by every other server module.
@@ -50,6 +50,8 @@ export function startEventHandlerInitialization(): Promise<void> {
 		.initialize({
 			appPrivateKey: APP_PRIVATE_KEY || '',
 			adminPubkeys: [],
+			hasExistingSetup: getAppSettings() !== null,
+			allowPublicBootstrap: process.env.ALLOW_PUBLIC_BOOTSTRAP === 'true',
 			relayUrl: RELAY_URL,
 		})
 		.then(() => {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -4,6 +4,8 @@ import type { UnsignedEvent } from 'nostr-tools/pure'
 export interface EventHandlerConfig {
 	appPrivateKey: string
 	adminPubkeys: string[]
+	hasExistingSetup: boolean
+	allowPublicBootstrap: boolean
 	relayUrl?: string
 }
 


### PR DESCRIPTION
## Summary

Harden the server startup boundary so public first-claim bootstrap authority is not granted implicitly.

- accept only usable authoritative app settings and fail closed on relay/fetch/authority/validation failures
- fail startup closed when app settings cannot be established safely
- keep bootstrap closed when persisted setup already exists, even before admin lists finish loading
- make public first-claim bootstrap an explicit operator opt-in via `ALLOW_PUBLIC_BOOTSTRAP=true`; default is closed
- add focused regression coverage for fresh-instance denial, explicit opt-in, persisted setup, persisted admin authorization, and app-settings failure semantics

## Why

The previous startup path initialized `EventHandler` with an empty admin list. `BootstrapManager` therefore entered bootstrap mode before persisted setup state was incorporated into the authorization decision.

On a configured restart, that created a window in which setup and role-list events from a non-admin could be accepted as first-claim bootstrap traffic.

Separately, `fetchAppSettings()` returned `null` both when no settings event was returned and when relay connectivity, returned authority, JSON parsing, or schema validation failed. That allowed indeterminate states to follow the same path as an apparently fresh installation.

This change fails closed on relay/fetch/authority/validation failures and, independently, makes public bootstrap default-deny.

An empty settings result may still cause the instance to report that setup is needed, but it does not grant anonymous bootstrap authority unless the operator explicitly enables public bootstrap.

## Compatibility / operations

Public web first-claim bootstrap is now disabled by default.

Operators that intentionally need the legacy public bootstrap flow must explicitly set:

```text
ALLOW_PUBLIC_BOOTSTRAP=true
```

Controlled deployments can instead use the existing `deploy-simple/scripts/app-settings/publish.ts` operator script to sign and publish app settings and admin/editor role lists with the app private key. The script also supports `--dry-run` inspection before publication.

`needsSetup=true` and public bootstrap authorization are intentionally separate: an instance may report that setup is needed while refusing anonymous first-claim setup unless the operator explicitly enables it.

## Scope

This PR hardens the **public bootstrap/startup authorization boundary**.

It does not redesign the separate `NDKService` restart-time owner/admin-list recovery behavior; that remains independent follow-up scope.

## Validation

Focused security regression:

```text
19 pass
0 fail
33 expect() calls
```

Also verified:

- touched files pass Prettier
- committed diff passes whitespace checks
- branch is exactly one commit ahead of the reviewed `auctions` base
- the broader unit run retains the same two pre-existing `document is not defined` test-environment failures reproduced on the untouched base
