### PR TITLE
fix(auctions): remove reserve checkbox dual-state, empty = no reserve

### DIFF
--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -900,7 +900,6 @@ function AuctionTabContent({
 	userRemovedMints: Set<string>
 	onUserRemovedMintsChange: (next: Set<string>) => void
 }) {
-	const [useReserve, setUseReserve] = useState(false)
 	const [inputSliderValue, setInputSliderValue] = useState<number>(() => {
 		const idx = DURATION_PRESETS.findIndex((p) => p.seconds === durationSeconds)
 		return idx >= 0 ? idx + 1 : 1
@@ -1166,38 +1165,22 @@ function AuctionTabContent({
 								</div>
 
 								<div className="space-y-3">
-									<div className="flex items-center space-x-2">
-										<Checkbox
-											id="use-reserve"
-											checked={!!formData.reserve || useReserve}
-											onCheckedChange={(checked) => {
-												if (checked === true) {
-													setUseReserve(true)
-													setFormData((prev) => ({ ...prev, reserve: formData.startingBid }))
-												} else {
-													setUseReserve(false)
-													setFormData((prev) => ({ ...prev, reserve: undefined }))
-												}
-											}}
-										/>
-										<Label htmlFor="use-reserve">Set Reserve Price</Label>
-										<InfoTooltip content="Minimum bid required for the auction to have a winner. No winner if highest bid is lower than the reserve." />
-									</div>
-
-									{(!!formData.reserve || useReserve) && (
-										<div className="grid w-full gap-1.5">
+									<div className="grid w-full gap-1.5">
+										<div className="flex items-center space-x-2">
 											<Label htmlFor="auction-reserve">Reserve (sats)</Label>
-											<Input
-												id="auction-reserve"
-												type="number"
-												min="0"
-												value={formData.reserve}
-												onFocus={(e) => e.target.select()}
-												onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
-											/>
-											{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
+											<InfoTooltip content="Minimum bid required for the auction to have a winner. No winner if highest bid is lower than the reserve. Leave empty for no reserve." />
 										</div>
-									)}
+										<Input
+											id="auction-reserve"
+											type="number"
+											min="0"
+											placeholder="Optional — no reserve if left empty"
+											value={formData.reserve ?? ''}
+											onFocus={(e) => e.target.select()}
+											onChange={(e) => setFormData((prev) => ({ ...prev, reserve: e.target.value }))}
+										/>
+										{validationMessages.reserve && <p className="text-xs text-red-600">{validationMessages.reserve}</p>}
+									</div>
 								</div>
 
 								{showBidLadder && <BidLadderViz startingBid={startingBidNum} bidIncrement={bidIncrementNum} reserve={reserveNum} />}

--- a/src/components/sheet-contents/auctions/AuctionFormContent.tsx
+++ b/src/components/sheet-contents/auctions/AuctionFormContent.tsx
@@ -932,8 +932,7 @@ function AuctionTabContent({
 	const startingBidNum = parseInt(formData.startingBid, 10)
 	const bidIncrementNum = parseInt(formData.bidIncrement, 10)
 	const reserveNum = parseInt(formData.reserve ?? '', 10)
-	const showBidLadder =
-		formData.startingBid !== '' && startingBidNum > 0 && formData.bidIncrement !== '' && bidIncrementNum > 0 && !isNaN(reserveNum)
+	const showBidLadder = formData.startingBid !== '' && startingBidNum > 0 && formData.bidIncrement !== '' && bidIncrementNum > 0
 	const antiSnipeWindowSeconds = formData.antiSnipeWindowMinutes * 60
 	const endTimeError = validationMessages.endAt ?? validationMessages.duration ?? validationMessages.startAt
 

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -91,6 +91,13 @@ describe('save/load roundtrip', () => {
 		expect(loaded!.formData.isNSFW).toBe(false)
 	})
 
+	test('a draft without a reserve reloads with empty string, not "0"', () => {
+		const draft = { ...baseDraft, formData: { ...baseDraft.formData, reserve: undefined } }
+		saveAuctionFormDraft(PUBKEY_A, draft)
+		const loaded = getAuctionFormDraft(PUBKEY_A)
+		expect(loaded!.formData.reserve).toBe('')
+	})
+
 	test('restores top-level draft fields', () => {
 		saveAuctionFormDraft(PUBKEY_A, baseDraft)
 		const loaded = getAuctionFormDraft(PUBKEY_A)

--- a/src/lib/__tests__/auctionPublishValidation.test.ts
+++ b/src/lib/__tests__/auctionPublishValidation.test.ts
@@ -38,6 +38,11 @@ describe('auction publish validation', () => {
 		expect(() => validate({ reserve: '99' })).toThrow('Reserve must be greater than or equal to the starting bid')
 	})
 
+	test('reserve of 0 is treated as no reserve, not rejected vs starting bid', () => {
+		const result = validate({ reserve: '0' })
+		expect(result.reserve).toBe(0)
+	})
+
 	test('starting bid below auction minimum is rejected', () => {
 		expect(() => validate({ startingBid: String(AUCTION_MIN_BID_SATS - 1) })).toThrow(
 			`Starting bid must be at least ${AUCTION_MIN_BID_SATS} sats`,

--- a/src/lib/auctionPublishValidation.ts
+++ b/src/lib/auctionPublishValidation.ts
@@ -255,7 +255,7 @@ const normalizeAuctionPublishInput = (
 		if (parsedReserve !== undefined) {
 			reserve = parsedReserve
 		}
-		if (startingBid !== undefined && parsedReserve !== undefined && parsedReserve < startingBid) {
+		if (startingBid !== undefined && parsedReserve !== undefined && parsedReserve !== 0 && parsedReserve < startingBid) {
 			issues.push({ field: 'reserve', message: 'Reserve must be greater than or equal to the starting bid' })
 		}
 	}

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -105,7 +105,7 @@ function validateDraft(raw: unknown): AuctionFormDraft | null {
 		description: str(fd.description),
 		startingBid: str(fd.startingBid),
 		bidIncrement: str(fd.bidIncrement, '1'),
-		reserve: str(fd.reserve, '0'),
+		reserve: str(fd.reserve, ''),
 		startAt: str(fd.startAt),
 		endAt: str(fd.endAt),
 		antiSnipeWindowMinutes,


### PR DESCRIPTION
## Summary

Fixes a bug in the create-auction form: opening the "Advanced" panel auto-checked the reserve checkbox, and a no-op close then left a "reserve required" validation error on submit.

The reserve field used **dual state** — a `useReserve` boolean *and* `formData.reserve` — with `checked={!!formData.reserve || useReserve}`. Two sources of truth drifted, producing the auto-check.

## Fix

- Removed the `useReserve` boolean and the "Set Reserve Price" checkbox entirely.
- The "Reserve (sats)" input is now always visible and optional (`placeholder="Optional — no reserve if left empty"`, `value={formData.reserve ?? ''}`).
- Empty input publishes `reserve: 0` (no reserve), which `src/lib/auctionPublishValidation.ts` already supports — it defaults missing/empty reserve to `0`.

## Files

- `src/components/sheet-contents/auctions/AuctionFormContent.tsx`

## Testing

- `bun run test:unit` → 760 pass / 0 fail
- Prettier clean
- Manually verified on a dev server (fresh form → Advanced → reserve is unchecked/optional; empty submits cleanly)
