### PR TITLE
security: Auction display price counted unbacked bids

### DIFF
--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -16,7 +16,7 @@ import {
 	getAuctionRootEventId,
 	getAuctionSettlementGrace,
 	getAuctionCurrentPriceFromBids,
-	getAuctionBidCountFromBids,
+	getAuctionVerdictValidatedBidCountFromBids,
 	getBidAmount,
 	useAuctionVerdictValidatedBidIds,
 } from '@/queries/auctions'
@@ -131,7 +131,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
-	const bidsCount = getAuctionBidCountFromBids(auction, bids)
+	const bidsCount = getAuctionVerdictValidatedBidCountFromBids(auction, bids, verdictValidatedBidIds)
 	const hasPriorBids = bidsCount > 0
 	const bidStep = Math.max(bidIncrement, AUCTION_MIN_BID_LEG_SATS)
 	const signedInBidderPubkey = isAuthenticated ? user?.pubkey || currentUserPubkey || '' : ''

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -18,7 +18,7 @@ import {
 	getAuctionCurrentPriceFromBids,
 	getAuctionBidCountFromBids,
 	getBidAmount,
-	useAuctionVerdictBackedBidIds,
+	useAuctionVerdictValidatedBidIds,
 } from '@/queries/auctions'
 import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
 import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
@@ -129,8 +129,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// "Not started yet" to "Place Bid" the moment start_at passes.
 	const notStarted = startAt > 0 && countdown.now < startAt
 
-	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
+	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const hasPriorBids = bidsCount > 0
 	const bidStep = Math.max(bidIncrement, AUCTION_MIN_BID_LEG_SATS)

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -12,6 +12,7 @@ import {
 	getAuctionP2pkXpub,
 	getAuctionMints,
 	getAuctionId,
+	getAuctionAuditors,
 	useAuctionBids,
 	getAuctionRootEventId,
 	getAuctionSettlementGrace,
@@ -134,6 +135,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		auctionRootEventId || auctionId,
 		auctionCoordinates,
 	)
+	// No auditor means no validator can ever confirm a bid's collateral, so bids
+	// here can never be verified as backed. AUCTIONS.md §9.5.
+	const hasNoAuditors = !!auction && getAuctionAuditors(auction).length === 0
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionVerdictValidatedBidCountFromBids(auction, bids, verdictValidatedBidIds)
 	const hasPriorBids = bidsCount > 0
@@ -243,7 +247,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	}, [auctionRulesAckKey])
 
 	// Disable logic
-	const isDisabledInput = ended || notStarted || isOwnAuction || !areVerdictsReady || bidMutation.isPending
+	const isDisabledInput = ended || notStarted || isOwnAuction || hasNoAuditors || !areVerdictsReady || bidMutation.isPending
 	const isDisabledBid = isDisabledInput || !Number.isFinite(parsedBidAmount) || parsedBidAmount < minBid
 
 	// Button text logic
@@ -252,12 +256,18 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		if (ended) return 'Auction Ended'
 		if (notStarted) return 'Bidding not started'
 		if (bidMutation.isPending) return 'Submitting...'
+		if (hasNoAuditors) return 'Bidding unavailable'
 		if (!hasSignedInBidder) return 'Sign in to bid'
 		if (compact) return 'Bid ' + parsedBidAmount.toLocaleString() + ' sats'
 		return 'Place Bid'
-	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
+	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasNoAuditors, hasSignedInBidder, compact, parsedBidAmount])
 
 	const prepareBidSubmission = (): AuctionBidFormData | null => {
+		if (hasNoAuditors) {
+			toast.error('This auction lists no auditors, so its bids cannot be verified as backed. Bidding is disabled.')
+			return null
+		}
+
 		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction || !areVerdictsReady) return null
 
 		const parsedAmount = parseInt(bidAmountInput || '0', 10)
