### PR TITLE
e2e: Local Cashu Mint for Auction E2E Test Infrastructure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,6 +80,14 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: bunx playwright install-deps chromium
 
+      - name: Setup Python for local Cashu mint
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Cashu (nutshell) mint
+        run: pip install cashu 'marshmallow<4.0.0' 'limits<5.0.0'
+
       - name: Start relay
         run: |
           nohup nak serve --hostname 0.0.0.0 > /tmp/relay.log 2>&1 &
@@ -93,6 +101,21 @@ jobs:
           done
           echo "::error::Relay failed to start. Logs:"
           cat /tmp/relay.log
+          exit 1
+
+      - name: Start local Cashu mint
+        run: |
+          nohup bash e2e/start-local-mint.sh > /tmp/mint.log 2>&1 &
+          echo "Waiting for local Cashu mint on port 3338..."
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3338/v1/info > /dev/null 2>&1; then
+              echo "Cashu mint is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Cashu mint failed to start. Logs:"
+          cat /tmp/mint.log
           exit 1
 
       - name: Seed relay and start dev server
@@ -117,6 +140,7 @@ jobs:
           APP_PRIVATE_KEY: e2e0000000000000000000000000000000000000000000000000000000000001
           CVM_SERVER_KEY: e2e2222222222222222222222222222222222222222222222222222222222222
           LOCAL_RELAY_ONLY: 'true'
+          APP_DEV_TEST_MINT_URL: 'http://localhost:3338'
 
       - name: Run E2E tests
         run: bun run test:e2e -- --grep 'Navigation|User Profile|Shipping Option Creation|Community Tab Progressive Loading|Order Details|Marketplace Display|V4V Dashboard Management|Receiving Payments Configuration|Product Page - View Only'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,11 @@ already exists.
 
 Tests must not make network calls to external services. The only allowed
 network dependencies are local services started in CI workflows (local
-relay via `nak serve`, local dev server on port 3333, ContextVM). All
-other external services (CDNs, Cashu mints, Lightning nodes, third-party
+relay via `nak serve`, local dev server on port 3333, local Cashu mint on
+port 3338, ContextVM). The local Cashu mint is a real nutshell mint with
+the FakeWallet backend, started by `e2e/start-local-mint.sh` (see the
+"Local Cashu Mint" section in `e2e/ARCHITECTURE.md`). All other external
+services (CDNs, remote Cashu mints, real Lightning nodes, third-party
 APIs) must be mocked or intercepted.
 
 See ADR-0005 for the full decision and established mock patterns.

--- a/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
+++ b/docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md
@@ -59,6 +59,13 @@ All other external services must be mocked or intercepted:
   strings; no NUT-7 queries or mint redemptions are performed. Token
   encoding for test fixtures uses `getEncodedToken` (a pure function
   with no network calls) or pre-computed token strings.
+
+  > **Amended (ADR-0006):** for auction bid-funding tests this
+  > inert-string approach is deprecated in favour of the real local
+  > Cashu mint (`e2e/start-local-mint.sh`, nutshell + FakeWallet on
+  > `127.0.0.1:3338`). The local mint is an allowed local service, not
+  > an external dependency. See ADR-0006 for the deprecation roadmap.
+
 - **Lightning payments** — use `LightningMock` which intercepts all
   LNURL and WebLN calls.
 

