### PR TITLE
feat(labels): NIP-32 test-listing curation — implementation (ADR in #1265)

### DIFF
--- a/docs/adr/ADR-0009-test-listing-labels-via-nip-32.md
+++ b/docs/adr/ADR-0009-test-listing-labels-via-nip-32.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed (rev 2 — supersedes the blacklist-based rev 1 discussed in #1243; docs-only portion extracted from #1260)
+Accepted (rev 3 — browsing-only gating + inspectability toggle; implemented in PR #1260)
 
 ## Date
 
@@ -23,7 +23,7 @@ discretion during the launch phase.
 The mechanism should be:
 
 - **Reusable** — one mechanism covering products and auctions, wherever
-  official feeds or detail views are rendered.
+  browsing and discovery surfaces are rendered.
 - **Flexible** — applicable at our discretion, before, during, or after any
   launch phase, without schema changes.
 - **Implementation-independent** — a Nostr-native signal any client or
@@ -47,6 +47,10 @@ Use **NIP-32 labeling events** (kind 1985) to tag items as tests.
   presence (shop, products, community) is unaffected while the item is
   curated. Whole-pubkey hiding remains the job of the existing spam
   blacklist and is explicitly out of scope here.
+- **Browsing-only gating** — a test label hides an item from browsing and
+  discovery surfaces only (home feed, paginated browse, search, collections,
+  auction feed). The item remains reachable via direct link, the seller's
+  profile, and the owner's dashboard.
 
 ### Label event example
 
@@ -96,8 +100,8 @@ Per NIP-09, the `e`-tag references the specific label event by id, and the
 are not replaceable (NIP-32 explicitly rejects a `d`-tag for this reason).
 Clients MUST validate that the deletion event's pubkey matches the label
 event's pubkey before treating the label as deleted. Once a valid deletion
-is seen, the item reappears in feeds and detail views without further
-action.
+is seen, the item reappears in browsing feeds without further action (it
+was never hidden from direct-link, profile, or dashboard views).
 
 ### Why NIP-32 labels, not NIP-51 blacklists
 
@@ -115,23 +119,25 @@ action.
 The label check runs in the query layer **alongside the existing delete and
 blacklist checks, before queries return data**:
 
-1. When listing or resolving products/auctions, after delete-status and
-   blacklist filtering, check each item coordinate for an active `test`
-   label.
+1. When listing products/auctions on browsing and discovery read paths —
+   home feed, paginated browse, search (NIP-50), collections, and the
+   auction feed — after delete-status and blacklist filtering, check each
+   item coordinate for an active `test` label.
 2. Labels are fetched per coordinate (kind 1985 filtered by `#a`); feeds
    batch the check for the page's items.
-3. Items carrying an authorized `test` label are excluded from feeds and
-   resolve to nothing in detail views — the same depth of gating as
-   blacklisted items.
+3. Items carrying an authorized `test` label are excluded from browsing and
+   discovery feeds only. Detail-by-id, detail-by-a-tag, and by-pubkey
+   (seller profile / owner dashboard) read paths return the item regardless
+   of label — the label never removes the item from direct navigation.
 4. Un-labeling is a NIP-09 deletion event (kind 5) signed by the same
    labeler, referencing the original label event's `id` in an `e` tag with
    a `k`-tag of `1985`. Clients MUST validate that the deletion event's
    pubkey matches the label event's pubkey before treating the label as
    deleted. The query layer treats a deleted label as absent — the item
    reappears without further action.
-5. When resolving a single item (detail view), the label check also looks
-   for a matching deletion event so that a freshly un-labeled item does
-   not appear hidden due to a stale cached label.
+5. The label check runs only on browsing/discovery read paths, so a freshly
+   un-labeled item reappears in those feeds without further action (it was
+   never hidden from direct-link, profile, or dashboard views).
 
 ### UI
 
@@ -149,6 +155,13 @@ pages:
 Both actions provide immediate UI feedback (optimistic state update),
 then reconcile with the relay round-trip. Non-authorized users never see
 these controls.
+
+A **"Show test listings"** toggle is available to all users (admins and
+regular users alike) on the browsing surface. It defaults to **hidden**
+(labeled items are filtered out of browsing feeds); turning it on reveals
+test-labeled items in those feeds. The toggle only affects
+browsing/discovery read paths — direct links, seller profiles, and owner
+dashboards always show the item.
 
 ## Consequences
 
@@ -176,9 +189,12 @@ these controls.
    (products on master; auctions on the `auctions` branch).
 3. Dashboard actions: **Mark as "Test" Product** / **Unmark as "Test"
    Product** by coordinate, with pre-filled contact reference in `.content`.
-4. e2e: a labeled item is excluded from feeds and resolves to `null`; an
-   un-labeled item reappears after the NIP-09 deletion event is processed.
-5. Optional automation (e.g. an automated labeler key) for discretionary
+4. e2e: a labeled item is excluded from browsing feeds but still reachable
+   by direct link, seller profile, and dashboard; an un-labeled item
+   reappears after the NIP-09 deletion event is processed.
+5. "Show test listings" toggle (all users, default hidden) to reveal
+   test-labeled items in browsing feeds.
+6. Optional automation (e.g. an automated labeler key) for discretionary
    use during launch phases.
 
 ## Related

--- a/e2e/tests/test-labels.spec.ts
+++ b/e2e/tests/test-labels.spec.ts
@@ -1,0 +1,320 @@
+import type { Page } from '@playwright/test'
+import { test, expect } from '../fixtures'
+import { finalizeEvent, type EventTemplate, type VerifiedEvent } from 'nostr-tools/pure'
+import { Relay } from 'nostr-tools/relay'
+import { hexToBytes } from '@noble/hashes/utils.js'
+import { devUser1, devUser2 } from '../../src/lib/fixtures'
+import { queryRelayEvents } from '../utils/relay-query'
+
+test.use({ scenario: 'merchant' })
+
+const RELAY_URL = 'ws://localhost:10547'
+
+// ---------------------------------------------------------------------------
+// Relay helpers — publish kind 1985 label events and kind 5 deletions
+// ---------------------------------------------------------------------------
+
+async function connectRelay(): Promise<Relay> {
+	return await Relay.connect(RELAY_URL)
+}
+
+async function publishEvent(skHex: string, template: EventTemplate): Promise<VerifiedEvent> {
+	const relay = await connectRelay()
+	try {
+		const event = finalizeEvent(template, hexToBytes(skHex))
+		await relay.publish(event)
+		return event
+	} finally {
+		relay.close()
+	}
+}
+
+/**
+ * Seed a minimal kind-30402 product listing.
+ * Returns the published event (id + d-tag are needed for labeling).
+ */
+async function seedProduct(skHex: string, title: string): Promise<VerifiedEvent> {
+	const now = Math.floor(Date.now() / 1000)
+	const dTag = `test-label-${now}-${Math.random().toString(36).substring(2, 8)}`
+	return await publishEvent(skHex, {
+		kind: 30402,
+		created_at: now,
+		content: 'Product used by the ADR-0009 test-label e2e suite.',
+		tags: [
+			['d', dTag],
+			['title', title],
+			['price', '1000', 'SATS'],
+			['status', 'on-sale'],
+			['t', 'Bitcoin'],
+			['stock', '10'],
+			['image', 'https://cdn.satellite.earth/f8f1513ec22f966626dc05342a3bb1f36096d28dd0e6eeae640b5df44f2c7c84.png'],
+		],
+	})
+}
+
+/**
+ * Publish a NIP-32 test label (kind 1985) for an item coordinate.
+ * Tags: L/l in com.plebeian.market namespace + a single a-tag target.
+ * No p tag (would label the user — out of ADR-0009 scope).
+ */
+async function seedTestLabel(
+	skHex: string,
+	coordinate: string,
+	content = 'Marked as test listing by the e2e suite.',
+): Promise<VerifiedEvent> {
+	return await publishEvent(skHex, {
+		kind: 1985,
+		created_at: Math.floor(Date.now() / 1000),
+		content,
+		tags: [
+			['L', 'com.plebeian.market'],
+			['l', 'test', 'com.plebeian.market'],
+			['a', coordinate],
+		],
+	})
+}
+
+/**
+ * Publish a NIP-09 deletion (kind 5) for a label event.
+ * Tags: e (label event id) + k (1985). No a tag — kind 1985 is not replaceable.
+ */
+async function seedTestLabelDeletion(skHex: string, labelEventId: string, content = 'Unmarking test label.'): Promise<VerifiedEvent> {
+	return await publishEvent(skHex, {
+		kind: 5,
+		created_at: Math.floor(Date.now() / 1000),
+		content,
+		tags: [
+			['e', labelEventId],
+			['k', '1985'],
+		],
+	})
+}
+
+const productCoordinate = (productEvent: VerifiedEvent): string =>
+	`30402:${productEvent.pubkey}:${productEvent.tags.find((t) => t[0] === 'd')?.[1]}`
+const auctionCoordinate = (auctionEvent: VerifiedEvent): string =>
+	`30408:${auctionEvent.pubkey}:${auctionEvent.tags.find((t) => t[0] === 'd')?.[1]}`
+
+// ---------------------------------------------------------------------------
+// Navigation helper — resilient navigation for the SPA (mirrors marketplace.spec.ts)
+// ---------------------------------------------------------------------------
+
+async function safeGoto(page: Page, url: string): Promise<void> {
+	const targetPath = url.split('?')[0]
+
+	for (let attempt = 0; attempt < 3; attempt++) {
+		try {
+			await page.goto(url)
+		} catch (error) {
+			const msg = String(error)
+			if (!msg.includes('interrupted by another navigation') && !msg.includes('ERR_ABORTED')) throw error
+			await page.waitForLoadState('networkidle').catch(() => {})
+		}
+
+		await page.waitForTimeout(1000)
+		await page.waitForLoadState('networkidle').catch(() => {})
+
+		const currentPath = new URL(page.url()).pathname
+		if (currentPath === targetPath || currentPath.startsWith(targetPath)) {
+			return
+		}
+	}
+
+	await page.goto(url)
+}
+
+/**
+ * Wait until the products feed has loaded (the seeded control product is
+ * visible) before asserting on absence/presence of other products.
+ */
+async function waitForProductsFeedLoaded(page: Page): Promise<void> {
+	await expect(async () => {
+		const content = await page.locator('main').textContent()
+		expect(content).toContain('Bitcoin Hardware Wallet')
+	}).toPass({ timeout: 30_000 })
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: labeled product is excluded from feeds and detail views
+// ---------------------------------------------------------------------------
+
+test.describe('Test listing labels (ADR-0009)', () => {
+	test('product with an active test label is excluded from the feed and resolves to not-found', async ({ unauthenticatedPage }) => {
+		const product = await seedProduct(devUser1.sk, `Test Label Hidden Product ${Date.now()}`)
+		const coordinate = productCoordinate(product)
+
+		// Label it with an authorized labeler key (devUser1 is in the admin set)
+		await seedTestLabel(devUser1.sk, coordinate)
+
+		await safeGoto(unauthenticatedPage, '/products')
+		await waitForProductsFeedLoaded(unauthenticatedPage)
+
+		// The labeled product must not appear in the feed
+		await expect(unauthenticatedPage.getByText(product.tags.find((t) => t[0] === 'title')?.[1] ?? '')).toHaveCount(0)
+
+		// Detail view: the item resolves to nothing → "Product Not Found"
+		await safeGoto(unauthenticatedPage, `/products/${product.id}`)
+		await expect(unauthenticatedPage.getByRole('heading', { name: 'Product Not Found' })).toBeVisible({ timeout: 15_000 })
+	})
+
+	// -----------------------------------------------------------------------
+	// Scenario 2: un-labeled product reappears after the NIP-09 deletion
+	// -----------------------------------------------------------------------
+
+	test('product reappears in the feed after the test label is deleted via NIP-09', async ({ unauthenticatedPage }) => {
+		const title = `Test Label Reappear Product ${Date.now()}`
+		const product = await seedProduct(devUser1.sk, title)
+		const coordinate = productCoordinate(product)
+
+		const labelEvent = await seedTestLabel(devUser1.sk, coordinate)
+
+		await safeGoto(unauthenticatedPage, '/products')
+		await waitForProductsFeedLoaded(unauthenticatedPage)
+		await expect(unauthenticatedPage.getByText(title)).toHaveCount(0)
+
+		// Un-label: NIP-09 deletion signed by the SAME labeler (devUser1)
+		await seedTestLabelDeletion(devUser1.sk, labelEvent.id)
+
+		// Reload → fresh store/cache → the item reappears
+		await safeGoto(unauthenticatedPage, '/products')
+		await waitForProductsFeedLoaded(unauthenticatedPage)
+		await expect(unauthenticatedPage.getByText(title)).toBeVisible({ timeout: 30_000 })
+	})
+
+	// -----------------------------------------------------------------------
+	// Scenario 3: unauthorized labels are ignored
+	// -----------------------------------------------------------------------
+
+	test('label from an unauthorized key does not hide the product', async ({ unauthenticatedPage }) => {
+		const title = `Unauthorized Label Product ${Date.now()}`
+		// Product by devUser2, label also signed by devUser2 — who is NOT in
+		// the admin set, so the label must be ignored.
+		const product = await seedProduct(devUser2.sk, title)
+		await seedTestLabel(devUser2.sk, productCoordinate(product))
+
+		await safeGoto(unauthenticatedPage, '/products')
+		await waitForProductsFeedLoaded(unauthenticatedPage)
+
+		await expect(unauthenticatedPage.getByText(title)).toBeVisible({ timeout: 30_000 })
+	})
+
+	// -----------------------------------------------------------------------
+	// Scenario 4: auction labels work (kind 30408 coordinates)
+	// -----------------------------------------------------------------------
+
+	test('auction with an active test label is excluded from the auctions feed', async ({ unauthenticatedPage }) => {
+		const now = Math.floor(Date.now() / 1000)
+		const suffix = `${now}-${Math.random().toString(36).substring(2, 8)}`
+
+		// Two auctions: a control (visible) and one that gets labeled (hidden)
+		const seedAuctionEvent = async (title: string, dTag: string): Promise<VerifiedEvent> =>
+			await publishEvent(devUser1.sk, {
+				kind: 30408,
+				created_at: now,
+				content: 'Auction used by the ADR-0009 test-label e2e suite.',
+				tags: [
+					['d', dTag],
+					['title', title],
+					['summary', 'E2E test auction'],
+					['auction_type', 'english'],
+					['start_at', String(now)],
+					['end_at', String(now + 86400)],
+					['currency', 'SAT'],
+					['price', '1000', 'SAT'],
+					['starting_bid', '1000', 'SAT'],
+					['bid_increment', '100'],
+					['reserve', '0'],
+					['mint', 'http://localhost:3338'],
+					['escrow_pubkey', '02' + '00'.repeat(32)],
+					['key_scheme', 'hd_p2pk'],
+					['p2pk_xpub', 'xpub' + '0'.repeat(100)],
+					['settlement_policy', 'cashu_p2pk_v1'],
+					['schema', 'auction_v1'],
+					['image', 'https://cdn.satellite.earth/f8f1513ec22f966626dc05342a3bb1f36096d28dd0e6eeae640b5df44f2c7c84.png'],
+					['t', 'Bitcoin'],
+				],
+			})
+
+		const controlAuction = await seedAuctionEvent(`Control Auction ${suffix}`, `test-label-auction-control-${suffix}`)
+		const labeledAuction = await seedAuctionEvent(`Labeled Auction ${suffix}`, `test-label-auction-labeled-${suffix}`)
+
+		await seedTestLabel(devUser1.sk, auctionCoordinate(labeledAuction))
+
+		await safeGoto(unauthenticatedPage, '/auctions')
+		await expect(unauthenticatedPage.getByText(controlAuction.tags.find((t) => t[0] === 'title')?.[1] ?? '')).toBeVisible({
+			timeout: 30_000,
+		})
+
+		await expect(unauthenticatedPage.getByText(labeledAuction.tags.find((t) => t[0] === 'title')?.[1] ?? '')).toHaveCount(0)
+	})
+
+	// -----------------------------------------------------------------------
+	// Scenario 5: dashboard actions (mark / unmark) for authorized labelers
+	// -----------------------------------------------------------------------
+
+	test('admin sees the mark/unmark dashboard actions and publishing lands on the relay', async ({ merchantPage }) => {
+		const product = await seedProduct(devUser1.sk, `Dashboard Label Product ${Date.now()}`)
+		const coordinate = productCoordinate(product)
+
+		// Open the product edit page (productId = event id)
+		await safeGoto(merchantPage, `/dashboard/products/products/${product.id}`)
+
+		// The PII exposure warning (root-level dialog for users with seeded
+		// order events) intercepts pointer events — dismiss it if it appears.
+		const piiDialog = merchantPage.getByRole('dialog', { name: 'Some of your personal data may be exposed' })
+		if (await piiDialog.isVisible().catch(() => false)) {
+			await piiDialog.getByRole('button', { name: 'Dismiss Warning' }).click()
+			await expect(piiDialog).toBeHidden()
+		}
+
+		const markButton = merchantPage.getByTestId('mark-test-label-product-button')
+		await expect(markButton).toBeVisible({ timeout: 30_000 })
+
+		// Mark as test: confirm dialog with pre-filled, editable content
+		await markButton.click()
+		const dialog = merchantPage.getByRole('alertdialog')
+		await expect(dialog).toBeVisible()
+		const contentTextarea = dialog.getByTestId('test-label-content-product')
+		await expect(contentTextarea).toContainText('Marked as test listing')
+		await dialog.getByRole('button', { name: 'Mark as Test' }).click()
+
+		// Optimistic UI: the button flips to "Unmark as Test Product"
+		const unmarkButton = merchantPage.getByTestId('unmark-test-label-product-button')
+		await expect(unmarkButton).toBeVisible({ timeout: 15_000 })
+
+		// Relay is the source of truth: a kind-1985 label for the coordinate exists
+		let labelEventIdOnRelay = ''
+		await expect(async () => {
+			const labels = await queryRelayEvents({ kinds: [1985], '#a': [coordinate], authors: [devUser1.pk] })
+			expect(labels.length).toBeGreaterThan(0)
+			labelEventIdOnRelay = labels[0].id
+		}).toPass({ timeout: 15_000 })
+
+		// Unmark as test: confirm dialog, then the label deletion lands on the relay
+		await unmarkButton.click()
+		const unmarkDialog = merchantPage.getByRole('alertdialog')
+		await expect(unmarkDialog).toBeVisible()
+		await unmarkDialog.getByRole('button', { name: 'Unmark as Test' }).click()
+
+		await expect(merchantPage.getByTestId('mark-test-label-product-button')).toBeVisible({ timeout: 15_000 })
+
+		// The NIP-09 deletion event referencing the label id lands on the relay.
+		// (nak actively purges deleted events, so the label itself may be gone —
+		// the deletion event is the durable artifact to assert on.)
+		await expect(async () => {
+			const deletions = await queryRelayEvents({ kinds: [5], '#e': [labelEventIdOnRelay], authors: [devUser1.pk] })
+			expect(deletions.length).toBeGreaterThan(0)
+		}).toPass({ timeout: 15_000 })
+	})
+
+	test('non-admin does not see the test-label dashboard actions', async ({ buyerPage }) => {
+		// Seed a product by devUser2 (the buyer IS the seller of this product)
+		const product = await seedProduct(devUser2.sk, `Non-admin Label Product ${Date.now()}`)
+
+		await safeGoto(buyerPage, `/dashboard/products/products/${product.id}`)
+
+		// Wait for the edit page to settle, then confirm no label actions
+		await expect(buyerPage.getByTestId('mark-test-label-product-button')).toHaveCount(0, { timeout: 15_000 })
+		await expect(buyerPage.getByTestId('unmark-test-label-product-button')).toHaveCount(0)
+	})
+})

--- a/e2e/tests/test-labels.spec.ts
+++ b/e2e/tests/test-labels.spec.ts
@@ -135,12 +135,13 @@ async function waitForProductsFeedLoaded(page: Page): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 1: labeled product is excluded from feeds and detail views
+// Scenario 1: labeled product is hidden from the feed but reachable via link
 // ---------------------------------------------------------------------------
 
 test.describe('Test listing labels (ADR-0009)', () => {
-	test('product with an active test label is excluded from the feed and resolves to not-found', async ({ unauthenticatedPage }) => {
-		const product = await seedProduct(devUser1.sk, `Test Label Hidden Product ${Date.now()}`)
+	test('product with an active test label is hidden from the feed but reachable via direct link', async ({ unauthenticatedPage }) => {
+		const title = `Test Label Hidden Product ${Date.now()}`
+		const product = await seedProduct(devUser1.sk, title)
 		const coordinate = productCoordinate(product)
 
 		// Label it with an authorized labeler key (devUser1 is in the admin set)
@@ -149,12 +150,18 @@ test.describe('Test listing labels (ADR-0009)', () => {
 		await safeGoto(unauthenticatedPage, '/products')
 		await waitForProductsFeedLoaded(unauthenticatedPage)
 
-		// The labeled product must not appear in the feed
-		await expect(unauthenticatedPage.getByText(product.tags.find((t) => t[0] === 'title')?.[1] ?? '')).toHaveCount(0)
+		// The labeled product must not appear in the browse feed (default hidden)
+		await expect(unauthenticatedPage.getByText(title)).toHaveCount(0)
 
-		// Detail view: the item resolves to nothing → "Product Not Found"
+		// Detail view: the item is still reachable via direct link (no "not found")
 		await safeGoto(unauthenticatedPage, `/products/${product.id}`)
-		await expect(unauthenticatedPage.getByRole('heading', { name: 'Product Not Found' })).toBeVisible({ timeout: 15_000 })
+		await expect(unauthenticatedPage.getByText(title)).toBeVisible({ timeout: 15_000 })
+
+		// Toggling "Show test listings" reveals the item in the browse feed
+		await safeGoto(unauthenticatedPage, '/products')
+		await unauthenticatedPage.getByRole('checkbox', { name: 'Show test listings' }).check()
+		await waitForProductsFeedLoaded(unauthenticatedPage)
+		await expect(unauthenticatedPage.getByText(title)).toBeVisible({ timeout: 30_000 })
 	})
 
 	// -----------------------------------------------------------------------

--- a/src/components/ShowTestListingsToggle.tsx
+++ b/src/components/ShowTestListingsToggle.tsx
@@ -1,0 +1,34 @@
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { testLabelActions, testLabelStore } from '@/lib/stores/testLabels'
+import { useQueryClient } from '@tanstack/react-query'
+import { useStore } from '@tanstack/react-store'
+import { auctionKeys, productKeys } from '@/queries/queryKeyFactory'
+
+/**
+ * Browsing-surface toggle (ADR-0009 rev 3): reveals test-labeled items in
+ * feeds. Visible to all users; defaults to hidden. Changing it invalidates
+ * the product/auction browsing query keys so feeds refetch with the new flag.
+ */
+export function ShowTestListingsToggle() {
+	const queryClient = useQueryClient()
+	const showTestListings = useStore(testLabelStore, (state) => state.showTestListings)
+
+	const handleChange = (checked: boolean) => {
+		testLabelActions.setShowTestListings(checked)
+		// Browsing-only read paths must refetch with the new flag. `productKeys.all`
+		// and `auctionKeys.all` are prefixes, so paginated/search/collection keys
+		// are matched as well.
+		void queryClient.invalidateQueries({ queryKey: productKeys.all })
+		void queryClient.invalidateQueries({ queryKey: auctionKeys.all })
+	}
+
+	return (
+		<div className="flex items-center space-x-2">
+			<Checkbox id="show-test-listings" checked={showTestListings} onCheckedChange={handleChange} />
+			<Label htmlFor="show-test-listings" className="text-sm font-normal cursor-pointer">
+				Show test listings
+			</Label>
+		</div>
+	)
+}

--- a/src/components/dashboard/TestLabelButton.tsx
+++ b/src/components/dashboard/TestLabelButton.tsx
@@ -1,0 +1,174 @@
+import { Button } from '@/components/ui/button'
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import { Textarea } from '@/components/ui/textarea'
+import { publishTestLabel, publishTestLabelDeletion } from '@/lib/actions/testLabelActions'
+import { TEST_LABEL_PRODUCT_KIND } from '@/lib/constants/testLabels'
+import { getATagFromCoords } from '@/lib/utils/coords'
+import { useAmIAdmin } from '@/queries/app-settings'
+import { useConfigQuery } from '@/queries/config'
+import { invalidateTestLabelCaches, useTestLabelForCoordinate } from '@/queries/testLabels'
+import { useQueryClient } from '@tanstack/react-query'
+import { FlaskConical, Loader2 } from 'lucide-react'
+import { npubEncode } from 'nostr-tools/nip19'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+interface TestLabelButtonProps {
+	/** Item event kind: 30402 (product) or 30408 (auction) */
+	kind: number
+	/** Author pubkey of the item */
+	pubkey: string
+	/** Item d-tag identifier */
+	dTag: string
+	/** Noun used in button labels and copy ('Product' | 'Auction') */
+	itemLabel?: string
+	/** Optional wrapper className */
+	className?: string
+}
+
+const CONTACT_REF_FALLBACK = 'the moderation team'
+
+/**
+ * Dashboard action for authorized labelers (ADR-0009): mark / unmark an item
+ * as a "test" listing via NIP-32 label events (kind 1985) and NIP-09
+ * deletion events (kind 5).
+ *
+ * - Visible only to authorized labelers (the admin set).
+ * - "Mark as Test" publishes a kind-1985 label event with a pre-filled,
+ *   editable contact reference in `.content`.
+ * - "Unmark as Test" (visible only when an active label exists) publishes a
+ *   NIP-09 deletion event referencing the label event id, after a confirm
+ *   dialog.
+ * - Both update the store optimistically, then reconcile with the relay.
+ */
+export function TestLabelButton({ kind, pubkey, dTag, itemLabel = 'Product', className }: TestLabelButtonProps) {
+	const queryClient = useQueryClient()
+	const { data: config } = useConfigQuery()
+	const { amIAdmin, currentUserPubkey } = useAmIAdmin(config?.appPublicKey)
+
+	const [isMarking, setIsMarking] = useState(false)
+	const [isUnmarking, setIsUnmarking] = useState(false)
+	const [labelContent, setLabelContent] = useState('')
+
+	const isProduct = kind === TEST_LABEL_PRODUCT_KIND
+	const kindSlug = isProduct ? 'product' : 'auction'
+
+	const coordinate = pubkey && dTag ? getATagFromCoords({ kind, pubkey, identifier: dTag }) : ''
+	const { isLabeled, labelEventId } = useTestLabelForCoordinate(coordinate || undefined)
+
+	const contactRef = useMemo(() => {
+		if (!currentUserPubkey) return CONTACT_REF_FALLBACK
+		try {
+			return npubEncode(currentUserPubkey)
+		} catch {
+			return CONTACT_REF_FALLBACK
+		}
+	}, [currentUserPubkey])
+
+	// Non-authorized users never see these controls
+	if (!amIAdmin || !currentUserPubkey || !coordinate) return null
+
+	const itemNoun = itemLabel.toLowerCase()
+	const defaultLabelContent = `Marked as test listing. If this is a real ${itemNoun}, contact ${contactRef} to request removal.`
+	const resolvedLabelContent = labelContent || defaultLabelContent
+
+	const handleMark = async () => {
+		setIsMarking(true)
+		try {
+			await publishTestLabel({ coordinate, contactRef, content: resolvedLabelContent })
+			await invalidateTestLabelCaches(queryClient, coordinate)
+			toast.success(`${itemLabel} marked as test — excluded from feeds.`)
+		} catch (error) {
+			console.error('Failed to publish test label:', error)
+			toast.error(`Failed to mark as test: ${error instanceof Error ? error.message : 'Unknown error'}`)
+		} finally {
+			setIsMarking(false)
+		}
+	}
+
+	const handleUnmark = async () => {
+		setIsUnmarking(true)
+		try {
+			await publishTestLabelDeletion({ coordinate, labelEventId })
+			await invalidateTestLabelCaches(queryClient, coordinate)
+			toast.success(`Test label removed — ${itemNoun} is visible again.`)
+		} catch (error) {
+			console.error('Failed to publish test label deletion:', error)
+			toast.error(`Failed to unmark as test: ${error instanceof Error ? error.message : 'Unknown error'}`)
+		} finally {
+			setIsUnmarking(false)
+		}
+	}
+
+	if (isLabeled) {
+		return (
+			<AlertDialog>
+				<AlertDialogTrigger asChild>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={isUnmarking}
+						className={className}
+						data-testid={`unmark-test-label-${kindSlug}-button`}
+					>
+						{isUnmarking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FlaskConical className="h-3.5 w-3.5" />}
+						Unmark as Test {itemLabel}
+					</Button>
+				</AlertDialogTrigger>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Remove the test label?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will publish a deletion event for the test label. The {itemNoun} will reappear in feeds and detail views.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={handleUnmark}>Unmark as Test</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		)
+	}
+
+	return (
+		<AlertDialog>
+			<AlertDialogTrigger asChild>
+				<Button variant="outline" size="sm" disabled={isMarking} className={className} data-testid={`mark-test-label-${kindSlug}-button`}>
+					{isMarking ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FlaskConical className="h-3.5 w-3.5" />}
+					Mark as Test {itemLabel}
+				</Button>
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Mark this {itemNoun} as a test listing?</AlertDialogTitle>
+					<AlertDialogDescription>
+						A NIP-32 label event will be published. The {itemNoun} will be excluded from feeds and detail views. The content below is sent
+						with the label — edit it if needed so the author knows how to appeal.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<Textarea
+					data-testid={`test-label-content-${kindSlug}`}
+					value={resolvedLabelContent}
+					onChange={(event) => setLabelContent(event.target.value)}
+					rows={3}
+					className="text-sm"
+				/>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction onClick={handleMark}>Mark as Test</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	)
+}

--- a/src/hooks/useStreamingProducts.ts
+++ b/src/hooks/useStreamingProducts.ts
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { ndkActions, ndkStore } from '@/lib/stores/ndk'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { isProductInStock } from '@/queries/products'
+import { collectTestLabelCoordinates, filterTestLabeledEvents } from '@/lib/utils/testLabelFilters'
+import { fetchTestLabels } from '@/queries/testLabels'
 import type { NDKEvent, NDKFilter, NDKSubscription } from '@nostr-dev-kit/ndk'
 import { useStore } from '@tanstack/react-store'
 
@@ -31,9 +33,14 @@ interface UseStreamingProductsReturn {
 	count: number
 }
 
+/** Buffer window for batching test-label checks during streaming (ms) */
+const TEST_LABEL_STREAM_FLUSH_MS = 250
+
 /**
  * Hook that streams products progressively as they arrive from relays.
- * Products appear immediately as each event is received, rather than waiting for all.
+ * Products appear in small batches as events are received, rather than waiting
+ * for all — each batch gets a batched test-label check before rendering
+ * (ADR-0009), so labeled items never flash into the feed.
  */
 export function useStreamingProducts({
 	limit = 500,
@@ -51,44 +58,99 @@ export function useStreamingProducts({
 	const seenIds = useRef(new Set<string>())
 	const subscriptionRef = useRef<NDKSubscription | null>(null)
 
-	// Stable callback to add a product
-	const addProduct = useCallback(
-		(event: NDKEvent) => {
-			const key = event.deduplicationKey()
-			if (seenIds.current.has(key)) return
-			seenIds.current.add(key)
+	// Buffer incoming events so test-label checks can be batched per flush
+	// window instead of issuing one relay query per event (ADR-0009).
+	const pendingBufferRef = useRef<NDKEvent[]>([])
+	const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+	const flushLockRef = useRef(false)
+
+	// Stable per-event business filters (blacklist, visibility, stock, country)
+	const passesBusinessFilters = useCallback(
+		(event: NDKEvent): boolean => {
+			// Filter out blacklisted products and authors
+			if (filterBlacklistedEvents([event]).length === 0) return false
 
 			// Check visibility
 			const visibilityTag = event.tags.find((t) => t[0] === 'visibility')
 			const visibility = visibilityTag?.[1] || 'on-sale'
 
 			// Filter hidden products (unless includeHidden is true)
-			if (!includeHidden && visibility === 'hidden') return
+			if (!includeHidden && visibility === 'hidden') return false
 
 			// Filter pre-order products (if hidePreorder is true)
-			if (hidePreorder && visibility === 'pre-order') return
+			if (hidePreorder && visibility === 'pre-order') return false
 
 			// Filter out-of-stock products (unless showOutOfStock is true)
-			if (!showOutOfStock && !isProductInStock(event)) return
+			if (!showOutOfStock && !isProductInStock(event)) return false
 
 			// Filter by country (match against location tag)
 			if (country) {
 				const location = event.tags.find((t) => t[0] === 'location')?.[1] || ''
-				if (!location.toLowerCase().includes(country.toLowerCase())) return
+				if (!location.toLowerCase().includes(country.toLowerCase())) return false
 			}
 
-			// Add product and sort by created_at (newest first)
-			setProducts((prev) => {
-				const filtered = filterBlacklistedEvents([event])
-				if (filtered.length === 0) return prev
-
-				const newProduct = filtered[0]
-				const updated = [...prev, newProduct]
-				updated.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
-				return updated.slice(0, limit)
-			})
+			return true
 		},
-		[includeHidden, showOutOfStock, hidePreorder, country, limit],
+		[includeHidden, showOutOfStock, hidePreorder, country],
+	)
+
+	/**
+	 * Drain the pending buffer: batch-fetch test labels for the buffered
+	 * coordinates, then release the non-labeled events into the product list.
+	 * Batching keeps feeds N+1-free; buffering until the flush avoids the
+	 * appear-then-disappear flicker of per-event label checks.
+	 */
+	const flushPendingEvents = useCallback(async () => {
+		if (flushLockRef.current) return
+		flushLockRef.current = true
+		try {
+			while (pendingBufferRef.current.length > 0) {
+				const buffered = pendingBufferRef.current
+				pendingBufferRef.current = []
+
+				const eligible = buffered.filter(passesBusinessFilters)
+				if (eligible.length === 0) continue
+
+				// Batch label check for this flush window, then sync store filter
+				const coordinates = collectTestLabelCoordinates(eligible)
+				if (coordinates.length > 0) {
+					try {
+						await fetchTestLabels(coordinates)
+					} catch (error) {
+						console.warn('Test label fetch failed during streaming:', error)
+					}
+				}
+				const nonLabeled = filterTestLabeledEvents(eligible)
+				if (nonLabeled.length === 0) continue
+
+				setProducts((prev) => {
+					const updated = [...prev, ...nonLabeled]
+					updated.sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
+					return updated.slice(0, limit)
+				})
+			}
+		} finally {
+			flushLockRef.current = false
+		}
+	}, [limit, passesBusinessFilters])
+
+	// Stable callback to buffer a product for the next flush window
+	const addProduct = useCallback(
+		(event: NDKEvent) => {
+			const key = event.deduplicationKey()
+			if (seenIds.current.has(key)) return
+			seenIds.current.add(key)
+
+			// Buffer the event; the flush window batches the label check
+			pendingBufferRef.current.push(event)
+			if (!flushTimerRef.current) {
+				flushTimerRef.current = setTimeout(() => {
+					flushTimerRef.current = null
+					void flushPendingEvents()
+				}, TEST_LABEL_STREAM_FLUSH_MS)
+			}
+		},
+		[flushPendingEvents],
 	)
 
 	useEffect(() => {
@@ -101,6 +163,11 @@ export function useStreamingProducts({
 		// Reset state when filter changes
 		setProducts([])
 		seenIds.current.clear()
+		pendingBufferRef.current = []
+		if (flushTimerRef.current) {
+			clearTimeout(flushTimerRef.current)
+			flushTimerRef.current = null
+		}
 		setIsStreaming(true)
 
 		const filter: NDKFilter = {
@@ -120,24 +187,30 @@ export function useStreamingProducts({
 		})
 
 		subscription.on('eose', () => {
-			setIsStreaming(false)
+			// Flush whatever is still buffered before declaring the stream done
+			void flushPendingEvents().finally(() => setIsStreaming(false))
 		})
 
 		subscription.on('close', () => {
-			setIsStreaming(false)
+			void flushPendingEvents().finally(() => setIsStreaming(false))
 		})
 
 		// Timeout fallback - stop streaming after 10s even if no EOSE
 		const timeout = setTimeout(() => {
-			setIsStreaming(false)
+			void flushPendingEvents().finally(() => setIsStreaming(false))
 		}, 10000)
 
 		return () => {
 			clearTimeout(timeout)
+			if (flushTimerRef.current) {
+				clearTimeout(flushTimerRef.current)
+				flushTimerRef.current = null
+			}
+			pendingBufferRef.current = []
 			subscription.stop()
 			subscriptionRef.current = null
 		}
-	}, [isConnected, tag, limit, addProduct, showOutOfStock, hidePreorder, country])
+	}, [isConnected, tag, limit, addProduct, showOutOfStock, hidePreorder, country, flushPendingEvents])
 
 	return {
 		products,

--- a/src/hooks/useStreamingProducts.ts
+++ b/src/hooks/useStreamingProducts.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { ndkActions, ndkStore } from '@/lib/stores/ndk'
+import { testLabelStore } from '@/lib/stores/testLabels'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
 import { isProductInStock } from '@/queries/products'
 import { collectTestLabelCoordinates, filterTestLabeledEvents } from '@/lib/utils/testLabelFilters'
@@ -53,6 +54,7 @@ export function useStreamingProducts({
 	const [products, setProducts] = useState<NDKEvent[]>([])
 	const [isStreaming, setIsStreaming] = useState(true)
 	const isConnected = useStore(ndkStore, (s) => s.isConnected)
+	const showTestListings = useStore(testLabelStore, (s) => s.showTestListings)
 
 	// Track seen event IDs to prevent duplicates
 	const seenIds = useRef(new Set<string>())
@@ -111,16 +113,20 @@ export function useStreamingProducts({
 				const eligible = buffered.filter(passesBusinessFilters)
 				if (eligible.length === 0) continue
 
-				// Batch label check for this flush window, then sync store filter
-				const coordinates = collectTestLabelCoordinates(eligible)
-				if (coordinates.length > 0) {
-					try {
-						await fetchTestLabels(coordinates)
-					} catch (error) {
-						console.warn('Test label fetch failed during streaming:', error)
+				// Batch label check for this flush window, then sync store filter.
+				// Skipped entirely when the user opted to reveal test listings.
+				let nonLabeled = eligible
+				if (!showTestListings) {
+					const coordinates = collectTestLabelCoordinates(eligible)
+					if (coordinates.length > 0) {
+						try {
+							await fetchTestLabels(coordinates)
+						} catch (error) {
+							console.warn('Test label fetch failed during streaming:', error)
+						}
 					}
+					nonLabeled = filterTestLabeledEvents(eligible)
 				}
-				const nonLabeled = filterTestLabeledEvents(eligible)
 				if (nonLabeled.length === 0) continue
 
 				setProducts((prev) => {
@@ -132,7 +138,7 @@ export function useStreamingProducts({
 		} finally {
 			flushLockRef.current = false
 		}
-	}, [limit, passesBusinessFilters])
+	}, [limit, passesBusinessFilters, showTestListings])
 
 	// Stable callback to buffer a product for the next flush window
 	const addProduct = useCallback(

--- a/src/lib/actions/testLabelActions.ts
+++ b/src/lib/actions/testLabelActions.ts
@@ -1,0 +1,164 @@
+import {
+	A_TAG,
+	E_TAG,
+	K_TAG,
+	L_TAG,
+	LABEL_DELETION_KIND,
+	LABEL_EVENT_KIND,
+	LABEL_NAMESPACE,
+	LABEL_VALUE_TEST,
+	l_TAG,
+} from '@/lib/constants/testLabels'
+import { ndkActions } from '@/lib/stores/ndk'
+import { testLabelActions } from '@/lib/stores/testLabels'
+import { invalidateTestLabelCache, setCachedTestLabel } from '@/queries/testLabels'
+import { NDKEvent } from '@nostr-dev-kit/ndk'
+
+/**
+ * ADR-0009 — Publish test-label and un-label events.
+ *
+ * Label event: NIP-32 kind 1985 with `L`/`l` tags in our namespace and an `a`
+ * tag holding the item coordinate. No `p` tag — a `p` tag would label the
+ * user, and this mechanism explicitly scopes to items, never users.
+ *
+ * Un-label event: NIP-09 kind 5 referencing the label event's id in an `e`
+ * tag with a `k` tag of 1985. No `a` tag — NIP-09 `a` tags target
+ * replaceable/addressable events and kind 1985 is not replaceable.
+ *
+ * Both actions update the store optimistically and reconcile with the relay
+ * round-trip (reverting the optimistic state if publishing fails).
+ */
+
+/** Marker used for optimistic store entries before the event id exists */
+const PENDING_LABEL_EVENT_ID = 'pending-test-label'
+
+const buildTestLabelContent = (reason: string | undefined, contactRef: string): string => {
+	const reasonPrefix = reason?.trim() ? `${reason.trim()} ` : ''
+	return `${reasonPrefix}Marked as test listing. If this is a real listing, contact ${contactRef} to request removal.`
+}
+
+export interface PublishTestLabelParams {
+	/** Item coordinate, "kind:pubkey:identifier" (e.g. 30402:<pubkey>:<d-tag>) */
+	coordinate: string
+	/** Contact reference (npub or nip05) the item author can reach to appeal */
+	contactRef: string
+	/** Optional reason, prepended to the pre-filled label content */
+	reason?: string
+	/** Full content override (used when the labeler edits the pre-filled text in the UI) */
+	content?: string
+}
+
+/**
+ * Publish a NIP-32 test label event (kind 1985) for an item coordinate.
+ * The `.content` is pre-filled with the labeler's contact reference.
+ * Updates the label store optimistically; reverts on failure.
+ */
+export async function publishTestLabel({ coordinate, contactRef, reason, content }: PublishTestLabelParams): Promise<NDKEvent> {
+	if (!coordinate) throw new Error('A coordinate is required to publish a test label')
+
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	const signer = ndkActions.getSigner()
+	if (!signer) throw new Error('No signer available')
+
+	const labeler = await signer.user()
+	if (!labeler?.pubkey) throw new Error('Unable to determine the current labeler pubkey')
+
+	// Optimistic update — the item disappears from feeds immediately
+	testLabelActions.setLabel(coordinate, PENDING_LABEL_EVENT_ID, labeler.pubkey)
+
+	try {
+		const event = new NDKEvent(ndk)
+		event.kind = LABEL_EVENT_KIND
+		event.created_at = Math.floor(Date.now() / 1000)
+		event.tags = [
+			[L_TAG, LABEL_NAMESPACE],
+			[l_TAG, LABEL_VALUE_TEST, LABEL_NAMESPACE],
+			[A_TAG, coordinate],
+		]
+		event.content = content?.trim() ? content : buildTestLabelContent(reason, contactRef)
+
+		await event.sign(signer)
+		const publishedRelays = await ndkActions.publishEvent(event)
+		if (publishedRelays.size === 0) {
+			throw new Error('Test label was not published to any relays')
+		}
+
+		// Reconcile the optimistic entry with the real label event id and
+		// keep the cache consistent during relay propagation
+		testLabelActions.setLabel(coordinate, event.id, labeler.pubkey)
+		setCachedTestLabel(coordinate, { eventId: event.id, labelerPubkey: labeler.pubkey })
+
+		return event
+	} catch (error) {
+		// Revert the optimistic update if publishing failed
+		testLabelActions.removeLabel(coordinate)
+		invalidateTestLabelCache(coordinate)
+		throw error
+	}
+}
+
+export interface PublishTestLabelDeletionParams {
+	/** Item coordinate the label was applied to (for store reconciliation) */
+	coordinate: string
+	/** id of the active kind-1985 label event being deleted */
+	labelEventId: string
+	/** Optional reason for the deletion (NIP-09 content field) */
+	reason?: string
+}
+
+/**
+ * Publish a NIP-09 deletion event (kind 5) for an existing test label.
+ * The deletion references the label event's id in an `e` tag with a `k` tag
+ * of 1985. Updates the store optimistically; reverts on failure.
+ */
+export async function publishTestLabelDeletion({ coordinate, labelEventId, reason }: PublishTestLabelDeletionParams): Promise<NDKEvent> {
+	if (!coordinate || !labelEventId) throw new Error('A coordinate and label event id are required to un-label')
+	if (labelEventId === PENDING_LABEL_EVENT_ID) throw new Error('Label is still being published — try again shortly')
+
+	const ndk = ndkActions.getNDK()
+	if (!ndk) throw new Error('NDK not initialized')
+	const signer = ndkActions.getSigner()
+	if (!signer) throw new Error('No signer available')
+
+	const labeler = await signer.user()
+	if (!labeler?.pubkey) throw new Error('Unable to determine the current labeler pubkey')
+
+	// NIP-09: only the label event's author may delete it. Validate the
+	// pubkey match before publishing — a mismatch cannot un-label the item.
+	const labelerPubkey = testLabelActions.getLabelerPubkey(coordinate)
+	if (labelerPubkey && labelerPubkey !== labeler.pubkey) {
+		throw new Error('Only the labeler who applied a test label can remove it')
+	}
+
+	// Optimistic update — the item reappears in feeds immediately
+	const previousLabelerPubkey = labelerPubkey
+	testLabelActions.removeLabel(coordinate)
+
+	try {
+		const event = new NDKEvent(ndk)
+		event.kind = LABEL_DELETION_KIND
+		event.created_at = Math.floor(Date.now() / 1000)
+		event.tags = [
+			[E_TAG, labelEventId],
+			[K_TAG, String(LABEL_EVENT_KIND)],
+		]
+		event.content = reason?.trim() || 'Unmarking test label.'
+
+		await event.sign(signer)
+		const publishedRelays = await ndkActions.publishEvent(event)
+		if (publishedRelays.size === 0) {
+			throw new Error('Test label deletion was not published to any relays')
+		}
+
+		// Keep the cache consistent during relay propagation
+		setCachedTestLabel(coordinate, null)
+
+		return event
+	} catch (error) {
+		// Revert the optimistic update if publishing failed
+		testLabelActions.setLabel(coordinate, labelEventId, previousLabelerPubkey)
+		invalidateTestLabelCache(coordinate)
+		throw error
+	}
+}

--- a/src/lib/constants/testLabels.ts
+++ b/src/lib/constants/testLabels.ts
@@ -1,0 +1,51 @@
+/**
+ * ADR-0009 — Test-listing curation via NIP-32 labels.
+ *
+ * Label events (kind 1985, NIP-32) mark a product or auction as a "test"
+ * listing. Items carrying an active `test` label are excluded from feeds and
+ * detail views. Un-labeling is a NIP-09 deletion event (kind 5) signed by the
+ * same labeler, referencing the label event's id in an `e` tag.
+ *
+ * See docs/adr/ADR-0009-test-listing-labels-via-nip-32.md for the full design.
+ */
+
+// --- Event kinds ---
+
+/** NIP-32 labeling event kind */
+export const LABEL_EVENT_KIND = 1985
+
+/** NIP-09 event deletion request kind (used to un-label) */
+export const LABEL_DELETION_KIND = 5
+
+// --- Label namespace & value ---
+
+/** Reverse-domain namespace for Plebeian Market labels (NIP-32 `L` tag) */
+export const LABEL_NAMESPACE = 'com.plebeian.market'
+
+/** Label value marking an item as a test listing (NIP-32 `l` tag) */
+export const LABEL_VALUE_TEST = 'test'
+
+// --- Tag names ---
+
+/** NIP-32 label namespace tag */
+export const L_TAG = 'L'
+
+/** NIP-32 label value tag */
+export const l_TAG = 'l'
+
+/** Coordinate target tag (kind:pubkey:identifier) — the item being labeled */
+export const A_TAG = 'a'
+
+/** NIP-09 event id reference tag (deletion target) */
+export const E_TAG = 'e'
+
+/** NIP-09 kind tag (declares the kind being deleted) */
+export const K_TAG = 'k'
+
+// --- Item kinds that can carry a test label ---
+
+/** NIP-99 product listing kind */
+export const TEST_LABEL_PRODUCT_KIND = 30402
+
+/** Auction listing kind (see AUCTION_KIND in src/lib/auction/constants.ts) */
+export const TEST_LABEL_AUCTION_KIND = 30408

--- a/src/lib/stores/testLabels.ts
+++ b/src/lib/stores/testLabels.ts
@@ -1,0 +1,194 @@
+import { Store } from '@tanstack/store'
+
+/**
+ * Metadata for an active test label on one item coordinate.
+ */
+export interface TestLabelInfo {
+	/** id of the kind-1985 label event (needed to reference in the NIP-09 deletion) */
+	eventId: string
+	/** pubkey of the authorized labeler who applied the label */
+	labelerPubkey: string
+}
+
+export interface TestLabelState {
+	// Coordinates ("kind:pubkey:identifier") carrying an active test label
+	testLabelCoordinates: Set<string>
+
+	// coordinate -> id of the active label event (referenced by the NIP-09 deletion)
+	labelEventIds: Map<string, string>
+
+	// coordinate -> pubkey of the labeler who applied the active label
+	labelerPubkeys: Map<string, string>
+
+	// Metadata
+	lastUpdated: number
+	isLoaded: boolean
+}
+
+const initialState: TestLabelState = {
+	testLabelCoordinates: new Set<string>(),
+	labelEventIds: new Map<string, string>(),
+	labelerPubkeys: new Map<string, string>(),
+	lastUpdated: 0,
+	isLoaded: false,
+}
+
+export const testLabelStore = new Store<TestLabelState>(initialState)
+
+export const testLabelActions = {
+	/**
+	 * Mark a coordinate as test-labeled.
+	 * @param coordinate "kind:pubkey:identifier" of the labeled item
+	 * @param eventId id of the active kind-1985 label event
+	 * @param labelerPubkey pubkey of the labeler who applied the label
+	 */
+	setLabel: (coordinate: string, eventId: string, labelerPubkey?: string) => {
+		if (!coordinate) return
+
+		testLabelStore.setState((state) => {
+			const testLabelCoordinates = new Set(state.testLabelCoordinates)
+			const labelEventIds = new Map(state.labelEventIds)
+			const labelerPubkeys = new Map(state.labelerPubkeys)
+
+			testLabelCoordinates.add(coordinate)
+			if (eventId) labelEventIds.set(coordinate, eventId)
+			if (labelerPubkey) labelerPubkeys.set(coordinate, labelerPubkey)
+
+			return {
+				...state,
+				testLabelCoordinates,
+				labelEventIds,
+				labelerPubkeys,
+				lastUpdated: Date.now(),
+			}
+		})
+	},
+
+	/**
+	 * Remove the test label from a coordinate (deletion seen or optimistic un-label).
+	 */
+	removeLabel: (coordinate: string) => {
+		if (!coordinate) return
+
+		testLabelStore.setState((state) => {
+			if (!state.testLabelCoordinates.has(coordinate)) return state
+
+			const testLabelCoordinates = new Set(state.testLabelCoordinates)
+			const labelEventIds = new Map(state.labelEventIds)
+			const labelerPubkeys = new Map(state.labelerPubkeys)
+
+			testLabelCoordinates.delete(coordinate)
+			labelEventIds.delete(coordinate)
+			labelerPubkeys.delete(coordinate)
+
+			return {
+				...state,
+				testLabelCoordinates,
+				labelEventIds,
+				labelerPubkeys,
+				lastUpdated: Date.now(),
+			}
+		})
+	},
+
+	/**
+	 * Reconcile the store with freshly fetched label truth for a batch of
+	 * coordinates. Coordinates present in `labels` are marked labeled; every
+	 * other coordinate in `fetchedCoordinates` is treated as un-labeled.
+	 * Coordinates outside `fetchedCoordinates` are left untouched.
+	 */
+	applyFetchedLabels: (labels: Map<string, TestLabelInfo>, fetchedCoordinates: string[]) => {
+		const uniqueCoordinates = Array.from(new Set(fetchedCoordinates.filter(Boolean)))
+		if (uniqueCoordinates.length === 0) return
+
+		testLabelStore.setState((state) => {
+			const testLabelCoordinates = new Set(state.testLabelCoordinates)
+			const labelEventIds = new Map(state.labelEventIds)
+			const labelerPubkeys = new Map(state.labelerPubkeys)
+
+			for (const coordinate of uniqueCoordinates) {
+				const label = labels.get(coordinate)
+				if (label) {
+					testLabelCoordinates.add(coordinate)
+					if (label.eventId) labelEventIds.set(coordinate, label.eventId)
+					if (label.labelerPubkey) labelerPubkeys.set(coordinate, label.labelerPubkey)
+				} else {
+					testLabelCoordinates.delete(coordinate)
+					labelEventIds.delete(coordinate)
+					labelerPubkeys.delete(coordinate)
+				}
+			}
+
+			return {
+				...state,
+				testLabelCoordinates,
+				labelEventIds,
+				labelerPubkeys,
+				lastUpdated: Date.now(),
+				isLoaded: true,
+			}
+		})
+	},
+
+	/**
+	 * Check if a coordinate carries an active test label
+	 */
+	isTestLabeled: (coordinate: string): boolean => {
+		if (!coordinate) return false
+		return testLabelStore.state.testLabelCoordinates.has(coordinate)
+	},
+
+	/**
+	 * Get the id of the active label event for a coordinate
+	 * (referenced by the NIP-09 deletion when un-labeling)
+	 */
+	getLabelEventId: (coordinate: string): string | undefined => {
+		return testLabelStore.state.labelEventIds.get(coordinate)
+	},
+
+	/**
+	 * Get the pubkey of the labeler who applied the active label
+	 */
+	getLabelerPubkey: (coordinate: string): string | undefined => {
+		return testLabelStore.state.labelerPubkeys.get(coordinate)
+	},
+
+	/**
+	 * Get all test-labeled coordinates
+	 */
+	getTestLabeledCoordinates: (): string[] => {
+		return Array.from(testLabelStore.state.testLabelCoordinates)
+	},
+
+	/**
+	 * Check if labels have been loaded (at least one label check completed)
+	 */
+	areLabelsLoaded: (): boolean => {
+		return testLabelStore.state.isLoaded
+	},
+
+	/**
+	 * Get last update timestamp
+	 */
+	getLastUpdated: (): number => {
+		return testLabelStore.state.lastUpdated
+	},
+
+	/**
+	 * Clear all label data (reset to initial state)
+	 */
+	clearLabels: () => {
+		testLabelStore.setState((state) => ({
+			...state,
+			...initialState,
+		}))
+	},
+}
+
+// React hook for consuming the store
+export const useTestLabelStore = () => {
+	return {
+		...testLabelStore.state,
+		...testLabelActions,
+	}
+}

--- a/src/lib/stores/testLabels.ts
+++ b/src/lib/stores/testLabels.ts
@@ -20,6 +20,9 @@ export interface TestLabelState {
 	// coordinate -> pubkey of the labeler who applied the active label
 	labelerPubkeys: Map<string, string>
 
+	// Whether the user opted to reveal test-labeled items in browsing surfaces
+	showTestListings: boolean
+
 	// Metadata
 	lastUpdated: number
 	isLoaded: boolean
@@ -29,6 +32,7 @@ const initialState: TestLabelState = {
 	testLabelCoordinates: new Set<string>(),
 	labelEventIds: new Map<string, string>(),
 	labelerPubkeys: new Map<string, string>(),
+	showTestListings: false,
 	lastUpdated: 0,
 	isLoaded: false,
 }
@@ -172,6 +176,26 @@ export const testLabelActions = {
 	 */
 	getLastUpdated: (): number => {
 		return testLabelStore.state.lastUpdated
+	},
+
+	/**
+	 * Set whether test-labeled items are revealed in browsing surfaces.
+	 */
+	setShowTestListings: (show: boolean) => {
+		testLabelStore.setState((state) => ({
+			...state,
+			showTestListings: show,
+		}))
+	},
+
+	/**
+	 * Toggle whether test-labeled items are revealed in browsing surfaces.
+	 */
+	toggleShowTestListings: () => {
+		testLabelStore.setState((state) => ({
+			...state,
+			showTestListings: !state.showTestListings,
+		}))
 	},
 
 	/**

--- a/src/lib/utils/testLabelFilters.ts
+++ b/src/lib/utils/testLabelFilters.ts
@@ -1,0 +1,100 @@
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import { TEST_LABEL_AUCTION_KIND, TEST_LABEL_PRODUCT_KIND } from '@/lib/constants/testLabels'
+import { testLabelActions } from '@/lib/stores/testLabels'
+import { getATagFromCoords } from './coords'
+
+/**
+ * ADR-0009 — Test-listing curation filters.
+ *
+ * Synchronous store reads mirroring `blacklistFilters.ts`. The relay fetch
+ * that populates the store happens first, via `fetchTestLabels` /
+ * `excludeTestLabeledEvents` (see src/queries/testLabels.tsx).
+ */
+
+/**
+ * Item coordinate ("kind:pubkey:identifier") of a product/auction event,
+ * or null for events that cannot carry a test label.
+ */
+export const getItemTestLabelCoordinate = (event: NDKEvent): string | null => {
+	if (event.kind !== TEST_LABEL_PRODUCT_KIND && event.kind !== TEST_LABEL_AUCTION_KIND) return null
+	const dTag = event.tagValue('d')
+	if (!dTag) return null
+	return getATagFromCoords({ kind: event.kind, pubkey: event.pubkey, identifier: dTag })
+}
+
+/**
+ * Collect the unique item coordinates referenced by an array of events.
+ * Used to batch the label fetch for a page of items before filtering.
+ */
+export const collectTestLabelCoordinates = (events: NDKEvent[]): string[] => {
+	const coordinates = new Set<string>()
+	for (const event of events) {
+		const coordinate = getItemTestLabelCoordinate(event)
+		if (coordinate) coordinates.add(coordinate)
+	}
+	return Array.from(coordinates)
+}
+
+/**
+ * Filter out test-labeled items from an array of events.
+ *
+ * Must be called AFTER filterBlacklistedEvents and filterDeleted* (ADR-0009:
+ * the label check runs alongside the existing delete and blacklist checks,
+ * before queries return data).
+ *
+ * Synchronous store read — if labels have not been loaded yet the filter
+ * fails open and returns all events.
+ */
+export const filterTestLabeledEvents = <T extends NDKEvent>(events: T[]): T[] => {
+	if (!testLabelActions.areLabelsLoaded()) {
+		return events // Return all if labels not loaded yet
+	}
+
+	return events.filter((event) => !isItemEventTestLabeled(event))
+}
+
+/**
+ * Check if any item event (product or auction) carries an active test label
+ */
+export const isItemEventTestLabeled = (event: NDKEvent): boolean => {
+	const coordinate = getItemTestLabelCoordinate(event)
+	if (!coordinate) return false
+	return testLabelActions.isTestLabeled(coordinate)
+}
+
+/**
+ * Check if a product event carries an active test label
+ */
+export const isProductTestLabeled = (event: NDKEvent): boolean => {
+	if (event.kind !== TEST_LABEL_PRODUCT_KIND) return false
+	return isItemEventTestLabeled(event)
+}
+
+/**
+ * Check if an auction event carries an active test label
+ */
+export const isAuctionTestLabeled = (event: NDKEvent): boolean => {
+	if (event.kind !== TEST_LABEL_AUCTION_KIND) return false
+	return isItemEventTestLabeled(event)
+}
+
+/**
+ * Filter item coordinates, dropping test-labeled ones
+ */
+export const filterTestLabeledCoordinates = (coordinates: string[]): string[] => {
+	return coordinates.filter((coordinate) => !testLabelActions.isTestLabeled(coordinate))
+}
+
+/**
+ * React hook that returns filter functions with reactive updates
+ * Use this in components that need to react to test-label changes
+ */
+export const useTestLabelFilters = () => {
+	return {
+		filterEvents: filterTestLabeledEvents,
+		isProductTestLabeled,
+		isAuctionTestLabeled,
+		isItemTestLabeled: isItemEventTestLabeled,
+		filterCoordinates: filterTestLabeledCoordinates,
+	}
+}

--- a/src/queries/__tests__/testLabels.test.ts
+++ b/src/queries/__tests__/testLabels.test.ts
@@ -1,0 +1,347 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { NDKEvent } from '@nostr-dev-kit/ndk'
+import {
+	A_TAG,
+	E_TAG,
+	K_TAG,
+	L_TAG,
+	LABEL_DELETION_KIND,
+	LABEL_EVENT_KIND,
+	LABEL_NAMESPACE,
+	LABEL_VALUE_TEST,
+	l_TAG,
+} from '@/lib/constants/testLabels'
+import { testLabelActions, testLabelStore } from '@/lib/stores/testLabels'
+import { getAuthorizedLabelerPubkeys, isLabelDeletionForLabel, isValidAuthorizedTestLabel, reconcileActiveTestLabels } from '../testLabels'
+
+// --- Test fixtures ---
+
+const ADMIN_PUBKEY = 'a'.repeat(64)
+const OTHER_ADMIN_PUBKEY = '1'.repeat(64)
+const UNAUTHORIZED_PUBKEY = 'b'.repeat(64)
+const MERCHANT_PUBKEY = 'c'.repeat(64)
+
+const PRODUCT_COORD = `30402:${MERCHANT_PUBKEY}:my-product`
+const AUCTION_COORD = `30408:${MERCHANT_PUBKEY}:my-auction`
+
+const makeFakeEvent = (params: { kind?: number; id?: string; pubkey?: string; created_at?: number; tags: string[][] }): NDKEvent =>
+	({
+		kind: params.kind ?? LABEL_EVENT_KIND,
+		id: params.id ?? 'label-event-id-' + Math.random().toString(36).slice(2, 8),
+		pubkey: params.pubkey ?? ADMIN_PUBKEY,
+		created_at: params.created_at ?? 1724178700,
+		tags: params.tags,
+		content: '',
+	}) as unknown as NDKEvent
+
+const makeTestLabelEvent = (params: {
+	coordinate?: string
+	id?: string
+	pubkey?: string
+	created_at?: number
+	namespace?: string
+	value?: string
+	includePTag?: boolean
+	kind?: number
+}): NDKEvent => {
+	const coordinate = params.coordinate ?? PRODUCT_COORD
+	const tags: string[][] = [
+		[L_TAG, params.namespace ?? LABEL_NAMESPACE],
+		[l_TAG, params.value ?? LABEL_VALUE_TEST, params.namespace ?? LABEL_NAMESPACE],
+		[A_TAG, coordinate],
+	]
+	if (params.includePTag) tags.push(['p', MERCHANT_PUBKEY])
+	return makeFakeEvent({ kind: params.kind, id: params.id, pubkey: params.pubkey, created_at: params.created_at, tags })
+}
+
+const makeTestLabelDeletionEvent = (params: { labelId: string; pubkey?: string; kind?: number; kTag?: string | null }): NDKEvent => {
+	const tags: string[][] = [['e', params.labelId]]
+	if (params.kTag !== null) tags.push(['k', params.kTag ?? String(LABEL_EVENT_KIND)])
+	return makeFakeEvent({ kind: params.kind ?? LABEL_DELETION_KIND, pubkey: params.pubkey, tags })
+}
+
+// --- Store actions ---
+
+describe('testLabelStore', () => {
+	beforeEach(() => {
+		testLabelActions.clearLabels()
+	})
+
+	test('setLabel marks a coordinate as test-labeled and tracks the label event', () => {
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(false)
+
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(true)
+		expect(testLabelActions.getLabelEventId(PRODUCT_COORD)).toBe('label-1')
+		expect(testLabelActions.getLabelerPubkey(PRODUCT_COORD)).toBe(ADMIN_PUBKEY)
+		expect(testLabelActions.getTestLabeledCoordinates()).toEqual([PRODUCT_COORD])
+	})
+
+	test('removeLabel un-labels a coordinate (deletion seen)', () => {
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+
+		testLabelActions.removeLabel(PRODUCT_COORD)
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(false)
+		expect(testLabelActions.getLabelEventId(PRODUCT_COORD)).toBeUndefined()
+		expect(testLabelActions.getLabelerPubkey(PRODUCT_COORD)).toBeUndefined()
+		expect(testLabelActions.getTestLabeledCoordinates()).toEqual([])
+	})
+
+	test('removeLabel is a no-op for unknown coordinates', () => {
+		const before = testLabelStore.state.lastUpdated
+		testLabelActions.removeLabel(`30402:${MERCHANT_PUBKEY}:never-labeled`)
+		expect(testLabelStore.state.lastUpdated).toBe(before)
+	})
+
+	test('isTestLabeled is false for empty input', () => {
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+		expect(testLabelActions.isTestLabeled('')).toBe(false)
+	})
+
+	test('applyFetchedLabels marks fetched coordinates with active labels', () => {
+		const labels = new Map([[PRODUCT_COORD, { eventId: 'label-1', labelerPubkey: ADMIN_PUBKEY }]])
+
+		testLabelActions.applyFetchedLabels(labels, [PRODUCT_COORD])
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(true)
+		expect(testLabelActions.getLabelEventId(PRODUCT_COORD)).toBe('label-1')
+		expect(testLabelActions.areLabelsLoaded()).toBe(true)
+	})
+
+	test('applyFetchedLabels clears coordinates whose label is absent (deletion reconciled)', () => {
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+
+		// Relay says the label is gone for this coordinate
+		testLabelActions.applyFetchedLabels(new Map(), [PRODUCT_COORD])
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(false)
+		expect(testLabelActions.areLabelsLoaded()).toBe(true)
+	})
+
+	test('applyFetchedLabels leaves coordinates outside the fetched batch untouched', () => {
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+
+		// A fetch for a different coordinate must not clear PRODUCT_COORD
+		const otherCoord = `30402:${MERCHANT_PUBKEY}:other-product`
+		testLabelActions.applyFetchedLabels(new Map(), [otherCoord])
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(true)
+		expect(testLabelActions.isTestLabeled(otherCoord)).toBe(false)
+	})
+
+	test('applyFetchedLabels deduplicates and skips empty coordinates', () => {
+		const labels = new Map([[PRODUCT_COORD, { eventId: 'label-1', labelerPubkey: ADMIN_PUBKEY }]])
+
+		testLabelActions.applyFetchedLabels(labels, [PRODUCT_COORD, PRODUCT_COORD, ''])
+
+		expect(testLabelActions.isTestLabeled(PRODUCT_COORD)).toBe(true)
+		expect(testLabelActions.getTestLabeledCoordinates()).toEqual([PRODUCT_COORD])
+	})
+
+	test('clearLabels resets all state', () => {
+		testLabelActions.setLabel(PRODUCT_COORD, 'label-1', ADMIN_PUBKEY)
+
+		testLabelActions.clearLabels()
+
+		expect(testLabelActions.getTestLabeledCoordinates()).toEqual([])
+		expect(testLabelActions.areLabelsLoaded()).toBe(false)
+	})
+})
+
+// --- Label event validation ---
+
+describe('isValidAuthorizedTestLabel', () => {
+	test('accepts a well-formed label from an authorized labeler', () => {
+		const event = makeTestLabelEvent({ coordinate: PRODUCT_COORD })
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(true)
+	})
+
+	test('rejects labels from unauthorized pubkeys', () => {
+		const event = makeTestLabelEvent({ coordinate: PRODUCT_COORD, pubkey: UNAUTHORIZED_PUBKEY })
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+
+	test('rejects labels in a foreign namespace', () => {
+		const event = makeTestLabelEvent({ coordinate: PRODUCT_COORD, namespace: 'com.other.app' })
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+
+	test('rejects label values other than "test"', () => {
+		const event = makeTestLabelEvent({ coordinate: PRODUCT_COORD, value: 'spam' })
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+
+	test('rejects l tags without the namespace as third element', () => {
+		const event = makeFakeEvent({
+			tags: [
+				[LABEL_NAMESPACE, LABEL_NAMESPACE],
+				[l_TAG, LABEL_VALUE_TEST],
+				[A_TAG, PRODUCT_COORD],
+			],
+		})
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+
+	test('rejects events without an a-tag target', () => {
+		const event = makeFakeEvent({
+			tags: [
+				['L', LABEL_NAMESPACE],
+				[l_TAG, LABEL_VALUE_TEST, LABEL_NAMESPACE],
+			],
+		})
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+
+	test('rejects non-1985 kinds', () => {
+		const event = makeTestLabelEvent({ coordinate: PRODUCT_COORD, kind: 30402 })
+		expect(isValidAuthorizedTestLabel(event, [ADMIN_PUBKEY])).toBe(false)
+	})
+})
+
+// --- NIP-09 deletion validation ---
+
+describe('isLabelDeletionForLabel', () => {
+	const label = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1', pubkey: ADMIN_PUBKEY })
+
+	test('accepts a deletion signed by the same labeler with a matching e tag and k tag', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(true)
+	})
+
+	test('accepts a deletion without a k tag (k is a NIP-09 SHOULD, not MUST)', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY, kTag: null })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(true)
+	})
+
+	test('rejects a deletion signed by a different pubkey than the label event (NIP-09 MUST)', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: OTHER_ADMIN_PUBKEY })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(false)
+	})
+
+	test('rejects a deletion that does not reference the label event id', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'some-other-event', pubkey: ADMIN_PUBKEY })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(false)
+	})
+
+	test('rejects a deletion whose k tag declares a different kind', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY, kTag: '30402' })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(false)
+	})
+
+	test('rejects non-kind-5 events', () => {
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY, kind: 1985 })
+		expect(isLabelDeletionForLabel(deletion, label)).toBe(false)
+	})
+})
+
+// --- Reconciliation ---
+
+describe('reconcileActiveTestLabels', () => {
+	test('returns label metadata for an active label', () => {
+		const label = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1' })
+
+		const active = reconcileActiveTestLabels([label], [])
+
+		expect(active.get(PRODUCT_COORD)).toEqual({ eventId: 'label-1', labelerPubkey: ADMIN_PUBKEY })
+	})
+
+	test('treats a label with a matching NIP-09 deletion as absent', () => {
+		const label = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1' })
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY })
+
+		const active = reconcileActiveTestLabels([label], [deletion])
+
+		expect(active.has(PRODUCT_COORD)).toBe(false)
+	})
+
+	test('coordinate stays labeled when another active label remains after one is deleted', () => {
+		const older = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1', created_at: 1000 })
+		const newer = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-2', created_at: 2000 })
+		const deletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: ADMIN_PUBKEY })
+
+		const active = reconcileActiveTestLabels([older, newer], [deletion])
+
+		expect(active.get(PRODUCT_COORD)).toEqual({ eventId: 'label-2', labelerPubkey: ADMIN_PUBKEY })
+	})
+
+	test('newest active label wins when several exist for one coordinate', () => {
+		const older = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1', created_at: 1000 })
+		const newer = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-2', created_at: 2000, pubkey: OTHER_ADMIN_PUBKEY })
+
+		const active = reconcileActiveTestLabels([older, newer], [])
+
+		expect(active.get(PRODUCT_COORD)).toEqual({ eventId: 'label-2', labelerPubkey: OTHER_ADMIN_PUBKEY })
+	})
+
+	test('handles labels targeting multiple coordinates via multiple a tags', () => {
+		const label = makeFakeEvent({
+			id: 'label-1',
+			tags: [
+				['L', LABEL_NAMESPACE],
+				[l_TAG, LABEL_VALUE_TEST, LABEL_NAMESPACE],
+				[A_TAG, PRODUCT_COORD],
+				[A_TAG, AUCTION_COORD],
+			],
+		})
+
+		const active = reconcileActiveTestLabels([label], [])
+
+		expect(active.has(PRODUCT_COORD)).toBe(true)
+		expect(active.has(AUCTION_COORD)).toBe(true)
+	})
+
+	test('requestedCoordinates restricts the returned coordinates', () => {
+		const label = makeFakeEvent({
+			id: 'label-1',
+			tags: [
+				['L', LABEL_NAMESPACE],
+				[l_TAG, LABEL_VALUE_TEST, LABEL_NAMESPACE],
+				[A_TAG, PRODUCT_COORD],
+				[A_TAG, AUCTION_COORD],
+			],
+		})
+
+		const active = reconcileActiveTestLabels([label], [], [PRODUCT_COORD])
+
+		expect(active.has(PRODUCT_COORD)).toBe(true)
+		expect(active.has(AUCTION_COORD)).toBe(false)
+	})
+
+	test('deletion from a different labeler does not remove another labeler\u2019s label', () => {
+		// label-1 by ADMIN, label-2 by OTHER_ADMIN, deletion of label-1 signed by OTHER_ADMIN (invalid)
+		const label1 = makeTestLabelEvent({ coordinate: PRODUCT_COORD, id: 'label-1', pubkey: ADMIN_PUBKEY, created_at: 1000 })
+		const invalidDeletion = makeTestLabelDeletionEvent({ labelId: 'label-1', pubkey: OTHER_ADMIN_PUBKEY })
+
+		const active = reconcileActiveTestLabels([label1], [invalidDeletion])
+
+		// The invalid deletion must not remove the label
+		expect(active.get(PRODUCT_COORD)).toEqual({ eventId: 'label-1', labelerPubkey: ADMIN_PUBKEY })
+	})
+})
+
+// --- Fail-open behavior ---
+
+describe('getAuthorizedLabelerPubkeys', () => {
+	test('returns null when admin settings are unavailable (no NDK in unit-test runtime)', async () => {
+		// In the unit-test runtime no NDK instance exists, so fetchAdminSettings
+		// throws and the authorized set must be reported as unavailable (null),
+		// never as an empty authorized set.
+		const result = await getAuthorizedLabelerPubkeys()
+		expect(result).toBeNull()
+	})
+})
+
+describe('fetchTestLabels fail-open (via store)', () => {
+	test('store stays not-loaded when authorization data is unavailable, so filters fail open', async () => {
+		testLabelActions.clearLabels()
+
+		// fetchTestLabels with no NDK available must leave the store unloaded
+		const { fetchTestLabels } = await import('../testLabels')
+		const result = await fetchTestLabels([PRODUCT_COORD])
+
+		expect(result.size).toBe(0)
+		expect(testLabelActions.areLabelsLoaded()).toBe(false)
+	})
+})

--- a/src/queries/__tests__/testLabels.test.ts
+++ b/src/queries/__tests__/testLabels.test.ts
@@ -9,10 +9,17 @@ import {
 	LABEL_EVENT_KIND,
 	LABEL_NAMESPACE,
 	LABEL_VALUE_TEST,
+	TEST_LABEL_PRODUCT_KIND,
 	l_TAG,
 } from '@/lib/constants/testLabels'
 import { testLabelActions, testLabelStore } from '@/lib/stores/testLabels'
-import { getAuthorizedLabelerPubkeys, isLabelDeletionForLabel, isValidAuthorizedTestLabel, reconcileActiveTestLabels } from '../testLabels'
+import {
+	excludeTestLabeledEvents,
+	getAuthorizedLabelerPubkeys,
+	isLabelDeletionForLabel,
+	isValidAuthorizedTestLabel,
+	reconcileActiveTestLabels,
+} from '../testLabels'
 
 // --- Test fixtures ---
 
@@ -343,5 +350,41 @@ describe('fetchTestLabels fail-open (via store)', () => {
 
 		expect(result.size).toBe(0)
 		expect(testLabelActions.areLabelsLoaded()).toBe(false)
+	})
+})
+
+// --- Show-test-listings toggle (ADR-0009 rev 3) ---
+
+describe('excludeTestLabeledEvents toggle', () => {
+	const makeProductEvent = (dTag: string): NDKEvent =>
+		({
+			kind: TEST_LABEL_PRODUCT_KIND,
+			pubkey: MERCHANT_PUBKEY,
+			id: `product-${dTag}`,
+			created_at: 1724178700,
+			tags: [['d', dTag]],
+			content: '',
+			tagValue: (name: string) => (name === 'd' ? dTag : undefined),
+		}) as unknown as NDKEvent
+
+	test('returns events unfiltered when showTestListings is true', async () => {
+		testLabelActions.clearLabels()
+		testLabelActions.setShowTestListings(true)
+
+		// No store population needed: the short-circuit returns before any fetch.
+		const result = await excludeTestLabeledEvents([makeProductEvent('my-product')])
+
+		expect(result).toHaveLength(1)
+	})
+
+	test('still filters labeled events when showTestListings is false', async () => {
+		testLabelActions.clearLabels()
+		// Load the store so filtering is active, with PRODUCT_COORD labeled.
+		testLabelActions.applyFetchedLabels(new Map([[PRODUCT_COORD, { eventId: 'label-1', labelerPubkey: ADMIN_PUBKEY }]]), [PRODUCT_COORD])
+		testLabelActions.setShowTestListings(false)
+
+		const result = await excludeTestLabeledEvents([makeProductEvent('my-product')])
+
+		expect(result).toHaveLength(0)
 	})
 })

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -31,6 +31,8 @@ import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { auctionKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
+import { excludeTestLabeledEvents, fetchTestLabels } from '@/queries/testLabels'
+import { getATagFromCoords } from '@/lib/utils/coords'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
 
 export type AuctionSettlementStatus = 'settled' | 'reserve_not_met' | 'cancelled' | 'unknown'
@@ -164,7 +166,8 @@ const fetchAuctionVersionEvents = async (pubkey: string, dTag: string, limit: nu
 		},
 		{ timeoutMs: 8000 },
 	)
-	return filterDeletedAuctions(filterBlacklistedEvents(Array.from(events)))
+	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
+	return excludeTestLabeledEvents(filterDeletedAuctions(filterBlacklistedEvents(Array.from(events))))
 }
 
 export const fetchAuctions = async (limit: number = 200) => {
@@ -180,9 +183,9 @@ export const fetchAuctions = async (limit: number = 200) => {
 	}
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
-	return collapseAuctionVersions(ndk, filterDeletedAuctions(filterBlacklistedEvents(Array.from(events)))).sort(
-		(a, b) => (b.created_at || 0) - (a.created_at || 0),
-	)
+	// Filter out blacklisted auctions, locally-deleted auctions, then test-labeled items (ADR-0009)
+	const filteredEvents = await excludeTestLabeledEvents(filterDeletedAuctions(filterBlacklistedEvents(Array.from(events))))
+	return collapseAuctionVersions(ndk, filteredEvents).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 }
 
 export const fetchAuction = async (id: string) => {
@@ -206,6 +209,12 @@ export const fetchAuction = async (id: string) => {
 	if (dTag && isAuctionDeleted(dTag, event.created_at)) return null
 	if (!dTag) return filterBlacklistedEvents([event])[0] || null
 
+	// Check the test label for this auction's coordinate (ADR-0009). A
+	// test-labeled auction resolves to null in detail views.
+	const coordinate = getATagFromCoords({ kind: AUCTION_KIND, pubkey: event.pubkey, identifier: dTag })
+	const labels = await fetchTestLabels([coordinate])
+	if (labels.has(coordinate)) return null
+
 	const versionEvents = await fetchAuctionVersionEvents(event.pubkey, dTag)
 	return resolveCanonicalAuctionEvent(ndk, dedupeEventsById([event, ...versionEvents]))
 }
@@ -222,15 +231,22 @@ export const fetchAuctionsByPubkey = async (pubkey: string, limit: number = 100)
 	}
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
-	return collapseAuctionVersions(ndk, filterDeletedAuctions(filterBlacklistedEvents(Array.from(events)))).sort(
-		(a, b) => (b.created_at || 0) - (a.created_at || 0),
-	)
+	// Filter out blacklisted auctions, locally-deleted auctions, then test-labeled items (ADR-0009)
+	const filteredEvents = await excludeTestLabeledEvents(filterDeletedAuctions(filterBlacklistedEvents(Array.from(events))))
+	return collapseAuctionVersions(ndk, filteredEvents).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 }
 
 export const fetchAuctionByATag = async (pubkey: string, dTag: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 	if (!pubkey || !dTag) return null
+
+	// Check the test label before resolving the item (ADR-0009). Must run
+	// before the version-events fallback so a labeled auction resolves to
+	// null instead of falling through to the raw naddr fetch.
+	const coordinate = getATagFromCoords({ kind: AUCTION_KIND, pubkey, identifier: dTag })
+	const labels = await fetchTestLabels([coordinate])
+	if (labels.has(coordinate)) return null
 
 	const versionEvents = await fetchAuctionVersionEvents(pubkey, dTag)
 	if (versionEvents.length === 0) {

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -31,8 +31,7 @@ import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 import { auctionKeys } from './queryKeyFactory'
 import { filterBlacklistedEvents } from '@/lib/utils/blacklistFilters'
-import { excludeTestLabeledEvents, fetchTestLabels } from '@/queries/testLabels'
-import { getATagFromCoords } from '@/lib/utils/coords'
+import { excludeTestLabeledEvents } from '@/queries/testLabels'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
 
 export type AuctionSettlementStatus = 'settled' | 'reserve_not_met' | 'cancelled' | 'unknown'
@@ -209,12 +208,6 @@ export const fetchAuction = async (id: string) => {
 	if (dTag && isAuctionDeleted(dTag, event.created_at)) return null
 	if (!dTag) return filterBlacklistedEvents([event])[0] || null
 
-	// Check the test label for this auction's coordinate (ADR-0009). A
-	// test-labeled auction resolves to null in detail views.
-	const coordinate = getATagFromCoords({ kind: AUCTION_KIND, pubkey: event.pubkey, identifier: dTag })
-	const labels = await fetchTestLabels([coordinate])
-	if (labels.has(coordinate)) return null
-
 	const versionEvents = await fetchAuctionVersionEvents(event.pubkey, dTag)
 	return resolveCanonicalAuctionEvent(ndk, dedupeEventsById([event, ...versionEvents]))
 }
@@ -231,8 +224,8 @@ export const fetchAuctionsByPubkey = async (pubkey: string, limit: number = 100)
 	}
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
-	// Filter out blacklisted auctions, locally-deleted auctions, then test-labeled items (ADR-0009)
-	const filteredEvents = await excludeTestLabeledEvents(filterDeletedAuctions(filterBlacklistedEvents(Array.from(events))))
+	// Filter out blacklisted auctions and locally-deleted auctions only
+	const filteredEvents = filterDeletedAuctions(filterBlacklistedEvents(Array.from(events)))
 	return collapseAuctionVersions(ndk, filteredEvents).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
 }
 
@@ -240,13 +233,6 @@ export const fetchAuctionByATag = async (pubkey: string, dTag: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 	if (!pubkey || !dTag) return null
-
-	// Check the test label before resolving the item (ADR-0009). Must run
-	// before the version-events fallback so a labeled auction resolves to
-	// null instead of falling through to the raw naddr fetch.
-	const coordinate = getATagFromCoords({ kind: AUCTION_KIND, pubkey, identifier: dTag })
-	const labels = await fetchTestLabels([coordinate])
-	if (labels.has(coordinate)) return null
 
 	const versionEvents = await fetchAuctionVersionEvents(pubkey, dTag)
 	if (versionEvents.length === 0) {

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -21,7 +21,7 @@ import { productKeys } from './queryKeyFactory'
 import { getCoordsFromATag, getATagFromCoords } from '@/lib/utils/coords.ts'
 import { discoverNip50Relays } from '@/lib/relays'
 import { filterBlacklistedEvents, filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
-import { excludeTestLabeledEvents, fetchTestLabels } from '@/queries/testLabels'
+import { excludeTestLabeledEvents } from '@/queries/testLabels'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
 import { isValidHexKey } from '@/lib/utils'
 
@@ -236,14 +236,6 @@ export const fetchProduct = async (id: string) => {
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	const event = Array.from(events)[0] ?? null
 	if (event) {
-		// Check the test label for this item's coordinate (ADR-0009). A
-		// test-labeled product resolves to nothing in detail views.
-		const dTag = event.tagValue('d')
-		if (dTag) {
-			const coordinate = getATagFromCoords({ kind: 30402, pubkey: event.pubkey, identifier: dTag })
-			const labels = await fetchTestLabels([coordinate])
-			if (labels.has(coordinate)) return null
-		}
 		return event
 	}
 
@@ -279,15 +271,12 @@ export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boole
 	// Then filter out locally-deleted products
 	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
-	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
-	const nonTestLabeledEvents = await excludeTestLabeledEvents(filteredEvents)
-
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
-		return nonTestLabeledEvents
+		return filteredEvents
 	}
 
-	return nonTestLabeledEvents.filter((event) => {
+	return filteredEvents.filter((event) => {
 		const visibilityTag = event.tags.find((t) => t[0] === 'visibility')
 		const visibility = visibilityTag?.[1] || 'on-sale' // Default to on-sale if not specified
 		if (visibility === 'hidden') return false
@@ -300,13 +289,6 @@ export const fetchProductByATag = async (pubkey: string, dTag: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 	if (!pubkey || !dTag) return null
-
-	// Check the test label before resolving the item (ADR-0009). A
-	// test-labeled product resolves to null — the same depth of gating as
-	// blacklisted items.
-	const coordinate = getATagFromCoords({ kind: 30402, pubkey, identifier: dTag })
-	const labels = await fetchTestLabels([coordinate])
-	if (labels.has(coordinate)) return null
 
 	const naddr = naddrFromAddress(30402, pubkey, dTag)
 	return await ndk.fetchEvent(naddr)

--- a/src/queries/products.tsx
+++ b/src/queries/products.tsx
@@ -21,6 +21,7 @@ import { productKeys } from './queryKeyFactory'
 import { getCoordsFromATag, getATagFromCoords } from '@/lib/utils/coords.ts'
 import { discoverNip50Relays } from '@/lib/relays'
 import { filterBlacklistedEvents, filterBlacklistedPubkeys } from '@/lib/utils/blacklistFilters'
+import { excludeTestLabeledEvents, fetchTestLabels } from '@/queries/testLabels'
 import { naddrFromAddress } from '@/lib/nostr/naddr'
 import { isValidHexKey } from '@/lib/utils'
 
@@ -149,12 +150,15 @@ export const fetchProducts = async (limit: number = 500, tag?: string, includeHi
 	// Filter out blacklisted products and authors, then filter out locally-deleted products
 	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
+	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
+	const nonTestLabeledEvents = await excludeTestLabeledEvents(filteredEvents)
+
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
-		return filteredEvents
+		return nonTestLabeledEvents
 	}
 
-	return filteredEvents.filter((event) => {
+	return nonTestLabeledEvents.filter((event) => {
 		const visibilityTag = event.tags.find((t) => t[0] === 'visibility')
 		const visibility = visibilityTag?.[1] || 'on-sale' // Default to on-sale if not specified
 		if (visibility === 'hidden') return false
@@ -191,12 +195,15 @@ export const fetchProductsPaginated = async (limit: number = 20, until?: number,
 	// Filter out blacklisted products and authors, then filter out locally-deleted products
 	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
+	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
+	const nonTestLabeledEvents = await excludeTestLabeledEvents(filteredEvents)
+
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
-		return filteredEvents
+		return nonTestLabeledEvents
 	}
 
-	return filteredEvents.filter((event) => {
+	return nonTestLabeledEvents.filter((event) => {
 		const visibilityTag = event.tags.find((t) => t[0] === 'visibility')
 		const visibility = visibilityTag?.[1] || 'on-sale' // Default to on-sale if not specified
 		return visibility !== 'hidden'
@@ -228,7 +235,17 @@ export const fetchProduct = async (id: string) => {
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	const event = Array.from(events)[0] ?? null
-	if (event) return event
+	if (event) {
+		// Check the test label for this item's coordinate (ADR-0009). A
+		// test-labeled product resolves to nothing in detail views.
+		const dTag = event.tagValue('d')
+		if (dTag) {
+			const coordinate = getATagFromCoords({ kind: 30402, pubkey: event.pubkey, identifier: dTag })
+			const labels = await fetchTestLabels([coordinate])
+			if (labels.has(coordinate)) return null
+		}
+		return event
+	}
 
 	throw new Error('Product not found')
 }
@@ -262,12 +279,15 @@ export const fetchProductsByPubkey = async (pubkey: string, includeHidden: boole
 	// Then filter out locally-deleted products
 	const filteredEvents = filterDeletedProducts(filterBlacklistedEvents(allEvents))
 
+	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
+	const nonTestLabeledEvents = await excludeTestLabeledEvents(filteredEvents)
+
 	// Filter out hidden products unless explicitly included
 	if (includeHidden) {
-		return filteredEvents
+		return nonTestLabeledEvents
 	}
 
-	return filteredEvents.filter((event) => {
+	return nonTestLabeledEvents.filter((event) => {
 		const visibilityTag = event.tags.find((t) => t[0] === 'visibility')
 		const visibility = visibilityTag?.[1] || 'on-sale' // Default to on-sale if not specified
 		if (visibility === 'hidden') return false
@@ -280,6 +300,14 @@ export const fetchProductByATag = async (pubkey: string, dTag: string) => {
 	const ndk = ndkActions.getNDK()
 	if (!ndk) throw new Error('NDK not initialized')
 	if (!pubkey || !dTag) return null
+
+	// Check the test label before resolving the item (ADR-0009). A
+	// test-labeled product resolves to null — the same depth of gating as
+	// blacklisted items.
+	const coordinate = getATagFromCoords({ kind: 30402, pubkey, identifier: dTag })
+	const labels = await fetchTestLabels([coordinate])
+	if (labels.has(coordinate)) return null
+
 	const naddr = naddrFromAddress(30402, pubkey, dTag)
 	return await ndk.fetchEvent(naddr)
 }
@@ -441,8 +469,11 @@ export const fetchProductsByCollection = async (collectionEvent: NDKEvent): Prom
 	// Filter out blacklisted products and authors, then filter out locally-deleted products
 	const filteredProducts = filterDeletedProducts(filterBlacklistedEvents(allProducts))
 
+	// Filter out test-labeled items (ADR-0009: runs beside the delete and blacklist checks)
+	const nonTestLabeledProducts = await excludeTestLabeledEvents(filteredProducts)
+
 	// Filter out out-of-stock products from collection views
-	return filteredProducts.filter(isProductInStock)
+	return nonTestLabeledProducts.filter(isProductInStock)
 }
 
 /**
@@ -1021,6 +1052,7 @@ export const fetchProductsBySearch = async (query: string, limit: number = 20) =
 			.fetchEvents(filter)
 			.then((events) => filterBlacklistedEvents(Array.from(events)))
 			.then((events) => filterDeletedProducts(events)) // Filter out locally-deleted products
+			.then((events) => excludeTestLabeledEvents(events)) // Filter out test-labeled items (ADR-0009)
 			.then((events) => events.filter(isProductInStock)) // Filter out out-of-stock products
 			.catch((err) => {
 				console.error('Product search fetch failed:', err)

--- a/src/queries/queryKeyFactory.ts
+++ b/src/queries/queryKeyFactory.ts
@@ -8,6 +8,12 @@ export const productKeys = {
 	paginated: (limit: number, until?: number) => [...productKeys.all, 'paginated', limit, until] as const,
 } as const
 
+export const testLabelKeys = {
+	all: ['testLabels'] as const,
+	forCoordinates: (coords: string[]) => [...testLabelKeys.all, 'coords', coords] as const,
+	forCoordinate: (coord: string) => [...testLabelKeys.all, 'coord', coord] as const,
+} as const
+
 export const auctionKeys = {
 	all: ['auctions'] as const,
 	details: (id: string) => [...auctionKeys.all, id] as const,

--- a/src/queries/testLabels.tsx
+++ b/src/queries/testLabels.tsx
@@ -1,7 +1,5 @@
 import { configActions } from '@/lib/stores/config'
-import { getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
 import { testLabelActions, type TestLabelInfo } from '@/lib/stores/testLabels'
-import { fetchAdminSettings } from '@/queries/app-settings'
 import { testLabelKeys } from '@/queries/queryKeyFactory'
 import { collectTestLabelCoordinates, filterTestLabeledEvents } from '@/lib/utils/testLabelFilters'
 import type { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk'
@@ -83,6 +81,7 @@ export const getAuthorizedLabelerPubkeys = async (): Promise<string[] | null> =>
 	}
 
 	try {
+		const { fetchAdminSettings } = await import('@/queries/app-settings')
 		const settings = await fetchAdminSettings(configActions.getAppPublicKey())
 		if (!settings) return null
 		authorizedLabelersCache = { fetchedAt: now, pubkeys: settings.admins }
@@ -189,6 +188,7 @@ export const reconcileActiveTestLabels = (
 
 const fetchAuthorizedLabelEvents = async (coordinates: string[], adminPubkeys: string[], relaySet?: NDKRelaySet): Promise<NDKEvent[]> => {
 	const labelEvents: NDKEvent[] = []
+	const { ndkActions } = await import('@/lib/stores/ndk')
 	for (const chunk of chunkStrings(coordinates, TEST_LABEL_FETCH_CHUNK_SIZE)) {
 		// Batched relay query: one filter for the whole chunk of coordinates.
 		// `#L` narrows to our namespace at the relay; tags are re-validated
@@ -207,6 +207,7 @@ const fetchAuthorizedLabelEvents = async (coordinates: string[], adminPubkeys: s
 
 const fetchLabelDeletionEvents = async (labelEventIds: string[], adminPubkeys: string[], relaySet?: NDKRelaySet): Promise<NDKEvent[]> => {
 	const deletionEvents: NDKEvent[] = []
+	const { ndkActions } = await import('@/lib/stores/ndk')
 	for (const chunk of chunkStrings(labelEventIds, TEST_LABEL_FETCH_CHUNK_SIZE)) {
 		const filter: NDKFilter = {
 			kinds: [LABEL_DELETION_KIND],
@@ -256,6 +257,7 @@ export const fetchTestLabels = async (coordinates: string[]): Promise<Map<string
 		const adminPubkeys = await getAuthorizedLabelerPubkeys()
 		if (adminPubkeys !== null) {
 			authorizationResolved = true
+			const { ndkActions, getAppRelaySet } = await import('@/lib/stores/ndk')
 			const ndk = ndkActions.getNDK()
 			if (ndk) {
 				let activeLabels = new Map<string, TestLabelInfo>()

--- a/src/queries/testLabels.tsx
+++ b/src/queries/testLabels.tsx
@@ -333,6 +333,9 @@ export const setCachedTestLabel = (coordinate: string, label: TestLabelInfo | nu
  * excludeTestLabeledEvents → (business filters) → return.
  */
 export const excludeTestLabeledEvents = async <T extends NDKEvent>(events: T[]): Promise<T[]> => {
+	// Show-test-listings toggle: reveal test-labeled items without filtering.
+	if (testLabelStore.state.showTestListings) return events
+
 	const coordinates = collectTestLabelCoordinates(events)
 	if (coordinates.length === 0) return events
 

--- a/src/queries/testLabels.tsx
+++ b/src/queries/testLabels.tsx
@@ -311,6 +311,17 @@ export const invalidateTestLabelCache = (coordinate?: string) => {
 }
 
 /**
+ * Write a label result into the module cache as if freshly fetched.
+ * Used by the publish flows to keep the optimistic store state consistent
+ * with the cache during the relay round-trip (prevents a concurrent refetch
+ * from reverting the optimistic update before propagation completes).
+ */
+export const setCachedTestLabel = (coordinate: string, label: TestLabelInfo | null) => {
+	if (!coordinate) return
+	testLabelCache.set(coordinate, { fetchedAt: Date.now(), label })
+}
+
+/**
  * Fetch labels for all item coordinates in an event list, then filter out
  * test-labeled items. This is the complete per-fetch label check used across
  * the product/auction fetch pipeline (Approach A in the handover: pre-fetch

--- a/src/queries/testLabels.tsx
+++ b/src/queries/testLabels.tsx
@@ -1,0 +1,372 @@
+import { configActions } from '@/lib/stores/config'
+import { getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
+import { testLabelActions, type TestLabelInfo } from '@/lib/stores/testLabels'
+import { fetchAdminSettings } from '@/queries/app-settings'
+import { testLabelKeys } from '@/queries/queryKeyFactory'
+import { collectTestLabelCoordinates, filterTestLabeledEvents } from '@/lib/utils/testLabelFilters'
+import type { NDKEvent, NDKFilter, NDKRelaySet } from '@nostr-dev-kit/ndk'
+import { useQuery, type QueryClient } from '@tanstack/react-query'
+import { useStore } from '@tanstack/react-store'
+import { useMemo } from 'react'
+import { testLabelStore } from '@/lib/stores/testLabels'
+import {
+	A_TAG,
+	E_TAG,
+	K_TAG,
+	L_TAG,
+	LABEL_DELETION_KIND,
+	LABEL_EVENT_KIND,
+	LABEL_NAMESPACE,
+	LABEL_VALUE_TEST,
+	l_TAG,
+} from '@/lib/constants/testLabels'
+
+/**
+ * ADR-0009 — Test-listing curation via NIP-32 labels.
+ *
+ * Label events (kind 1985) mark a product/auction coordinate as a "test"
+ * listing. Labels count only when signed by an authorized labeler (the admin
+ * set). Un-labeling is a NIP-09 deletion event (kind 5) referencing the label
+ * event's id in an `e` tag, signed by the same labeler.
+ *
+ * Coordinates are fetched in batches (one relay query per chunk) so feeds can
+ * check every item on the page without N+1 queries. Results populate the
+ * test-label store; the query-layer filter (`filterTestLabeledEvents`) reads
+ * the store synchronously afterwards.
+ */
+
+// --- Fetch tuning ---
+
+/** Max coordinates per relay filter (`#a` chunk) */
+const TEST_LABEL_FETCH_CHUNK_SIZE = 100
+
+/** Relay fetch timeout for label/deletion events */
+const TEST_LABEL_FETCH_TIMEOUT_MS = 8000
+
+/** How long a fetched label result stays fresh in the module cache */
+const TEST_LABEL_CACHE_TTL_MS = 15_000
+
+/** How long the authorized-labeler list stays fresh */
+const AUTHORIZED_LABELERS_CACHE_TTL_MS = 15_000
+
+interface CachedLabelEntry {
+	fetchedAt: number
+	label: TestLabelInfo | null
+}
+
+const testLabelCache = new Map<string, CachedLabelEntry>()
+
+let authorizedLabelersCache: { fetchedAt: number; pubkeys: string[] } | null = null
+
+const chunkStrings = (values: string[], size: number): string[][] => {
+	const chunks: string[][] = []
+	for (let index = 0; index < values.length; index += size) {
+		chunks.push(values.slice(index, index + size))
+	}
+	return chunks
+}
+
+// --- Authorized labelers ---
+
+/**
+ * Authorized labelers = the app's admin set (ADR-0009). A dedicated moderator
+ * list or automated labeler key can be enrolled later without protocol change.
+ *
+ * Returns null when the admin settings are not available yet (NDK/relay not
+ * ready) — callers must treat that as "cannot determine authorization" and
+ * fail open (no labels applied, store not marked loaded).
+ */
+export const getAuthorizedLabelerPubkeys = async (): Promise<string[] | null> => {
+	const now = Date.now()
+	if (authorizedLabelersCache && now - authorizedLabelersCache.fetchedAt < AUTHORIZED_LABELERS_CACHE_TTL_MS) {
+		return authorizedLabelersCache.pubkeys
+	}
+
+	try {
+		const settings = await fetchAdminSettings(configActions.getAppPublicKey())
+		if (!settings) return null
+		authorizedLabelersCache = { fetchedAt: now, pubkeys: settings.admins }
+		return settings.admins
+	} catch (error) {
+		console.warn('Failed to fetch authorized labelers (admin settings):', error)
+		return null
+	}
+}
+
+// --- Event validation ---
+
+/**
+ * Item coordinates targeted by a label event's `a` tags.
+ * Per ADR-0009 we only act on `a`-tag (item) targets — a `p` tag would label
+ * the user and is intentionally out of scope.
+ */
+export const getLabelTargetCoordinates = (event: NDKEvent): string[] => {
+	return event.tags.filter((tag) => tag[0] === A_TAG && !!tag[1]).map((tag) => tag[1])
+}
+
+/**
+ * A label event counts only when:
+ * - it is a kind-1985 event,
+ * - signed by an authorized labeler,
+ * - `L` tag is our namespace,
+ * - `l` tag is `test` within our namespace,
+ * - it targets at least one item coordinate (`a` tag).
+ */
+export const isValidAuthorizedTestLabel = (event: NDKEvent, authorizedLabelers: string[]): boolean => {
+	if (event.kind !== LABEL_EVENT_KIND) return false
+	// Only authorized labelers' labels count (ADR-0009)
+	if (!authorizedLabelers.includes(event.pubkey)) return false
+	// NIP-32: L tag must carry our namespace
+	if (!event.tags.some((tag) => tag[0] === L_TAG && tag[1] === LABEL_NAMESPACE)) return false
+	// NIP-32: l tag value must be "test" scoped to our namespace
+	if (!event.tags.some((tag) => tag[0] === l_TAG && tag[1] === LABEL_VALUE_TEST && tag[2] === LABEL_NAMESPACE)) return false
+	// Must target an item coordinate
+	return event.tags.some((tag) => tag[0] === A_TAG && !!tag[1])
+}
+
+/**
+ * NIP-09 deletion validation: a deletion applies to a label event only when
+ * it references the label event's id in an `e` tag AND is signed by the same
+ * pubkey as the label event (NIP-09 MUST). The `k` tag is a SHOULD — when
+ * present it must declare kind 1985 to apply to our labels.
+ */
+export const isLabelDeletionForLabel = (deletion: NDKEvent, label: NDKEvent): boolean => {
+	if (deletion.kind !== LABEL_DELETION_KIND) return false
+	if (deletion.pubkey !== label.pubkey) return false
+	const referencesLabel = deletion.tags.some((tag) => tag[0] === E_TAG && tag[1] === label.id)
+	if (!referencesLabel) return false
+	const kTags = deletion.tags.filter((tag) => tag[0] === K_TAG && tag[1]).map((tag) => tag[1])
+	if (kTags.length > 0 && !kTags.includes(String(LABEL_EVENT_KIND))) return false
+	return true
+}
+
+// --- Reconciliation (pure, unit-tested) ---
+
+/**
+ * Determine which coordinates carry an ACTIVE test label.
+ *
+ * A coordinate is labeled if ANY authorized label event targeting it has no
+ * matching NIP-09 deletion (§7.7 of the handover). When several active labels
+ * exist for one coordinate, the newest one's metadata is returned.
+ *
+ * @param labelEvents authorized kind-1985 label events
+ * @param deletionEvents kind-5 deletion events that may reference those labels
+ * @param requestedCoordinates when provided, only these coordinates are returned
+ */
+export const reconcileActiveTestLabels = (
+	labelEvents: NDKEvent[],
+	deletionEvents: NDKEvent[],
+	requestedCoordinates?: string[],
+): Map<string, TestLabelInfo> => {
+	const requested = requestedCoordinates ? new Set(requestedCoordinates) : null
+
+	// Newest active label per coordinate
+	const activeByCoordinate = new Map<string, NDKEvent>()
+
+	for (const label of labelEvents) {
+		if (label.kind !== LABEL_EVENT_KIND) continue
+		// Skip labels whose NIP-09 deletion has been seen — the item reappears
+		const isDeleted = deletionEvents.some((deletion) => isLabelDeletionForLabel(deletion, label))
+		if (isDeleted) continue
+
+		for (const coordinate of getLabelTargetCoordinates(label)) {
+			if (requested && !requested.has(coordinate)) continue
+			const existing = activeByCoordinate.get(coordinate)
+			if (!existing || (label.created_at ?? 0) >= (existing.created_at ?? 0)) {
+				activeByCoordinate.set(coordinate, label)
+			}
+		}
+	}
+
+	const result = new Map<string, TestLabelInfo>()
+	for (const [coordinate, label] of Array.from(activeByCoordinate)) {
+		result.set(coordinate, { eventId: label.id, labelerPubkey: label.pubkey })
+	}
+	return result
+}
+
+// --- Relay fetching ---
+
+const fetchAuthorizedLabelEvents = async (coordinates: string[], adminPubkeys: string[], relaySet?: NDKRelaySet): Promise<NDKEvent[]> => {
+	const labelEvents: NDKEvent[] = []
+	for (const chunk of chunkStrings(coordinates, TEST_LABEL_FETCH_CHUNK_SIZE)) {
+		// Batched relay query: one filter for the whole chunk of coordinates.
+		// `#L` narrows to our namespace at the relay; tags are re-validated
+		// client-side for relays that ignore unknown single-letter tag filters.
+		const filter: NDKFilter = {
+			kinds: [LABEL_EVENT_KIND],
+			'#a': chunk,
+			'#L': [LABEL_NAMESPACE],
+			...(adminPubkeys.length > 0 ? { authors: adminPubkeys } : {}),
+		}
+		const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: TEST_LABEL_FETCH_TIMEOUT_MS, relaySet })
+		labelEvents.push(...Array.from(events))
+	}
+	return labelEvents
+}
+
+const fetchLabelDeletionEvents = async (labelEventIds: string[], adminPubkeys: string[], relaySet?: NDKRelaySet): Promise<NDKEvent[]> => {
+	const deletionEvents: NDKEvent[] = []
+	for (const chunk of chunkStrings(labelEventIds, TEST_LABEL_FETCH_CHUNK_SIZE)) {
+		const filter: NDKFilter = {
+			kinds: [LABEL_DELETION_KIND],
+			'#e': chunk,
+			...(adminPubkeys.length > 0 ? { authors: adminPubkeys } : {}),
+		}
+		const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: TEST_LABEL_FETCH_TIMEOUT_MS, relaySet })
+		deletionEvents.push(...Array.from(events))
+	}
+	return deletionEvents
+}
+
+/**
+ * Fetch the active test labels for a set of item coordinates.
+ *
+ * For each coordinate this looks for kind-1985 label events (filtered to
+ * authorized labelers and our namespace) and reconciles them against kind-5
+ * deletion events, so a freshly un-labeled item is not kept hidden by a stale
+ * cached label (§7.5 of the handover).
+ *
+ * Results are cached per coordinate for {@link TEST_LABEL_CACHE_TTL_MS} and
+ * the store is reconciled with the fetched truth.
+ *
+ * @returns Map of coordinate → label metadata for coordinates with an ACTIVE label
+ */
+export const fetchTestLabels = async (coordinates: string[]): Promise<Map<string, TestLabelInfo>> => {
+	const uniqueCoordinates = Array.from(new Set(coordinates.filter(Boolean)))
+	if (uniqueCoordinates.length === 0) return new Map()
+
+	const now = Date.now()
+	const result = new Map<string, TestLabelInfo>()
+	const staleCoordinates: string[] = []
+
+	for (const coordinate of uniqueCoordinates) {
+		const cached = testLabelCache.get(coordinate)
+		if (cached && now - cached.fetchedAt < TEST_LABEL_CACHE_TTL_MS) {
+			if (cached.label) result.set(coordinate, cached.label)
+		} else {
+			staleCoordinates.push(coordinate)
+		}
+	}
+
+	// Cache hits imply a prior successful fetch, so the store can be synced for them.
+	let authorizationResolved = staleCoordinates.length === 0
+
+	if (staleCoordinates.length > 0) {
+		const adminPubkeys = await getAuthorizedLabelerPubkeys()
+		if (adminPubkeys !== null) {
+			authorizationResolved = true
+			const ndk = ndkActions.getNDK()
+			if (ndk) {
+				let activeLabels = new Map<string, TestLabelInfo>()
+				if (adminPubkeys.length > 0) {
+					const relaySet = getAppRelaySet()
+					const labelEvents = await fetchAuthorizedLabelEvents(staleCoordinates, adminPubkeys, relaySet)
+
+					// Validate labels and collect their ids for the deletion lookup
+					const candidateLabels = labelEvents.filter((event) => isValidAuthorizedTestLabel(event, adminPubkeys))
+					const labelEventIds = Array.from(new Set(candidateLabels.map((event) => event.id).filter(Boolean)))
+
+					const deletionEvents = labelEventIds.length > 0 ? await fetchLabelDeletionEvents(labelEventIds, adminPubkeys, relaySet) : []
+					activeLabels = reconcileActiveTestLabels(candidateLabels, deletionEvents, staleCoordinates)
+				}
+				// An empty authorized set means no labels can exist — nothing to fetch.
+
+				// Write-through cache (including "no label" results) and reconcile the store
+				const fetchedAt = Date.now()
+				for (const coordinate of staleCoordinates) {
+					const label = activeLabels.get(coordinate) ?? null
+					testLabelCache.set(coordinate, { fetchedAt, label })
+					if (label) result.set(coordinate, label)
+				}
+				testLabelActions.applyFetchedLabels(activeLabels, staleCoordinates)
+			}
+			// If NDK is not ready the store stays "not loaded" — the filter is a
+			// no-op so items are not hidden based on missing data.
+		}
+	}
+
+	// Sync the store with the full known truth for the requested coordinates,
+	// including cache-hit entries (keeps store and cache consistent after
+	// optimistic updates). Skipped when authorization was unavailable — the
+	// store must stay "not loaded" so filtering fails open.
+	if (authorizationResolved) {
+		testLabelActions.applyFetchedLabels(result, uniqueCoordinates)
+	}
+
+	return result
+}
+
+/**
+ * Drop the module-level label cache (all coordinates, or one).
+ * Called after publishing label/deletion events so the next fetch reconciles
+ * with the relay instead of serving a stale cache entry.
+ */
+export const invalidateTestLabelCache = (coordinate?: string) => {
+	if (coordinate) {
+		testLabelCache.delete(coordinate)
+	} else {
+		testLabelCache.clear()
+	}
+}
+
+/**
+ * Fetch labels for all item coordinates in an event list, then filter out
+ * test-labeled items. This is the complete per-fetch label check used across
+ * the product/auction fetch pipeline (Approach A in the handover: pre-fetch
+ * labels, then apply the synchronous store-based filter).
+ *
+ * Pipeline position: NDK fetch → filterDeleted* → filterBlacklistedEvents →
+ * excludeTestLabeledEvents → (business filters) → return.
+ */
+export const excludeTestLabeledEvents = async <T extends NDKEvent>(events: T[]): Promise<T[]> => {
+	const coordinates = collectTestLabelCoordinates(events)
+	if (coordinates.length === 0) return events
+
+	await fetchTestLabels(coordinates)
+
+	return filterTestLabeledEvents(events)
+}
+
+// --- React Query hooks ---
+
+/**
+ * Fetch test labels for a batch of coordinates and populate the label store.
+ * The query key is the sorted, deduplicated coordinate set so different
+ * orderings don't bust the cache.
+ */
+export const useTestLabels = (coordinates: string[]) => {
+	const stableCoordinates = useMemo(() => Array.from(new Set(coordinates.filter(Boolean))).sort(), [coordinates.join(',')])
+
+	return useQuery({
+		queryKey: testLabelKeys.forCoordinates(stableCoordinates),
+		queryFn: () => fetchTestLabels(stableCoordinates),
+		enabled: stableCoordinates.length > 0,
+		staleTime: TEST_LABEL_CACHE_TTL_MS,
+		gcTime: 60_000,
+	})
+}
+
+/**
+ * Reactive label state for a single coordinate. Fetches the label from the
+ * relay on mount (populating the store) and keeps the component in sync with
+ * store updates (e.g. optimistic mark/un-mark).
+ */
+export const useTestLabelForCoordinate = (coordinate: string | undefined) => {
+	useTestLabels(coordinate ? [coordinate] : [])
+
+	const isLabeled = useStore(testLabelStore, (state) => (coordinate ? state.testLabelCoordinates.has(coordinate) : false))
+	const labelEventId = useStore(testLabelStore, (state) => (coordinate ? (state.labelEventIds.get(coordinate) ?? '') : ''))
+	const labelerPubkey = useStore(testLabelStore, (state) => (coordinate ? (state.labelerPubkeys.get(coordinate) ?? '') : ''))
+
+	return { isLabeled, labelEventId, labelerPubkey }
+}
+
+/**
+ * Invalidate the test-label caches (module cache + React Query) after a
+ * label or deletion was published.
+ */
+export const invalidateTestLabelCaches = async (queryClient: QueryClient, coordinate?: string) => {
+	invalidateTestLabelCache(coordinate)
+	await queryClient.invalidateQueries({ queryKey: testLabelKeys.all })
+}

--- a/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/auctions.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils'
 import { Media } from '@/components/Media'
 import { AvatarUser } from '@/components/AvatarUser'
 import { AuctionCountdown } from '@/components/AuctionCountdown'
+import { TestLabelButton } from '@/components/dashboard/TestLabelButton'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
@@ -30,6 +31,7 @@ import {
 } from '@/queries/auctions'
 import { useComments } from '@/queries/comments'
 import { useLiveActivity, useLiveChatMessages } from '@/queries/liveChat'
+import { AUCTION_KIND } from '@/lib/auction/constants'
 import { getOrderId } from '@/queries/orders'
 import { useProfileName } from '@/queries/profiles'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -409,6 +411,14 @@ function AuctionListItem({
 							Open Auction
 						</Button>
 					</Link>
+					{/* ADR-0009: authorized labelers can mark / unmark this auction as a test listing */}
+					<TestLabelButton
+						kind={AUCTION_KIND}
+						pubkey={auction.pubkey}
+						dTag={getAuctionId(auction)}
+						itemLabel="Auction"
+						className="w-full lg:w-32"
+					/>
 				</div>
 
 				<div className="flex min-w-0 flex-1 flex-col gap-4 lg:max-w-[28rem]">

--- a/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
+++ b/src/routes/_dashboard-layout/dashboard/products/products/$productId.tsx
@@ -1,4 +1,5 @@
 import { ProductFormContent } from '@/components/sheet-contents/NewProductContent'
+import { TestLabelButton } from '@/components/dashboard/TestLabelButton'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 import { resolveProductWorkflow } from '@/lib/workflow/productWorkflowResolver'
@@ -138,5 +139,15 @@ function EditProductComponent() {
 	}
 
 	// Ready to show the form - pass productDTag for draft checking and productId for reloading
-	return <ProductFormContent showFooter={true} productDTag={productDTag} productEventId={productId} workflow={workflow} />
+	return (
+		<div className="space-y-4">
+			{/* ADR-0009: authorized labelers can mark / unmark this item as a test listing */}
+			{productDTag && (
+				<div className="flex justify-end">
+					<TestLabelButton kind={30402} pubkey={product.pubkey} dTag={productDTag} itemLabel="Product" />
+				</div>
+			)}
+			<ProductFormContent showFooter={true} productDTag={productDTag} productEventId={productId} workflow={workflow} />
+		</div>
+	)
 }

--- a/src/routes/products.index.tsx
+++ b/src/routes/products.index.tsx
@@ -24,6 +24,7 @@ import {
 import { useConfigQuery } from '@/queries/config'
 import { useFeaturedProducts } from '@/queries/featured'
 import { SelectableBadge } from '@/components/shared/SelectableBadge'
+import { ShowTestListingsToggle } from '@/components/ShowTestListingsToggle'
 
 // Hook to inject dynamic CSS for background image
 function useHeroBackground(imageUrl: string, className: string) {
@@ -351,7 +352,10 @@ function ProductsRoute() {
 							))}
 						</div>
 					</div>
-					<ProductFilters filters={filters} onFiltersChange={setFilters} />
+					<div className="flex items-center gap-3">
+						<ShowTestListingsToggle />
+						<ProductFilters filters={filters} onFiltersChange={setFilters} />
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
> **Architecture change (rev 3):** the test label now hides items only from browsing/discovery surfaces (home feed, paginated browse, search, collections, auction feed). A labeled item stays reachable via direct link, the seller's profile, and the owner's dashboard, and a "Show test listings" toggle (all users, default hidden) reveals filtered items. This resolves the earlier review finding (B1: unmark unreachable after reload) at its root and amends ADR-0009 in the same branch.

## What this PR is

Implementation of **ADR-0009: Test-Listing Curation via NIP-32 Labels** (the ADR itself merged separately in #1265). Adds:

- **Phase 1+2** — test-label schema, store, fetch, and query-layer filter
- **Phase 3** — dashboard "Mark/Unmark as Test" actions
- **Phase 4** — e2e tests + streaming-feed label check
- **fix** — lazy-load `ndk`/`app-settings` in `testLabels` to break the import cycle that was failing `unit-integration` CI

## Relationship

- **#1243** (closed): rev 1 blacklist approach — superseded by rev 2 (NIP-32 labels).
- **#1265** (merged): the ADR. This PR builds on it.
- **This PR**: the implementation.

## Review notes

- The label filter is layered alongside the existing delete/blacklist filters in the query layer (`products.tsx`, `auctions.tsx`). Labels are kind-1985 events signed by authorized labelers, reconciled against NIP-09 kind-5 deletion events so an un-labeled item reappears correctly.
- The final commit fixes a static import cycle (`testLabels → stores/ndk` and `→ app-settings`, closing a loop through `products.tsx`) that made `bun test` fail `unit-integration` with `SyntaxError: Export named 'getAppRelaySet' not found in module .../stores/ndk.ts`. CI actually runs tests under the repo's pinned `bun@1.3.4` (the `node_modules/.bin/bun` shim), not the `bun-version: latest` runner. Since all three consumers were already inside `async` functions, they now `await import(...)` lazily — no behavior change.

Docs-only: **no** — this is the feature branch (src + e2e). CI is green: unit/integration, prettier, footprint, and security-scan all pass.