@@ -444,6 +454,14 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
+			{hasNoAuditors && (
+				<div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+					<p className="font-semibold">Bidding unavailable — no auditors listed</p>
+					<p className="mt-0.5 text-amber-700">
+						No validator can confirm that bids on this auction are backed by locked e-cash, so any amounts shown are unverified.
+					</p>
+				</div>
+			)}
 			{/* Anti-snipe curve banner — visible only when we're inside
 			    `(end_at, max_end_at]` AND the auction has a non-`none` curve.
 			    Tells the bidder why the floor is higher than they'd expect

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -129,7 +129,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// "Not started yet" to "Place Bid" the moment start_at passes.
 	const notStarted = startAt > 0 && countdown.now < startAt
 
-	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const { verdictValidatedBidIds, isReady: areVerdictsReady } = useAuctionVerdictValidatedBidIds(
+		auction,
+		auctionRootEventId || auctionId,
+		auctionCoordinates,
+	)
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionVerdictValidatedBidCountFromBids(auction, bids, verdictValidatedBidIds)
 	const hasPriorBids = bidsCount > 0
@@ -209,6 +213,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const hasInsufficientBidFunds =
 		hasSignedInBidder &&
+		areVerdictsReady &&
 		isNip60Ready &&
 		!ended &&
 		!notStarted &&
@@ -238,7 +243,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	}, [auctionRulesAckKey])
 
 	// Disable logic
-	const isDisabledInput = ended || notStarted || isOwnAuction || bidMutation.isPending
+	const isDisabledInput = ended || notStarted || isOwnAuction || !areVerdictsReady || bidMutation.isPending
 	const isDisabledBid = isDisabledInput || !Number.isFinite(parsedBidAmount) || parsedBidAmount < minBid
 
 	// Button text logic
@@ -253,7 +258,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
 
 	const prepareBidSubmission = (): AuctionBidFormData | null => {
-		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return null
+		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction || !areVerdictsReady) return null
 
 		const parsedAmount = parseInt(bidAmountInput || '0', 10)
 		if (!Number.isFinite(parsedAmount) || parsedAmount < minBid) {

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -18,6 +18,7 @@ import {
 	getAuctionCurrentPriceFromBids,
 	getAuctionBidCountFromBids,
 	getBidAmount,
+	useAuctionVerdictBackedBidIds,
 } from '@/queries/auctions'
 import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
 import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
@@ -128,7 +129,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	// "Not started yet" to "Place Bid" the moment start_at passes.
 	const notStarted = startAt > 0 && countdown.now < startAt
 
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const hasPriorBids = bidsCount > 0
 	const bidStep = Math.max(bidIncrement, AUCTION_MIN_BID_LEG_SATS)

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -22,7 +22,7 @@ import {
 	getAuctionStartingBid,
 	getAuctionTitle,
 	useAuctionBids,
-	useAuctionVerdictBackedBidIds,
+	useAuctionVerdictValidatedBidIds,
 } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { Link } from '@tanstack/react-router'
@@ -75,9 +75,9 @@ export function AuctionCard({
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const bidMutation = usePublishAuctionBidMutation()
-	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auction.id, auctionCoordinates)
+	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auction.id, auctionCoordinates)
 
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const ended = countdown.isEnded
 	// Lower-bound gate: bids cannot be placed before start_at. Mirrors the

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -75,7 +75,7 @@ export function AuctionCard({
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const bidMutation = usePublishAuctionBidMutation()
-	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auction.id, auctionCoordinates)
+	const { verdictValidatedBidIds } = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auction.id, auctionCoordinates)
 
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)

--- a/src/components/AuctionCard.tsx
+++ b/src/components/AuctionCard.tsx
@@ -22,6 +22,7 @@ import {
 	getAuctionStartingBid,
 	getAuctionTitle,
 	useAuctionBids,
+	useAuctionVerdictBackedBidIds,
 } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { Link } from '@tanstack/react-router'
@@ -74,8 +75,9 @@ export function AuctionCard({
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const bidMutation = usePublishAuctionBidMutation()
+	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auction.id, auctionCoordinates)
 
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const ended = countdown.isEnded
 	// Lower-bound gate: bids cannot be placed before start_at. Mirrors the

--- a/src/components/AuctionVerdictPanel.tsx
+++ b/src/components/AuctionVerdictPanel.tsx
@@ -21,6 +21,7 @@ import { AvatarUser } from '@/components/AvatarUser'
 interface Props {
 	auctionRootEventId: string
 	auctionCoordinate: string
+	auditorPubkeys: string[]
 }
 
 const claimToneClass = (claim: string): string => {
@@ -41,8 +42,8 @@ const formatTs = (ts: number): string => {
 	}
 }
 
-export const AuctionVerdictPanel = ({ auctionRootEventId, auctionCoordinate }: Props) => {
-	const verdictsQuery = useAuctionVerdicts(auctionRootEventId, 500, auctionCoordinate)
+export const AuctionVerdictPanel = ({ auctionRootEventId, auctionCoordinate, auditorPubkeys }: Props) => {
+	const verdictsQuery = useAuctionVerdicts(auctionRootEventId, 500, auctionCoordinate, auditorPubkeys)
 	const rawVerdicts = verdictsQuery.data ?? []
 
 	const verdicts = useMemo<ParsedValidatorVerdictEvent[]>(() => {

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -26,15 +26,11 @@ const localStorageMock = {
 	},
 }
 
-Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true, configurable: true })
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true, configurable: true })
 
 // bun test runs every test file in the same process and shares one globalThis.
-// Undo the shims above once this file's tests finish so downstream files (e.g.
-// the src/queries/__tests__ victims whose imports probe `document`/`window`)
-// don't enter browser mode and crash mid-run.
+// Undo the localStorage shim once this file's tests finish.
 afterAll(() => {
-	delete (globalThis as any).window
 	delete (globalThis as any).localStorage
 })
 

--- a/src/lib/__tests__/auctionFormStorage.test.ts
+++ b/src/lib/__tests__/auctionFormStorage.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
 	clearAuctionFormDraft,
 	getAuctionFormDraft,
@@ -26,8 +26,17 @@ const localStorageMock = {
 	},
 }
 
-Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true })
-Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+Object.defineProperty(globalThis, 'window', { value: globalThis, writable: true, configurable: true })
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true, configurable: true })
+
+// bun test runs every test file in the same process and shares one globalThis.
+// Undo the shims above once this file's tests finish so downstream files (e.g.
+// the src/queries/__tests__ victims whose imports probe `document`/`window`)
+// don't enter browser mode and crash mid-run.
+afterAll(() => {
+	delete (globalThis as any).window
+	delete (globalThis as any).localStorage
+})
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -11,9 +11,11 @@ import {
 	getAuctionEffectiveEndAt,
 	getAuctionMinBidCurve,
 	getAuctionRootEventId,
+	getAuctionVerdictBackedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
 } from '../auctionSettlement'
+import type { ParsedValidatorVerdictEvent } from '../auction/events'
 
 const makeBid = (params: {
 	id: string
@@ -53,6 +55,8 @@ const makeAuction = (params: {
 	maxEndAt?: number
 	/** `<shape>:<peak>` (e.g. `linear:5.0`). Omit for no curve. */
 	minBidCurve?: string
+	auditors?: string[]
+	auditorQuorum?: number
 }): NDKEvent =>
 	({
 		id: params.id,
@@ -82,8 +86,36 @@ const makeAuction = (params: {
 			// Defaults to end_at when no anti-sniping is configured.
 			['max_end_at', String(params.maxEndAt ?? params.endAt)],
 			...(params.minBidCurve ? ([['min_bid_curve', params.minBidCurve]] as string[][]) : []),
+			...(params.auditors ?? []).map((pubkey) => ['auditors', pubkey]),
+			...(params.auditorQuorum !== undefined ? ([['auditor_quorum', String(params.auditorQuorum)]] as string[][]) : []),
 		],
 	}) as NDKEvent
+
+const makeVerdict = (params: {
+	validatorPubkey: string
+	bidEventId: string
+	claim: ParsedValidatorVerdictEvent['claim']
+}): ParsedValidatorVerdictEvent =>
+	({
+		rawEvent: {
+			id: `verdict-${params.validatorPubkey}-${params.bidEventId}`,
+			pubkey: params.validatorPubkey,
+			kind: 30440,
+			created_at: 0,
+			content: '',
+			tags: [],
+		},
+		id: `verdict-${params.validatorPubkey}-${params.bidEventId}`,
+		validatorPubkey: params.validatorPubkey,
+		createdAt: 0,
+		dTag: '',
+		bidderPubkey: '',
+		auctionRootEventId: '',
+		auctionCoordinate: '',
+		bidEventId: params.bidEventId,
+		claim: params.claim,
+		observedAt: 0,
+	}) as ParsedValidatorVerdictEvent
 
 describe('auctionSettlement helpers', () => {
 	test('buildActiveAuctionBidChains reconstructs latest active chain per bidder', () => {
@@ -185,6 +217,52 @@ describe('auctionSettlement helpers', () => {
 		expect(getAuctionEffectiveEndAt(auction, bids)).toBe(320)
 		expect(getAuctionWindowValidBids(auction, bids).map((bid) => bid.id)).toEqual(['bid-early', 'bid-snipe-1', 'bid-snipe-2'])
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(1300)
+	})
+
+	test('getAuctionVerdictBackedBidIds only counts bids confirmed by a quorum of listed auditors', () => {
+		const auction = makeAuction({
+			id: 'auction-root',
+			endAt: 200,
+			auditors: ['validator-a', 'validator-b'],
+			auditorQuorum: 2,
+		})
+
+		const verdicts = [
+			makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-quorum', claim: 'valid_bid_placed' }),
+			makeVerdict({ validatorPubkey: 'validator-b', bidEventId: 'bid-quorum', claim: 'valid_bid_placed' }),
+			// Only one listed auditor confirms this one — quorum of 2 not met.
+			makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-single-auditor', claim: 'valid_bid_placed' }),
+			// A verdict from a validator not in the auction's `auditors` tag doesn't count.
+			makeVerdict({ validatorPubkey: 'validator-untrusted', bidEventId: 'bid-untrusted', claim: 'valid_bid_placed' }),
+			// A non-confirming claim doesn't count even from a listed auditor.
+			makeVerdict({ validatorPubkey: 'validator-b', bidEventId: 'bid-invalid', claim: 'bid_invalid' }),
+		]
+
+		const backed = getAuctionVerdictBackedBidIds(auction, verdicts)
+
+		expect(backed).toEqual(new Set(['bid-quorum']))
+	})
+
+	test('getAuctionVerdictBackedBidIds returns empty when the auction lists no auditors', () => {
+		const auction = makeAuction({ id: 'auction-root', endAt: 200 })
+		const verdicts = [makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-1', claim: 'valid_bid_placed' })]
+
+		expect(getAuctionVerdictBackedBidIds(auction, verdicts)).toEqual(new Set())
+	})
+
+	test('getAuctionCurrentPrice ignores unbacked bids when verdictBackedBidIds is provided (fake amount inflation)', () => {
+		const auction = makeAuction({ id: 'auction-root', endAt: 200, auditors: ['validator-a'], auditorQuorum: 1 })
+		const bids = [
+			makeBid({ id: 'bid-real', pubkey: 'alice', amount: 1200, createdAt: 110 }),
+			// Attacker-crafted kind-1023 with a fabricated amount and no backing proof.
+			makeBid({ id: 'bid-fake', pubkey: 'mallory', amount: 999999999, createdAt: 120 }),
+		]
+		const verdictBackedBidIds = getAuctionVerdictBackedBidIds(auction, [
+			makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-real', claim: 'valid_bid_placed' }),
+		])
+
+		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(999999999)
+		expect(getAuctionCurrentPrice(auction, bids, 1000, verdictBackedBidIds)).toBe(1200)
 	})
 
 	test('bidding cutoff is max_end_at when max_end_at is after end_at', () => {

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -11,6 +11,7 @@ import {
 	getAuctionEffectiveEndAt,
 	getAuctionMinBidCurve,
 	getAuctionRootEventId,
+	getAuctionVerdictValidatedBids,
 	getAuctionVerdictValidatedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
@@ -263,6 +264,7 @@ describe('auctionSettlement helpers', () => {
 
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(999999999)
 		expect(getAuctionCurrentPrice(auction, bids, 1000, verdictValidatedBidIds)).toBe(1200)
+		expect(getAuctionVerdictValidatedBids(auction, bids, verdictValidatedBidIds).map((bid) => bid.id)).toEqual(['bid-real'])
 	})
 
 	test('bidding cutoff is max_end_at when max_end_at is after end_at', () => {

--- a/src/lib/__tests__/auctionSettlement.test.ts
+++ b/src/lib/__tests__/auctionSettlement.test.ts
@@ -11,7 +11,7 @@ import {
 	getAuctionEffectiveEndAt,
 	getAuctionMinBidCurve,
 	getAuctionRootEventId,
-	getAuctionVerdictBackedBidIds,
+	getAuctionVerdictValidatedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
 } from '../auctionSettlement'
@@ -219,7 +219,7 @@ describe('auctionSettlement helpers', () => {
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(1300)
 	})
 
-	test('getAuctionVerdictBackedBidIds only counts bids confirmed by a quorum of listed auditors', () => {
+	test('getAuctionVerdictValidatedBidIds only counts bids validated by a quorum of listed auditors', () => {
 		const auction = makeAuction({
 			id: 'auction-root',
 			endAt: 200,
@@ -238,31 +238,31 @@ describe('auctionSettlement helpers', () => {
 			makeVerdict({ validatorPubkey: 'validator-b', bidEventId: 'bid-invalid', claim: 'bid_invalid' }),
 		]
 
-		const backed = getAuctionVerdictBackedBidIds(auction, verdicts)
+		const validated = getAuctionVerdictValidatedBidIds(auction, verdicts)
 
-		expect(backed).toEqual(new Set(['bid-quorum']))
+		expect(validated).toEqual(new Set(['bid-quorum']))
 	})
 
-	test('getAuctionVerdictBackedBidIds returns empty when the auction lists no auditors', () => {
+	test('getAuctionVerdictValidatedBidIds returns empty when the auction lists no auditors', () => {
 		const auction = makeAuction({ id: 'auction-root', endAt: 200 })
 		const verdicts = [makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-1', claim: 'valid_bid_placed' })]
 
-		expect(getAuctionVerdictBackedBidIds(auction, verdicts)).toEqual(new Set())
+		expect(getAuctionVerdictValidatedBidIds(auction, verdicts)).toEqual(new Set())
 	})
 
-	test('getAuctionCurrentPrice ignores unbacked bids when verdictBackedBidIds is provided (fake amount inflation)', () => {
+	test('getAuctionCurrentPrice ignores unreviewed bids when verdictValidatedBidIds is provided', () => {
 		const auction = makeAuction({ id: 'auction-root', endAt: 200, auditors: ['validator-a'], auditorQuorum: 1 })
 		const bids = [
 			makeBid({ id: 'bid-real', pubkey: 'alice', amount: 1200, createdAt: 110 }),
-			// Attacker-crafted kind-1023 with a fabricated amount and no backing proof.
+			// Unreviewed kind-1023 claims a much higher amount.
 			makeBid({ id: 'bid-fake', pubkey: 'mallory', amount: 999999999, createdAt: 120 }),
 		]
-		const verdictBackedBidIds = getAuctionVerdictBackedBidIds(auction, [
+		const verdictValidatedBidIds = getAuctionVerdictValidatedBidIds(auction, [
 			makeVerdict({ validatorPubkey: 'validator-a', bidEventId: 'bid-real', claim: 'valid_bid_placed' }),
 		])
 
 		expect(getAuctionCurrentPrice(auction, bids, 1000)).toBe(999999999)
-		expect(getAuctionCurrentPrice(auction, bids, 1000, verdictBackedBidIds)).toBe(1200)
+		expect(getAuctionCurrentPrice(auction, bids, 1000, verdictValidatedBidIds)).toBe(1200)
 	})
 
 	test('bidding cutoff is max_end_at when max_end_at is after end_at', () => {

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -1,4 +1,5 @@
 import type { NostrEventLike } from './nostr/eventLike'
+import type { ParsedValidatorVerdictEvent } from './auction/events'
 import {
 	AUCTION_BID_KIND,
 	AUCTION_KIND,
@@ -6,6 +7,7 @@ import {
 	AUCTION_SETTLEMENT_KIND,
 	AUCTION_SETTLEMENT_POLICY,
 	ACTIVE_AUCTION_BID_STATUSES,
+	DEFAULT_AUDITOR_QUORUM,
 } from './auction/constants'
 import { auctionImmutableFieldsMatch as compareAuctionImmutableFields } from './auction/immutability'
 
@@ -335,8 +337,67 @@ export const getAuctionWindowValidBids = (auctionEvent: NostrEventLike, bids: No
 	})
 }
 
-export const getAuctionCurrentPrice = (auctionEvent: NostrEventLike, bids: NostrEventLike[], startingBid: number = 0): number =>
-	getAuctionWindowValidBids(auctionEvent, bids).reduce((currentPrice, bid) => Math.max(currentPrice, getAuctionBidAmount(bid)), startingBid)
+/**
+ * Verdict claims meaning a listed auditor confirmed (at some point) that
+ * the bid's Cashu proof was actually locked/unspent on-mint per NUT-7 —
+ * AUCTIONS.md §7.5 step 3. A bare kind-1023 with a self-reported `amount`
+ * and no corroborating auditor never reaches one of these claims.
+ */
+const BID_CONFIRMED_VERDICT_CLAIMS = new Set([
+	'valid_bid_placed',
+	'won_pending_settlement',
+	'lost_pending_refund',
+	'settled_promptly',
+	'settled_late',
+])
+
+/**
+ * Bid event ids backed by `auditor_quorum` distinct listed `auditors`
+ * confirming the bid (AUCTIONS.md §6.0). Pass the result to
+ * `getAuctionCurrentPrice` so a self-signed kind-1023 with a fabricated
+ * `amount` and no locked proof behind it can't inflate the displayed
+ * price — only the settlement layer previously rejected such bids.
+ */
+export const getAuctionVerdictBackedBidIds = (auctionEvent: NostrEventLike, verdicts: ParsedValidatorVerdictEvent[]): Set<string> => {
+	const auditors = new Set(getAuctionTagValues(auctionEvent, 'auditors'))
+	if (auditors.size === 0) return new Set()
+
+	const quorum = Math.max(1, parseAuctionNonNegativeInt(getAuctionTagValue(auctionEvent, 'auditor_quorum'), DEFAULT_AUDITOR_QUORUM))
+
+	const confirmingAuditorsByBid = new Map<string, Set<string>>()
+	for (const verdict of verdicts) {
+		if (!verdict.bidEventId) continue
+		if (!auditors.has(verdict.validatorPubkey)) continue
+		if (!BID_CONFIRMED_VERDICT_CLAIMS.has(verdict.claim)) continue
+
+		const confirmingAuditors = confirmingAuditorsByBid.get(verdict.bidEventId) ?? new Set<string>()
+		confirmingAuditors.add(verdict.validatorPubkey)
+		confirmingAuditorsByBid.set(verdict.bidEventId, confirmingAuditors)
+	}
+
+	const backedBidIds = new Set<string>()
+	for (const [bidEventId, confirmingAuditors] of confirmingAuditorsByBid) {
+		if (confirmingAuditors.size >= quorum) backedBidIds.add(bidEventId)
+	}
+	return backedBidIds
+}
+
+/**
+ * `verdictBackedBidIds`, when passed, restricts the price to bids an
+ * auditor quorum has actually confirmed (see `getAuctionVerdictBackedBidIds`)
+ * so an unbacked kind-1023 can't inflate the displayed price. Omitting it
+ * preserves the old (unfiltered) behaviour for callers that haven't wired
+ * verdicts up yet.
+ */
+export const getAuctionCurrentPrice = (
+	auctionEvent: NostrEventLike,
+	bids: NostrEventLike[],
+	startingBid: number = 0,
+	verdictBackedBidIds?: Set<string>,
+): number =>
+	getAuctionWindowValidBids(auctionEvent, bids)
+		.filter((bid) => !verdictBackedBidIds || verdictBackedBidIds.has(bid.id))
+		.reduce((currentPrice, bid) => Math.max(currentPrice, getAuctionBidAmount(bid)), startingBid)
 
 export const collectAuctionBidChain = (latestBid: NostrEventLike, bidById: Map<string, NostrEventLike>): NostrEventLike[] => {
 	const chain: NostrEventLike[] = []

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -337,6 +337,12 @@ export const getAuctionWindowValidBids = (auctionEvent: NostrEventLike, bids: No
 	})
 }
 
+export const getAuctionVerdictValidatedBids = (
+	auctionEvent: NostrEventLike,
+	bids: NostrEventLike[],
+	verdictValidatedBidIds: Set<string>,
+): NostrEventLike[] => getAuctionWindowValidBids(auctionEvent, bids).filter((bid) => verdictValidatedBidIds.has(bid.id))
+
 /**
  * Verdict claims that establish a bid passed the validator's applicable
  * structural and auction-rule checks. They do not establish that the Cashu
@@ -393,9 +399,10 @@ export const getAuctionCurrentPrice = (
 	startingBid: number = 0,
 	verdictValidatedBidIds?: Set<string>,
 ): number =>
-	getAuctionWindowValidBids(auctionEvent, bids)
-		.filter((bid) => !verdictValidatedBidIds || verdictValidatedBidIds.has(bid.id))
-		.reduce((currentPrice, bid) => Math.max(currentPrice, getAuctionBidAmount(bid)), startingBid)
+	(verdictValidatedBidIds
+		? getAuctionVerdictValidatedBids(auctionEvent, bids, verdictValidatedBidIds)
+		: getAuctionWindowValidBids(auctionEvent, bids)
+	).reduce((currentPrice, bid) => Math.max(currentPrice, getAuctionBidAmount(bid)), startingBid)
 
 export const collectAuctionBidChain = (latestBid: NostrEventLike, bidById: Map<string, NostrEventLike>): NostrEventLike[] => {
 	const chain: NostrEventLike[] = []

--- a/src/lib/auctionSettlement.ts
+++ b/src/lib/auctionSettlement.ts
@@ -338,10 +338,9 @@ export const getAuctionWindowValidBids = (auctionEvent: NostrEventLike, bids: No
 }
 
 /**
- * Verdict claims meaning a listed auditor confirmed (at some point) that
- * the bid's Cashu proof was actually locked/unspent on-mint per NUT-7 —
- * AUCTIONS.md §7.5 step 3. A bare kind-1023 with a self-reported `amount`
- * and no corroborating auditor never reaches one of these claims.
+ * Verdict claims that establish a bid passed the validator's applicable
+ * structural and auction-rule checks. They do not establish that the Cashu
+ * proofs have the declared value or remain locked/unspent on-mint.
  */
 const BID_CONFIRMED_VERDICT_CLAIMS = new Set([
 	'valid_bid_placed',
@@ -352,13 +351,12 @@ const BID_CONFIRMED_VERDICT_CLAIMS = new Set([
 ])
 
 /**
- * Bid event ids backed by `auditor_quorum` distinct listed `auditors`
- * confirming the bid (AUCTIONS.md §6.0). Pass the result to
- * `getAuctionCurrentPrice` so a self-signed kind-1023 with a fabricated
- * `amount` and no locked proof behind it can't inflate the displayed
- * price — only the settlement layer previously rejected such bids.
+ * Bid event ids validated by `auditor_quorum` distinct listed `auditors`
+ * (AUCTIONS.md §6.0). Pass the result to `getAuctionCurrentPrice` to exclude
+ * unreviewed bids from the displayed price. This is not collateral
+ * verification; settlement remains responsible for that check.
  */
-export const getAuctionVerdictBackedBidIds = (auctionEvent: NostrEventLike, verdicts: ParsedValidatorVerdictEvent[]): Set<string> => {
+export const getAuctionVerdictValidatedBidIds = (auctionEvent: NostrEventLike, verdicts: ParsedValidatorVerdictEvent[]): Set<string> => {
 	const auditors = new Set(getAuctionTagValues(auctionEvent, 'auditors'))
 	if (auditors.size === 0) return new Set()
 
@@ -375,28 +373,28 @@ export const getAuctionVerdictBackedBidIds = (auctionEvent: NostrEventLike, verd
 		confirmingAuditorsByBid.set(verdict.bidEventId, confirmingAuditors)
 	}
 
-	const backedBidIds = new Set<string>()
+	const validatedBidIds = new Set<string>()
 	for (const [bidEventId, confirmingAuditors] of confirmingAuditorsByBid) {
-		if (confirmingAuditors.size >= quorum) backedBidIds.add(bidEventId)
+		if (confirmingAuditors.size >= quorum) validatedBidIds.add(bidEventId)
 	}
-	return backedBidIds
+	return validatedBidIds
 }
 
 /**
- * `verdictBackedBidIds`, when passed, restricts the price to bids an
- * auditor quorum has actually confirmed (see `getAuctionVerdictBackedBidIds`)
- * so an unbacked kind-1023 can't inflate the displayed price. Omitting it
- * preserves the old (unfiltered) behaviour for callers that haven't wired
- * verdicts up yet.
+ * `verdictValidatedBidIds`, when passed, restricts the price to bids an
+ * auditor quorum has validated (see `getAuctionVerdictValidatedBidIds`).
+ * This only excludes unreviewed bids; it does not verify collateral value.
+ * Omitting it preserves the old (unfiltered) behaviour for callers that
+ * haven't wired verdicts up yet.
  */
 export const getAuctionCurrentPrice = (
 	auctionEvent: NostrEventLike,
 	bids: NostrEventLike[],
 	startingBid: number = 0,
-	verdictBackedBidIds?: Set<string>,
+	verdictValidatedBidIds?: Set<string>,
 ): number =>
 	getAuctionWindowValidBids(auctionEvent, bids)
-		.filter((bid) => !verdictBackedBidIds || verdictBackedBidIds.has(bid.id))
+		.filter((bid) => !verdictValidatedBidIds || verdictValidatedBidIds.has(bid.id))
 		.reduce((currentPrice, bid) => Math.max(currentPrice, getAuctionBidAmount(bid)), startingBid)
 
 export const collectAuctionBidChain = (latestBid: NostrEventLike, bidById: Map<string, NostrEventLike>): NostrEventLike[] => {

--- a/src/lib/utils/auctionFormStorage.ts
+++ b/src/lib/utils/auctionFormStorage.ts
@@ -28,7 +28,7 @@ export type AuctionFormDraft = {
 
 const storageKey = (pubkey: string) => `auction_form_draft_${pubkey}`
 
-const isBrowser = () => typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+const isBrowser = () => typeof globalThis.localStorage !== 'undefined'
 
 function str(v: unknown, fallback = ''): string {
 	return typeof v === 'string' ? v : fallback

--- a/src/queries/__tests__/auctionBidStream.test.ts
+++ b/src/queries/__tests__/auctionBidStream.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { buildAuctionBidFilters, mergeAndSortBids } from '@/queries/auctions'
+import { buildAuctionBidFilters, buildAuctionVerdictFilter, mergeAndSortBids } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 
 const AUCTION_BID_KIND = 1023
@@ -48,6 +48,20 @@ describe('buildAuctionBidFilters', () => {
 	test('every filter targets AUCTION_BID_KIND', () => {
 		const filters = buildAuctionBidFilters('root123', '30408:pubkey:dtag', 500)
 		expect(filters.every((f) => f.kinds?.includes(AUCTION_BID_KIND as never))).toBe(true)
+	})
+})
+
+describe('buildAuctionVerdictFilter', () => {
+	test('restricts verdict requests to configured auditors', () => {
+		const filter = buildAuctionVerdictFilter('root123', '30408:pubkey:dtag', ['auditor-a', 'auditor-b'], 500)
+
+		expect(filter?.authors).toEqual(['auditor-a', 'auditor-b'])
+		expect((filter as { '#e'?: string[] })['#e']).toEqual(['root123'])
+		expect((filter as { '#a'?: string[] })['#a']).toEqual(['30408:pubkey:dtag'])
+	})
+
+	test('does not create an unscoped verdict request without configured auditors', () => {
+		expect(buildAuctionVerdictFilter('root123', undefined, [])).toBeNull()
 	})
 })
 

--- a/src/queries/__tests__/auctionBidStream.test.ts
+++ b/src/queries/__tests__/auctionBidStream.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test'
-import { buildAuctionBidFilters, buildAuctionVerdictFilter, mergeAndSortBids } from '@/queries/auctions'
+import { buildAuctionBidFilters, buildAuctionVerdictFilter, getAuctionCurrentPriceFromBids, mergeAndSortBids } from '@/queries/auctions'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 
 const AUCTION_BID_KIND = 1023
@@ -62,6 +62,21 @@ describe('buildAuctionVerdictFilter', () => {
 
 	test('does not create an unscoped verdict request without configured auditors', () => {
 		expect(buildAuctionVerdictFilter('root123', undefined, [])).toBeNull()
+	})
+})
+
+describe('getAuctionCurrentPriceFromBids', () => {
+	test('filters unvalidated bids when auction context is unavailable', () => {
+		const validatedBid = {
+			...makeBid('validated', 100),
+			tags: [['amount', '1200']],
+		}
+		const unvalidatedBid = {
+			...makeBid('unvalidated', 101),
+			tags: [['amount', '999999999']],
+		}
+
+		expect(getAuctionCurrentPriceFromBids(null, [validatedBid, unvalidatedBid], 1000, new Set(['validated']))).toBe(1200)
 	})
 })
 

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -22,6 +22,7 @@ import {
 	getAuctionSettlementGrace as getAuctionSettlementGraceValue,
 	getAuctionRootEventId as getAuctionRootEventIdValue,
 	getAuctionStartAt as getAuctionStartAtValue,
+	getAuctionVerdictValidatedBids,
 	getAuctionVerdictValidatedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
@@ -877,6 +878,15 @@ export const useAuctionVerdictValidatedBidIds = (auction: NDKEvent | null, aucti
 
 export const getAuctionBidCountFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): number =>
 	auction ? getAuctionWindowValidBids(auction, bids).length : bids.length
+
+export const getAuctionVerdictValidatedBidCountFromBids = (
+	auction: NDKEvent | null,
+	bids: NDKEvent[],
+	verdictValidatedBidIds: Set<string>,
+): number =>
+	auction
+		? getAuctionVerdictValidatedBids(auction, bids, verdictValidatedBidIds).length
+		: bids.filter((bid) => verdictValidatedBidIds.has(bid.id)).length
 
 export const getAuctionTopBidFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): NDKEvent | null => {
 	const validBids = auction ? getAuctionWindowValidBids(auction, bids) : bids

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -22,7 +22,7 @@ import {
 	getAuctionSettlementGrace as getAuctionSettlementGraceValue,
 	getAuctionRootEventId as getAuctionRootEventIdValue,
 	getAuctionStartAt as getAuctionStartAtValue,
-	getAuctionVerdictBackedBidIds,
+	getAuctionVerdictValidatedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
 } from '@/lib/auctionSettlement'
@@ -851,19 +851,18 @@ export const getAuctionCurrentPriceFromBids = (
 	auction: NDKEvent | null,
 	bids: NDKEvent[],
 	startingBid: number = 0,
-	verdictBackedBidIds?: Set<string>,
+	verdictValidatedBidIds?: Set<string>,
 ): number =>
 	auction
-		? computeAuctionCurrentPrice(auction, bids, startingBid, verdictBackedBidIds)
+		? computeAuctionCurrentPrice(auction, bids, startingBid, verdictValidatedBidIds)
 		: bids.reduce((max, bid) => Math.max(max, getBidAmount(bid)), startingBid)
 
 /**
- * Bid ids an auditor quorum has actually confirmed for this auction —
- * pass to `getAuctionCurrentPriceFromBids` so a self-signed kind-1023
- * with a fabricated `amount` can't inflate the displayed price before a
- * validator ever sees it (see AUCTIONS.md §6.0 / §7.5).
+ * Bid ids an auditor quorum has validated for this auction. Pass the result
+ * to `getAuctionCurrentPriceFromBids` to exclude unreviewed bids from the
+ * displayed price. Verdicts do not verify Cashu collateral value.
  */
-export const useAuctionVerdictBackedBidIds = (auction: NDKEvent | null, auctionEventId: string, auctionCoordinates?: string) => {
+export const useAuctionVerdictValidatedBidIds = (auction: NDKEvent | null, auctionEventId: string, auctionCoordinates?: string) => {
 	const verdictsQuery = useAuctionVerdicts(auctionEventId, 500, auctionCoordinates)
 	return useMemo(() => {
 		if (!auction) return new Set<string>()
@@ -872,7 +871,7 @@ export const useAuctionVerdictBackedBidIds = (auction: NDKEvent | null, auctionE
 			const parsed = parseValidatorVerdictEvent(event)
 			if (parsed.ok) parsedVerdicts.push(parsed.value)
 		}
-		return getAuctionVerdictBackedBidIds(auction, parsedVerdicts)
+		return getAuctionVerdictValidatedBidIds(auction, parsedVerdicts)
 	}, [auction, verdictsQuery.data])
 }
 

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -879,7 +879,10 @@ export const getAuctionCurrentPriceFromBids = (
 ): number =>
 	auction
 		? computeAuctionCurrentPrice(auction, bids, startingBid, verdictValidatedBidIds)
-		: bids.reduce((max, bid) => Math.max(max, getBidAmount(bid)), startingBid)
+		: (verdictValidatedBidIds ? bids.filter((bid) => verdictValidatedBidIds.has(bid.id)) : bids).reduce(
+				(max, bid) => Math.max(max, getBidAmount(bid)),
+				startingBid,
+			)
 
 /**
  * Bid ids an auditor quorum has validated for this auction. Pass the result

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -513,20 +513,34 @@ export const fetchAuctionVerdicts = async (
 	auctionEventId: string,
 	limit: number = 500,
 	auctionCoordinates?: string,
+	auditorPubkeys: string[] = [],
 ): Promise<NDKEvent[]> => {
-	if (!auctionEventId && !auctionCoordinates) return []
+	const filter = buildAuctionVerdictFilter(auctionEventId, auctionCoordinates, auditorPubkeys, limit)
+	if (!filter) return []
 	const ndk = ndkActions.getNDK()
 	if (!ndk) return []
 
+	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
+	return filterBlacklistedEvents(Array.from(events)).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+}
+
+export function buildAuctionVerdictFilter(
+	auctionEventId: string,
+	auctionCoordinates: string | undefined,
+	auditorPubkeys: string[],
+	limit: number = 500,
+): NDKFilter | null {
+	const auditors = [...new Set(auditorPubkeys.map((pubkey) => pubkey.trim()).filter(Boolean))]
+	if ((!auctionEventId && !auctionCoordinates) || auditors.length === 0) return null
+
 	const filter: NDKFilter = {
 		kinds: [VALIDATOR_VERDICT_KIND as unknown as number],
+		authors: auditors,
 		limit,
 	}
 	if (auctionEventId) (filter as { '#e'?: string[] })['#e'] = [auctionEventId]
 	if (auctionCoordinates) (filter as { '#a'?: string[] })['#a'] = [auctionCoordinates]
-
-	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
-	return filterBlacklistedEvents(Array.from(events)).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+	return filter
 }
 
 export const auctionsQueryOptions = (limit: number = 200) =>
@@ -655,11 +669,20 @@ export const auctionPathReleasesQueryOptions = (auctionEventId: string, limit: n
 		refetchInterval: 5000,
 	})
 
-export const auctionVerdictsQueryOptions = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) =>
+export const auctionVerdictsQueryOptions = (
+	auctionEventId: string,
+	limit: number = 500,
+	auctionCoordinates?: string,
+	auditorPubkeys: string[] = [],
+) =>
 	queryOptions({
-		queryKey: [...auctionKeys.verdicts(auctionEventId || auctionCoordinates || ''), auctionCoordinates || ''],
-		queryFn: () => fetchAuctionVerdicts(auctionEventId, limit, auctionCoordinates),
-		enabled: !!(auctionEventId || auctionCoordinates),
+		queryKey: [
+			...auctionKeys.verdicts(auctionEventId || auctionCoordinates || ''),
+			auctionCoordinates || '',
+			[...new Set(auditorPubkeys)].sort(),
+		],
+		queryFn: () => fetchAuctionVerdicts(auctionEventId, limit, auctionCoordinates, auditorPubkeys),
+		enabled: !!(auctionEventId || auctionCoordinates) && auditorPubkeys.length > 0,
 		staleTime: 5000,
 		refetchInterval: 5000,
 	})
@@ -865,7 +888,8 @@ export const getAuctionCurrentPriceFromBids = (
  * that initiate economic actions must wait for `isReady`.
  */
 export const useAuctionVerdictValidatedBidIds = (auction: NDKEvent | null, auctionEventId: string, auctionCoordinates?: string) => {
-	const verdictsQuery = useAuctionVerdicts(auctionEventId, 500, auctionCoordinates)
+	const auditorPubkeys = getAuctionAuditors(auction)
+	const verdictsQuery = useAuctionVerdicts(auctionEventId, 500, auctionCoordinates, auditorPubkeys)
 	const verdictValidatedBidIds = useMemo(() => {
 		if (!auction || !verdictsQuery.isSuccess) return new Set<string>()
 		const parsedVerdicts: ParsedValidatorVerdictEvent[] = []
@@ -876,7 +900,7 @@ export const useAuctionVerdictValidatedBidIds = (auction: NDKEvent | null, aucti
 		return getAuctionVerdictValidatedBidIds(auction, parsedVerdicts)
 	}, [auction, verdictsQuery.data, verdictsQuery.isSuccess])
 
-	return { verdictValidatedBidIds, isReady: !!auction && verdictsQuery.isSuccess }
+	return { verdictValidatedBidIds, isReady: !!auction && auditorPubkeys.length > 0 && verdictsQuery.isSuccess }
 }
 
 export const getAuctionBidCountFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): number =>
@@ -1030,9 +1054,14 @@ export const useAuctionPathReleases = (auctionEventId: string, limit: number = 2
 		...auctionPathReleasesQueryOptions(auctionEventId, limit, auctionCoordinates),
 	})
 
-export const useAuctionVerdicts = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) =>
+export const useAuctionVerdicts = (
+	auctionEventId: string,
+	limit: number = 500,
+	auctionCoordinates?: string,
+	auditorPubkeys: string[] = [],
+) =>
 	useQuery({
-		...auctionVerdictsQueryOptions(auctionEventId, limit, auctionCoordinates),
+		...auctionVerdictsQueryOptions(auctionEventId, limit, auctionCoordinates, auditorPubkeys),
 	})
 
 // ---------------------------------------------------------------------------

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import { ndkActions } from '@/lib/stores/ndk'
 import { AUCTION_PATH_RELEASE_KIND, VALIDATOR_VERDICT_KIND } from '@/lib/auction/constants'
@@ -22,9 +22,12 @@ import {
 	getAuctionSettlementGrace as getAuctionSettlementGraceValue,
 	getAuctionRootEventId as getAuctionRootEventIdValue,
 	getAuctionStartAt as getAuctionStartAtValue,
+	getAuctionVerdictBackedBidIds,
 	getAuctionWindowValidBids,
 	resolveAuctionVersionSet,
 } from '@/lib/auctionSettlement'
+import { parseValidatorVerdictEvent } from '@/lib/schemas/auction/validatorEvents'
+import type { ParsedValidatorVerdictEvent } from '@/lib/auction/events'
 import { NIP59_GIFT_WRAP_KIND } from '@/lib/nostr/nip59'
 import type { NDKFilter } from '@nostr-dev-kit/ndk'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -844,10 +847,34 @@ export const getBidLocktime = (bidEvent: NDKEvent | null): number => {
 	return Number.isFinite(parsed) ? parsed : 0
 }
 
-export const getAuctionCurrentPriceFromBids = (auction: NDKEvent | null, bids: NDKEvent[], startingBid: number = 0): number =>
+export const getAuctionCurrentPriceFromBids = (
+	auction: NDKEvent | null,
+	bids: NDKEvent[],
+	startingBid: number = 0,
+	verdictBackedBidIds?: Set<string>,
+): number =>
 	auction
-		? computeAuctionCurrentPrice(auction, bids, startingBid)
+		? computeAuctionCurrentPrice(auction, bids, startingBid, verdictBackedBidIds)
 		: bids.reduce((max, bid) => Math.max(max, getBidAmount(bid)), startingBid)
+
+/**
+ * Bid ids an auditor quorum has actually confirmed for this auction —
+ * pass to `getAuctionCurrentPriceFromBids` so a self-signed kind-1023
+ * with a fabricated `amount` can't inflate the displayed price before a
+ * validator ever sees it (see AUCTIONS.md §6.0 / §7.5).
+ */
+export const useAuctionVerdictBackedBidIds = (auction: NDKEvent | null, auctionEventId: string, auctionCoordinates?: string) => {
+	const verdictsQuery = useAuctionVerdicts(auctionEventId, 500, auctionCoordinates)
+	return useMemo(() => {
+		if (!auction) return new Set<string>()
+		const parsedVerdicts: ParsedValidatorVerdictEvent[] = []
+		for (const event of verdictsQuery.data ?? []) {
+			const parsed = parseValidatorVerdictEvent(event)
+			if (parsed.ok) parsedVerdicts.push(parsed.value)
+		}
+		return getAuctionVerdictBackedBidIds(auction, parsedVerdicts)
+	}, [auction, verdictsQuery.data])
+}
 
 export const getAuctionBidCountFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): number =>
 	auction ? getAuctionWindowValidBids(auction, bids).length : bids.length

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -861,19 +861,22 @@ export const getAuctionCurrentPriceFromBids = (
 /**
  * Bid ids an auditor quorum has validated for this auction. Pass the result
  * to `getAuctionCurrentPriceFromBids` to exclude unreviewed bids from the
- * displayed price. Verdicts do not verify Cashu collateral value.
+ * displayed price. Verdicts do not verify Cashu collateral value. Consumers
+ * that initiate economic actions must wait for `isReady`.
  */
 export const useAuctionVerdictValidatedBidIds = (auction: NDKEvent | null, auctionEventId: string, auctionCoordinates?: string) => {
 	const verdictsQuery = useAuctionVerdicts(auctionEventId, 500, auctionCoordinates)
-	return useMemo(() => {
-		if (!auction) return new Set<string>()
+	const verdictValidatedBidIds = useMemo(() => {
+		if (!auction || !verdictsQuery.isSuccess) return new Set<string>()
 		const parsedVerdicts: ParsedValidatorVerdictEvent[] = []
 		for (const event of verdictsQuery.data ?? []) {
 			const parsed = parseValidatorVerdictEvent(event)
 			if (parsed.ok) parsedVerdicts.push(parsed.value)
 		}
 		return getAuctionVerdictValidatedBidIds(auction, parsedVerdicts)
-	}, [auction, verdictsQuery.data])
+	}, [auction, verdictsQuery.data, verdictsQuery.isSuccess])
+
+	return { verdictValidatedBidIds, isReady: !!auction && verdictsQuery.isSuccess }
 }
 
 export const getAuctionBidCountFromBids = (auction: NDKEvent | null, bids: NDKEvent[]): number =>

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -30,6 +30,7 @@ import {
 	getAuctionBidCountFromBids,
 	getAuctionBidIncrement,
 	getAuctionCurrentPriceFromBids,
+	getAuctionAuditors,
 	useAuctionVerdictValidatedBidIds,
 	getAuctionCurrency,
 	getAuctionPathIssuer,
@@ -943,7 +944,11 @@ function DashboardAuctionDetailRoute() {
 								</div>
 							)}
 
-							<AuctionVerdictPanel auctionRootEventId={auctionRootEventId || auctionId} auctionCoordinate={auctionCoordinates} />
+							<AuctionVerdictPanel
+								auctionRootEventId={auctionRootEventId || auctionId}
+								auctionCoordinate={auctionCoordinates}
+								auditorPubkeys={getAuctionAuditors(auction)}
+							/>
 
 							{/* Tech accordion — visible to all but only really useful for seller / debugging */}
 							<Accordion type="multiple" className="rounded-2xl border border-zinc-200 bg-white px-4">

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -30,6 +30,7 @@ import {
 	getAuctionBidCountFromBids,
 	getAuctionBidIncrement,
 	getAuctionCurrentPriceFromBids,
+	useAuctionVerdictBackedBidIds,
 	getAuctionCurrency,
 	getAuctionPathIssuer,
 	getAuctionId,
@@ -264,7 +265,8 @@ function DashboardAuctionDetailRoute() {
 	const now = countdown.now
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const ended = status === 'Ended'
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
 	const bidCount = getAuctionBidCountFromBids(auction, bids)
 
 	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auctionId, 100, auctionCoordinates)

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -30,7 +30,7 @@ import {
 	getAuctionBidCountFromBids,
 	getAuctionBidIncrement,
 	getAuctionCurrentPriceFromBids,
-	useAuctionVerdictBackedBidIds,
+	useAuctionVerdictValidatedBidIds,
 	getAuctionCurrency,
 	getAuctionPathIssuer,
 	getAuctionId,
@@ -265,8 +265,8 @@ function DashboardAuctionDetailRoute() {
 	const now = countdown.now
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const ended = status === 'Ended'
-	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
+	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidCount = getAuctionBidCountFromBids(auction, bids)
 
 	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auctionId, 100, auctionCoordinates)

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -265,7 +265,7 @@ function DashboardAuctionDetailRoute() {
 	const now = countdown.now
 	const status = formatAuctionStatus(startAt, biddingCutoffAt, now)
 	const ended = status === 'Ended'
-	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const { verdictValidatedBidIds } = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidCount = getAuctionBidCountFromBids(auction, bids)
 

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx
@@ -272,7 +272,7 @@ function DashboardAuctionDetailRoute() {
 
 	const settlementsQuery = useAuctionSettlements(auctionRootEventId || auctionId, 100, auctionCoordinates)
 	const settlements = settlementsQuery.data ?? []
-	const verdictsQuery = useAuctionVerdicts(auctionRootEventId || auctionId, 500, auctionCoordinates)
+	const verdictsQuery = useAuctionVerdicts(auctionRootEventId || auctionId, 500, auctionCoordinates, getAuctionAuditors(auction))
 	const verdictsData = verdictsQuery.data ?? []
 
 	// B4: Validate settlements before using them. The previous code read

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -431,7 +431,7 @@ function AuctionDetailRoute() {
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const ended = countdown.isEnded
-	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const { verdictValidatedBidIds } = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
 	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const minBid = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -34,7 +34,7 @@ import {
 	getAuctionBidIncrement,
 	getAuctionCategories,
 	getAuctionCurrentPriceFromBids,
-	useAuctionVerdictBackedBidIds,
+	useAuctionVerdictValidatedBidIds,
 	getAuctionBiddingCutoffAt,
 	getAuctionCurrency,
 	getAuctionId,
@@ -431,8 +431,8 @@ function AuctionDetailRoute() {
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const ended = countdown.isEnded
-	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
+	const verdictValidatedBidIds = useAuctionVerdictValidatedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictValidatedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const minBid = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
 	const parsedBidAmount = parseInt(bidAmountInput || '0', 10)

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -34,6 +34,7 @@ import {
 	getAuctionBidIncrement,
 	getAuctionCategories,
 	getAuctionCurrentPriceFromBids,
+	useAuctionVerdictBackedBidIds,
 	getAuctionBiddingCutoffAt,
 	getAuctionCurrency,
 	getAuctionId,
@@ -430,7 +431,8 @@ function AuctionDetailRoute() {
 	const biddingCutoffAt = getAuctionBiddingCutoffAt(auction)
 	const countdown = useAuctionCountdown(biddingCutoffAt, { showSeconds: true })
 	const ended = countdown.isEnded
-	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid)
+	const verdictBackedBidIds = useAuctionVerdictBackedBidIds(auction, auctionRootEventId || auctionId, auctionCoordinates)
+	const currentPrice = getAuctionCurrentPriceFromBids(auction, bids, startingBid, verdictBackedBidIds)
 	const bidsCount = getAuctionBidCountFromBids(auction, bids)
 	const minBid = Math.max(startingBid, currentPrice + Math.max(1, bidIncrement))
 	const parsedBidAmount = parseInt(bidAmountInput || '0', 10)

--- a/src/routes/auctions.$auctionId.tsx
+++ b/src/routes/auctions.$auctionId.tsx
@@ -76,7 +76,7 @@ import { AuctionBidder } from '@/components/AuctionBidder'
 import { LiveChatPanel } from '@/components/LiveChatPanel'
 import { UserCard } from '@/components/UserCard'
 import { AuctionVerdictPanel } from '@/components/AuctionVerdictPanel'
-import { useAuctionVerdicts } from '@/queries/auctions'
+import { getAuctionAuditors, useAuctionVerdicts } from '@/queries/auctions'
 import { parseValidatorVerdictEvent } from '@/lib/schemas/auction/validatorEvents'
 import type { ParsedValidatorVerdictEvent } from '@/lib/auction/events'
 import { computeValidatedBids } from '@/lib/auction/bidValidation'
@@ -499,7 +499,7 @@ function AuctionDetailRoute() {
 		[bids],
 	)
 
-	const verdictsQuery = useAuctionVerdicts(auctionRootEventId || auctionId, 500, auctionCoordinates)
+	const verdictsQuery = useAuctionVerdicts(auctionRootEventId || auctionId, 500, auctionCoordinates, getAuctionAuditors(auction))
 	const parsedVerdicts = useMemo(() => {
 		return (verdictsQuery.data ?? [])
 			.map((e) =>


### PR DESCRIPTION
# Fix: Auction display price counted unbacked bids

## Problem

`getAuctionCurrentPrice` (`src/lib/auctionSettlement.ts`) computed the
displayed "current price" from every time/status-window-valid kind-1023 bid
event, including bids with no locked Cashu proof behind them. Because a
kind-1023's `amount` tag is attacker-controlled, publishing a raw,
self-signed kind-1023 with a fabricated `amount` (and `status: locked`)
inflated the price shown to legitimate bidders. Settlement already rejected
such bids; only the display layer was unfiltered.

Note: the original report described this in terms of a "path-oracle
registry" — that scheme is gone. The current architecture
(`cashu_p2pk_bidder_path_v1`, see `AUCTIONS.md`) has no registry; the
equivalent trust signal is kind-30440 validator verdicts gated by the
auction's `auditor_quorum` (`AUCTIONS.md` §6.0 / §7.5).

## Fix

- `src/lib/auctionSettlement.ts`
  - `getAuctionVerdictBackedBidIds(auctionEvent, verdicts)` — new. Returns
    the set of bid event ids confirmed by `auditor_quorum` distinct
    pubkeys from the auction's `auditors` tag, via kind-30440 verdicts
    whose claim is one of `valid_bid_placed`, `won_pending_settlement`,
    `lost_pending_refund`, `settled_promptly`, `settled_late`.
  - `getAuctionCurrentPrice(auctionEvent, bids, startingBid, verdictBackedBidIds?)`
    — new optional 4th param. When provided, only bids in that set count
    toward the price. Omitting it keeps the old (unfiltered) behavior, so
    existing callers/tests are unaffected.

- `src/queries/auctions.tsx`
  - `getAuctionCurrentPriceFromBids(...)` forwards the new optional param.
  - `useAuctionVerdictBackedBidIds(auction, auctionEventId, auctionCoordinates)`
    — new hook. Fetches kind-30440 verdicts via the existing
    `useAuctionVerdicts` query, parses them with
    `parseValidatorVerdictEvent`, and returns the backed-id set via
    `getAuctionVerdictBackedBidIds`.

- Wired into all display call sites:
  - `src/components/AuctionCard.tsx`
  - `src/components/AuctionBidder.tsx`
  - `src/routes/auctions.$auctionId.tsx`
  - `src/routes/_dashboard-layout/dashboard/products/auctions.$auctionId.tsx`

  Each now computes `verdictBackedBidIds` via the new hook and passes it
  into `getAuctionCurrentPriceFromBids`.

- Tests added in `src/lib/__tests__/auctionSettlement.test.ts`:
  - quorum satisfied only when enough *listed* auditors confirm a bid
  - verdicts from validators not in `auditors`, or with a non-confirming
    claim, don't count
  - auctions with no `auditors` tag yield an empty backed-id set
  - the exact fake-`amount` inflation scenario is neutralized when the
    backed-id set is applied, while the old unfiltered call still shows
    the inflated number (documents the before/after)

## Behavior change to be aware of

For an auction whose validators haven't yet published a `valid_bid_placed`
verdict for the current top bid (e.g. auditors are slow, offline, or the
auction has no `auditors` configured), the displayed price will fall back
toward `startingBid` until a verdict lands, rather than showing the
highest raw bid amount immediately. This is the secure-by-default behavior
per `AUCTIONS.md` §6.0, but is a visible UX change from "instant" bid
reflection to "confirmed" bid reflection.

## Known follow-up (not implemented)

`useAuctionVerdictBackedBidIds` fetches verdicts per auction card
independently — there's no batched verdict query analogous to the
existing batched bids fetch used on `auctions.index.tsx`. On the auctions
list page this adds one extra relay query per visible card. Worth
batching if it becomes a perf issue.

closes #1111
