### PR TITLE
security : add strict bid amount parsing

### DIFF
--- a/src/lib/__tests__/auctionBidEventSchema.test.ts
+++ b/src/lib/__tests__/auctionBidEventSchema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test'
+import { parseBidEvent } from '../schemas/auction/bidEvent'
+import type { NostrEventLike } from '../nostr/eventLike'
+import { AUCTION_BID_KIND } from '../auction/constants'
+
+const BIDDER_PK = 'b'.repeat(64)
+const SELLER_PK = 'a'.repeat(64)
+const ROOT_EVENT_ID = '1'.repeat(64)
+const BID_EVENT_ID = '2'.repeat(64)
+const CHILD_PK = '02' + 'd'.repeat(64)
+const REFUND_PK = '03' + 'e'.repeat(64)
+const PROOF_Y = '02' + 'f'.repeat(64)
+
+const buildBidEvent = (amount: string): NostrEventLike =>
+	({
+		id: BID_EVENT_ID,
+		kind: AUCTION_BID_KIND,
+		pubkey: BIDDER_PK,
+		created_at: 1_500,
+		content: '',
+		tags: [
+			['e', ROOT_EVENT_ID],
+			['a', `30408:${SELLER_PK}:auction-test`],
+			['p', SELLER_PK],
+			['amount', amount, 'SAT'],
+			['currency', 'SAT'],
+			['mint', 'https://mint.test'],
+			['locktime', '5700'],
+			['refund_pubkey', REFUND_PK],
+			['child_pubkey', CHILD_PK],
+			['lock_secret', 'lock-secret-1'],
+			['proof_y', PROOF_Y],
+			['created_for_end_at', '2000'],
+			['bid_nonce', 'nonce-1'],
+			['key_scheme', 'hd_p2pk'],
+			['status', 'locked'],
+		],
+	}) as NostrEventLike
+
+describe('parseBidEvent amount parsing', () => {
+	test('accepts a canonical integer amount', () => {
+		const result = parseBidEvent(buildBidEvent('100'))
+
+		expect(result.ok).toBe(true)
+		expect(result.ok && result.value.amount).toBe(100)
+	})
+
+	test('rejects a malformed amount instead of truncating it', () => {
+		const result = parseBidEvent(buildBidEvent('100abc'))
+
+		expect(result.ok).toBe(false)
+	})
+
+	test('rejects non-canonical numeric representations', () => {
+		for (const amount of ['1e308', '0x64', ' 100abc ', '-100']) {
+			expect(parseBidEvent(buildBidEvent(amount)).ok).toBe(false)
+		}
+	})
+})

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
 	clearAuctionFormDraft,
 	getAuctionFormDraft,
@@ -26,8 +26,17 @@ const localStorageMock = {
 	},
 }
 
-Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true })
-Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true, configurable: true })
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true, configurable: true })
+
+// bun test runs every test file in the same process and shares one globalThis.
+// Undo the shims above once this file's tests finish so downstream files (e.g.
+// the src/queries/__tests__ victims whose imports probe `document`/`window`)
+// don't enter browser mode and crash mid-run.
+afterAll(() => {
+	delete (globalThis as any).window
+	delete (globalThis as any).localStorage
+})
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -7,11 +7,13 @@ import {
 	computeAuctionFloorMultiplier,
 	getAuctionBidAcceptanceEndAt,
 	getAuctionBiddingCutoffAt,
+	getAuctionBidAmount,
 	getAuctionCurrentPrice,
 	getAuctionEffectiveEndAt,
 	getAuctionMinBidCurve,
 	getAuctionRootEventId,
 	getAuctionWindowValidBids,
+	parseAuctionNonNegativeInt,
 	resolveAuctionVersionSet,
 } from '../auctionSettlement'
 
@@ -86,6 +88,22 @@ const makeAuction = (params: {
 	}) as NDKEvent
 
 describe('auctionSettlement helpers', () => {
+	test('parses only complete safe nonnegative integer strings', () => {
+		expect(parseAuctionNonNegativeInt('100')).toBe(100)
+		expect(parseAuctionNonNegativeInt(' 100 ')).toBe(100)
+		expect(parseAuctionNonNegativeInt('100abc')).toBe(0)
+		expect(parseAuctionNonNegativeInt('1e308')).toBe(0)
+		expect(parseAuctionNonNegativeInt('0x64')).toBe(0)
+		expect(parseAuctionNonNegativeInt('9007199254740992')).toBe(0)
+	})
+
+	test('rejects malformed amount tags instead of truncating them', () => {
+		const bid = makeBid({ id: 'malformed-amount', pubkey: 'alice', amount: 100, createdAt: 10 })
+		bid.tags.find((tag) => tag[0] === 'amount')![1] = '100abc'
+
+		expect(getAuctionBidAmount(bid)).toBe(0)
+	})
+
 	test('buildActiveAuctionBidChains reconstructs latest active chain per bidder', () => {
 		const firstAliceBid = makeBid({ id: 'alice-1', pubkey: 'alice', amount: 1000, createdAt: 10 })
 		const secondAliceBid = makeBid({ id: 'alice-2', pubkey: 'alice', amount: 1400, createdAt: 20, prevBidId: 'alice-1' })

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -49,8 +49,11 @@ export const getAuctionTagValues = (event: NostrEventLike, tagName: string): str
 	event.tags.filter((tag) => tag[0] === tagName && !!tag[1]).map((tag) => tag[1] || '')
 
 export const parseAuctionNonNegativeInt = (value?: string, fallback: number = 0): number => {
-	const parsed = value ? parseInt(value, 10) : NaN
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback
+	const text = value?.trim() ?? ''
+	if (!/^\d+$/.test(text)) return fallback
+
+	const parsed = Number(text)
+	return Number.isSafeInteger(parsed) ? parsed : fallback
 }
 
 export const getAuctionBidAmount = (bidEvent: NostrEventLike): number => {

--- a/src/lib/schemas/auction/bidEvent.ts
+++ b/src/lib/schemas/auction/bidEvent.ts
@@ -131,8 +131,12 @@ export const parseBidEvent = (event: NostrEventLike): ParseBidEventResult => {
 	}
 }
 
+// Same grammar as `parseAuctionNonNegativeInt`: a non-canonical value like
+// "100abc" must not be truncated to 100, since `amount` drives bid ranking.
 const parseIntegerOrZero = (raw: string | undefined): number => {
-	if (raw === undefined) return 0
-	const n = Number.parseInt(raw, 10)
-	return Number.isFinite(n) ? n : 0
+	const text = raw?.trim() ?? ''
+	if (!/^\d+$/.test(text)) return 0
+
+	const parsed = Number(text)
+	return Number.isSafeInteger(parsed) ? parsed : 0
 }


### PR DESCRIPTION
# PR Summary: Strict Auction Bid Amount Parsing

## Summary

Reject malformed auction numeric tags instead of allowing `parseInt` to silently truncate them. This keeps relay event data and the amount used by settlement logic consistent.

## Changes

- Require a complete unsigned decimal string before parsing an auction numeric tag.
- Reject exponent notation, hexadecimal-like input, trailing characters, negative values, and integers outside JavaScript's safe-integer range.
- Add regression coverage for malformed bid amount tags, including `100abc`, `1e308`, and `0x64`.

## Security Impact

Previously, a relay event with `amount=100abc` could be interpreted as a 100-sat bid. The strict parser now treats it as invalid and uses the existing fallback value, preventing inconsistent bid ranking and settlement calculations across consumers.

## Validation

- `bun test src/lib/__tests__/auctionSettlement.test.ts`
- `git diff --check`