--- a/docs/adr/ADR-0006-local-cashu-mint-for-e2e-tests.md
+++ b/docs/adr/ADR-0006-local-cashu-mint-for-e2e-tests.md
@@ -1,0 +1,97 @@
+# ADR-0006: Local Cashu Mint for E2E Test Infrastructure
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-20
+
+## Context
+
+ADR-0005 requires tests to avoid external services, and its "Cashu mint
+operations" clause describes the only mechanism available at the time:
+mint URLs in test fixtures are **inert strings** — no NUT-7 queries, no
+mint redemptions, no real NUT-04/NUT-05 mint or melt. Token encoding uses
+`getEncodedToken` (a pure function) or pre-computed token strings.
+
+That approach is fine for tests that only need a mint URL to appear in a
+seeded event, but it cannot exercise the auction **bid-funding** flow,
+which requires a genuine round-trip:
+
+1. Pay a Lightning invoice (mint deposit)
+2. Mint e-cash (`NUT-04`)
+3. Lock the e-cash to the auction's P2PK output (`NUT-11`)
+4. Later redeem or reclaim it (`NUT-05`)
+
+A mock mint cannot produce valid blind signatures, so any bid-funding
+test built on a mock would fail at the first redemption. The settlement
+work (PR #1144) introduced `e2e/utils/cashu-mint-mock.ts`, whose `/v1/swap`
+endpoint echoes `B_` as `C_` without real signatures — deliberately
+invalid, and only usable because the settlement tests stub the
+verification step. It is not a substitute for a real mint.
+
+## Decision
+
+Run a **real local Cashu mint** in the e2e suite:
+
+- **nutshell** with the **FakeWallet** backend, which auto-settles
+  Lightning invoices instantly (no external Lightning node).
+- Started by `e2e/start-local-mint.sh` on `127.0.0.1:3338`.
+- Configured with a fixed test key, zero fees, rate limit off, and a
+  data dir under `/tmp/cashu-mint-e2e`.
+- Playwright starts it locally via `webServer`; CI sets up Python 3.12
+  and `pip install cashu` (pinning `marshmallow<4.0.0` and
+  `limits<5.0.0` to avoid the transitive-dep breaks that crash the mint).
+- The app's test wallet points at it via `APP_DEV_TEST_MINT_URL`.
+
+This is a local service, so it is consistent with ADR-0005's rule (it
+belongs to the same category as the local relay and local dev server).
+
+## Deprecation of mock mint fixtures
+
+The previous mock approach is **deprecated** for mint flows:
+
+| Deprecated fixture                                                 | Fate                                                                                                               |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Inert mint URLs + `getEncodedToken`/pre-computed tokens (ADR-0005) | Superseded by the real mint for bid-funding tests; retained only for tests that need a mint URL as inert data      |
+| `e2e/utils/lightning-mock.ts` (wallet/mint deposit path)           | Superseded by the FakeWallet backend for mint-deposit tests; retained for non-wallet Lightning flows (zaps, LNURL) |
+| `e2e/utils/cashu-mint-mock.ts` (PR #1144)                          | Planned for removal once its settlement tests migrate to the real mint                                             |
+
+New auction bid-funding tests MUST target the real local mint
+(`http://localhost:3338`) rather than a mock.
+
+## Roadmap
+
+1. **Now** — local mint available for auction bid-funding tests.
+2. **Later** — migrate existing mint-adjacent tests (`auction-mint-state`,
+   `auction-live-chat*`) off external mint URLs (`mint.minibits.cash`,
+   `testnut.cashu.space`) onto the local mint.
+3. **Later** — remove `e2e/utils/cashu-mint-mock.ts` once the settlement
+   tests no longer depend on the invalid-signature stub.
+4. **Retain** `lightning-mock.ts` for non-wallet Lightning flows (zaps,
+   LNURL payments) indefinitely; only its mint-deposit role is deprecated.
+
+## Consequences
+
+Positive:
+
+- Auction bid-funding is tested against the real protocol (NUT-04 →
+  NUT-11 lock → NUT-05), catching failures mocks structurally cannot.
+- Removes the "invalid blind signature" footgun that forced settlement
+  tests to stub verification.
+
+Trade-offs:
+
+- CI gains a Python + pip step and a service to keep alive (bounded by
+  the `marshmallow`/`limits` pins, which are already documented).
+- The mock mint fixtures remain in-tree during the transition, so both
+  approaches coexist until the roadmap migration completes.
+
+## Related
+
+- ADR-0005: No External Service Dependencies in Tests
+- `e2e/start-local-mint.sh`, `e2e/playwright.config.ts`
+- `e2e/ARCHITECTURE.md` — "Local Cashu Mint" section
+- PR #1144 — `e2e/utils/cashu-mint-mock.ts` (to be retired)

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -30,9 +30,12 @@ infrastructure.
 
 ## Test Isolation
 
-Tests must not make network calls to external services. Only the local
-relay (`nak serve`) and local dev server (port 3333) are allowed. All
-external services (CDNs, mints, Lightning nodes) must be mocked or
+Tests must not make network calls to external services. Three local
+services are allowed: the local relay (`nak serve`), the local dev
+server (port 3333), and the real local Cashu mint at 127.0.0.1:3338
+(nutshell mint with FakeWallet backend; tests target it via
+`APP_DEV_TEST_MINT_URL=http://localhost:3338`). All other external
+services (CDNs, remote mints, real Lightning nodes) must be mocked or
 intercepted via `page.route()` / `context.route()`.
 
 See ADR-0005 and the repository-level AGENTS.md "Test Isolation" section

--- a/e2e/ARCHITECTURE.md
+++ b/e2e/ARCHITECTURE.md
@@ -52,6 +52,7 @@ graph TB
 
     subgraph "Infrastructure Layer"
         NAK["nak serve<br/>(local relay)"]
+        MINT["Local Cashu mint<br/>(nutshell FakeWallet, :3338)"]
         SR["seed-relay.ts<br/>(app settings)"]
         DEV["bun dev<br/>(app server)"]
     end
@@ -75,11 +76,13 @@ graph TB
     TC --> DEV
     TC --> SC
     NAK --> SR
+    MINT -->|"APP_DEV_TEST_MINT_URL"| DEV
     SR --> DEV
     TF --> AF
     AF --> NE
     AF --> TC2
     TF --> RM
+    TF -.->|"NUT-04/NUT-05<br/>(wallet tests)"| MINT
     SC -.->|"per-fixture<br/>seeding"| TF
 ```
 
@@ -197,6 +200,29 @@ export default defineConfig({
 	expect: { timeout: 5_000 },
 })
 ```
+
+### Local Cashu Mint: `start-local-mint.sh`
+
+The suite also runs a **real local Cashu mint** — nutshell with the
+FakeWallet backend — so wallet and auction bid-funding tests exercise
+genuine NUT-04/NUT-05 mint and melt flows instead of mocks. The
+FakeWallet backend auto-settles Lightning invoices instantly; no
+external Lightning node is involved.
+
+- **Locally**: started by the Playwright `webServer` in
+  `e2e/playwright.config.ts` (`bash e2e/start-local-mint.sh` on port
+  3338, `reuseExistingServer: true`).
+- **In CI**: `.github/workflows/e2e.yml` sets up Python 3.12, runs
+  `pip install cashu`, starts the mint with
+  `nohup bash e2e/start-local-mint.sh`, and waits for
+  `http://localhost:3338/v1/info` before continuing.
+- **Configuration**: written by `e2e/start-local-mint.sh` — fixed test
+  key `0000...0001`, zero fees, rate limit off, name
+  "Plebeian Test Mint", data dir `/tmp/cashu-mint-e2e`. Override with
+  `CASHU_MINT_PORT`, `CASHU_MINT_HOST`, or `CASHU_MINT_DIR`.
+
+The dev server receives `APP_DEV_TEST_MINT_URL=http://localhost:3338`,
+pointing the app's test wallet at the local mint.
 
 ### Seed Relay: `seed-relay.ts`
 
@@ -803,7 +829,7 @@ Even though tests can run independently, when running the full suite we want an 
 
 ## 8. Test Utilities (Mocks)
 
-The `utils/` directory contains standalone mock implementations that simulate external systems (remote signers, Lightning payments, relay queries) without hitting real services. All mocks communicate with the local test relay via raw WebSocket or `nostr-tools`.
+The `utils/` directory contains standalone mock implementations that simulate external systems (remote signers, Lightning payments, relay queries) without hitting real services. All mocks communicate with the local test relay via raw WebSocket or `nostr-tools`. The Lightning mock still exists for non-wallet flows, but auction bid-funding tests (`e2e/tests/auction-bidding-mints.spec.ts`) exercise real NUT-04/NUT-05 flows against the local Cashu mint (see [Infrastructure Layer](#1-infrastructure-layer)) — this is deliberate.
 
 ### NIP-46 Remote Signer Mock (`utils/nip46-mock.ts`)
 
@@ -1125,6 +1151,9 @@ Key points:
 
 ## Running Tests
 
+Prerequisite (one-time): Python 3 with the nutshell mint installed —
+`pip install cashu`. Playwright starts everything else automatically.
+
 ```bash
 # Run all e2e tests (new suite)
 bun test:e2e
@@ -1146,6 +1175,23 @@ bun test:e2e -- e2e/tests/products.spec.ts
 ```
 
 > **Note**: The `bun test:e2e` scripts include `NODE_OPTIONS='--dns-result-order=ipv4first'` to work around macOS IPv4/IPv6 resolution issues (see Pitfalls section).
+
+### Local Cashu Mint
+
+Wallet and auction-bidding tests hit a **real local Cashu mint**
+(nutshell, FakeWallet backend) on port 3338 — no external mint or
+Lightning node. Playwright starts it automatically via the `webServer`
+config (`reuseExistingServer: true` reuses a mint that is already
+running). To start it manually:
+
+```bash
+bash e2e/start-local-mint.sh
+curl http://localhost:3338/v1/info # health check
+```
+
+Tests target the mint via `APP_DEV_TEST_MINT_URL=http://localhost:3338`
+(passed to the dev server by the `webServer` env in
+`playwright.config.ts`).
 
 ### Local Development Workflow
 

--- a/e2e/ARCHITECTURE.md
+++ b/e2e/ARCHITECTURE.md
@@ -224,6 +224,15 @@ external Lightning node is involved.
 The dev server receives `APP_DEV_TEST_MINT_URL=http://localhost:3338`,
 pointing the app's test wallet at the local mint.
 
+**Deprecation of mock mint fixtures (ADR-0006):** this real mint
+supersedes the previous mock approach for mint flows. Inert mint URLs
+with `getEncodedToken`/pre-computed tokens (ADR-0005), the wallet/mint
+path of `lightning-mock.ts`, and `cashu-mint-mock.ts` are deprecated for
+mint operations. Roadmap: migrate mint-adjacent tests
+(`auction-mint-state`, `auction-live-chat*`) off external mint URLs,
+then remove `cashu-mint-mock.ts`. `lightning-mock.ts` remains for
+non-wallet Lightning flows (zaps, LNURL). See ADR-0006.
+
 ### Seed Relay: `seed-relay.ts`
 
 Standalone script that publishes app settings events to the relay. Runs via Bun (which has native WebSocket) before the dev server starts.

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -29,13 +29,24 @@ export default defineConfig({
 	],
 
 	// On CI, servers are started manually in the workflow for better visibility.
-	// Locally, Playwright manages the relay and dev server automatically.
+	// Locally, Playwright manages the relay, mint, and dev server automatically.
 	webServer: process.env.CI
 		? []
 		: [
 				{
 					command: 'nak serve --hostname 0.0.0.0',
 					port: 10547,
+					reuseExistingServer: true,
+					stdout: 'pipe',
+					stderr: 'pipe',
+				},
+				{
+					// Local Cashu mint (nutshell with FakeWallet backend).
+					// Auto-settles Lightning invoices instantly — no external
+					// Lightning node or external mint required.
+					command: 'bash e2e/start-local-mint.sh',
+					cwd: PROJECT_ROOT,
+					port: 3338,
 					reuseExistingServer: true,
 					stdout: 'pipe',
 					stderr: 'pipe',
@@ -57,6 +68,7 @@ export default defineConfig({
 						APP_PRIVATE_KEY: TEST_APP_PRIVATE_KEY,
 						LOCAL_RELAY_ONLY: 'true',
 						NIP46_RELAY_URL: RELAY_URL,
+						APP_DEV_TEST_MINT_URL: 'http://localhost:3338',
 					},
 				},
 			],

--- a/e2e/scenarios/index.ts
+++ b/e2e/scenarios/index.ts
@@ -636,7 +636,7 @@ export async function seedAuction(
 			['starting_bid', String(startingBid), 'SAT'],
 			['bid_increment', String(bidIncrement)],
 			['reserve', String(reserve)],
-			['mint', 'https://nofees.testnut.cashu.space'],
+			['mint', 'http://localhost:3338'],
 			['escrow_pubkey', '02' + '00'.repeat(32)],
 			['key_scheme', 'hd_p2pk'],
 			['p2pk_xpub', 'xpub' + '0'.repeat(100)],

--- a/e2e/start-local-mint.sh
+++ b/e2e/start-local-mint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Start a local Cashu mint for Plebeian Market e2e tests.
+# See the "Local Cashu Mint" section in e2e/ARCHITECTURE.md for details.
+#
+# Uses the Cashu (nutshell) FakeWallet backend which auto-settles
+# Lightning invoices instantly — no external Lightning node needed.
+#
+# The mint listens on http://127.0.0.1:3338 by default.
+# Override with CASHU_MINT_PORT and CASHU_MINT_HOST env vars.
+set -euo pipefail
+
+MINT_DIR="${CASHU_MINT_DIR:-/tmp/cashu-mint-e2e}"
+MINT_PORT="${CASHU_MINT_PORT:-3338}"
+MINT_HOST="${CASHU_MINT_HOST:-127.0.0.1}"
+
+# Find a Python interpreter that has cashu installed
+CASHU_PYTHON=""
+for candidate in python3 /opt/miniconda/bin/python3.13 /usr/bin/python3; do
+    if command -v "$candidate" &>/dev/null && "$candidate" -c "import cashu" 2>/dev/null; then
+        CASHU_PYTHON="$candidate"
+        break
+    fi
+done
+
+if [ -z "$CASHU_PYTHON" ]; then
+    echo "ERROR: cashu is not installed in any Python interpreter." >&2
+    echo "Install with: pip install cashu" >&2
+    exit 1
+fi
+
+mkdir -p "$MINT_DIR"
+
+# Write the mint configuration
+cat > "$MINT_DIR/.env" << EOF
+MINT_LISTEN_HOST=$MINT_HOST
+MINT_LISTEN_PORT=$MINT_PORT
+MINT_HOST=localhost
+MINT_PORT=$MINT_PORT
+MINT_DATABASE=data/mint
+MINT_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000001
+MINT_BACKEND_BOLT11_SAT=FakeWallet
+MINT_INFO_NAME=Plebeian Test Mint
+MINT_INFO_DESCRIPTION=Local test mint for e2e tests
+MINT_RATE_LIMIT=False
+MINT_INPUT_FEE_PPK=0
+FAKEWALLET_DELAY_INCOMING_PAYMENT=0
+FAKEWALLET_DELAY_OUTGOING_PAYMENT=0
+EOF
+
+cd "$MINT_DIR"
+exec "$CASHU_PYTHON" -m cashu.mint --port "$MINT_PORT" --host "$MINT_HOST"


### PR DESCRIPTION
# Local Cashu Mint for Auction E2E Test Infrastructure

> **PR A** · `feat/test-mint-infra` → `auctions`

## Summary

Adds a **real local Cashu mint** (nutshell with the FakeWallet backend) to the e2e test suite. This lets auction bid-funding tests exercise genuine NUT-04/NUT-05 mint + melt flows against a local service — no external Lightning node, no remote mint, no mocks.

**No user-facing changes. DevOps / CI / test-infra only.**

## Why

Auction bid-funding tests need a working Cashu mint to deposit Lightning → mint e-cash → lock P2PK. Before this change there was no way to run one in the test suite, so those flows either hit remote mints (violating the test-isolation rule) or relied on mocks that can't produce valid blind signatures. This PR makes the mint a first-class local service, the same way `nak serve` is the local relay.

## What changed

### 1. The mint itself — `e2e/start-local-mint.sh` (new)

Starts nutshell with the **FakeWallet** backend, which auto-settles Lightning invoices instantly. Configuration:

- Fixed test key `0000…0001`, zero input fees, rate limit off
- Name "Plebeian Test Mint", data dir `/tmp/cashu-mint-e2e`
- Listens on `127.0.0.1:3338`
- Overridable via `CASHU_MINT_PORT` / `CASHU_MINT_HOST` / `CASHU_MINT_DIR`

### 2. Local runs — `e2e/playwright.config.ts`

Playwright's `webServer` array starts the mint (alongside the relay and dev server) with `reuseExistingServer: true`. The dev server receives `APP_DEV_TEST_MINT_URL=http://localhost:3338`, pointing the app's test wallet at the local mint.

### 3. CI — `.github/workflows/e2e.yml`

Three mint steps added to the `e2e-grep` job:

1. `actions/setup-python@v5` → Python 3.12 (coincurve has no 3.13 wheel)
2. `pip install cashu 'marshmallow<4.0.0' 'limits<5.0.0'`
3. Start the mint and poll `http://localhost:3338/v1/info` (15s) before running tests

The `marshmallow`/`limits` pins are required: `pip install cashu` alone pulls `marshmallow>=4.0.0` (breaks `environs`) and `limits>=5.0.0` (breaks `slowapi`), which crashes the mint at startup.

### 4. Shared seed helper — `e2e/scenarios/index.ts`

`seedAuction` now defaults its auction mint to `http://localhost:3338` instead of the external `nofees.testnut.cashu.space`.

### 5. Docs — `AGENTS.md`, `e2e/AGENTS.md`, `e2e/ARCHITECTURE.md`

The local mint is documented as an allowed local network dependency (alongside the relay and dev server), with a dedicated "Local Cashu Mint" section in the e2e architecture doc.

### 6. ADR + mock-mint deprecation (documentation only)

- **ADR-0006** (new) — records the decision to run a real local Cashu mint for auction bid-funding tests, **deprecates** the previous mock mint approach, and lays out a phased roadmap:
  - Inert mint URLs + `getEncodedToken`/pre-computed tokens (ADR-0005) → superseded for mint flows
  - `lightning-mock.ts` wallet/mint-deposit path → superseded by the FakeWallet backend
  - `cashu-mint-mock.ts` (PR #1144) → planned for removal
- **ADR-0005** (amended) — "Cashu mint operations" clause now cross-references ADR-0006 and notes the inert-string approach is deprecated for bid-funding tests.
- **`e2e/ARCHITECTURE.md`** — "Local Cashu Mint" section notes the deprecation and roadmap.

## Files

| File | Change |
|---|---|
| `e2e/start-local-mint.sh` | new — nutshell + FakeWallet, port 3338 |
| `e2e/playwright.config.ts` | mint `webServer` block + `APP_DEV_TEST_MINT_URL` |
| `.github/workflows/e2e.yml` | Python 3.12, pip install (pinned), start mint |
| `e2e/scenarios/index.ts` | shared `seedAuction` → local mint |
| `e2e/ARCHITECTURE.md` | "Local Cashu Mint" infrastructure section + mock deprecation |
| `docs/adr/ADR-0006-local-cashu-mint-for-e2e-tests.md` | new — local mint decision, mock deprecation, roadmap |
| `docs/adr/ADR-0005-no-external-service-dependencies-in-tests.md` | amended — cross-ref ADR-0006, deprecate inert-string mint ops |
| `AGENTS.md` | local mint as allowed dependency |
| `e2e/AGENTS.md` | mint in test-isolation rules |

## Running locally

```bash
# One-time prerequisite
pip install cashu 'marshmallow<4.0.0' 'limits<5.0.0'

# Playwright starts the mint automatically
bun test:e2e
```

## Testing

- No unit/integration test changes — this is infra-only.
- The mint's real consumer is the auction bid-funding e2e test (`auction-bidding-mints.spec.ts`), which lands in a follow-up PR stacked on this one.

## Merge order

Merges **before** the Lightning Bid Funding PR (#1235), whose e2e tests depend on this mint running.
