### PR TITLE
Port lost review fixes + staged bid-progress UX (idempotent retry, verdict quorum, QR-path lifecycle) — stacked on #1235

### DIFF
--- a/.git-pr-body.md
+++ b/.git-pr-body.md
@@ -1,0 +1,37 @@
+# Direct Lightning invoice funding for auction bids
+
+Supersedes #1205 by @hkarani (no longer active). All 7 should-fix items + 5 nits from that PR's review are addressed here, plus additional hardening, tests, and [ADR-0004](docs/adr/ADR-0004-direct-lightning-bid-funding.md).
+
+## What it does
+
+Replaces the old "insufficient balance → generic wallet top-up" path with a dedicated bid-funding flow: when the bidder's NIP-60 wallet can't cover the bid delta, the app creates a Lightning invoice for the exact amount (fee padding included) that mints e-cash directly to one of the auction's accepted mints. Once the invoice is paid and the e-cash is minted, the bid publishes automatically — no separate top-up step, no manual re-entry of the bid.
+
+## How it works
+
+- `src/hooks/useAuctionBidFunding.ts` — a 13-state lifecycle state machine mapped 1:1 to ADR-0004 §"Payment and Bid State Model": funding session → invoice created → payment acknowledged → minting → e-cash minted → (rules-ack gate) → bid publish attempted → bid published, with explicit reclaimable failure states and guarded transitions (`canTransitionAuctionBidFundingState`).
+- `src/lib/stores/nip60.ts` — fee-aware deposit quote estimation (Lightning fee padding + mint fee padding, preferring mint-provided quotes with a conservative fallback); wallet-acknowledgment/mint-confirmation timeout policy with an in-modal "Retry confirmation"; dev-mode test mints default to `https://testnut.cashu.space` with a `APP_DEV_TEST_MINT_URL` override for local nutshell mints.
+- `src/components/AuctionBidder.tsx` — bid UI wired to the funding path; bidder chooses among the seller-provided mint options; rules acknowledgment is scoped per-auction (`auction-rules-ack:<version>:<bidder>:<auction-identity>`) and gates the first bid on each auction; on the funded path a bid whose rules aren't yet acknowledged is held in `ecash_minted_pending_rules_ack` until acknowledged, then published.
+- `src/feature/wallet/components/DepositLightningModal.tsx` — "Bid with lightning" quick-view variant: generate / pay (paste or NWC) / confirm a funding invoice without leaving the bid flow; retry-confirmation affordance on timeout.
+- `src/lib/wallet/proofs.ts` — `getSpendableProofsForMint` returns only spendable proofs (filters `spent`/`deleted`) so proofs cannot be reused for a new bid or send; logs when it falls back to dump-based extraction.
+
+## Reclaimable failure states — how funds are recovered
+
+- `invoice_unpaid_or_expired_reclaimable` — invoice never paid, no funds moved. Recovery = retry the bid, which opens a fresh funding session.
+- `invoice_paid_mint_failed_reclaimable` — invoice paid but mint confirmation failed/timed out. The paid mint quote stays valid at the mint; the modal's "Retry confirmation" button (`nip60Actions.retryDepositConfirmation()` → `activeDeposit.check()`) completes minting into the wallet.
+- `mint_succeeded_bid_publish_failed_reclaimable` — e-cash is already minted into the bidder's wallet as ordinary spendable balance; only the Nostr publish failed. Retry the bid (balance is now sufficient) or spend the funds elsewhere — nothing is locked, no separate reclaim needed.
+- Separately, sats locked in P2PK bid outputs are reclaimed after auction locktime via the pre-existing `nip60Actions.reclaimToken()` auto-reclaim sweep.
+
+## Testing
+
+- Unit: `bun run test:unit` — 844 tests pass, incl. new `auctionBidFundingLifecycle.test.ts` (state-machine transition integrity), `nip60.test.ts`, `proofs.test.ts`, `auctionMintSelection.test.ts`.
+- Integration: `CVM_SERVER_KEY=<key> bun run test:integration` — 11 tests pass.
+- E2E: `e2e/tests/auction-bidding-mints.spec.ts` (+642 lines) — run with `bun run test:e2e -- e2e/tests/auction-bidding-mints.spec.ts`. The suite runs against a **local Cashu mint** (nutshell with FakeWallet backend, auto-settles invoices instantly) that Playwright itself starts via `e2e/start-local-mint.sh` as a `webServer` (port 3338, `reuseExistingServer`), with `APP_DEV_TEST_MINT_URL=http://localhost:3338` pointed at it. No external Lightning node or testnet mint is needed, so the e2e CI job is self-contained.
+
+## Manual test walkthrough
+
+1. Open an auction bid screen with insufficient wallet balance.
+2. Confirm the UI routes through the direct Lightning funding path (quick-view invoice modal) instead of a generic pre-top-up.
+3. Select one of the seller-provided mints; confirm the invoice amount includes fee padding.
+4. Pay the invoice and verify the bid continues automatically with the minted e-cash.
+
+Continues the work of @hkarani from #1205. 🤝

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Python for local Cashu mint
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
 
       - name: Install Cashu (nutshell) mint
         run: pip install cashu

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -80,6 +80,14 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: bunx playwright install-deps chromium
 
+      - name: Setup Python for local Cashu mint
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Cashu (nutshell) mint
+        run: pip install cashu
+
       - name: Start relay
         run: |
           nohup nak serve --hostname 0.0.0.0 > /tmp/relay.log 2>&1 &
@@ -93,6 +101,21 @@ jobs:
           done
           echo "::error::Relay failed to start. Logs:"
           cat /tmp/relay.log
+          exit 1
+
+      - name: Start local Cashu mint
+        run: |
+          nohup bash e2e/start-local-mint.sh > /tmp/mint.log 2>&1 &
+          echo "Waiting for local Cashu mint on port 3338..."
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3338/v1/info > /dev/null 2>&1; then
+              echo "Cashu mint is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Cashu mint failed to start. Logs:"
+          cat /tmp/mint.log
           exit 1
 
       - name: Seed relay and start dev server
@@ -117,9 +140,10 @@ jobs:
           APP_PRIVATE_KEY: e2e0000000000000000000000000000000000000000000000000000000000001
           CVM_SERVER_KEY: e2e2222222222222222222222222222222222222222222222222222222222222
           LOCAL_RELAY_ONLY: 'true'
+          APP_DEV_TEST_MINT_URL: 'http://localhost:3338'
 
       - name: Run E2E tests
-        run: bun run test:e2e -- --grep 'Navigation|User Profile|Shipping Option Creation|Community Tab Progressive Loading|Order Details|Marketplace Display|V4V Dashboard Management|Receiving Payments Configuration|Product Page - View Only'
+        run: bun run test:e2e -- --grep 'Navigation|User Profile|Shipping Option Creation|Community Tab Progressive Loading|Order Details|Marketplace Display|V4V Dashboard Management|Receiving Payments Configuration|Product Page - View Only|Auction Bidding'
 
       - name: Show server logs on failure
         if: failure()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,11 @@ already exists.
 
 Tests must not make network calls to external services. The only allowed
 network dependencies are local services started in CI workflows (local
-relay via `nak serve`, local dev server on port 3333, ContextVM). All
-other external services (CDNs, Cashu mints, Lightning nodes, third-party
+relay via `nak serve`, local dev server on port 3333, local Cashu mint on
+port 3338, ContextVM). The local Cashu mint is a real nutshell mint with
+the FakeWallet backend, started by `e2e/start-local-mint.sh` (see the
+"Local Cashu Mint" section in `e2e/ARCHITECTURE.md`). All other external
+services (CDNs, remote Cashu mints, real Lightning nodes, third-party
 APIs) must be mocked or intercepted.
 
 See ADR-0005 for the full decision and established mock patterns.

--- a/docs/adr/ADR-0004-direct-lightning-bid-funding.md
+++ b/docs/adr/ADR-0004-direct-lightning-bid-funding.md
@@ -1,0 +1,252 @@
+# ADR-0004: Direct Lightning Invoice Funding for Auction Bids
+
+## Status
+
+Proposed
+
+## Date
+
+2026-07-31
+
+## Scope
+
+This ADR defines implementation decisions for auction bid funding via direct Lightning invoices.
+
+This ADR does not define broader wallet redesign, global payment abstractions, or non-auction checkout changes.
+
+## Context
+
+The current auction bid flow requires users to pre-fund a wallet with e-cash via Lightning before they can bid.
+
+This creates two user and product issues:
+
+- Funds are held in the user's wallet before a bid is actually placed, increasing custody-like friction for normal bidding activity.
+- Users must repeatedly top up wallet balance during bidding sessions when balance becomes insufficient.
+
+For auction participation, users should be able to fund a bid at the moment of intent, not through repeated pre-deposit steps.
+
+## Decision
+
+Adopt a direct Lightning invoice bid-funding flow that replaces the current insufficient-balance deposit prompt during bidding.
+
+When a user submits a bid:
+
+1. The system calculates the required bid funding amount, including e-cash transaction fees.
+2. The system resolves the seller-provided mint options and validates mint eligibility constraints.
+3. The user is prompted to pay a Lightning invoice for that selected mint target.
+4. After the invoice is acknowledged as paid, funds are minted as e-cash via that mint and prepared for bid locking.
+5. The bid is placed immediately using the minted e-cash.
+
+This flow replaces the current behavior where insufficient wallet balance leads users into a generic wallet top-up flow before bidding can continue.
+
+## Implementation Decisions
+
+### Decision 1: Auction bidding uses an invoice-first funding path
+
+When wallet balance is insufficient for a bid, the auction bid flow must invoke direct invoice funding instead of redirecting users to a generic pre-deposit top-up path.
+
+### Decision 2: Funding orchestration is isolated behind a dedicated boundary
+
+Implementation should introduce or use a dedicated funding orchestration boundary for:
+
+- invoice creation
+- payment detection and acknowledgment
+- mint quote/mint execution
+- handoff to bid publish
+
+This logic should not be embedded directly in UI components.
+
+### Decision 3: Bid publish is gated on minted e-cash availability
+
+A bid publish attempt is allowed only after the Lightning payment is acknowledged and the selected mint returns spendable e-cash proofs for the required amount.
+
+### Decision 3a: Invoice amount must include fee padding
+
+Invoice calculation must include the bid amount plus fee padding for both Lightning fees and e-cash mint transaction fees.
+
+When possible, fee values should be queried from the selected mint to produce an exact required amount for the mint-fee portion.
+
+If exact fee values are not available, the system must use a conservative estimate that does not fall below the actual required fee.
+
+### Decision 3b: Wallet acknowledgment and mint confirmation timeout policy
+
+Wallet acknowledgment and mint confirmation checks use a 15-second timeout per transaction attempt.
+
+When timeout is reached, the flow must expose a manual retry path.
+
+### Decision 4: Single-mint bids are the baseline design
+
+The baseline implementation assumes one selected mint per bid funding flow.
+
+Multi-mint bid funding is not required for this ADR and should be treated as a future extension if product requirements change.
+
+### Decision 5: Bid-lock conversion occurs only after the single invoice is paid
+
+For the baseline single-invoice flow, bid-lock conversion must occur only after the invoice is paid and the selected mint returns spendable e-cash proofs.
+
+If the invoice fails or expires, no bid lock conversion or bid publication occurs.
+
+### Decision 6: Invoice failure preserves reclaimability
+
+If a single invoice payment fails, expires, or is otherwise not acknowledged, the funding attempt must remain reclaimable and must not leave the user with an unrecoverable intermediate state.
+
+### Decision 7: Bidder selects one mint from seller-provided mints
+
+The bidder can only select a single mint from the mints provided by the seller.
+
+Invoice generation must use only that bidder-selected mint after eligibility and policy checks.
+
+### Decision 8: Failure modes are explicit and recoverable
+
+Implementations must preserve and expose at least these distinct failure classes:
+
+- invoice expired or unpaid
+- invoice paid but mint failed
+- mint succeeded but bid publish failed
+
+Each class should support deterministic retry or compensating action, instead of collapsing into a generic payment failed outcome.
+
+### Decision 9: Mint-success and publish-failure requires reconciliation
+
+If e-cash minting succeeds and bid publish fails, minted funds must remain reclaimable to the user and the flow must surface a resumable retry path for publish.
+
+### Decision 9a: Publish retries are user-confirmed
+
+Retrying bid publish after a publish failure must be user-confirmed, not automatic.
+
+### Decision 10: Losing bids return reclaimable value as e-cash
+
+When a bid loses, reclaimable funds are refunded as e-cash and represented with dedicated refund lifecycle states.
+
+### Decision 10a: Refund processing and withdrawal UX
+
+Losing-bid e-cash refunds should be processed automatically.
+
+After refund processing, funds available to withdraw via Lightning must be clearly highlighted to the user, while withdrawal remains a manual action so the user can provide a destination address.
+
+### Decision 11: State transitions remain distinct across payment lifecycle
+
+Wallet acknowledgment, invoice payment, e-cash minting, bid publication, and auction settlement/refund outcomes must remain separate lifecycle transitions in code and UI.
+
+### Decision 12: Payment/privacy-safe telemetry and logs only
+
+Errors, logs, and telemetry must avoid leaking sensitive payment material such as invoice preimages, token proofs, seed material, or private wallet configuration.
+
+## Payment and Bid State Model
+
+The bid flow must preserve explicit lifecycle states and not collapse them into a single paid/unpaid flag.
+
+Minimum states for this flow:
+
+- Bid requested
+- Funding session created
+- Mint target resolved
+- Invoice created
+- Invoice payment attempted
+- Invoice paid
+- Invoice expired or unpaid
+- Wallet acknowledged payment
+- E-cash minting attempted
+- E-cash minted
+- Bid lock conversion attempted
+- Bid lock conversion complete
+- Bid publish attempted
+- Bid published
+- Bid funding failed
+- Bid publish failed
+- Funding failed, funds reclaimable
+
+Auction outcome states relevant to reclaimable funds:
+
+- Bid lost, reclaimable
+- Refund minted as e-cash
+- Refund claim published or acknowledged (implementation-specific)
+
+## Consequences
+
+- Improved bidder UX: users pay only when placing a bid, reducing repeated top-ups and idle wallet balances.
+- Reduced pre-funding friction: bidding becomes invoice-first instead of wallet-balance-first.
+- Clearer operational semantics: funding, minting, and bid publication are tracked as separate state transitions.
+- Fee correctness becomes a hard requirement: invoice amounts must include e-cash transaction fees to avoid underfunded bid attempts.
+- Fee policy is explicit: invoices include padding for both Lightning fees and e-cash mint fees.
+- Failure handling requirements: the app must handle invoice-paid-but-mint-failed and mint-successful-but-bid-publish-failed paths explicitly.
+- Single-invoice simplicity: the baseline flow remains focused on one invoice and one mint target per bid.
+- Mint-selection boundary is explicit: bidder selection is limited to seller-provided mint options.
+- Refund handling requirement: if a bid loses, reclaimable funds are refunded as e-cash.
+- Testing requirement: integration tests should cover success path, payment interruption, mint failure, publish failure, and losing-bid refund path.
+
+## Non-goals
+
+- No change to non-auction order checkout payment flow.
+- No assumption that wallet acknowledgment equals final settlement.
+- No removal of explicit refund and failure states.
+- No requirement to remove optional manual top-up for unrelated workflows.
+
+## Implementation Plan
+
+### PR 1: Funding orchestration boundary and state machine
+
+Scope:
+
+- add direct invoice funding orchestration for bidding
+- add single-invoice funding state machine with payment and mint checkpoints
+- add fee quote/estimate handling that prefers exact mint-provided values
+- add 15-second timeout handling for wallet acknowledgment and mint confirmation, with manual retry state
+- encode explicit funding and bid publish states
+- preserve recovery metadata for retries
+
+### PR 2: Bid flow integration
+
+Scope:
+
+- wire auction bid submit to invoice-first funding path
+- render the selected invoice and payment status in the bidding UX
+- surface seller-provided mint options and selected mint-target plan before payment
+- enforce bidder mint selection only from seller-provided mint options
+- replace insufficient-balance top-up prompt in auction bidding UX
+- gate publish on minted-proof readiness
+
+### PR 3: Refund and reconciliation paths
+
+Scope:
+
+- implement losing-bid reclaim as e-cash refund lifecycle
+- implement invoice-failure reclaim and redeem flow for abandoned funding attempts
+- implement invoice-paid/mint-failed and mint-succeeded/publish-failed reconciliation behavior
+- implement automatic refund processing and highlighted manual Lightning withdrawal action
+
+## Testing Strategy
+
+The implementation should add integration tests for:
+
+- happy path single-invoice: invoice paid -> e-cash minted -> bid published
+- exact mint fee quote path used in invoice calculation
+- fallback fee estimate path does not underfund invoice amount
+- invoice amount includes configured Lightning-fee and mint-fee padding
+- invoice expiration/unpaid interruption path
+- bidder can select only from seller-provided mint options
+- bidder-selected mint fails eligibility/policy checks and is rejected deterministically
+- wallet acknowledgment and mint confirmation timeout at 15 seconds with manual retry
+- invoice paid but mint failure path
+- mint success but bid publish failure with user-confirmed retry and reclaim behavior
+- losing-bid e-cash refund path
+- losing-bid refund is automatic and manual withdrawal CTA is highlighted
+- state transition integrity (no lifecycle collapse)
+
+## Resolved Policy Answers
+
+1. Invoice amounts include fee padding for both Lightning fees and e-cash mint fees.
+2. Wallet acknowledgment and mint confirmation use a 15-second timeout with a manual retry path.
+3. Publish retries are user-confirmed.
+4. Losing-bid refunds are processed automatically as e-cash; withdrawable funds are clearly highlighted and withdrawn manually so the user can enter a destination address.
+5. If seller preference and bidder-selected mint differ: bidder selection is allowed only from seller-provided mint options.
+
+## Alternatives Considered
+
+- Keep current pre-deposit e-cash wallet top-up flow during bidding.
+
+Rejected because it keeps unnecessary custodial friction and repeated balance-management overhead for users.
+
+## Notes
+
+This ADR defines flow and state semantics. Specific UI copy, retry policy, timeout values, and relay/publication sequencing remain implementation details to be finalized in code and tests.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -30,9 +30,12 @@ infrastructure.
 
 ## Test Isolation
 
-Tests must not make network calls to external services. Only the local
-relay (`nak serve`) and local dev server (port 3333) are allowed. All
-external services (CDNs, mints, Lightning nodes) must be mocked or
+Tests must not make network calls to external services. Three local
+services are allowed: the local relay (`nak serve`), the local dev
+server (port 3333), and the real local Cashu mint at 127.0.0.1:3338
+(nutshell mint with FakeWallet backend; tests target it via
+`APP_DEV_TEST_MINT_URL=http://localhost:3338`). All other external
+services (CDNs, remote mints, real Lightning nodes) must be mocked or
 intercepted via `page.route()` / `context.route()`.
 
 See ADR-0005 and the repository-level AGENTS.md "Test Isolation" section

--- a/e2e/ARCHITECTURE.md
+++ b/e2e/ARCHITECTURE.md
@@ -52,6 +52,7 @@ graph TB
 
     subgraph "Infrastructure Layer"
         NAK["nak serve<br/>(local relay)"]
+        MINT["Local Cashu mint<br/>(nutshell FakeWallet, :3338)"]
         SR["seed-relay.ts<br/>(app settings)"]
         DEV["bun dev<br/>(app server)"]
     end
@@ -75,11 +76,13 @@ graph TB
     TC --> DEV
     TC --> SC
     NAK --> SR
+    MINT -->|"APP_DEV_TEST_MINT_URL"| DEV
     SR --> DEV
     TF --> AF
     AF --> NE
     AF --> TC2
     TF --> RM
+    TF -.->|"NUT-04/NUT-05<br/>(wallet tests)"| MINT
     SC -.->|"per-fixture<br/>seeding"| TF
 ```
 
@@ -197,6 +200,29 @@ export default defineConfig({
 	expect: { timeout: 5_000 },
 })
 ```
+
+### Local Cashu Mint: `start-local-mint.sh`
+
+The suite also runs a **real local Cashu mint** — nutshell with the
+FakeWallet backend — so wallet and auction bid-funding tests exercise
+genuine NUT-04/NUT-05 mint and melt flows instead of mocks. The
+FakeWallet backend auto-settles Lightning invoices instantly; no
+external Lightning node is involved.
+
+- **Locally**: started by the Playwright `webServer` in
+  `e2e/playwright.config.ts` (`bash e2e/start-local-mint.sh` on port
+  3338, `reuseExistingServer: true`).
+- **In CI**: `.github/workflows/e2e.yml` sets up Python 3.12, runs
+  `pip install cashu`, starts the mint with
+  `nohup bash e2e/start-local-mint.sh`, and waits for
+  `http://localhost:3338/v1/info` before continuing.
+- **Configuration**: written by `e2e/start-local-mint.sh` — fixed test
+  key `0000...0001`, zero fees, rate limit off, name
+  "Plebeian Test Mint", data dir `/tmp/cashu-mint-e2e`. Override with
+  `CASHU_MINT_PORT`, `CASHU_MINT_HOST`, or `CASHU_MINT_DIR`.
+
+The dev server receives `APP_DEV_TEST_MINT_URL=http://localhost:3338`,
+pointing the app's test wallet at the local mint.
 
 ### Seed Relay: `seed-relay.ts`
 
@@ -803,7 +829,7 @@ Even though tests can run independently, when running the full suite we want an 
 
 ## 8. Test Utilities (Mocks)
 
-The `utils/` directory contains standalone mock implementations that simulate external systems (remote signers, Lightning payments, relay queries) without hitting real services. All mocks communicate with the local test relay via raw WebSocket or `nostr-tools`.
+The `utils/` directory contains standalone mock implementations that simulate external systems (remote signers, Lightning payments, relay queries) without hitting real services. All mocks communicate with the local test relay via raw WebSocket or `nostr-tools`. The Lightning mock still exists for non-wallet flows, but auction bid-funding tests (`e2e/tests/auction-bidding-mints.spec.ts`) exercise real NUT-04/NUT-05 flows against the local Cashu mint (see [Infrastructure Layer](#1-infrastructure-layer)) — this is deliberate.
 
 ### NIP-46 Remote Signer Mock (`utils/nip46-mock.ts`)
 
@@ -1125,6 +1151,9 @@ Key points:
 
 ## Running Tests
 
+Prerequisite (one-time): Python 3 with the nutshell mint installed —
+`pip install cashu`. Playwright starts everything else automatically.
+
 ```bash
 # Run all e2e tests (new suite)
 bun test:e2e
@@ -1146,6 +1175,23 @@ bun test:e2e -- e2e/tests/products.spec.ts
 ```
 
 > **Note**: The `bun test:e2e` scripts include `NODE_OPTIONS='--dns-result-order=ipv4first'` to work around macOS IPv4/IPv6 resolution issues (see Pitfalls section).
+
+### Local Cashu Mint
+
+Wallet and auction-bidding tests hit a **real local Cashu mint**
+(nutshell, FakeWallet backend) on port 3338 — no external mint or
+Lightning node. Playwright starts it automatically via the `webServer`
+config (`reuseExistingServer: true` reuses a mint that is already
+running). To start it manually:
+
+```bash
+bash e2e/start-local-mint.sh
+curl http://localhost:3338/v1/info # health check
+```
+
+Tests target the mint via `APP_DEV_TEST_MINT_URL=http://localhost:3338`
+(passed to the dev server by the `webServer` env in
+`playwright.config.ts`).
 
 ### Local Development Workflow
 

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -36,7 +36,7 @@ export const test = base.extend<TestFixtures>({
 
 	merchantPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
-		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
+		const context = await browser.newContext()
 		await setupAuthContext(context, devUser1)
 		const page = await context.newPage()
 
@@ -53,7 +53,7 @@ export const test = base.extend<TestFixtures>({
 	buyerPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
 		await resetRemoteCartForUser(devUser2.sk)
-		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
+		const context = await browser.newContext()
 		await setupAuthContext(context, devUser2)
 		const page = await context.newPage()
 
@@ -68,7 +68,7 @@ export const test = base.extend<TestFixtures>({
 	newUserPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
 		await resetRemoteCartForUser(devUser3.sk)
-		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
+		const context = await browser.newContext()
 		await setupAuthContext(context, devUser3)
 		const page = await context.newPage()
 
@@ -82,7 +82,7 @@ export const test = base.extend<TestFixtures>({
 
 	unauthenticatedPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
-		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
+		const context = await browser.newContext()
 		// Do NOT call setupAuthContext here. This leaves the user logged out.
 		const page = await context.newPage()
 

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -36,7 +36,7 @@ export const test = base.extend<TestFixtures>({
 
 	merchantPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
-		const context = await browser.newContext()
+		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
 		await setupAuthContext(context, devUser1)
 		const page = await context.newPage()
 
@@ -53,7 +53,7 @@ export const test = base.extend<TestFixtures>({
 	buyerPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
 		await resetRemoteCartForUser(devUser2.sk)
-		const context = await browser.newContext()
+		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
 		await setupAuthContext(context, devUser2)
 		const page = await context.newPage()
 
@@ -68,7 +68,7 @@ export const test = base.extend<TestFixtures>({
 	newUserPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
 		await resetRemoteCartForUser(devUser3.sk)
-		const context = await browser.newContext()
+		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
 		await setupAuthContext(context, devUser3)
 		const page = await context.newPage()
 
@@ -82,7 +82,7 @@ export const test = base.extend<TestFixtures>({
 
 	unauthenticatedPage: async ({ browser, scenario }, use) => {
 		await ensureScenario(scenario)
-		const context = await browser.newContext()
+		const context = await browser.newContext({ recordVideo: { mode: 'on' } })
 		// Do NOT call setupAuthContext here. This leaves the user logged out.
 		const page = await context.newPage()
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,24 +18,35 @@ export default defineConfig({
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
-		video: 'retain-on-failure',
+		video: 'on',
 	},
 
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'] },
+			use: { ...devices['Desktop Chrome'], channel: 'chrome' },
 		},
 	],
 
 	// On CI, servers are started manually in the workflow for better visibility.
-	// Locally, Playwright manages the relay and dev server automatically.
+	// Locally, Playwright manages the relay, mint, and dev server automatically.
 	webServer: process.env.CI
 		? []
 		: [
 				{
 					command: 'nak serve --hostname 0.0.0.0',
 					port: 10547,
+					reuseExistingServer: true,
+					stdout: 'pipe',
+					stderr: 'pipe',
+				},
+				{
+					// Local Cashu mint (nutshell with FakeWallet backend).
+					// Auto-settles Lightning invoices instantly — no external
+					// Lightning node or external mint required.
+					command: 'bash e2e/start-local-mint.sh',
+					cwd: PROJECT_ROOT,
+					port: 3338,
 					reuseExistingServer: true,
 					stdout: 'pipe',
 					stderr: 'pipe',
@@ -57,6 +68,8 @@ export default defineConfig({
 						APP_PRIVATE_KEY: TEST_APP_PRIVATE_KEY,
 						LOCAL_RELAY_ONLY: 'true',
 						NIP46_RELAY_URL: RELAY_URL,
+						APP_DEV_TEST_MINT_URL: 'http://localhost:3338',
+						CVM_SERVER_KEY: 'a49a0def40602d795b7d037dd85cb8626a2fb2975403f3a5bf2ed74a54dd7628',
 					},
 				},
 			],

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,13 +18,13 @@ export default defineConfig({
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
-		video: 'on',
+		video: 'retain-on-failure',
 	},
 
 	projects: [
 		{
 			name: 'chromium',
-			use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+			use: { ...devices['Desktop Chrome'] },
 		},
 	],
 

--- a/e2e/scenarios/index.ts
+++ b/e2e/scenarios/index.ts
@@ -636,7 +636,7 @@ export async function seedAuction(
 			['starting_bid', String(startingBid), 'SAT'],
 			['bid_increment', String(bidIncrement)],
 			['reserve', String(reserve)],
-			['mint', 'https://nofees.testnut.cashu.space'],
+			['mint', 'http://localhost:3338'],
 			['escrow_pubkey', '02' + '00'.repeat(32)],
 			['key_scheme', 'hd_p2pk'],
 			['p2pk_xpub', 'xpub' + '0'.repeat(100)],

--- a/e2e/start-local-mint.sh
+++ b/e2e/start-local-mint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Start a local Cashu mint for Plebeian Market e2e tests.
+# See the "Local Cashu Mint" section in e2e/ARCHITECTURE.md for details.
 #
 # Uses the Cashu (nutshell) FakeWallet backend which auto-settles
 # Lightning invoices instantly — no external Lightning node needed.

--- a/e2e/start-local-mint.sh
+++ b/e2e/start-local-mint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Start a local Cashu mint for Plebeian Market e2e tests.
+#
+# Uses the Cashu (nutshell) FakeWallet backend which auto-settles
+# Lightning invoices instantly — no external Lightning node needed.
+#
+# The mint listens on http://127.0.0.1:3338 by default.
+# Override with CASHU_MINT_PORT and CASHU_MINT_HOST env vars.
+set -euo pipefail
+
+MINT_DIR="${CASHU_MINT_DIR:-/tmp/cashu-mint-e2e}"
+MINT_PORT="${CASHU_MINT_PORT:-3338}"
+MINT_HOST="${CASHU_MINT_HOST:-127.0.0.1}"
+
+# Find a Python interpreter that has cashu installed
+CASHU_PYTHON=""
+for candidate in python3 /opt/miniconda/bin/python3.13 /usr/bin/python3; do
+    if command -v "$candidate" &>/dev/null && "$candidate" -c "import cashu" 2>/dev/null; then
+        CASHU_PYTHON="$candidate"
+        break
+    fi
+done
+
+if [ -z "$CASHU_PYTHON" ]; then
+    echo "ERROR: cashu is not installed in any Python interpreter." >&2
+    echo "Install with: pip install cashu" >&2
+    exit 1
+fi
+
+mkdir -p "$MINT_DIR"
+
+# Write the mint configuration
+cat > "$MINT_DIR/.env" << EOF
+MINT_LISTEN_HOST=$MINT_HOST
+MINT_LISTEN_PORT=$MINT_PORT
+MINT_HOST=localhost
+MINT_PORT=$MINT_PORT
+MINT_DATABASE=data/mint
+MINT_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000001
+MINT_BACKEND_BOLT11_SAT=FakeWallet
+MINT_INFO_NAME=Plebeian Test Mint
+MINT_INFO_DESCRIPTION=Local test mint for e2e tests
+MINT_RATE_LIMIT=False
+MINT_INPUT_FEE_PPK=0
+FAKEWALLET_DELAY_INCOMING_PAYMENT=0
+FAKEWALLET_DELAY_OUTGOING_PAYMENT=0
+EOF
+
+cd "$MINT_DIR"
+exec "$CASHU_PYTHON" -m cashu.mint --port "$MINT_PORT" --host "$MINT_HOST"

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -1,10 +1,19 @@
+/**
+ * TODO(CI): These tests rely on external Cashu test mints (testnut.cashu.space).
+ * For CI reliability, run a local Cashu mint (e.g., nutmint / cashu-crumb) and
+ * configure DEV_TEST_MINT_URL to point at it. External mints can be rate-limited,
+ * down, or change behaviour without notice, causing flaky CI runs. A local mint
+ * also eliminates the ADR-0005 test-isolation violation from calling external
+ * services.
+ */
+
 import { test, expect } from '../fixtures'
 import { RELAY_URL, TEST_APP_PUBLIC_KEY } from '../test-config'
 import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
 import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
 import { hexToBytes } from '@noble/hashes/utils.js'
 import WebSocket from 'ws'
-import { devUser1 } from '../../src/lib/fixtures'
+import { devUser1, devUser2 } from '../../src/lib/fixtures'
 import path from 'node:path'
 import { decode } from 'light-bolt11-decoder'
 
@@ -276,6 +285,329 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 
 			const invoiceAmountSats = parseBolt11Sats(invoiceValue)
 			expect(invoiceAmountSats).toBeGreaterThan(requestedAmount)
+		} finally {
+			relay.close()
+		}
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Direct Lightning Bid Funding — video-recorded e2e scenarios (PR #1205)
+//
+// These tests exercise the full bid → deposit → mint → publish lifecycle
+// using the __nip60 dev bridge to simulate Lightning payment confirmation
+// without a real Lightning node. Video recording is always on for this group.
+//
+// NOTE: These tests require a running dev server (port 34567), local relay
+// (nak serve on port 10547), and a reachable Cashu test mint. Do NOT run
+// them in CI until a local mint is available (see TODO at top of file).
+// ---------------------------------------------------------------------------
+
+test.describe('Direct Lightning Bid Funding (video recorded)', () => {
+	test.use({ video: 'on' })
+	test.slow()
+
+	/** Bid event kind per AUCTIONS.md §4.2. */
+	const AUCTION_BID_KIND = 1023
+
+	/** Timeout for the deposit confirmation monitor (must match nip60 store). */
+	const DEPOSIT_TIMEOUT_MS = 15_000
+
+	/**
+	 * Set the auction-rules acknowledgment in localStorage so the rules dialog
+	 * is skipped and the Confirm Bid dialog appears directly.
+	 */
+	async function acknowledgeAuctionRules(page: import('@playwright/test').Page) {
+		await page.evaluate((pubkey) => {
+			localStorage.setItem(`auction-rules-ack:v1:${pubkey}`, 'true')
+		}, devUser2.pk)
+	}
+
+	/**
+	 * Wait for the deposit QR code to appear inside the bid-variant
+	 * DepositLightningModal. The QR is rendered as an <svg> inside the dialog.
+	 */
+	async function waitForDepositQR(page: import('@playwright/test').Page, timeoutMs = 30_000) {
+		const dialog = page.getByRole('dialog', { name: /bid with lightning/i })
+		await expect(dialog).toBeVisible({ timeout: 15_000 })
+		await expect(dialog.locator('svg')).toBeVisible({ timeout: timeoutMs })
+		return dialog
+	}
+
+	/**
+	 * Simulate a Lightning invoice payment by emitting 'success' on the active
+	 * deposit via the __nip60 dev bridge. This triggers the same store
+	 * transition as a real mint confirmation.
+	 */
+	async function simulateDepositPayment(page: import('@playwright/test').Page) {
+		const ok = await page.evaluate(() => {
+			const w = (window as any).__nip60
+			if (w?.simulateDepositSuccess) {
+				w.simulateDepositSuccess()
+				return true
+			}
+			return false
+		})
+		expect(ok).toBe(true)
+	}
+
+	/**
+	 * Subscribe to the relay and wait for a kind-1023 bid event referencing
+	 * the given auction root event id. Returns the event or null on timeout.
+	 */
+	async function waitForBidEvent(
+		relay: Relay,
+		auctionEventId: string,
+		timeoutMs = 30_000,
+	): Promise<{ id: string; pubkey: string; kind: number; tags: string[][] } | null> {
+		return new Promise((resolve) => {
+			const sub = relay.subscribe([{ kinds: [AUCTION_BID_KIND], '#e': [auctionEventId], limit: 1 }], {
+				onevent(event) {
+					sub.close()
+					resolve(event)
+				},
+				oneose() {
+					// No events yet — keep waiting, the EOSE just means the
+					// initial scan is done.
+				},
+			})
+			setTimeout(() => {
+				sub.close()
+				resolve(null)
+			}, timeoutMs)
+		})
+	}
+
+	// ── Scenario 1: Happy Path ─────────────────────────────────────────
+
+	test('happy path: bid → insufficient funds → QR invoice → pay → e-cash minted → bid published', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+				dTag: 'e2e-ln-bid-funding-happy-path',
+			})
+
+			// Pre-set auction rules ack to skip the rules dialog.
+			await acknowledgeAuctionRules(buyerPage)
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			// Wait for wallet to initialise — no funding, so balance is 0
+			// (insufficient for the 100 sat starting bid).
+			await waitForWalletReady(buyerPage)
+
+			// Click the bid button — opens the Confirm Bid dialog.
+			await buyerPage
+				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
+				.first()
+				.click()
+
+			const confirmDialog = buyerPage.getByRole('dialog', { name: /confirm bid/i })
+			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+
+			// Select a mint in the confirm dialog (if a mint selector is shown).
+			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
+			if (await mintSelectTrigger.isVisible().catch(() => false)) {
+				await mintSelectTrigger.click()
+				await confirmDialog.getByRole('option').first().click()
+			}
+
+			// Confirm the bid — since wallet has insufficient funds, the
+			// DepositLightningModal (bid variant) opens with a QR invoice.
+			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+			// Wait for the QR code to appear (auto-generated in bid variant).
+			const depositDialog = await waitForDepositQR(buyerPage)
+
+			// Verify the invoice amount is displayed.
+			await expect(depositDialog.getByText(/sats/i)).toBeVisible({ timeout: 10_000 })
+
+			// Simulate the Lightning payment being received by the mint.
+			// This triggers depositStatus → 'success' → onSuccess callback →
+			// handleFundingSuccess → submitPreparedBid → kind-1023 published.
+			await simulateDepositPayment(buyerPage)
+
+			// Verify the deposit success UI appears.
+			await expect(buyerPage.getByText('Deposit Successful!')).toBeVisible({ timeout: 30_000 })
+
+			// Verify the bid event (kind 1023) was published to the relay.
+			const bidEvent = await waitForBidEvent(relay, auctionEvent.id, 30_000)
+			expect(bidEvent).not.toBeNull()
+			expect(bidEvent!.kind).toBe(AUCTION_BID_KIND)
+			expect(bidEvent!.pubkey).toBe(devUser2.pk)
+			// The bid event must reference the auction root event id via 'e' tag.
+			expect(bidEvent!.tags.some((t) => t[0] === 'e' && t[1] === auctionEvent.id)).toBe(true)
+
+			await buyerPage.screenshot({
+				path: path.join(SCREENSHOT_DIR, 'pr1205-ln-bid-funding-happy-path.png'),
+				fullPage: true,
+			})
+		} finally {
+			relay.close()
+		}
+	})
+
+	// ── Scenario 2: Timeout ────────────────────────────────────────────
+
+	test('timeout: invoice generated → 15s timeout → retry confirmation', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+				dTag: 'e2e-ln-bid-funding-timeout',
+			})
+
+			await acknowledgeAuctionRules(buyerPage)
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await waitForWalletReady(buyerPage)
+
+			// Place a bid to open the deposit modal.
+			await buyerPage
+				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
+				.first()
+				.click()
+
+			const confirmDialog = buyerPage.getByRole('dialog', { name: /confirm bid/i })
+			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+
+			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
+			if (await mintSelectTrigger.isVisible().catch(() => false)) {
+				await mintSelectTrigger.click()
+				await confirmDialog.getByRole('option').first().click()
+			}
+
+			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+			// Wait for the QR invoice to appear.
+			await waitForDepositQR(buyerPage)
+
+			// Wait for the deposit confirmation timeout (15 s + buffer).
+			// The deposit monitor sets depositStatus to 'awaiting_confirmation_retry'.
+			await buyerPage.waitForTimeout(DEPOSIT_TIMEOUT_MS + 2_000)
+
+			// Verify the deposit status is 'awaiting_confirmation_retry' via
+			// the __nip60 dev bridge.
+			const depositStatus = await buyerPage.evaluate(() => {
+				const w = (window as any).__nip60
+				return w?.getDepositStatus?.() ?? null
+			})
+			expect(depositStatus).not.toBeNull()
+			expect(depositStatus.depositStatus).toBe('awaiting_confirmation_retry')
+
+			// Switch to the classic top-up view where the "Retry confirmation"
+			// button is rendered (the bid-variant view uses the same "Confirm"
+			// button for both initial check and retry).
+			const depositDialog = buyerPage.getByRole('dialog')
+			await depositDialog.getByRole('button', { name: /or top up your wallet/i }).click()
+
+			// In the classic view, the "Retry confirmation" button appears
+			// when needsConfirmationRetry is true.
+			await expect(depositDialog.getByText(/confirmation timed out/i)).toBeVisible({ timeout: 10_000 })
+			const retryButton = depositDialog.getByRole('button', { name: /retry confirmation/i })
+			await expect(retryButton).toBeVisible({ timeout: 10_000 })
+
+			// Click "Retry confirmation" — this calls retryDepositConfirmation()
+			// which resets depositStatus to 'pending' and re-checks the mint.
+			await retryButton.click()
+
+			// Verify the deposit status returned to 'pending' after retry.
+			const postRetryStatus = await buyerPage.evaluate(() => {
+				const w = (window as any).__nip60
+				return w?.getDepositStatus?.() ?? null
+			})
+			expect(postRetryStatus).not.toBeNull()
+			expect(postRetryStatus.depositStatus).toBe('pending')
+
+			await buyerPage.screenshot({
+				path: path.join(SCREENSHOT_DIR, 'pr1205-ln-bid-funding-timeout.png'),
+				fullPage: true,
+			})
+		} finally {
+			relay.close()
+		}
+	})
+
+	// ── Scenario 3: Publish Failure ────────────────────────────────────
+
+	test('publish failure: sufficient funds → bid publish fails → retry available', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A],
+				dTag: 'e2e-ln-bid-funding-publish-failure',
+			})
+
+			await acknowledgeAuctionRules(buyerPage)
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			// Wait for wallet and fund with sufficient balance (500 sats ≥ 100 sat bid).
+			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 500, MINT_A)
+			await waitForWalletBalance(buyerPage, 400)
+			await buyerPage.reload()
+			await waitForWalletBalance(buyerPage, 400)
+
+			// Intercept NIP-07 signEvent for kind-1023 to simulate a publish
+			// failure (e.g., relay rejection). The bid mutation will throw,
+			// and the funding hook transitions to
+			// 'mint_succeeded_bid_publish_failed_reclaimable' with a toast.
+			await buyerPage.evaluate(() => {
+				const nostr = (window as any).nostr
+				if (!nostr) return
+				const originalSignEvent = nostr.signEvent
+				;(window as any).__originalSignEvent = originalSignEvent
+				nostr.signEvent = async (event: any) => {
+					if (event.kind === 1023) {
+						throw new Error('Mock: relay rejected bid event')
+					}
+					return originalSignEvent.call(nostr, event)
+				}
+			})
+
+			// Place a bid — with sufficient funds, no deposit modal opens;
+			// the bid goes directly to publish, which fails.
+			await buyerPage
+				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
+				.first()
+				.click()
+
+			const confirmDialog = buyerPage.getByRole('dialog', { name: /confirm bid/i })
+			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+
+			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
+			if (await mintSelectTrigger.isVisible().catch(() => false)) {
+				await mintSelectTrigger.click()
+				await confirmDialog.getByRole('option').first().click()
+			}
+
+			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+			// Verify the error toast appears indicating publish failure.
+			await expect(buyerPage.getByText(/bid publishing failed/i)).toBeVisible({ timeout: 30_000 })
+
+			// Restore the original signEvent so a retry can succeed.
+			await buyerPage.evaluate(() => {
+				const nostr = (window as any).nostr
+				if (nostr && (window as any).__originalSignEvent) {
+					nostr.signEvent = (window as any).__originalSignEvent
+					delete (window as any).__originalSignEvent
+				}
+			})
+
+			// Verify the bid button is still available for retry.
+			await expect(buyerPage.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i }).first()).toBeVisible({ timeout: 10_000 })
+
+			await buyerPage.screenshot({
+				path: path.join(SCREENSHOT_DIR, 'pr1205-ln-bid-funding-publish-failure.png'),
+				fullPage: true,
+			})
 		} finally {
 			relay.close()
 		}

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -1,10 +1,15 @@
 /**
- * TODO(CI): These tests rely on external Cashu test mints (testnut.cashu.space).
- * For CI reliability, run a local Cashu mint (e.g., nutmint / cashu-crumb) and
- * configure DEV_TEST_MINT_URL to point at it. External mints can be rate-limited,
- * down, or change behaviour without notice, causing flaky CI runs. A local mint
- * also eliminates the ADR-0005 test-isolation violation from calling external
- * services.
+ * E2E tests for auction bidding with Cashu mints.
+ *
+ * These tests use a LOCAL Cashu mint (nutshell with FakeWallet backend)
+ * started automatically by the Playwright webServer config on port 3338.
+ * The FakeWallet auto-settles Lightning invoices instantly, so no external
+ * Lightning node or external mint is required.
+ *
+ * MINT_A and MINT_B point to the same local mint via different hostnames
+ * (localhost vs 127.0.0.1) so the wallet treats them as separate mints.
+ * MINT_UNTRUSTED is a non-working local URL; mintTestEcash falls back to
+ * the trusted dev mints when the preferred URL is not in the trusted list.
  */
 
 import { test, expect } from '../fixtures'
@@ -13,16 +18,16 @@ import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
 import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
 import { hexToBytes } from '@noble/hashes/utils.js'
 import WebSocket from 'ws'
-import { devUser1, devUser2 } from '../../src/lib/fixtures'
+import { devUser1, devUser2, XPUB } from '../../src/lib/fixtures'
 import path from 'node:path'
 import { decode } from 'light-bolt11-decoder'
 
 useWebSocketImplementation(WebSocket)
 
 const D_TAG = 'e2e-auction-mint-test'
-const MINT_A = 'https://testnut.cashu.space'
-const MINT_B = 'https://nofees.testnut.cashu.space'
-const MINT_UNTRUSTED = 'https://mint.minibits.cash/Bitcoin'
+const MINT_A = 'http://localhost:3338'
+const MINT_B = 'http://127.0.0.1:3338'
+const MINT_UNTRUSTED = 'http://untrusted.localhost:3340'
 const SCREENSHOT_DIR = 'test-results'
 
 async function seedAuction(relay: Relay, overrides: { mints: string[]; dTag?: string }) {
@@ -52,6 +57,7 @@ async function seedAuction(relay: Relay, overrides: { mints: string[]; dTag?: st
 				['reserve', '0'],
 				['settlement_policy', 'cashu_p2pk_path_oracle_v1'],
 				['key_scheme', 'hd_p2pk'],
+				['p2pk_xpub', XPUB],
 				['path_issuer', TEST_APP_PUBLIC_KEY],
 				['settlement_grace', '7200'],
 				['extension_rule', 'none'],
@@ -121,7 +127,7 @@ test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
 		const relay = await Relay.connect(RELAY_URL)
 		try {
 			const auctionEvent = await seedAuction(relay, {
-				mints: [MINT_A, 'https://nofees.testnut.cashu.space'],
+				mints: [MINT_A, MINT_B],
 			})
 
 			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
@@ -169,7 +175,7 @@ test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
 		const relay = await Relay.connect(RELAY_URL)
 		try {
 			const auctionEvent = await seedAuction(relay, {
-				mints: [MINT_A, 'https://nofees.testnut.cashu.space'],
+				mints: [MINT_A, MINT_B],
 				dTag: 'e2e-auction-second-mint-test',
 			})
 
@@ -268,9 +274,9 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 
 			const mintSelect = depositDialog.locator('select').first()
 			const optionLabels = await mintSelect.locator('option').allTextContents()
-			expect(optionLabels).toContain('testnut.cashu.space')
-			expect(optionLabels).toContain('nofees.testnut.cashu.space')
-			expect(optionLabels).not.toContain('mint.minibits.cash')
+			expect(optionLabels).toContain('localhost')
+			expect(optionLabels).toContain('127.0.0.1')
+			expect(optionLabels).not.toContain('untrusted.localhost')
 
 			const amountInput = depositDialog.locator('input[type="number"]').first()
 			const requestedAmount = Number(await amountInput.inputValue())
@@ -299,12 +305,12 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 // without a real Lightning node. Video recording is always on for this group.
 //
 // NOTE: These tests require a running dev server (port 34567), local relay
-// (nak serve on port 10547), and a reachable Cashu test mint. Do NOT run
-// them in CI until a local mint is available (see TODO at top of file).
+// (nak serve on port 10547), and a local Cashu mint (port 3338, started
+// automatically by the Playwright webServer config).
 // ---------------------------------------------------------------------------
 
 test.describe('Direct Lightning Bid Funding (video recorded)', () => {
-	test.use({ video: 'on' })
+	// video: 'on' set in playwright.config.ts
 	test.slow()
 
 	/** Bid event kind per AUCTIONS.md §4.2. */

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -372,10 +372,13 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 			// Explicitly register mints after reload — the wallet re-inits from
 			// relay events and may not have the mint in its store when the
 			// deposit modal opens, causing filteredMints to be empty.
-			await buyerPage.evaluate((mints) => {
-				const w = (window as any).__nip60
-				if (w?.addMint) mints.forEach((m: string) => w.addMint(m))
-			}, [MINT_A, MINT_B])
+			await buyerPage.evaluate(
+				(mints) => {
+					const w = (window as any).__nip60
+					if (w?.addMint) mints.forEach((m: string) => w.addMint(m))
+				},
+				[MINT_A, MINT_B],
+			)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -134,8 +134,12 @@ async function ensureInsufficientBidFunds(page: import('@playwright/test').Page)
 	})
 
 	// seedAuction sets starting_bid to 100 SAT, so minBid = 100.
+	// Previous bids from earlier test runs may persist on the relay,
+	// raising the "current price" above 100. deltaAmount = bidAmount - currentPrice.
+	// We need deltaAmount > balance, so bidAmount > currentPrice + balance.
+	// Use a large bid amount to guarantee this regardless of currentPrice.
 	const minBid = 100
-	const bidAmount = Math.max(minBid, balance + 100)
+	const bidAmount = Math.max(minBid, balance + 500)
 
 	// Enter edit mode to access the custom bid input field.
 	const editButton = page.locator('button[title="Customize bid"]')
@@ -188,17 +192,13 @@ async function purgeWalletEvents() {
 		// Fetch all kind 7375/7376 events by devUser2 via subscribe (Relay has no .list())
 		const events: Event[] = []
 		await new Promise<void>((resolve) => {
-			const sub = relay.subscribe(
-				[{ kinds: [7375, 7376], authors: [devUser2.pk] }],
-				{
-					onevent: (event: Event) => events.push(event),
-					oneose: () => {
-						sub.close()
-						resolve()
-					},
+			const sub = relay.subscribe([{ kinds: [7375, 7376], authors: [devUser2.pk] }], {
+				onevent: (event: Event) => events.push(event),
+				oneose: () => {
+					sub.close()
+					resolve()
 				},
-				undefined,
-			)
+			})
 		})
 		const skBytes = hexToBytes(devUser2.sk)
 		for (const event of events) {

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -110,6 +110,43 @@ async function waitForWalletBalance(page: import('@playwright/test').Page, minBa
 	throw new Error(`Wallet balance did not reach ${minBalance} within timeout`)
 }
 
+/**
+ * Dynamically set the bid amount to exceed the actual wallet balance,
+ * ensuring `hasInsufficientBidFunds = true` regardless of accumulated
+ * balance from previous tests.
+ *
+ * The wallet balance persists across tests because NDK loads wallet state
+ * from IndexedDB/localStorage, not just from relay events. Hardcoding a
+ * small bid amount (e.g. 100 sats) may not trigger insufficient funds
+ * if the wallet already has thousands of sats.
+ *
+ * This helper reads the balance via __nip60.getStatus(), computes a bid
+ * amount of max(100, balance + 100), and enters it using the "Customize
+ * bid" edit mode.
+ *
+ * Must be called after waitForWalletReady (or waitForWalletBalance) and
+ * before clicking the bid button.
+ */
+async function ensureInsufficientBidFunds(page: import('@playwright/test').Page) {
+	const balance = await page.evaluate(() => {
+		const w = (window as any).__nip60
+		return w ? (w.getStatus().balance ?? 0) : 0
+	})
+
+	// seedAuction sets starting_bid to 100 SAT, so minBid = 100.
+	const minBid = 100
+	const bidAmount = Math.max(minBid, balance + 100)
+
+	// Enter edit mode to access the custom bid input field.
+	const editButton = page.locator('button[title="Customize bid"]')
+	await editButton.waitFor({ state: 'visible', timeout: 10_000 })
+	await editButton.click()
+
+	// Clear and type the new bid amount.
+	const bidInput = page.locator('input[type="number"]').first()
+	await bidInput.fill(String(bidAmount))
+}
+
 const parseBolt11Sats = (bolt11: string): number => {
 	const amountMillisatsRaw = decode(bolt11).sections.find((section) => section.name === 'amount')?.value
 	if (!amountMillisatsRaw) {
@@ -331,6 +368,10 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 			await buyerPage.reload()
 			await waitForWalletBalance(buyerPage, 5_000)
 
+			// Dynamically set bid amount to exceed actual wallet balance, ensuring
+			// hasInsufficientBidFunds = true regardless of accumulated balance.
+			await ensureInsufficientBidFunds(buyerPage)
+
 			await buyerPage
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
 				.first()
@@ -349,8 +390,8 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 				await buyerPage.getByRole('option').first().click()
 			}
 
-			// Confirm the bid — wallet has insufficient funds (40 sats on accepted
-			// mints vs 100 sat starting bid), so the DepositLightningModal opens in
+			// Confirm the bid — wallet has insufficient funds (bid amount exceeds
+			// total wallet balance), so the DepositLightningModal opens in
 			// bid-variant quick view.
 			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
 
@@ -495,12 +536,16 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
 			// Wait for wallet to initialise, then fund with a small amount so
-			// the wallet knows about the mint. The 20 sat balance is insufficient
-			// for the 100 sat starting bid, so the deposit modal will open.
+			// the wallet knows about the mint. The bid amount is set dynamically
+			// to exceed the wallet balance, so the deposit modal will open.
 			await waitForWalletReady(buyerPage)
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+
+			// Dynamically set bid amount to exceed actual wallet balance, ensuring
+			// hasInsufficientBidFunds = true regardless of accumulated balance.
+			await ensureInsufficientBidFunds(buyerPage)
 
 			// Click the bid button — opens the Confirm Bid dialog.
 			await buyerPage
@@ -574,6 +619,10 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+
+			// Dynamically set bid amount to exceed actual wallet balance, ensuring
+			// hasInsufficientBidFunds = true regardless of accumulated balance.
+			await ensureInsufficientBidFunds(buyerPage)
 
 			// Place a bid to open the deposit modal.
 			await buyerPage
@@ -657,12 +706,16 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
 			// Wait for wallet and fund with a small amount so the wallet
-			// knows about the mint. The 20 sat balance is insufficient for
-			// the 100 sat starting bid, so the deposit modal will open.
+			// knows about the mint. The bid amount is set dynamically to
+			// exceed the wallet balance, so the deposit modal will open.
 			await waitForWalletReady(buyerPage)
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+
+			// Dynamically set bid amount to exceed actual wallet balance, ensuring
+			// hasInsufficientBidFunds = true regardless of accumulated balance.
+			await ensureInsufficientBidFunds(buyerPage)
 
 			// Intercept NIP-07 signEvent for kind-1023 to simulate a publish
 			// failure (e.g., relay rejection). After the deposit succeeds and
@@ -682,8 +735,8 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 				}
 			})
 
-			// Place a bid — wallet has insufficient funds (20 sats < 100 sat
-			// starting bid), so the deposit modal opens after Confirm.
+			// Place a bid — wallet has insufficient funds (bid amount exceeds
+			// wallet balance), so the deposit modal opens after Confirm.
 			await buyerPage
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
 				.first()

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -113,6 +113,27 @@ async function waitForWalletBalance(page: import('@playwright/test').Page, minBa
 }
 
 /**
+ * Wait until a mint URL is registered in the wallet store. The __nip60
+ * addMint bridge updates the store synchronously, but polling makes the
+ * registration explicit (and fails loudly if the wallet was not ready to
+ * accept it) instead of relying on a fixed sleep for React to pick up the
+ * store update.
+ */
+async function waitForWalletMint(page: import('@playwright/test').Page, mintUrl: string, timeoutMs = 30_000) {
+	const start = Date.now()
+	while (Date.now() - start < timeoutMs) {
+		const registered = await page.evaluate((url) => {
+			const w = (window as any).__nip60
+			const mints: string[] = w ? (w.getStatus().mints ?? []) : []
+			return mints.includes(url)
+		}, mintUrl)
+		if (registered) return
+		await page.waitForTimeout(500)
+	}
+	throw new Error(`Mint ${mintUrl} did not appear in the wallet store within timeout`)
+}
+
+/**
  * Dynamically set the bid amount to exceed the actual wallet balance,
  * ensuring `hasInsufficientBidFunds = true` regardless of accumulated
  * balance from previous tests.
@@ -554,6 +575,11 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Wait for the wallet balance to be loaded from relay events after
+			// reload. waitForWalletReady only checks status === 'ready', but the
+			// mint balances may not be loaded yet, causing resolveAuctionMintSelection
+			// to see no available mints and depositMint to be null.
+			await waitForWalletBalance(buyerPage, 1)
 			// Explicitly register mint after reload — wallet re-inits from relay
 			// events and may not have the mint in its store when the deposit
 			// modal opens, causing filteredMints to be empty.
@@ -561,6 +587,9 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 				const w = (window as any).__nip60
 				if (w?.addMint) w.addMint(mint)
 			}, MINT_A)
+			// Wait until the mint is registered in the wallet store so the
+			// deposit modal's mint selection sees it.
+			await waitForWalletMint(buyerPage, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
@@ -637,11 +666,19 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Wait for the wallet balance to be loaded from relay events after
+			// reload. waitForWalletReady only checks status === 'ready', but the
+			// mint balances may not be loaded yet, causing resolveAuctionMintSelection
+			// to see no available mints and depositMint to be null.
+			await waitForWalletBalance(buyerPage, 1)
 			// Explicitly register mint after reload.
 			await buyerPage.evaluate((mint) => {
 				const w = (window as any).__nip60
 				if (w?.addMint) w.addMint(mint)
 			}, MINT_A)
+			// Wait until the mint is registered in the wallet store so the
+			// deposit modal's mint selection sees it.
+			await waitForWalletMint(buyerPage, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
@@ -734,11 +771,19 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Wait for the wallet balance to be loaded from relay events after
+			// reload. waitForWalletReady only checks status === 'ready', but the
+			// mint balances may not be loaded yet, causing resolveAuctionMintSelection
+			// to see no available mints and depositMint to be null.
+			await waitForWalletBalance(buyerPage, 1)
 			// Explicitly register mint after reload.
 			await buyerPage.evaluate((mint) => {
 				const w = (window as any).__nip60
 				if (w?.addMint) w.addMint(mint)
 			}, MINT_A)
+			// Wait until the mint is registered in the wallet store so the
+			// deposit modal's mint selection sees it.
+			await waitForWalletMint(buyerPage, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -284,7 +284,34 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
 				.first()
 				.click()
+
+			// Confirm Bid dialog appears (rules already acknowledged).
+			const confirmDialog = buyerPage.getByRole('dialog', { name: /confirm bid/i })
+			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
+
+			// Select a mint in the confirm dialog (if a mint selector is shown).
+			// The mint selector is a Radix Select (combobox) whose dropdown content
+			// is portaled outside the dialog DOM, so we query options at page level.
+			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
+			if (await mintSelectTrigger.isVisible().catch(() => false)) {
+				await mintSelectTrigger.click()
+				await buyerPage.getByRole('option').first().click()
+			}
+
+			// Confirm the bid — wallet has insufficient funds (40 sats on accepted
+			// mints vs 100 sat starting bid), so the DepositLightningModal opens in
+			// bid-variant quick view.
+			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+			// The deposit modal opens in bid-variant quick view (title "Bid with
+			// lightning"). Switch to the classic top-up view to access the mint
+			// selector and form fields.
 			const depositDialog = buyerPage.getByRole('dialog')
+			await expect(depositDialog.getByText('Bid with lightning')).toBeVisible({ timeout: 10_000 })
+			await depositDialog.getByRole('button', { name: /or top up your wallet/i }).click()
+
+			// In classic view the title changes to "Deposit Lightning" and the
+			// form (amount input, mint selector, Generate Invoice button) appears.
 			await expect(depositDialog.getByText('Deposit Lightning')).toBeVisible({ timeout: 10_000 })
 
 			const mintSelect = depositDialog.locator('select').first()
@@ -339,9 +366,16 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 	 * DepositLightningModal. The QR is rendered as an <svg> inside the dialog.
 	 */
 	async function waitForDepositQR(page: import('@playwright/test').Page, timeoutMs = 30_000) {
-		const dialog = page.getByRole('dialog', { name: /bid with lightning/i })
+		// The DepositLightningModal renders a Radix Dialog whose DialogTitle is
+		// "Bid with lightning" (bid variant). The title contains a Zap icon <svg>,
+		// so we locate the dialog by its visible title text rather than by role
+		// name (which can be unreliable when the title has mixed content).
+		const dialog = page.getByRole('dialog').filter({ hasText: /bid with lightning/i })
 		await expect(dialog).toBeVisible({ timeout: 15_000 })
-		await expect(dialog.locator('svg')).toBeVisible({ timeout: timeoutMs })
+		// The QR code is rendered as a <QRCodeSVG> which produces an <svg> inside
+		// a <button>. The title's Zap icon is also an <svg>, so target the QR
+		// container specifically (it's inside a div with fixed 216×216 dimensions).
+		await expect(dialog.locator('div[class*="216"] svg')).toBeVisible({ timeout: timeoutMs })
 		return dialog
 	}
 

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -122,6 +122,18 @@ const parseBolt11Sats = (bolt11: string): number => {
 	return Math.floor(amountMillisats / 1000)
 }
 
+/**
+ * Set the auction-rules acknowledgment in localStorage so the rules dialog
+ * is skipped and the Confirm Bid dialog appears directly.
+ * Must be called BEFORE navigating to the auction page (localStorage
+ * persists across same-origin navigations on the same page).
+ */
+async function acknowledgeAuctionRules(page: import('@playwright/test').Page) {
+	await page.evaluate((pubkey) => {
+		localStorage.setItem(`auction-rules-ack:v1:${pubkey}`, 'true')
+	}, devUser2.pk)
+}
+
 test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
 	test('auction detail page renders bid button for multi-mint auction', async ({ buyerPage }) => {
 		const relay = await Relay.connect(RELAY_URL)
@@ -255,6 +267,9 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 				dTag: 'e2e-auction-funding-fee-padding-test',
 			})
 
+			// Pre-set auction rules ack to skip the rules dialog.
+			await acknowledgeAuctionRules(buyerPage)
+
 			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
@@ -318,16 +333,6 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 
 	/** Timeout for the deposit confirmation monitor (must match nip60 store). */
 	const DEPOSIT_TIMEOUT_MS = 15_000
-
-	/**
-	 * Set the auction-rules acknowledgment in localStorage so the rules dialog
-	 * is skipped and the Confirm Bid dialog appears directly.
-	 */
-	async function acknowledgeAuctionRules(page: import('@playwright/test').Page) {
-		await page.evaluate((pubkey) => {
-			localStorage.setItem(`auction-rules-ack:v1:${pubkey}`, 'true')
-		}, devUser2.pk)
-	}
 
 	/**
 	 * Wait for the deposit QR code to appear inside the bid-variant
@@ -414,10 +419,12 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await expect(confirmDialog).toBeVisible({ timeout: 10_000 })
 
 			// Select a mint in the confirm dialog (if a mint selector is shown).
+			// The mint selector is a Radix Select (combobox) whose dropdown content
+			// is portaled outside the dialog DOM, so we query options at page level.
 			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
 			if (await mintSelectTrigger.isVisible().catch(() => false)) {
 				await mintSelectTrigger.click()
-				await confirmDialog.getByRole('option').first().click()
+				await buyerPage.getByRole('option').first().click()
 			}
 
 			// Confirm the bid — since wallet has insufficient funds, the
@@ -484,7 +491,7 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
 			if (await mintSelectTrigger.isVisible().catch(() => false)) {
 				await mintSelectTrigger.click()
-				await confirmDialog.getByRole('option').first().click()
+				await buyerPage.getByRole('option').first().click()
 			}
 
 			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
@@ -590,7 +597,7 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			const mintSelectTrigger = confirmDialog.getByRole('combobox').first()
 			if (await mintSelectTrigger.isVisible().catch(() => false)) {
 				await mintSelectTrigger.click()
-				await confirmDialog.getByRole('option').first().click()
+				await buyerPage.getByRole('option').first().click()
 			}
 
 			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -14,7 +14,7 @@
 
 import { test, expect } from '../fixtures'
 import { RELAY_URL, TEST_APP_PUBLIC_KEY } from '../test-config'
-import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
+import { finalizeEvent, type EventTemplate, type Event } from 'nostr-tools/pure'
 import { Relay, useWebSocketImplementation } from 'nostr-tools/relay'
 import { hexToBytes } from '@noble/hashes/utils.js'
 import WebSocket from 'ws'
@@ -134,6 +134,53 @@ async function acknowledgeAuctionRules(page: import('@playwright/test').Page) {
 	}, devUser2.pk)
 }
 
+/**
+ * Purge devUser2's NDK wallet events (kind 7375/7376) from the local relay.
+ *
+ * Tests 1-6 fund the wallet with 20-5000 sats. Without purging, the wallet
+ * balance accumulates across tests (e.g. 25,004 sats by test 7), making
+ * `canFund = true` and `hasInsufficientBidFunds = false`, so
+ * `startFundingForBid` returns bidData instead of opening the deposit modal.
+ *
+ * This helper fetches all kind 7375 and 7376 events authored by devUser2 and
+ * publishes kind 5 (deletion) events for each, signed with devUser2's key.
+ */
+async function purgeWalletEvents() {
+	const relay = await Relay.connect(RELAY_URL)
+	try {
+		// Fetch all kind 7375/7376 events by devUser2 via subscribe (Relay has no .list())
+		const events: Event[] = []
+		await new Promise<void>((resolve) => {
+			const sub = relay.subscribe(
+				[{ kinds: [7375, 7376], authors: [devUser2.pk] }],
+				{
+					onevent: (event: Event) => events.push(event),
+					oneose: () => {
+						sub.close()
+						resolve()
+					},
+				},
+				undefined,
+			)
+		})
+		const skBytes = hexToBytes(devUser2.sk)
+		for (const event of events) {
+			const deletionEvent = finalizeEvent(
+				{
+					kind: 5,
+					created_at: Math.floor(Date.now() / 1000),
+					tags: [['e', event.id]],
+					content: 'purge wallet event for e2e test',
+				},
+				skBytes,
+			)
+			await relay.publish(deletionEvent)
+		}
+	} finally {
+		relay.close()
+	}
+}
+
 test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
 	test('auction detail page renders bid button for multi-mint auction', async ({ buyerPage }) => {
 		const relay = await Relay.connect(RELAY_URL)
@@ -203,6 +250,10 @@ test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
 
 test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 	test.slow()
+
+	test.beforeEach(async () => {
+		await purgeWalletEvents()
+	})
 
 	test('mint selector shows funded mint with balance', async ({ buyerPage }) => {
 		const relay = await Relay.connect(RELAY_URL)
@@ -354,6 +405,10 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 	// video: 'on' set in playwright.config.ts
 	test.slow()
+
+	test.beforeEach(async () => {
+		await purgeWalletEvents()
+	})
 
 	/** Bid event kind per AUCTIONS.md §4.2. */
 	const AUCTION_BID_KIND = 1023

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -6,11 +6,14 @@ import { hexToBytes } from '@noble/hashes/utils.js'
 import WebSocket from 'ws'
 import { devUser1 } from '../../src/lib/fixtures'
 import path from 'node:path'
+import { decode } from 'light-bolt11-decoder'
 
 useWebSocketImplementation(WebSocket)
 
 const D_TAG = 'e2e-auction-mint-test'
 const MINT_A = 'https://testnut.cashu.space'
+const MINT_B = 'https://nofees.testnut.cashu.space'
+const MINT_UNTRUSTED = 'https://mint.minibits.cash/Bitcoin'
 const SCREENSHOT_DIR = 'test-results'
 
 async function seedAuction(relay: Relay, overrides: { mints: string[]; dTag?: string }) {
@@ -90,6 +93,18 @@ async function waitForWalletBalance(page: import('@playwright/test').Page, minBa
 		await page.waitForTimeout(500)
 	}
 	throw new Error(`Wallet balance did not reach ${minBalance} within timeout`)
+}
+
+const parseBolt11Sats = (bolt11: string): number => {
+	const amountMillisatsRaw = decode(bolt11).sections.find((section) => section.name === 'amount')?.value
+	if (!amountMillisatsRaw) {
+		throw new Error('No amount section found in bolt11 invoice')
+	}
+	const amountMillisats = parseInt(amountMillisatsRaw, 10)
+	if (!Number.isFinite(amountMillisats) || amountMillisats <= 0) {
+		throw new Error(`Invalid bolt11 amount section: ${amountMillisatsRaw}`)
+	}
+	return Math.floor(amountMillisats / 1000)
 }
 
 test.describe('Auction Bidding with Multiple Mints — Rendering', () => {
@@ -212,6 +227,55 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 				path: path.join(SCREENSHOT_DIR, 'pr886-funded-mint-no-reload.png'),
 				fullPage: true,
 			})
+		} finally {
+			relay.close()
+		}
+	})
+
+	test('auction funding modal only lists accepted mints and invoice amount includes fee padding', async ({ buyerPage }) => {
+		const relay = await Relay.connect(RELAY_URL)
+		try {
+			const auctionEvent = await seedAuction(relay, {
+				mints: [MINT_A, MINT_B],
+				dTag: 'e2e-auction-funding-fee-padding-test',
+			})
+
+			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
+			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
+
+			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 20, MINT_A)
+			await fundWallet(buyerPage, 20, MINT_B)
+			await fundWallet(buyerPage, 5_000, MINT_UNTRUSTED)
+			await buyerPage.reload()
+			await waitForWalletBalance(buyerPage, 5_000)
+
+			await buyerPage
+				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
+				.first()
+				.click()
+			const depositDialog = buyerPage.getByRole('dialog')
+			await expect(depositDialog.getByText('Deposit Lightning')).toBeVisible({ timeout: 10_000 })
+
+			const mintSelect = depositDialog.locator('select').first()
+			const optionLabels = await mintSelect.locator('option').allTextContents()
+			expect(optionLabels).toContain('testnut.cashu.space')
+			expect(optionLabels).toContain('nofees.testnut.cashu.space')
+			expect(optionLabels).not.toContain('mint.minibits.cash')
+
+			const amountInput = depositDialog.locator('input[type="number"]').first()
+			const requestedAmount = Number(await amountInput.inputValue())
+			expect(Number.isFinite(requestedAmount)).toBe(true)
+			expect(requestedAmount).toBeGreaterThan(0)
+
+			await depositDialog.getByRole('button', { name: 'Generate Invoice' }).click()
+			await expect(depositDialog.getByText('Lightning Invoice')).toBeVisible({ timeout: 15_000 })
+
+			const invoiceValue = await depositDialog.locator('input[readonly]').first().inputValue()
+			expect(invoiceValue.toLowerCase().startsWith('ln')).toBe(true)
+
+			const invoiceAmountSats = parseBolt11Sats(invoiceValue)
+			expect(invoiceAmountSats).toBeGreaterThan(requestedAmount)
 		} finally {
 			relay.close()
 		}

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -439,8 +439,12 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
-			// Wait for wallet to initialise — no funding, so balance is 0
-			// (insufficient for the 100 sat starting bid).
+			// Wait for wallet to initialise, then fund with a small amount so
+			// the wallet knows about the mint. The 20 sat balance is insufficient
+			// for the 100 sat starting bid, so the deposit modal will open.
+			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 20, MINT_A)
+			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
 
 			// Click the bid button — opens the Confirm Bid dialog.
@@ -512,6 +516,9 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
 			await waitForWalletReady(buyerPage)
+			await fundWallet(buyerPage, 20, MINT_A)
+			await buyerPage.reload()
+			await waitForWalletReady(buyerPage)
 
 			// Place a bid to open the deposit modal.
 			await buyerPage
@@ -581,7 +588,7 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 
 	// ── Scenario 3: Publish Failure ────────────────────────────────────
 
-	test('publish failure: sufficient funds → bid publish fails → retry available', async ({ buyerPage }) => {
+	test('publish failure: deposit succeeds → bid publish fails → retry available', async ({ buyerPage }) => {
 		const relay = await Relay.connect(RELAY_URL)
 		try {
 			const auctionEvent = await seedAuction(relay, {
@@ -594,16 +601,18 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await buyerPage.goto(`/auctions/${auctionEvent.id}`)
 			await expect(buyerPage.locator('h1')).toContainText('E2E Mint Test Auction', { timeout: 15_000 })
 
-			// Wait for wallet and fund with sufficient balance (500 sats ≥ 100 sat bid).
+			// Wait for wallet and fund with a small amount so the wallet
+			// knows about the mint. The 20 sat balance is insufficient for
+			// the 100 sat starting bid, so the deposit modal will open.
 			await waitForWalletReady(buyerPage)
-			await fundWallet(buyerPage, 500, MINT_A)
-			await waitForWalletBalance(buyerPage, 400)
+			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
-			await waitForWalletBalance(buyerPage, 400)
+			await waitForWalletReady(buyerPage)
 
 			// Intercept NIP-07 signEvent for kind-1023 to simulate a publish
-			// failure (e.g., relay rejection). The bid mutation will throw,
-			// and the funding hook transitions to
+			// failure (e.g., relay rejection). After the deposit succeeds and
+			// e-cash is minted, the bid mutation will throw, and the funding
+			// hook transitions to
 			// 'mint_succeeded_bid_publish_failed_reclaimable' with a toast.
 			await buyerPage.evaluate(() => {
 				const nostr = (window as any).nostr
@@ -618,8 +627,8 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 				}
 			})
 
-			// Place a bid — with sufficient funds, no deposit modal opens;
-			// the bid goes directly to publish, which fails.
+			// Place a bid — wallet has insufficient funds (20 sats < 100 sat
+			// starting bid), so the deposit modal opens after Confirm.
 			await buyerPage
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
 				.first()
@@ -635,6 +644,12 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			}
 
 			await confirmDialog.getByRole('button', { name: 'Confirm' }).click()
+
+			// Wait for the deposit QR invoice to appear, then simulate the
+			// Lightning payment. This triggers depositStatus → 'success' →
+			// onSuccess → submitPreparedBid → kind-1023 publish (which fails).
+			await waitForDepositQR(buyerPage)
+			await simulateDepositPayment(buyerPage)
 
 			// Verify the error toast appears indicating publish failure.
 			await expect(buyerPage.getByText(/bid publishing failed/i)).toBeVisible({ timeout: 30_000 })

--- a/e2e/tests/auction-bidding-mints.spec.ts
+++ b/e2e/tests/auction-bidding-mints.spec.ts
@@ -24,6 +24,8 @@ import { decode } from 'light-bolt11-decoder'
 
 useWebSocketImplementation(WebSocket)
 
+test.use({ video: 'on' })
+
 const D_TAG = 'e2e-auction-mint-test'
 const MINT_A = 'http://localhost:3338'
 const MINT_B = 'http://127.0.0.1:3338'
@@ -367,6 +369,13 @@ test.describe('Auction Bidding — Wallet-Funded Mint Selection', () => {
 			await fundWallet(buyerPage, 5_000, MINT_UNTRUSTED)
 			await buyerPage.reload()
 			await waitForWalletBalance(buyerPage, 5_000)
+			// Explicitly register mints after reload — the wallet re-inits from
+			// relay events and may not have the mint in its store when the
+			// deposit modal opens, causing filteredMints to be empty.
+			await buyerPage.evaluate((mints) => {
+				const w = (window as any).__nip60
+				if (w?.addMint) mints.forEach((m: string) => w.addMint(m))
+			}, [MINT_A, MINT_B])
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
@@ -542,11 +551,17 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Explicitly register mint after reload — wallet re-inits from relay
+			// events and may not have the mint in its store when the deposit
+			// modal opens, causing filteredMints to be empty.
+			await buyerPage.evaluate((mint) => {
+				const w = (window as any).__nip60
+				if (w?.addMint) w.addMint(mint)
+			}, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
 			await ensureInsufficientBidFunds(buyerPage)
-
 			// Click the bid button — opens the Confirm Bid dialog.
 			await buyerPage
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
@@ -619,11 +634,15 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Explicitly register mint after reload.
+			await buyerPage.evaluate((mint) => {
+				const w = (window as any).__nip60
+				if (w?.addMint) w.addMint(mint)
+			}, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
 			await ensureInsufficientBidFunds(buyerPage)
-
 			// Place a bid to open the deposit modal.
 			await buyerPage
 				.getByRole('button', { name: /place bid|bid\s+[\d,]+\s+sats/i })
@@ -712,11 +731,15 @@ test.describe('Direct Lightning Bid Funding (video recorded)', () => {
 			await fundWallet(buyerPage, 20, MINT_A)
 			await buyerPage.reload()
 			await waitForWalletReady(buyerPage)
+			// Explicitly register mint after reload.
+			await buyerPage.evaluate((mint) => {
+				const w = (window as any).__nip60
+				if (w?.addMint) w.addMint(mint)
+			}, MINT_A)
 
 			// Dynamically set bid amount to exceed actual wallet balance, ensuring
 			// hasInsufficientBidFunds = true regardless of accumulated balance.
 			await ensureInsufficientBidFunds(buyerPage)
-
 			// Intercept NIP-07 signEvent for kind-1023 to simulate a publish
 			// failure (e.g., relay rejection). After the deposit succeeds and
 			// e-cash is minted, the bid mutation will throw, and the funding

--- a/src/components/AuctionBidProgressDialog.tsx
+++ b/src/components/AuctionBidProgressDialog.tsx
@@ -15,6 +15,8 @@ import { Button } from '@/components/ui/button'
 import { Loader2, Check, AlertCircle } from 'lucide-react'
 import { useAuctionVerdicts } from '@/queries/auctions'
 import { parseValidatorVerdictEvent } from '@/lib/schemas/auction/validatorEvents'
+import type { ParsedValidatorVerdictEvent } from '@/lib/auction/events'
+import { computeVerdictQuorum } from '@/lib/auction/verdictQuorum'
 import type { AuctionBidFundingLifecycleState } from '@/hooks/useAuctionBidFunding'
 import { AvatarUser } from '@/components/AvatarUser'
 import { cn } from '@/lib/utils'
@@ -25,13 +27,17 @@ interface AuctionBidProgressDialogProps {
 	lifecycleState: AuctionBidFundingLifecycleState
 	auctionRootEventId: string
 	auctionCoordinates: string
-	bidderPubkey: string
 	validatorPubkeys: string[]
+	/**
+	 * Id of the exact published kind-1023 bid event. When provided, only
+	 * verdicts bound to this bid count (a rebid's verdict cannot leak into an
+	 * earlier leg and vice-versa).
+	 */
+	bidEventId?: string
+	/** Number of distinct auditor verdicts required to confirm/reject the bid. */
+	auditorQuorum?: number
 	onRetryPublish?: () => void
 }
-
-const POSITIVE_VERDICT_CLAIMS = ['valid_bid_placed', 'won_pending_settlement', 'settled_promptly'] as const
-const NEGATIVE_VERDICT_CLAIMS = ['bid_invalid', 'fraudulent_bid', 'griefed', 'griefed_pending_fallback', 'cancelled'] as const
 
 type StageStatus = 'done' | 'active' | 'pending' | 'error'
 
@@ -76,30 +82,40 @@ export function AuctionBidProgressDialog({
 	lifecycleState,
 	auctionRootEventId,
 	auctionCoordinates,
-	bidderPubkey,
 	validatorPubkeys,
+	bidEventId,
+	auditorQuorum,
 	onRetryPublish,
 }: AuctionBidProgressDialogProps) {
-	const verdictsQuery = useAuctionVerdicts(auctionRootEventId, 500, auctionCoordinates)
+	// Fetch only verdicts from the auction's configured auditors (when the
+	// auction lists any) — forged verdicts from arbitrary pubkeys are never
+	// even requested, let alone counted.
+	const verdictsQuery = useAuctionVerdicts(auctionRootEventId, 500, auctionCoordinates, validatorPubkeys)
 
-	const myVerdict = useMemo(() => {
-		const raw = verdictsQuery.data ?? []
-		for (const event of raw) {
-			const parsed = parseValidatorVerdictEvent(event)
-			if (parsed.ok && parsed.value.bidderPubkey === bidderPubkey) {
-				return parsed.value
-			}
-		}
-		return null
-	}, [verdictsQuery.data, bidderPubkey])
+	const parsedVerdicts = useMemo(
+		() =>
+			(verdictsQuery.data ?? [])
+				.map(parseValidatorVerdictEvent)
+				.filter((r): r is { ok: true; value: ParsedValidatorVerdictEvent } => r.ok)
+				.map((r) => r.value),
+		[verdictsQuery.data],
+	)
+
+	// Quorum gate: bind to the exact published bid event, accept only the
+	// auction's configured auditors, dedupe per validator, and require
+	// `auditorQuorum` distinct confirms/condemns before a terminal state.
+	const { representativeVerdict, hasPositiveVerdict, hasNegativeVerdict, hasNeutralVerdict } = computeVerdictQuorum(
+		parsedVerdicts,
+		bidEventId,
+		validatorPubkeys,
+		auditorQuorum,
+	)
 
 	const isPublishAttempted = lifecycleState === 'bid_publish_attempted'
 	const isBidPublished = lifecycleState === 'bid_published'
 	const isPublishFailed = lifecycleState === 'mint_succeeded_bid_publish_failed_reclaimable'
 
-	const hasPositiveVerdict = !!myVerdict && (POSITIVE_VERDICT_CLAIMS as readonly string[]).includes(myVerdict.claim)
-	const hasNegativeVerdict = !!myVerdict && (NEGATIVE_VERDICT_CLAIMS as readonly string[]).includes(myVerdict.claim)
-	const isAwaitingValidator = isBidPublished && !myVerdict
+	const isAwaitingValidator = isBidPublished && !hasPositiveVerdict && !hasNegativeVerdict
 
 	const isTerminal = hasPositiveVerdict || hasNegativeVerdict || isPublishFailed
 
@@ -110,7 +126,7 @@ export function AuctionBidProgressDialog({
 		? 'done'
 		: hasNegativeVerdict
 			? 'error'
-			: isAwaitingValidator
+			: isAwaitingValidator && validatorPubkeys.length > 0
 				? 'active'
 				: 'pending'
 
@@ -140,7 +156,7 @@ export function AuctionBidProgressDialog({
 							: isPublishFailed
 								? 'Your e-cash was minted but the bid could not be published to relays. You can retry or reclaim your funds.'
 								: hasNegativeVerdict
-									? `A validator has flagged this bid: ${myVerdict?.claim ?? 'rejected'}`
+									? `A validator has flagged this bid: ${representativeVerdict?.claim ?? 'rejected'}`
 									: 'Tracking your bid through confirmation stages.'}
 					</DialogDescription>
 				</DialogHeader>
@@ -157,12 +173,16 @@ export function AuctionBidProgressDialog({
 						status={validatorStage}
 						description={
 							hasPositiveVerdict
-								? `Validator confirmed: ${myVerdict?.claim}`
+								? `Validator confirmed: ${representativeVerdict?.claim}`
 								: hasNegativeVerdict
-									? `Validator verdict: ${myVerdict?.claim}`
-									: isAwaitingValidator
-										? 'Waiting for kind-30440 verdict from auction validators'
-										: undefined
+									? `Validator verdict: ${representativeVerdict?.claim}`
+									: isAwaitingValidator && validatorPubkeys.length === 0
+										? 'No validators configured for this auction'
+										: isAwaitingValidator && hasNeutralVerdict
+											? `Validator review pending (${representativeVerdict?.claim}) — awaiting final verdict`
+											: isAwaitingValidator
+												? 'Waiting for kind-30440 verdict from auction validators'
+												: undefined
 						}
 					/>
 				</div>

--- a/src/components/AuctionBidProgressDialog.tsx
+++ b/src/components/AuctionBidProgressDialog.tsx
@@ -1,12 +1,25 @@
 /**
- * Bid submission progress dialog — shows a visual stepper tracking the
- * bid from e-cash minting through relay publication to third-party
- * validator (kind-30440) confirmation.
+ * Bid submission progress dialog — a single modal that tracks the entire
+ * bid lifecycle from e-cash funding through relay publication to
+ * third-party validator (kind-30440) confirmation.
  *
- * Rendered by AuctionBidder when the funding lifecycle enters the
- * publish/validator phase. The dialog stays open until the user
- * dismisses it or a terminal outcome (validator confirmed, bid
- * rejected, or publish failure) is reached.
+ * Protocol stages per AUCTIONS.md:
+ *
+ *   Funding phase (when deposit is needed):
+ *     1a. Invoice created (Lightning invoice for selected mint)
+ *     1b. Payment acknowledged (wallet detects payment)
+ *     1c. E-cash minted (mint returns P2PK-locked proofs)
+ *
+ *   Publication phase:
+ *     2. Locking e-cash (P2PK lock with seller child pubkey + refund timelock)
+ *     3. Publishing bid to relays (kind-1023 event signed and published)
+ *
+ *   Validation phase:
+ *     4. Validator checks bid (kind-30440 verdict — rules + NUT-7 proof state)
+ *     5. Bid confirmed (valid_bid_placed from enough distinct auditors)
+ *
+ * The dialog does NOT auto-close. The user dismisses it explicitly after
+ * a terminal state (confirmed, rejected, or failed).
  */
 
 import { useMemo } from 'react'
@@ -36,6 +49,10 @@ interface AuctionBidProgressDialogProps {
 	bidEventId?: string
 	/** Number of distinct auditor verdicts required to confirm/reject the bid. */
 	auditorQuorum?: number
+	/** The bid amount (sats) placed for this submission — shown in the success summary. */
+	bidAmount?: number
+	/** Unix seconds at which the locked funds become refundable (cutoff + settlement grace). */
+	refundLocktime?: number
 	onRetryPublish?: () => void
 }
 
@@ -46,6 +63,27 @@ interface StageProps {
 	status: StageStatus
 	description?: string
 }
+
+// Lifecycle state groups
+const FUNDING_STATES: ReadonlySet<string> = new Set([
+	'funding_session_created',
+	'invoice_created',
+	'payment_acknowledged',
+	'minting_started',
+])
+const FUNDING_DONE_STATES: ReadonlySet<string> = new Set([
+	'ecash_minted',
+	'ecash_minted_pending_rules_ack',
+	'bid_publish_attempted',
+	'bid_published',
+])
+const FUNDING_FAILED_STATES: ReadonlySet<string> = new Set([
+	'invoice_unpaid_or_expired_reclaimable',
+	'invoice_paid_mint_failed_reclaimable',
+])
+const PUBLISH_ACTIVE_STATES: ReadonlySet<string> = new Set(['bid_publish_attempted'])
+const PUBLISH_DONE_STATES: ReadonlySet<string> = new Set(['bid_published'])
+const PUBLISH_FAILED_STATES: ReadonlySet<string> = new Set(['mint_succeeded_bid_publish_failed_reclaimable'])
 
 function ProgressStage({ label, status, description }: StageProps) {
 	const icon = {
@@ -76,6 +114,18 @@ function ProgressStage({ label, status, description }: StageProps) {
 	)
 }
 
+function formatLocktime(unixSeconds: number): string {
+	if (!unixSeconds || unixSeconds <= 0) return ''
+	try {
+		return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+			dateStyle: 'medium',
+			timeStyle: 'short',
+		})
+	} catch {
+		return ''
+	}
+}
+
 export function AuctionBidProgressDialog({
 	open,
 	onClose,
@@ -85,6 +135,8 @@ export function AuctionBidProgressDialog({
 	validatorPubkeys,
 	bidEventId,
 	auditorQuorum,
+	bidAmount,
+	refundLocktime,
 	onRetryPublish,
 }: AuctionBidProgressDialogProps) {
 	// Fetch only verdicts from the auction's configured auditors (when the
@@ -111,17 +163,30 @@ export function AuctionBidProgressDialog({
 		auditorQuorum,
 	)
 
-	const isPublishAttempted = lifecycleState === 'bid_publish_attempted'
-	const isBidPublished = lifecycleState === 'bid_published'
-	const isPublishFailed = lifecycleState === 'mint_succeeded_bid_publish_failed_reclaimable'
+	const isFundingActive = FUNDING_STATES.has(lifecycleState)
+	const isFundingDone = FUNDING_DONE_STATES.has(lifecycleState)
+	const isFundingFailed = FUNDING_FAILED_STATES.has(lifecycleState)
+	const isPublishActive = PUBLISH_ACTIVE_STATES.has(lifecycleState)
+	const isPublishDone = PUBLISH_DONE_STATES.has(lifecycleState)
+	const isPublishFailed = PUBLISH_FAILED_STATES.has(lifecycleState)
 
-	const isAwaitingValidator = isBidPublished && !hasPositiveVerdict && !hasNegativeVerdict
+	const isAwaitingValidator = isPublishDone && !hasPositiveVerdict && !hasNegativeVerdict
 
-	const isTerminal = hasPositiveVerdict || hasNegativeVerdict || isPublishFailed
+	const isTerminal = hasPositiveVerdict || hasNegativeVerdict || isPublishFailed || isFundingFailed
 
 	// Stage statuses
-	const fundingStage: StageStatus = 'done' // Funding is always complete by the time the dialog opens
-	const publishStage: StageStatus = isPublishFailed ? 'error' : isBidPublished ? 'done' : isPublishAttempted ? 'active' : 'pending'
+	const fundingStage: StageStatus = isFundingFailed ? 'error' : isFundingDone ? 'done' : isFundingActive ? 'active' : 'pending'
+
+	const lockStage: StageStatus = isPublishFailed
+		? 'error'
+		: isPublishActive || isPublishDone
+			? 'done'
+			: isFundingDone
+				? 'active'
+				: 'pending'
+
+	const publishStage: StageStatus = isPublishFailed ? 'error' : isPublishDone ? 'done' : isPublishActive ? 'active' : 'pending'
+
 	const validatorStage: StageStatus = hasPositiveVerdict
 		? 'done'
 		: hasNegativeVerdict
@@ -130,6 +195,25 @@ export function AuctionBidProgressDialog({
 				? 'active'
 				: 'pending'
 
+	// Funding sub-step label (more granular within the funding stage)
+	const fundingDescription = (() => {
+		switch (lifecycleState) {
+			case 'funding_session_created':
+				return 'Creating Lightning invoice...'
+			case 'invoice_created':
+				return 'Invoice generated — waiting for payment'
+			case 'payment_acknowledged':
+				return 'Payment received — minting e-cash...'
+			case 'minting_started':
+				return 'Mint processing proofs...'
+			case 'ecash_minted':
+			case 'ecash_minted_pending_rules_ack':
+				return 'E-cash minted with P2PK lock'
+			default:
+				return undefined
+		}
+	})()
+
 	return (
 		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
 			<DialogContent className="sm:max-w-md">
@@ -137,57 +221,116 @@ export function AuctionBidProgressDialog({
 					<DialogTitle className="flex items-center gap-2">
 						{hasPositiveVerdict ? (
 							<Check className="w-5 h-5 text-green-500" />
-						) : isPublishFailed || hasNegativeVerdict ? (
+						) : isFundingFailed || isPublishFailed || hasNegativeVerdict ? (
 							<AlertCircle className="w-5 h-5 text-destructive" />
 						) : (
 							<Loader2 className="w-5 h-5 animate-spin text-blue-500" />
 						)}
 						{hasPositiveVerdict
-							? 'Bid Confirmed'
-							: isPublishFailed
-								? 'Bid Publish Failed'
-								: hasNegativeVerdict
-									? 'Bid Rejected'
-									: 'Placing Your Bid'}
+							? 'Bid successfully placed!'
+							: isFundingFailed
+								? 'Funding Failed'
+								: isPublishFailed
+									? 'Bid Publish Failed'
+									: hasNegativeVerdict
+										? 'Bid Rejected'
+										: 'Placing Your Bid'}
 					</DialogTitle>
 					<DialogDescription>
 						{hasPositiveVerdict
-							? 'Your bid has been published and validated by the auction validators.'
-							: isPublishFailed
-								? 'Your e-cash was minted but the bid could not be published to relays. You can retry or reclaim your funds.'
-								: hasNegativeVerdict
-									? `A validator has flagged this bid: ${representativeVerdict?.claim ?? 'rejected'}`
-									: 'Tracking your bid through confirmation stages.'}
+							? `Your bid of ${bidAmount?.toLocaleString() ?? ''} sats has been published and validated by the auction validators.`
+							: isFundingFailed
+								? 'The Lightning payment could not be completed. Your funds are reclaimable.'
+								: isPublishFailed
+									? 'Your e-cash was minted but the bid could not be published to relays. You can retry or reclaim your funds.'
+									: hasNegativeVerdict
+										? `A validator has flagged this bid: ${representativeVerdict?.claim ?? 'rejected'}`
+										: 'Tracking your bid through confirmation stages.'}
 					</DialogDescription>
 				</DialogHeader>
 
-				<div className="space-y-1 py-2">
-					<ProgressStage label="Funding confirmed" status={fundingStage} description="Lightning payment received and e-cash minted" />
-					<ProgressStage
-						label="Publishing bid to relays"
-						status={publishStage}
-						description={isPublishFailed ? 'Failed to publish — retry available below' : undefined}
-					/>
-					<ProgressStage
-						label="Awaiting validator check"
-						status={validatorStage}
-						description={
-							hasPositiveVerdict
-								? `Validator confirmed: ${representativeVerdict?.claim}`
-								: hasNegativeVerdict
-									? `Validator verdict: ${representativeVerdict?.claim}`
-									: isAwaitingValidator && validatorPubkeys.length === 0
-										? 'No validators configured for this auction'
-										: isAwaitingValidator && hasNeutralVerdict
-											? `Validator review pending (${representativeVerdict?.claim}) — awaiting final verdict`
-											: isAwaitingValidator
-												? 'Waiting for kind-30440 verdict from auction validators'
-												: undefined
-						}
-					/>
-				</div>
+				{hasPositiveVerdict ? (
+					/* Success summary — bid amount + refund locktime */
+					<div className="space-y-3 py-2">
+						<div className="rounded-lg border border-green-200 bg-green-50 p-4 text-center">
+							<Check className="w-8 h-8 text-green-500 mx-auto mb-2" />
+							<p className="text-2xl font-bold text-green-700">{bidAmount?.toLocaleString() ?? 0} sats</p>
+							<p className="text-sm text-green-600 mt-1">bid locked</p>
+						</div>
+						{refundLocktime && refundLocktime > 0 && (
+							<div className="flex items-center justify-between text-xs text-muted-foreground px-1">
+								<span>Refund available after:</span>
+								<span className="font-medium text-foreground">{formatLocktime(refundLocktime)}</span>
+							</div>
+						)}
+						<div className="space-y-1 pt-1">
+							<ProgressStage label="E-cash funded" status="done" />
+							<ProgressStage label="P2PK lock applied" status="done" />
+							<ProgressStage label="Bid published to relays" status="done" description="Kind-1023 event with P2PK lock" />
+							<ProgressStage
+								label="Validator confirmed"
+								status="done"
+								description={representativeVerdict ? `Verdict: ${representativeVerdict.claim}` : undefined}
+							/>
+						</div>
+					</div>
+				) : (
+					/* Active/error stepper — shows all protocol stages */
+					<div className="space-y-1 py-2">
+						<ProgressStage
+							label="Funding e-cash"
+							status={fundingStage}
+							description={
+								isFundingFailed ? 'Lightning payment failed or expired' : isFundingDone ? 'E-cash minted and ready' : fundingDescription
+							}
+						/>
+						<ProgressStage
+							label="Locking e-cash (P2PK)"
+							status={lockStage}
+							description={
+								isPublishFailed
+									? undefined
+									: lockStage === 'done'
+										? 'Seller child pubkey + refund timelock applied'
+										: lockStage === 'active'
+											? 'Deriving path and applying NUT-11 lock...'
+											: undefined
+							}
+						/>
+						<ProgressStage
+							label="Publishing bid to relays"
+							status={publishStage}
+							description={
+								isPublishFailed
+									? 'Failed to publish — retry available below'
+									: isPublishDone
+										? 'Kind-1023 event published'
+										: isPublishActive
+											? 'Signing and broadcasting kind-1023...'
+											: undefined
+							}
+						/>
+						<ProgressStage
+							label="Awaiting validator check"
+							status={validatorStage}
+							description={
+								hasPositiveVerdict
+									? `Validator confirmed: ${representativeVerdict?.claim}`
+									: hasNegativeVerdict
+										? `Validator verdict: ${representativeVerdict?.claim}`
+										: isAwaitingValidator && validatorPubkeys.length === 0
+											? 'No validators configured for this auction'
+											: isAwaitingValidator && hasNeutralVerdict
+												? `Validator review pending (${representativeVerdict?.claim}) — awaiting final verdict`
+												: isAwaitingValidator
+													? 'Waiting for kind-30440 verdict from auction validators'
+													: undefined
+							}
+						/>
+					</div>
+				)}
 
-				{validatorPubkeys.length > 0 && (
+				{validatorPubkeys.length > 0 && !hasPositiveVerdict && (
 					<div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
 						<span>Validators:</span>
 						{validatorPubkeys.map((pk) => (
@@ -198,8 +341,8 @@ export function AuctionBidProgressDialog({
 
 				<DialogFooter>
 					{isPublishFailed && onRetryPublish && (
-						<Button onClick={onRetryPublish} disabled={isPublishAttempted}>
-							{isPublishAttempted ? (
+						<Button onClick={onRetryPublish} disabled={isPublishActive}>
+							{isPublishActive ? (
 								<>
 									<Loader2 className="w-4 h-4 animate-spin mr-2" />
 									Retrying...
@@ -210,7 +353,7 @@ export function AuctionBidProgressDialog({
 						</Button>
 					)}
 					<Button variant={isTerminal ? 'default' : 'outline'} onClick={onClose}>
-						{isTerminal ? 'Done' : 'Close'}
+						{isTerminal ? 'Done' : 'Cancel'}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/src/components/AuctionBidProgressDialog.tsx
+++ b/src/components/AuctionBidProgressDialog.tsx
@@ -1,0 +1,199 @@
+/**
+ * Bid submission progress dialog — shows a visual stepper tracking the
+ * bid from e-cash minting through relay publication to third-party
+ * validator (kind-30440) confirmation.
+ *
+ * Rendered by AuctionBidder when the funding lifecycle enters the
+ * publish/validator phase. The dialog stays open until the user
+ * dismisses it or a terminal outcome (validator confirmed, bid
+ * rejected, or publish failure) is reached.
+ */
+
+import { useMemo } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Loader2, Check, AlertCircle } from 'lucide-react'
+import { useAuctionVerdicts } from '@/queries/auctions'
+import { parseValidatorVerdictEvent } from '@/lib/schemas/auction/validatorEvents'
+import type { AuctionBidFundingLifecycleState } from '@/hooks/useAuctionBidFunding'
+import { AvatarUser } from '@/components/AvatarUser'
+import { cn } from '@/lib/utils'
+
+interface AuctionBidProgressDialogProps {
+	open: boolean
+	onClose: () => void
+	lifecycleState: AuctionBidFundingLifecycleState
+	auctionRootEventId: string
+	auctionCoordinates: string
+	bidderPubkey: string
+	validatorPubkeys: string[]
+	onRetryPublish?: () => void
+}
+
+const POSITIVE_VERDICT_CLAIMS = ['valid_bid_placed', 'won_pending_settlement', 'settled_promptly'] as const
+const NEGATIVE_VERDICT_CLAIMS = ['bid_invalid', 'fraudulent_bid', 'griefed', 'griefed_pending_fallback', 'cancelled'] as const
+
+type StageStatus = 'done' | 'active' | 'pending' | 'error'
+
+interface StageProps {
+	label: string
+	status: StageStatus
+	description?: string
+}
+
+function ProgressStage({ label, status, description }: StageProps) {
+	const icon = {
+		done: <Check className="w-5 h-5 text-green-500" />,
+		active: <Loader2 className="w-5 h-5 animate-spin text-blue-500" />,
+		pending: <div className="w-5 h-5 rounded-full border-2 border-muted-foreground/30" />,
+		error: <AlertCircle className="w-5 h-5 text-destructive" />,
+	}[status]
+
+	return (
+		<div className="flex items-start gap-3 py-2.5">
+			<div className="mt-0.5 shrink-0">{icon}</div>
+			<div className="flex flex-col gap-0.5 min-w-0">
+				<span
+					className={cn(
+						'text-sm font-medium',
+						status === 'pending' && 'text-muted-foreground',
+						status === 'done' && 'text-foreground',
+						status === 'active' && 'text-foreground',
+						status === 'error' && 'text-destructive',
+					)}
+				>
+					{label}
+				</span>
+				{description && <span className="text-xs text-muted-foreground">{description}</span>}
+			</div>
+		</div>
+	)
+}
+
+export function AuctionBidProgressDialog({
+	open,
+	onClose,
+	lifecycleState,
+	auctionRootEventId,
+	auctionCoordinates,
+	bidderPubkey,
+	validatorPubkeys,
+	onRetryPublish,
+}: AuctionBidProgressDialogProps) {
+	const verdictsQuery = useAuctionVerdicts(auctionRootEventId, 500, auctionCoordinates)
+
+	const myVerdict = useMemo(() => {
+		const raw = verdictsQuery.data ?? []
+		for (const event of raw) {
+			const parsed = parseValidatorVerdictEvent(event)
+			if (parsed.ok && parsed.value.bidderPubkey === bidderPubkey) {
+				return parsed.value
+			}
+		}
+		return null
+	}, [verdictsQuery.data, bidderPubkey])
+
+	const isPublishAttempted = lifecycleState === 'bid_publish_attempted'
+	const isBidPublished = lifecycleState === 'bid_published'
+	const isPublishFailed = lifecycleState === 'mint_succeeded_bid_publish_failed_reclaimable'
+
+	const hasPositiveVerdict = !!myVerdict && (POSITIVE_VERDICT_CLAIMS as readonly string[]).includes(myVerdict.claim)
+	const hasNegativeVerdict = !!myVerdict && (NEGATIVE_VERDICT_CLAIMS as readonly string[]).includes(myVerdict.claim)
+	const isAwaitingValidator = isBidPublished && !myVerdict
+
+	const isTerminal = hasPositiveVerdict || hasNegativeVerdict || isPublishFailed
+
+	// Stage statuses
+	const fundingStage: StageStatus = 'done' // Funding is always complete by the time the dialog opens
+	const publishStage: StageStatus = isPublishFailed ? 'error' : isBidPublished ? 'done' : isPublishAttempted ? 'active' : 'pending'
+	const validatorStage: StageStatus = hasPositiveVerdict
+		? 'done'
+		: hasNegativeVerdict
+			? 'error'
+			: isAwaitingValidator
+				? 'active'
+				: 'pending'
+
+	return (
+		<Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						{hasPositiveVerdict ? (
+							<Check className="w-5 h-5 text-green-500" />
+						) : isPublishFailed || hasNegativeVerdict ? (
+							<AlertCircle className="w-5 h-5 text-destructive" />
+						) : (
+							<Loader2 className="w-5 h-5 animate-spin text-blue-500" />
+						)}
+						{hasPositiveVerdict
+							? 'Bid Confirmed'
+							: isPublishFailed
+								? 'Bid Publish Failed'
+								: hasNegativeVerdict
+									? 'Bid Rejected'
+									: 'Placing Your Bid'}
+					</DialogTitle>
+					<DialogDescription>
+						{hasPositiveVerdict
+							? 'Your bid has been published and validated by the auction validators.'
+							: isPublishFailed
+								? 'Your e-cash was minted but the bid could not be published to relays. You can retry or reclaim your funds.'
+								: hasNegativeVerdict
+									? `A validator has flagged this bid: ${myVerdict?.claim ?? 'rejected'}`
+									: 'Tracking your bid through confirmation stages.'}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-1 py-2">
+					<ProgressStage label="Funding confirmed" status={fundingStage} description="Lightning payment received and e-cash minted" />
+					<ProgressStage
+						label="Publishing bid to relays"
+						status={publishStage}
+						description={isPublishFailed ? 'Failed to publish — retry available below' : undefined}
+					/>
+					<ProgressStage
+						label="Awaiting validator check"
+						status={validatorStage}
+						description={
+							hasPositiveVerdict
+								? `Validator confirmed: ${myVerdict?.claim}`
+								: hasNegativeVerdict
+									? `Validator verdict: ${myVerdict?.claim}`
+									: isAwaitingValidator
+										? 'Waiting for kind-30440 verdict from auction validators'
+										: undefined
+						}
+					/>
+				</div>
+
+				{validatorPubkeys.length > 0 && (
+					<div className="flex items-center gap-2 py-1 text-xs text-muted-foreground">
+						<span>Validators:</span>
+						{validatorPubkeys.map((pk) => (
+							<AvatarUser key={pk} pubkey={pk} colored deterministicFallbackText className="h-5 w-5" />
+						))}
+					</div>
+				)}
+
+				<DialogFooter>
+					{isPublishFailed && onRetryPublish && (
+						<Button onClick={onRetryPublish} disabled={isPublishAttempted}>
+							{isPublishAttempted ? (
+								<>
+									<Loader2 className="w-4 h-4 animate-spin mr-2" />
+									Retrying...
+								</>
+							) : (
+								'Retry publish'
+							)}
+						</Button>
+					)}
+					<Button variant={isTerminal ? 'default' : 'outline'} onClick={onClose}>
+						{isTerminal ? 'Done' : 'Close'}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -43,6 +43,7 @@ import { uiActions } from '@/lib/stores/ui'
 import { normalizeMintUrl } from '@/lib/wallet'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
 import { useAuctionBidFunding } from '@/hooks/useAuctionBidFunding'
+import { AuctionBidProgressDialog } from '@/components/AuctionBidProgressDialog'
 
 const AUCTION_RULES_ACK_VERSION = 'v1'
 
@@ -194,11 +195,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
-	const auctionRulesAuctionIdentity = auctionRootEventId || auction.id
+	// Rules ack is scoped per-ruleset (version + bidder), not per-auction —
+	// the rules content is static across all auctions, so acknowledging once
+	// should suppress the dialog for every auction until the version bumps.
 	const auctionRulesAckKey =
-		hasSignedInBidder && auctionRulesBidderPubkey && auctionRulesAuctionIdentity
-			? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}:${auctionRulesAuctionIdentity}`
-			: null
+		hasSignedInBidder && auctionRulesBidderPubkey ? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}` : null
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
@@ -208,6 +209,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const [isConfirmBidDialogOpen, setIsConfirmBidDialogOpen] = useState(false)
 	const [pendingBidData, setPendingBidData] = useState<AuctionBidFormData | null>(null)
 	const [isConfirmBidMintChosen, setIsConfirmBidMintChosen] = useState(false)
+	const [isBidProgressDialogOpen, setIsBidProgressDialogOpen] = useState(false)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -232,6 +234,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		handleDepositModalClose,
 		bidFundingLifecycleState,
 		resumeBidAfterRulesAck,
+		retryBidPublish,
 	} = useAuctionBidFunding({
 		previousBidAmount,
 		publishBid: bidMutation.mutateAsync,
@@ -273,6 +276,21 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			setHasAcknowledgedAuctionRules(false)
 		}
 	}, [auctionRulesAckKey])
+
+	// Open the bid progress dialog when the lifecycle enters the publish phase,
+	// and auto-close when returning to idle or canceled.
+	useEffect(() => {
+		if (['bid_publish_attempted', 'bid_published'].includes(bidFundingLifecycleState)) {
+			setIsBidProgressDialogOpen(true)
+		}
+		if (['idle', 'funding_canceled'].includes(bidFundingLifecycleState)) {
+			setIsBidProgressDialogOpen(false)
+		}
+	}, [bidFundingLifecycleState])
+
+	const handleCloseBidProgressDialog = useCallback(() => {
+		setIsBidProgressDialogOpen(false)
+	}, [])
 
 	// Disable logic
 	const isDisabledInput = ended || notStarted || isOwnAuction || bidMutation.isPending
@@ -361,18 +379,22 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		}
 	}
 
-	const handleSubmitBid = async () => {
-		if (hasSignedInBidder && !hasAcknowledgedAuctionRules) {
-			setIsRulesDialogOpen(true)
-			return
-		}
-
+	const openConfirmBidDialog = () => {
 		const bidData = prepareBidSubmission()
 		if (!bidData) return
 
 		setPendingBidData(bidData)
 		setIsConfirmBidMintChosen(false)
 		setIsConfirmBidDialogOpen(true)
+	}
+
+	const handleSubmitBid = async () => {
+		if (hasSignedInBidder && !hasAcknowledgedAuctionRules) {
+			setIsRulesDialogOpen(true)
+			return
+		}
+
+		openConfirmBidDialog()
 	}
 
 	const handleConfirmBidDialogOpenChange = (open: boolean) => {
@@ -424,9 +446,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		if (bidFundingLifecycleState === 'ecash_minted_pending_rules_ack') {
 			toast.info('Auction rules reviewed. Publishing your funded bid now.')
 			void resumeBidAfterRulesAck()
-		} else {
-			toast.info('Auction rules reviewed. Check the current bid amount before placing your bid.')
+			return
 		}
+
+		// Rules just acknowledged — immediately proceed to the bid confirmation dialog.
+		openConfirmBidDialog()
 	}
 
 	return (
@@ -443,6 +467,16 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				onMintingStarted={handleMintingStarted}
 				onFundingFailed={handleFundingFailed}
 				variant="bid"
+			/>
+			<AuctionBidProgressDialog
+				open={isBidProgressDialogOpen}
+				onClose={handleCloseBidProgressDialog}
+				lifecycleState={bidFundingLifecycleState}
+				auctionRootEventId={auctionRootEventId || auction.id}
+				auctionCoordinates={auctionCoordinates}
+				bidderPubkey={signedInBidderPubkey}
+				validatorPubkeys={auctionValidators}
+				onRetryPublish={() => void retryBidPublish()}
 			/>
 			<Dialog open={isRulesDialogOpen} onOpenChange={handleRulesDialogOpenChange}>
 				<DialogContent className="sm:max-w-lg">

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -23,6 +23,7 @@ import {
 	getAuctionTitle,
 	getAuctionImages,
 	getAuctionAuditors,
+	getAuctionAuditorQuorum,
 } from '@/queries/auctions'
 import { UserCard } from './UserCard'
 import { AvatarUser } from './AvatarUser'
@@ -193,6 +194,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const auctionTitle = getAuctionTitle(auction)
 	const auctionThumbnailUrl = getAuctionImages(auction)[0]?.[1] || ''
 	const auctionValidators = useMemo(() => getAuctionAuditors(auction), [auction])
+	const auctionAuditorQuorum = getAuctionAuditorQuorum(auction)
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
@@ -236,6 +238,7 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		bidFundingLifecycleState,
 		resumeBidAfterRulesAck,
 		retryBidPublish,
+		publishedBidEventId,
 	} = useAuctionBidFunding({
 		previousBidAmount,
 		publishBid: bidMutation.mutateAsync,
@@ -484,8 +487,9 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				lifecycleState={bidFundingLifecycleState}
 				auctionRootEventId={auctionRootEventId || auction.id}
 				auctionCoordinates={auctionCoordinates}
-				bidderPubkey={signedInBidderPubkey}
 				validatorPubkeys={auctionValidators}
+				bidEventId={publishedBidEventId ?? undefined}
+				auditorQuorum={auctionAuditorQuorum}
 				onRetryPublish={() => void retryBidPublish()}
 			/>
 			<Dialog open={isRulesDialogOpen} onOpenChange={handleRulesDialogOpenChange}>

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -317,6 +317,13 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
 	})
 
+	// #9: prepareBidSubmission returns null on any pre-funding validation
+	// failure (invalid auction state, bad bid amount, not signed in, wallet
+	// loading, missing p2pk_xpub). A null return is the correct signal to
+	// handleConfirmBid that funding should NOT proceed — startFundingForBid
+	// is never called, so no funding lifecycle state transition occurs.
+	// This keeps the funding state machine clean: it only enters non-idle
+	// states after pre-funding validation has passed.
 	const prepareBidSubmission = (): AuctionBidFormData | null => {
 		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return null
 

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -194,8 +194,11 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
+	const auctionRulesAuctionIdentity = auctionRootEventId || auction.id
 	const auctionRulesAckKey =
-		hasSignedInBidder && auctionRulesBidderPubkey ? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}` : null
+		hasSignedInBidder && auctionRulesBidderPubkey && auctionRulesAuctionIdentity
+			? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}:${auctionRulesAuctionIdentity}`
+			: null
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -227,12 +227,18 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		handleMintingStarted,
 		handleFundingFailed,
 		handleDepositModalClose,
+		bidFundingLifecycleState,
+		resumeBidAfterRulesAck,
 	} = useAuctionBidFunding({
 		previousBidAmount,
 		publishBid: bidMutation.mutateAsync,
 		onBidSuccess: () => {
 			setIsEditing(false)
 			onBidSuccess?.()
+		},
+		hasAcknowledgedRules: hasAcknowledgedAuctionRules,
+		onPendingRulesAck: () => {
+			setIsRulesDialogOpen(true)
 		},
 	})
 
@@ -403,7 +409,14 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 		setHasAcknowledgedAuctionRules(true)
 		setIsRulesDialogOpen(false)
-		toast.info('Auction rules reviewed. Check the current bid amount before placing your bid.')
+
+		// If funding completed while rules were unacknowledged, resume the bid publish now.
+		if (bidFundingLifecycleState === 'ecash_minted_pending_rules_ack') {
+			toast.info('Auction rules reviewed. Publishing your funded bid now.')
+			void resumeBidAfterRulesAck()
+		} else {
+			toast.info('Auction rules reviewed. Check the current bid amount before placing your bid.')
+		}
 	}
 
 	return (

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
 import { usePublishAuctionBidMutation, type AuctionBidFormData } from '@/publish/auctions'
@@ -19,7 +20,12 @@ import {
 	getAuctionCurrentPriceFromBids,
 	getAuctionBidCountFromBids,
 	getBidAmount,
+	getAuctionTitle,
+	getAuctionImages,
+	getAuctionAuditors,
 } from '@/queries/auctions'
+import { UserCard } from './UserCard'
+import { AvatarUser } from './AvatarUser'
 import { computeAuctionFloorMultiplier, getAuctionMinBidCurve } from '@/lib/auctionSettlement'
 import { AUCTION_MIN_BID_LEG_SATS, AUCTION_MIN_BID_SATS } from '@/lib/auction/constants'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
@@ -36,6 +42,7 @@ import { authStore } from '@/lib/stores/auth'
 import { uiActions } from '@/lib/stores/ui'
 import { normalizeMintUrl } from '@/lib/wallet'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
+import { useAuctionBidFunding } from '@/hooks/useAuctionBidFunding'
 
 const AUCTION_RULES_ACK_VERSION = 'v1'
 
@@ -181,22 +188,23 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 	const minBid = Math.max(flatFloor, curveFloor)
 	const inCurveWindow = countdown.now > endAt && countdown.now < biddingCutoffAt
 
+	const auctionTitle = getAuctionTitle(auction)
+	const auctionThumbnailUrl = getAuctionImages(auction)[0]?.[1] || ''
+	const auctionValidators = useMemo(() => getAuctionAuditors(auction), [auction])
+
 	const isOwnAuction = signedInBidderPubkey === auction.pubkey
 	const auctionRulesBidderPubkey = signedInBidderPubkey || currentUserPubkey || ''
-	const auctionRulesAuctionIdentity = auctionRootEventId || auction.id
 	const auctionRulesAckKey =
-		hasSignedInBidder && auctionRulesBidderPubkey && auctionRulesAuctionIdentity
-			? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}:${auctionRulesAuctionIdentity}`
-			: null
+		hasSignedInBidder && auctionRulesBidderPubkey ? `auction-rules-ack:${AUCTION_RULES_ACK_VERSION}:${auctionRulesBidderPubkey}` : null
 
 	// State for input and view mode
 	const [bidAmountInput, setBidAmountInput] = useState<string>('')
 	const [isEditing, setIsEditing] = useState(false)
-	const [isDepositOpen, setIsDepositOpen] = useState(false)
-	const [depositAmount, setDepositAmount] = useState(0)
-	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
 	const [isRulesDialogOpen, setIsRulesDialogOpen] = useState(false)
 	const [hasAcknowledgedAuctionRules, setHasAcknowledgedAuctionRules] = useState(false)
+	const [isConfirmBidDialogOpen, setIsConfirmBidDialogOpen] = useState(false)
+	const [pendingBidData, setPendingBidData] = useState<AuctionBidFormData | null>(null)
+	const [isConfirmBidMintChosen, setIsConfirmBidMintChosen] = useState(false)
 
 	// Parse the input safely
 	const parsedBidAmount = useMemo(() => {
@@ -206,6 +214,27 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 
 	const { selectedMint, depositMint, availableMints, showMintSelector, mintError, setSelectedMint, canFund, deltaAmount } =
 		useAuctionMintSelection(trustedMints, Number.isFinite(parsedBidAmount) ? parsedBidAmount : 0, previousBidAmount)
+
+	const {
+		isDepositOpen,
+		depositAmount,
+		preferredDepositMint,
+		startFundingForBid,
+		submitPreparedBid,
+		handleFundingSuccess,
+		handleInvoiceCreated,
+		handlePaymentAcknowledged,
+		handleMintingStarted,
+		handleFundingFailed,
+		handleDepositModalClose,
+	} = useAuctionBidFunding({
+		previousBidAmount,
+		publishBid: bidMutation.mutateAsync,
+		onBidSuccess: () => {
+			setIsEditing(false)
+			onBidSuccess?.()
+		},
+	})
 
 	const hasInsufficientBidFunds =
 		hasSignedInBidder &&
@@ -269,6 +298,19 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		return 'Place Bid'
 	}, [isOwnAuction, ended, notStarted, bidMutation.isPending, hasSignedInBidder, compact, parsedBidAmount])
 
+	const createBidSubmission = (): AuctionBidFormData => ({
+		auctionEventId: auctionRootEventId || auction.id,
+		auctionCoordinates,
+		amount: parsedBidAmount,
+		auctionStartAt: startAt,
+		auctionEffectiveEndAt: biddingCutoffAt,
+		auctionLocktimeAt: biddingCutoffAt,
+		settlementGraceSeconds: getAuctionSettlementGrace(auction),
+		sellerPubkey: auction.pubkey,
+		p2pkXpub: p2pkXpub || '',
+		mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
+	})
+
 	const prepareBidSubmission = (): AuctionBidFormData | null => {
 		if (!auction || !auctionCoordinates || ended || notStarted || isOwnAuction) return null
 
@@ -292,71 +334,56 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 			return null
 		}
 
-		if (hasInsufficientBidFunds) {
-			if (!depositMint) {
-				toast.error(mintError || 'No suitable mint available for bidding.')
-				return null
-			}
-
-			setDepositAmount(Math.ceil(deltaAmount))
-			setPreferredDepositMint(depositMint)
-			setIsDepositOpen(true)
-			return null
-		}
-
-		// Under `cashu_p2pk_bidder_path_v1` the bidder generates the
-		// derivation path locally and never consults a "path issuer"
-		// oracle - that was the v1 CVM-coordinator scheme. The only
-		// auction tag the bidder actually needs is `p2pk_xpub`; if
-		// it's absent the auction isn't biddable.
 		if (!p2pkXpub) {
 			toast.error('This auction is missing a p2pk_xpub and cannot accept bids.')
 			return null
 		}
-		if (!selectedMint) {
-			toast.error(mintError || 'No suitable mint available for bidding.')
-			return null
-		}
-		if (!canFund) {
-			toast.error('Insufficient balance on selected mint to cover the required delta.')
-			return null
-		}
 
 		return {
-			auctionEventId: auctionRootEventId || auction.id,
-			auctionCoordinates,
+			...createBidSubmission(),
 			amount: parsedAmount,
-			auctionStartAt: startAt,
-			auctionEffectiveEndAt: biddingCutoffAt,
-			auctionLocktimeAt: biddingCutoffAt,
-			settlementGraceSeconds: getAuctionSettlementGrace(auction),
-			sellerPubkey: auction.pubkey,
-			p2pkXpub,
-			mintCandidates: selectedMint ? [selectedMint, ...trustedMints.filter((m) => m !== selectedMint)] : trustedMints,
-		}
-	}
-
-	const submitPreparedBid = async (bidData: AuctionBidFormData) => {
-		try {
-			await bidMutation.mutateAsync(bidData)
-			toast.success('Bid placed successfully')
-			setIsEditing(false)
-			onBidSuccess?.()
-		} catch {
-			// Error handled by mutation
 		}
 	}
 
 	const handleSubmitBid = async () => {
-		const bidData = prepareBidSubmission()
-		if (!bidData) return
-
-		if (!hasAcknowledgedAuctionRules) {
+		if (hasSignedInBidder && !hasAcknowledgedAuctionRules) {
 			setIsRulesDialogOpen(true)
 			return
 		}
 
-		await submitPreparedBid(bidData)
+		const bidData = prepareBidSubmission()
+		if (!bidData) return
+
+		setPendingBidData(bidData)
+		setIsConfirmBidMintChosen(false)
+		setIsConfirmBidDialogOpen(true)
+	}
+
+	const handleConfirmBidDialogOpenChange = (open: boolean) => {
+		setIsConfirmBidDialogOpen(open)
+		if (!open) {
+			setPendingBidData(null)
+			setIsConfirmBidMintChosen(false)
+		}
+	}
+
+	const handleConfirmBid = async () => {
+		if (!pendingBidData) return
+		setIsConfirmBidDialogOpen(false)
+
+		const readyBidData = startFundingForBid({
+			bidData: pendingBidData,
+			hasInsufficientBidFunds,
+			depositMint,
+			deltaAmount,
+			mintError,
+			selectedMint,
+			canFund,
+		})
+		setPendingBidData(null)
+		if (!readyBidData) return
+
+		await submitPreparedBid(readyBidData)
 	}
 
 	const handleRulesDialogOpenChange = (open: boolean) => {
@@ -383,9 +410,16 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		<div className="flex flex-col gap-2 w-full">
 			<DepositLightningModal
 				open={isDepositOpen}
-				onClose={() => setIsDepositOpen(false)}
+				onClose={handleDepositModalClose}
 				initialAmount={depositAmount}
 				preferredMint={preferredDepositMint}
+				allowedMints={trustedMints}
+				onSuccess={handleFundingSuccess}
+				onInvoiceCreated={handleInvoiceCreated}
+				onPaymentAcknowledged={handlePaymentAcknowledged}
+				onMintingStarted={handleMintingStarted}
+				onFundingFailed={handleFundingFailed}
+				variant="bid"
 			/>
 			<Dialog open={isRulesDialogOpen} onOpenChange={handleRulesDialogOpenChange}>
 				<DialogContent className="sm:max-w-lg">
@@ -425,6 +459,75 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 						</Button>
 						<Button onClick={handleConfirmRules} disabled={bidMutation.isPending}>
 							I understand these rules
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+			<Dialog open={isConfirmBidDialogOpen} onOpenChange={handleConfirmBidDialogOpenChange}>
+				<DialogContent className="sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Confirm Bid</DialogTitle>
+						<DialogDescription>Review the auction details before placing your bid.</DialogDescription>
+					</DialogHeader>
+					<div className="flex gap-4 py-2">
+						{auctionThumbnailUrl && (
+							<img src={auctionThumbnailUrl} alt={auctionTitle} className="w-20 h-20 rounded object-cover shrink-0 border border-border" />
+						)}
+						<div className="flex flex-col gap-2 min-w-0 grow text-sm">
+							<div className="min-w-0">
+								<div className="text-xs text-foreground/60">Auction Name</div>
+								<div className="font-medium truncate">{auctionTitle}</div>
+							</div>
+							<div className="min-w-0">
+								<div className="text-xs text-foreground/60">Seller</div>
+								<UserCard pubkey={auction.pubkey} size="xs" subtitle="none" onPress="none" />
+							</div>
+							<div className="min-w-0">
+								<div className="text-xs text-foreground/60">Selected Mint</div>
+								{availableMints.length > 0 ? (
+									<Select
+										value={isConfirmBidMintChosen ? (selectedMint ?? '') : ''}
+										onValueChange={(val) => {
+											setSelectedMint(val)
+											setIsConfirmBidMintChosen(true)
+										}}
+									>
+										<SelectTrigger size="sm" className="w-full mt-0.5">
+											<SelectValue placeholder="Select a mint" />
+										</SelectTrigger>
+										<SelectContent>
+											{availableMints.map((m) => (
+												<SelectItem key={m.mintUrl} value={m.mintUrl}>
+													{m.hostname} <span className="text-foreground/50">({m.balance.toLocaleString()})</span>
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								) : (
+									<div className="font-medium truncate">Not selected</div>
+								)}
+							</div>
+							{auctionValidators.length > 0 && (
+								<div className="min-w-0">
+									<div className="text-xs text-foreground/60">Validators</div>
+									<div className="flex items-center gap-1 mt-0.5">
+										{auctionValidators.map((pubkey) => (
+											<AvatarUser key={pubkey} pubkey={pubkey} colored deterministicFallbackText className="h-5 w-5" />
+										))}
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+					<div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-center text-2xl font-bold">
+						{Number.isFinite(parsedBidAmount) ? parsedBidAmount.toLocaleString() : 0} sats
+					</div>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => handleConfirmBidDialogOpenChange(false)} disabled={bidMutation.isPending}>
+							Cancel
+						</Button>
+						<Button onClick={handleConfirmBid} disabled={bidMutation.isPending || (availableMints.length > 0 && !isConfirmBidMintChosen)}>
+							{bidMutation.isPending ? 'Submitting...' : 'Confirm'}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -44,7 +44,7 @@ import { uiActions } from '@/lib/stores/ui'
 import { normalizeMintUrl } from '@/lib/wallet'
 import { ndkActions } from '@/lib/stores/ndk'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
-import { useAuctionBidFunding } from '@/hooks/useAuctionBidFunding'
+import { useAuctionBidFunding, shouldOpenBidProgressDialog } from '@/hooks/useAuctionBidFunding'
 import { AuctionBidProgressDialog } from '@/components/AuctionBidProgressDialog'
 
 const AUCTION_RULES_ACK_VERSION = 'v1'
@@ -290,14 +290,19 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		}
 	}, [auctionRulesAckKey])
 
-	// Open the bid progress dialog when the lifecycle enters the publish phase,
-	// and auto-close when returning to idle or canceled.
+	// Open the bid progress dialog only AFTER funding is complete — i.e.,
+	// when e-cash has been minted and we're in the publish/validation phase.
+	// During the funding stage (invoice_created, payment_acknowledged, etc.)
+	// the DepositLightningModal is the sole UI — showing both simultaneously
+	// causes interference and duplicate dialogs. The publish-failure state is
+	// in the open-set so a failed publish keeps a retry surface even if the
+	// user dismissed the dialog mid-attempt.
+	// The dialog does NOT auto-close — the user dismisses it explicitly via
+	// the Done/Cancel button after reaching a terminal state, and closing the
+	// dialog never touches the funding lifecycle.
 	useEffect(() => {
-		if (['bid_publish_attempted', 'bid_published'].includes(bidFundingLifecycleState)) {
+		if (shouldOpenBidProgressDialog(bidFundingLifecycleState)) {
 			setIsBidProgressDialogOpen(true)
-		}
-		if (['idle', 'funding_canceled'].includes(bidFundingLifecycleState)) {
-			setIsBidProgressDialogOpen(false)
 		}
 	}, [bidFundingLifecycleState])
 
@@ -490,6 +495,8 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 				validatorPubkeys={auctionValidators}
 				bidEventId={publishedBidEventId ?? undefined}
 				auditorQuorum={auctionAuditorQuorum}
+				bidAmount={Number.isFinite(parsedBidAmount) ? parsedBidAmount : undefined}
+				refundLocktime={biddingCutoffAt + getAuctionSettlementGrace(auction)}
 				onRetryPublish={() => void retryBidPublish()}
 			/>
 			<Dialog open={isRulesDialogOpen} onOpenChange={handleRulesDialogOpenChange}>

--- a/src/components/AuctionBidder.tsx
+++ b/src/components/AuctionBidder.tsx
@@ -4,7 +4,7 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { DepositLightningModal } from '@/feature/wallet/components/DepositLightningModal'
-import { usePublishAuctionBidMutation, type AuctionBidFormData } from '@/publish/auctions'
+import { usePublishAuctionBidMutation, republishAuctionBid, type AuctionBidFormData } from '@/publish/auctions'
 import {
 	getAuctionBiddingCutoffAt,
 	getAuctionEndAt,
@@ -41,6 +41,7 @@ import { nip60Store } from '@/lib/stores/nip60'
 import { authStore } from '@/lib/stores/auth'
 import { uiActions } from '@/lib/stores/ui'
 import { normalizeMintUrl } from '@/lib/wallet'
+import { ndkActions } from '@/lib/stores/ndk'
 import { resolveAuctionMintSelection, type AvailableMint, type MintSelectionResult } from '@/lib/auctionMintSelection'
 import { useAuctionBidFunding } from '@/hooks/useAuctionBidFunding'
 import { AuctionBidProgressDialog } from '@/components/AuctionBidProgressDialog'
@@ -245,6 +246,15 @@ export function AuctionBidder({ auction, bids: bidsProp, currentUserPubkey, onBi
 		hasAcknowledgedRules: hasAcknowledgedAuctionRules,
 		onPendingRulesAck: () => {
 			setIsRulesDialogOpen(true)
+		},
+		// #12 (Blocker 1): retry of a failed publish rebroadcasts the already-
+		// signed kind-1023 event by id instead of re-running the lock+sign
+		// pipeline (which would double-charge the bidder). Falls back to the
+		// full re-submit inside the hook when no event id was captured.
+		republishBid: async (bidEventId) => {
+			const ndk = ndkActions.getNDK()
+			if (!ndk) throw new Error('NDK not initialized — cannot rebroadcast bid event')
+			await republishAuctionBid(bidEventId, ndk)
 		},
 	})
 

--- a/src/feature/wallet/components/DepositLightningModal.tsx
+++ b/src/feature/wallet/components/DepositLightningModal.tsx
@@ -293,24 +293,28 @@ export function DepositLightningModal({
 	const handleClose = () => {
 		if (isPayingWithNwc) return
 
-		const hasSentNwcPayment = nwcPaymentStatus === 'sent' || nwcPaymentSentForCurrentInvoice
-		const isTerminalDepositState = depositStatus === 'success' || depositStatus === 'error'
+		const isPendingDeposit = depositStatus === 'pending' || depositStatus === 'awaiting_confirmation_retry'
 
-		if (depositStatus === 'pending' && !hasSentNwcPayment) {
-			onFundingFailed?.('invoice_unpaid_or_expired_reclaimable')
-			failureNotifiedRef.current = true
-			nip60Actions.cancelDeposit()
+		// Always tear down the deposit so the modal starts fresh on reopen.
+		// For pending deposits, notify the funding lifecycle so it transitions
+		// to a reclaimable terminal state instead of hanging.
+		if (isPendingDeposit && !failureNotifiedRef.current) {
+			onFundingFailed?.(paymentAcknowledgedRef.current ? 'invoice_paid_mint_failed_reclaimable' : 'invoice_unpaid_or_expired_reclaimable')
 		}
-		if (isTerminalDepositState) {
-			nip60Actions.clearDepositResult()
-		}
+		// cancelDeposit() unconditionally resets the store to idle — works for
+		// pending, terminal, and idle states. This replaces the previous
+		// conditional cancel/clear that left stale state in the NWC-sent case.
+		nip60Actions.cancelDeposit()
 
+		// Reset ALL local state for a clean reopen.
 		setAmount('')
 		setCopied(false)
 		resetNwcPaymentState()
 		successNotifiedRef.current = false
 		paymentAcknowledgedRef.current = false
 		failureNotifiedRef.current = false
+		notifiedInvoiceRef.current = null
+		sentNwcInvoiceRef.current = null
 		setShowClassicTopUp(false)
 		setIsCheckingDeposit(false)
 		autoGenerateAttemptedKeyRef.current = null

--- a/src/feature/wallet/components/DepositLightningModal.tsx
+++ b/src/feature/wallet/components/DepositLightningModal.tsx
@@ -8,19 +8,61 @@ import { useStore } from '@tanstack/react-store'
 import { Loader2, Copy, Check, Zap } from 'lucide-react'
 import { toast } from 'sonner'
 import { QRCodeSVG } from 'qrcode.react'
-import { normalizeMintUrl } from '@/lib/wallet'
+import { getMintHostname, normalizeMintUrl } from '@/lib/wallet'
+
+const isValidMintUrl = (mintUrl: string): boolean => {
+	const normalizedMintUrl = normalizeMintUrl(mintUrl)
+	if (!normalizedMintUrl) return false
+	try {
+		new URL(normalizedMintUrl)
+		return true
+	} catch {
+		return false
+	}
+}
+
+const normalizeValidMintUrl = (mintUrl: string): string | null => {
+	const normalizedMintUrl = normalizeMintUrl(mintUrl)
+	return isValidMintUrl(normalizedMintUrl) ? normalizedMintUrl : null
+}
 
 interface DepositLightningModalProps {
 	open: boolean
 	onClose: () => void
 	initialAmount?: number
 	preferredMint?: string
+	allowedMints?: string[]
+	onSuccess?: () => void
+	onInvoiceCreated?: (invoice: string) => void
+	onPaymentAcknowledged?: () => void
+	onMintingStarted?: () => void
+	onFundingFailed?: (reason: AuctionFundingFailureReason) => void
+	/**
+	 * 'bid' renders the compact "Bid with lightning" quick-pay view: fixed
+	 * (non-editable) amount, auto-generated QR once a mint resolves, and a
+	 * "Top up your wallet" escape hatch into the classic form below.
+	 */
+	variant?: 'bid' | 'topup'
 }
+
+export type AuctionFundingFailureReason = 'invoice_unpaid_or_expired_reclaimable' | 'invoice_paid_mint_failed_reclaimable'
 
 type NwcDepositPaymentStatus = 'idle' | 'paying' | 'sent'
 
-export function DepositLightningModal({ open, onClose, initialAmount, preferredMint }: DepositLightningModalProps) {
-	const { mints, defaultMint, depositInvoice, depositStatus } = useStore(nip60Store)
+export function DepositLightningModal({
+	open,
+	onClose,
+	initialAmount,
+	preferredMint,
+	allowedMints,
+	onSuccess,
+	onInvoiceCreated,
+	onPaymentAcknowledged,
+	onMintingStarted,
+	onFundingFailed,
+	variant = 'topup',
+}: DepositLightningModalProps) {
+	const { mints, defaultMint, depositInvoice, depositStatus, error: depositError } = useStore(nip60Store)
 	const { wallets, isInitialized: walletsInitialized, isLoading: walletsLoading, initialize: initializeWallets } = useWallets()
 	const [amount, setAmount] = useState('')
 	const [selectedMint, setSelectedMint] = useState<string>('')
@@ -28,12 +70,31 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 	const [copied, setCopied] = useState(false)
 	const [selectedNwcWalletId, setSelectedNwcWalletId] = useState('')
 	const [nwcPaymentStatus, setNwcPaymentStatus] = useState<NwcDepositPaymentStatus>('idle')
+	const [showClassicTopUp, setShowClassicTopUp] = useState(false)
+	const [isCheckingDeposit, setIsCheckingDeposit] = useState(false)
+	const isBidQuickView = variant === 'bid' && !showClassicTopUp
+	const autoGenerateAttemptedKeyRef = useRef<string | null>(null)
 	const wasOpenRef = useRef(false)
 	const sentNwcInvoiceRef = useRef<string | null>(null)
 	const nwcPaymentSentForCurrentInvoice = !!depositInvoice && sentNwcInvoiceRef.current === depositInvoice
 	const isPayingWithNwc = nwcPaymentStatus === 'paying'
+	const needsConfirmationRetry = depositStatus === 'awaiting_confirmation_retry'
 	const nwcPaymentSent = nwcPaymentStatus === 'sent' || nwcPaymentSentForCurrentInvoice
 	const nwcPaymentAttempted = nwcPaymentStatus !== 'idle' || nwcPaymentSentForCurrentInvoice
+	const successNotifiedRef = useRef(false)
+	const paymentAcknowledgedRef = useRef(false)
+	const failureNotifiedRef = useRef(false)
+	const notifiedInvoiceRef = useRef<string | null>(null)
+	const filteredMints = useMemo(() => {
+		const normalizedWalletMints = mints.map(normalizeValidMintUrl).filter((mintUrl): mintUrl is string => mintUrl !== null)
+		const normalizedAllowedMints = allowedMints?.map(normalizeValidMintUrl).filter((mintUrl): mintUrl is string => mintUrl !== null) ?? []
+
+		if (!allowedMints?.length) return normalizedWalletMints
+
+		const allowedMintSet = new Set(normalizedAllowedMints)
+		return normalizedWalletMints.filter((mint) => allowedMintSet.has(mint))
+	}, [allowedMints, mints])
+	const hasAllowedMints = filteredMints.length > 0
 
 	const savedNwcWallets = useMemo(() => wallets.filter((wallet) => !!wallet.nwcUri), [wallets])
 
@@ -47,16 +108,29 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 			return
 		}
 
-		if (wasOpenRef.current) return
-		wasOpenRef.current = true
+		const normalizedPreferredMint = normalizeValidMintUrl(preferredMint ?? '')
+		const normalizedDefaultMint = normalizeValidMintUrl(defaultMint ?? '')
+		const preferred = normalizedPreferredMint ? filteredMints.find((mint) => mint === normalizedPreferredMint) : ''
+		const defaultAllowedMint = normalizedDefaultMint ? filteredMints.find((mint) => mint === normalizedDefaultMint) : ''
+		const nextSelectedMint = preferred || defaultAllowedMint || filteredMints[0] || ''
 
-		const preferred = preferredMint ? mints.find((mint) => normalizeMintUrl(mint) === normalizeMintUrl(preferredMint)) : ''
-		setSelectedMint(preferred || defaultMint || mints[0] || '')
-
-		if (typeof initialAmount === 'number' && Number.isFinite(initialAmount) && initialAmount > 0) {
-			setAmount(String(Math.ceil(initialAmount)))
+		if (!wasOpenRef.current) {
+			wasOpenRef.current = true
+			setSelectedMint(nextSelectedMint)
+			if (typeof initialAmount === 'number' && Number.isFinite(initialAmount) && initialAmount > 0) {
+				setAmount(String(Math.ceil(initialAmount)))
+			}
+			return
 		}
-	}, [open, defaultMint, mints, initialAmount, preferredMint])
+
+		setSelectedMint((currentMint) => {
+			const normalizedCurrentMint = normalizeValidMintUrl(currentMint)
+			if (normalizedCurrentMint && filteredMints.includes(normalizedCurrentMint)) {
+				return currentMint
+			}
+			return nextSelectedMint
+		})
+	}, [open, defaultMint, filteredMints, initialAmount, preferredMint])
 
 	useEffect(() => {
 		if (open && !walletsInitialized && !walletsLoading) {
@@ -83,6 +157,72 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 		}
 	}, [depositInvoice, depositStatus, resetNwcPaymentState])
 
+	useEffect(() => {
+		if (!depositInvoice || depositStatus !== 'pending') {
+			if (!depositInvoice) notifiedInvoiceRef.current = null
+			return
+		}
+		if (notifiedInvoiceRef.current === depositInvoice) return
+		notifiedInvoiceRef.current = depositInvoice
+		onInvoiceCreated?.(depositInvoice)
+	}, [depositInvoice, depositStatus, onInvoiceCreated])
+
+	useEffect(() => {
+		if (nwcPaymentStatus !== 'sent' && !nwcPaymentSentForCurrentInvoice) return
+		paymentAcknowledgedRef.current = true
+		onPaymentAcknowledged?.()
+		onMintingStarted?.()
+	}, [nwcPaymentSentForCurrentInvoice, nwcPaymentStatus, onMintingStarted, onPaymentAcknowledged])
+
+	useEffect(() => {
+		if (depositStatus !== 'error') return
+		if (failureNotifiedRef.current) return
+		failureNotifiedRef.current = true
+		onFundingFailed?.(paymentAcknowledgedRef.current ? 'invoice_paid_mint_failed_reclaimable' : 'invoice_unpaid_or_expired_reclaimable')
+	}, [depositStatus, onFundingFailed])
+
+	useEffect(() => {
+		if (depositStatus !== 'success') {
+			successNotifiedRef.current = false
+			return
+		}
+
+		if (successNotifiedRef.current) return
+		successNotifiedRef.current = true
+		failureNotifiedRef.current = false
+		onSuccess?.()
+	}, [depositStatus, onSuccess])
+
+	// Bid quick view has no "Generate Invoice" button — once a mint resolves
+	// (auto-picked from preferredMint/defaultMint/filteredMints), immediately
+	// start the deposit so the QR appears without an extra click.
+	useEffect(() => {
+		if (!isBidQuickView || !open || !selectedMint) return
+		if (depositInvoice || depositStatus === 'pending' || depositStatus === 'success') return
+
+		const amountNum = parseInt(amount, 10)
+		if (!Number.isFinite(amountNum) || amountNum <= 0) return
+
+		const genKey = `${selectedMint}:${amountNum}`
+		if (autoGenerateAttemptedKeyRef.current === genKey) return
+		autoGenerateAttemptedKeyRef.current = genKey
+
+		setIsGenerating(true)
+		resetNwcPaymentState()
+		void nip60Actions
+			.startDeposit(amountNum, selectedMint, { includeFeePadding: !!allowedMints?.length })
+			.finally(() => setIsGenerating(false))
+	}, [isBidQuickView, open, selectedMint, depositInvoice, depositStatus, amount, allowedMints, resetNwcPaymentState])
+
+	const handleConfirmCheckNow = async () => {
+		setIsCheckingDeposit(true)
+		try {
+			await nip60Actions.checkDepositNow()
+		} finally {
+			setIsCheckingDeposit(false)
+		}
+	}
+
 	const handleGenerateInvoice = async () => {
 		const amountNum = parseInt(amount, 10)
 		if (isNaN(amountNum) || amountNum <= 0) {
@@ -98,7 +238,9 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 		setIsGenerating(true)
 		resetNwcPaymentState()
 		try {
-			await nip60Actions.startDeposit(amountNum, selectedMint)
+			await nip60Actions.startDeposit(amountNum, selectedMint, {
+				includeFeePadding: !!allowedMints?.length,
+			})
 		} finally {
 			setIsGenerating(false)
 		}
@@ -144,6 +286,10 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 		}
 	}
 
+	const handleRetryConfirmation = () => {
+		nip60Actions.retryDepositConfirmation()
+	}
+
 	const handleClose = () => {
 		if (isPayingWithNwc) return
 
@@ -151,6 +297,8 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 		const isTerminalDepositState = depositStatus === 'success' || depositStatus === 'error'
 
 		if (depositStatus === 'pending' && !hasSentNwcPayment) {
+			onFundingFailed?.('invoice_unpaid_or_expired_reclaimable')
+			failureNotifiedRef.current = true
 			nip60Actions.cancelDeposit()
 		}
 		if (isTerminalDepositState) {
@@ -160,6 +308,12 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 		setAmount('')
 		setCopied(false)
 		resetNwcPaymentState()
+		successNotifiedRef.current = false
+		paymentAcknowledgedRef.current = false
+		failureNotifiedRef.current = false
+		setShowClassicTopUp(false)
+		setIsCheckingDeposit(false)
+		autoGenerateAttemptedKeyRef.current = null
 		onClose()
 	}
 
@@ -169,9 +323,11 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
 						<Zap className="w-5 h-5 text-yellow-500" />
-						Deposit Lightning
+						{isBidQuickView ? 'Bid with lightning' : 'Deposit Lightning'}
 					</DialogTitle>
-					<DialogDescription>Generate a Lightning invoice to mint eCash</DialogDescription>
+					<DialogDescription>
+						{isBidQuickView ? 'Pay this invoice to fund your bid.' : 'Generate a Lightning invoice to mint eCash'}
+					</DialogDescription>
 				</DialogHeader>
 
 				{depositStatus === 'success' ? (
@@ -184,6 +340,50 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 						<Button onClick={handleClose} className="mt-4">
 							Done
 						</Button>
+					</div>
+				) : isBidQuickView ? (
+					<div className="space-y-4">
+						<div className="flex justify-center">
+							<div className="w-[216px] h-[216px] flex items-center justify-center bg-white rounded-lg p-4">
+								{depositInvoice ? (
+									<button type="button" onClick={handleCopyInvoice} className="cursor-pointer outline-none" title="Click to copy invoice">
+										<QRCodeSVG value={depositInvoice} size={184} />
+									</button>
+								) : (
+									<div className="text-xs text-muted-foreground text-center px-2">
+										{selectedMint || isGenerating ? <Loader2 className="w-6 h-6 animate-spin mx-auto" /> : 'No mint selected yet'}
+									</div>
+								)}
+							</div>
+						</div>
+
+						<p className="text-center text-2xl font-bold">
+							{Number.isFinite(parseInt(amount, 10)) ? parseInt(amount, 10).toLocaleString() : 0} sats
+						</p>
+
+						{copied && <p className="text-xs text-center text-muted-foreground">Invoice copied to clipboard</p>}
+
+						{depositStatus === 'error' && (
+							<p className="text-sm text-destructive text-center">{depositError || 'Failed to generate invoice. Please try again.'}</p>
+						)}
+						{!hasAllowedMints && !depositInvoice && (
+							<p className="text-sm text-destructive text-center">No accepted auction mints are available in this wallet.</p>
+						)}
+
+						<div className="flex items-center justify-between gap-2 pt-1">
+							<Button
+								type="button"
+								variant="link"
+								className="h-auto px-0 text-sm text-muted-foreground"
+								onClick={() => setShowClassicTopUp(true)}
+							>
+								OR Top up your wallet
+							</Button>
+							<Button type="button" onClick={handleConfirmCheckNow} disabled={!depositInvoice || isCheckingDeposit}>
+								{isCheckingDeposit ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
+								Confirm
+							</Button>
+						</div>
 					</div>
 				) : depositInvoice ? (
 					<div className="space-y-4">
@@ -236,11 +436,23 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 							</div>
 						)}
 						<p className="text-sm text-muted-foreground text-center">
-							{nwcPaymentSent ? 'Payment sent. Waiting for mint confirmation...' : 'Waiting for payment...'}
+							{needsConfirmationRetry
+								? 'Confirmation timed out. Retry to check the mint again.'
+								: nwcPaymentSent
+									? 'Payment sent. Waiting for mint confirmation...'
+									: 'Waiting for payment...'}
 						</p>
-						<div className="flex justify-center">
-							<Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-						</div>
+						{needsConfirmationRetry ? (
+							<div className="flex justify-center">
+								<Button type="button" onClick={handleRetryConfirmation}>
+									Retry confirmation
+								</Button>
+							</div>
+						) : (
+							<div className="flex justify-center">
+								<Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+							</div>
+						)}
 						<div className="flex justify-end gap-2">
 							<Button variant="outline" onClick={handleClose} disabled={isPayingWithNwc}>
 								{nwcPaymentAttempted ? 'Close' : 'Cancel'}
@@ -263,26 +475,34 @@ export function DepositLightningModal({ open, onClose, initialAmount, preferredM
 
 						<div className="space-y-2">
 							<label className="text-sm font-medium">Mint</label>
-							<select
-								value={selectedMint}
-								onChange={(e) => setSelectedMint(e.target.value)}
-								className="w-full px-3 py-2 text-sm border rounded-md bg-background"
-							>
-								{mints.map((mint) => (
-									<option key={mint} value={mint}>
-										{new URL(mint).hostname}
-									</option>
-								))}
-							</select>
+							{hasAllowedMints ? (
+								<select
+									value={selectedMint}
+									onChange={(e) => setSelectedMint(e.target.value)}
+									className="w-full px-3 py-2 text-sm border rounded-md bg-background"
+								>
+									{filteredMints.map((mint) => (
+										<option key={mint} value={mint}>
+											{getMintHostname(mint)}
+										</option>
+									))}
+								</select>
+							) : (
+								<p className="text-sm text-destructive">
+									{allowedMints?.length ? 'No accepted auction mints are available in this wallet.' : 'No mints available.'}
+								</p>
+							)}
 						</div>
 
-						{depositStatus === 'error' && <p className="text-sm text-destructive">Failed to generate invoice. Please try again.</p>}
+						{depositStatus === 'error' && (
+							<p className="text-sm text-destructive">{depositError || 'Failed to generate invoice. Please try again.'}</p>
+						)}
 
 						<div className="flex justify-end gap-2">
 							<Button variant="outline" onClick={handleClose}>
 								Cancel
 							</Button>
-							<Button onClick={handleGenerateInvoice} disabled={isGenerating || !amount || !selectedMint}>
+							<Button onClick={handleGenerateInvoice} disabled={isGenerating || !amount || !selectedMint || !hasAllowedMints}>
 								{isGenerating ? <Loader2 className="w-4 h-4 animate-spin mr-2" /> : null}
 								Generate Invoice
 							</Button>

--- a/src/feature/wallet/components/DepositLightningModal.tsx
+++ b/src/feature/wallet/components/DepositLightningModal.tsx
@@ -9,6 +9,7 @@ import { Loader2, Copy, Check, Zap } from 'lucide-react'
 import { toast } from 'sonner'
 import { QRCodeSVG } from 'qrcode.react'
 import { getMintHostname, normalizeMintUrl } from '@/lib/wallet'
+import { resolveAuctionBidFundingFailureReason } from '@/hooks/useAuctionBidFunding'
 
 const isValidMintUrl = (mintUrl: string): boolean => {
 	const normalizedMintUrl = normalizeMintUrl(mintUrl)
@@ -28,7 +29,13 @@ const normalizeValidMintUrl = (mintUrl: string): string | null => {
 
 interface DepositLightningModalProps {
 	open: boolean
-	onClose: () => void
+	/**
+	 * Called when the user closes the modal. On a close while a deposit is
+	 * still pending, the paid-or-unknown failure classification is handed over
+	 * as `reason` so the funding lifecycle classifies BEFORE the modal-open
+	 * state flips (and exactly once per failure path). Plain closes pass null.
+	 */
+	onClose: (reason?: AuctionFundingFailureReason | null) => void
 	initialAmount?: number
 	preferredMint?: string
 	allowedMints?: string[]
@@ -178,8 +185,17 @@ export function DepositLightningModal({
 		if (depositStatus !== 'error') return
 		if (failureNotifiedRef.current) return
 		failureNotifiedRef.current = true
-		onFundingFailed?.(paymentAcknowledgedRef.current ? 'invoice_paid_mint_failed_reclaimable' : 'invoice_unpaid_or_expired_reclaimable')
-	}, [depositStatus, onFundingFailed])
+		// Paid-or-unknown classification: NWC failures with no payment sent are
+		// genuinely unpaid; QR failures can't be observed, so lean toward
+		// "paid but mint failed" instead of stranding a paid user's sats at the
+		// mint behind an "invoice unpaid/expired" message.
+		onFundingFailed?.(
+			resolveAuctionBidFundingFailureReason({
+				paymentAcknowledged: paymentAcknowledgedRef.current,
+				nwcPaymentAttempted,
+			}),
+		)
+	}, [depositStatus, onFundingFailed, nwcPaymentAttempted])
 
 	useEffect(() => {
 		if (depositStatus !== 'success') {
@@ -295,12 +311,20 @@ export function DepositLightningModal({
 
 		const isPendingDeposit = depositStatus === 'pending' || depositStatus === 'awaiting_confirmation_retry'
 
-		// Always tear down the deposit so the modal starts fresh on reopen.
-		// For pending deposits, notify the funding lifecycle so it transitions
-		// to a reclaimable terminal state instead of hanging.
+		// Paid-or-unknown close classification (error/close/timeout each fire
+		// exactly once): a QR payer can't be observed by the app, so lean toward
+		// reclaimable instead of claiming "unpaid" and stranding their sats at
+		// the mint. The reason is handed to the funding hook via onClose so the
+		// classification lands BEFORE the modal-open state flips and cannot be
+		// clobbered by the hook's funding_canceled fallback.
+		let closeReason: AuctionFundingFailureReason | null = null
 		if (isPendingDeposit && !failureNotifiedRef.current) {
-			onFundingFailed?.(paymentAcknowledgedRef.current ? 'invoice_paid_mint_failed_reclaimable' : 'invoice_unpaid_or_expired_reclaimable')
+			closeReason = resolveAuctionBidFundingFailureReason({
+				paymentAcknowledged: paymentAcknowledgedRef.current,
+				nwcPaymentAttempted,
+			})
 		}
+
 		// cancelDeposit() unconditionally resets the store to idle — works for
 		// pending, terminal, and idle states. This replaces the previous
 		// conditional cancel/clear that left stale state in the NWC-sent case.
@@ -318,7 +342,7 @@ export function DepositLightningModal({
 		setShowClassicTopUp(false)
 		setIsCheckingDeposit(false)
 		autoGenerateAttemptedKeyRef.current = null
-		onClose()
+		onClose(closeReason)
 	}
 
 	return (

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -172,7 +172,17 @@ const CLOSE_PRESERVE_PENDING_SUBMISSION_STATES = new Set<AuctionBidFundingLifecy
 const AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS: Record<AuctionBidFundingLifecycleState, ReadonlySet<AuctionBidFundingLifecycleState>> = {
 	idle: new Set(['funding_session_created', 'invoice_unpaid_or_expired_reclaimable', 'bid_publish_attempted', 'funding_canceled']),
 	funding_session_created: new Set(['invoice_created', 'invoice_unpaid_or_expired_reclaimable', 'funding_canceled']),
-	invoice_created: new Set(['payment_acknowledged', 'invoice_unpaid_or_expired_reclaimable', 'funding_canceled']),
+	invoice_created: new Set([
+		'payment_acknowledged',
+		// Paid-or-unknown close/error classification (QR path): the app cannot
+		// observe an external wallet's payment, so a failure while an invoice is
+		// outstanding leans toward "paid but mint failed" instead of stranding a
+		// paid user's sats behind an "unpaid" claim. payment_acknowledged is
+		// implied-but-unobserved here, hence the direct edge.
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'funding_canceled',
+	]),
 	payment_acknowledged: new Set(['minting_started', 'invoice_paid_mint_failed_reclaimable']),
 	minting_started: new Set(['ecash_minted', 'invoice_paid_mint_failed_reclaimable']),
 	ecash_minted: new Set(['ecash_minted_pending_rules_ack', 'bid_publish_attempted', 'invoice_paid_mint_failed_reclaimable']),
@@ -198,6 +208,62 @@ export const shouldCancelFundingOnModalClose = (state: AuctionBidFundingLifecycl
 
 export const shouldPreservePendingBidSubmissionOnModalClose = (state: AuctionBidFundingLifecycleState): boolean =>
 	CLOSE_PRESERVE_PENDING_SUBMISSION_STATES.has(state)
+
+/**
+ * Paid-or-unknown failure classification (S2/S4).
+ *
+ * Used by BOTH deposit-failure paths (the modal's error effect and the modal's
+ * user-close path):
+ *
+ * - NWC: `paymentAcknowledged` tells us whether the invoice was actually
+ *   sent/paid, so an NWC failure with no payment sent is genuinely "unpaid".
+ * - QR: we can't observe the external wallet's payment, so lean toward
+ *   "paid but mint failed" rather than stranding a paid user's sats at the
+ *   mint behind an "invoice unpaid/expired" message that implies nothing
+ *   was paid.
+ */
+export const resolveAuctionBidFundingFailureReason = ({
+	paymentAcknowledged,
+	nwcPaymentAttempted,
+}: {
+	paymentAcknowledged: boolean
+	nwcPaymentAttempted: boolean
+}): AuctionBidFundingFailureReason =>
+	paymentAcknowledged || !nwcPaymentAttempted ? 'invoice_paid_mint_failed_reclaimable' : 'invoice_unpaid_or_expired_reclaimable'
+
+export interface AuctionBidFundingModalCloseResolution {
+	/** Lifecycle state after the close: classified failure reason applied, then the funding_canceled fallback. */
+	nextState: AuctionBidFundingLifecycleState
+	/** Whether the preserved pending bid submission must survive this close. */
+	preservePendingSubmission: boolean
+}
+
+/**
+ * Resolve a deposit-modal close against the funding lifecycle.
+ *
+ * Ported from the lost full-UX lineage so closing cannot race or double-fire:
+ * the (optional) failure classification is applied against the CURRENT state
+ * inside a functional state updater, and the `funding_canceled` fallback is
+ * only considered AFTER classification — so a reclaimable terminal state can
+ * never be clobbered by funding_canceled.
+ *
+ * A close that carries a failure reason (error/close/timeout classification)
+ * always preserves the pending bid submission; a plain close falls back to
+ * the state-based CLOSE_PRESERVE_PENDING_SUBMISSION_STATES rule.
+ */
+export const resolveAuctionBidFundingModalClose = (
+	currentState: AuctionBidFundingLifecycleState,
+	reason?: AuctionBidFundingFailureReason | null,
+): AuctionBidFundingModalCloseResolution => {
+	const classifiedState = reason ? resolveAuctionBidFundingTransition(currentState, reason) : currentState
+	const nextState = shouldCancelFundingOnModalClose(classifiedState)
+		? resolveAuctionBidFundingTransition(classifiedState, 'funding_canceled')
+		: classifiedState
+	return {
+		nextState,
+		preservePendingSubmission: reason != null || shouldPreservePendingBidSubmissionOnModalClose(classifiedState),
+	}
+}
 
 export function useAuctionBidFunding({
 	previousBidAmount,
@@ -294,6 +360,18 @@ export function useAuctionBidFunding({
 		if (!pendingBidSubmission) return
 
 		void (async () => {
+			// Advance through the intermediate funding states to ecash_minted.
+			// For QR-scan deposits, payment_acknowledged and minting_started are not
+			// separately observable (only the final mint 'success' event fires), so
+			// the lifecycle may still be at invoice_created when the deposit
+			// confirms. Walk forward through the unobservable intermediate states so
+			// the transition is valid regardless of which pre-mint state we last
+			// observed. Each step is a silent no-op if the state already moved on
+			// (invalid transitions keep the current state; self-transitions are
+			// allowed), so this is safe and idempotent on the NWC path too, where the
+			// modal's payment effect may already have advanced the lifecycle.
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'payment_acknowledged'))
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'minting_started'))
 			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'ecash_minted'))
 
 			try {
@@ -408,15 +486,20 @@ export function useAuctionBidFunding({
 		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, reason))
 	}, [])
 
-	const handleDepositModalClose = useCallback(() => {
-		if (shouldCancelFundingOnModalClose(bidFundingLifecycleState)) {
-			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'funding_canceled'))
-		}
-		setIsDepositOpen(false)
-		if (!shouldPreservePendingBidSubmissionOnModalClose(bidFundingLifecycleState)) {
-			setPendingBidSubmission(null)
-		}
-	}, [bidFundingLifecycleState])
+	const handleDepositModalClose = useCallback(
+		(reason?: AuctionBidFundingFailureReason | null) => {
+			// Apply the (optional) close classification BEFORE the modal-open state
+			// flips, against the CURRENT lifecycle state inside a functional updater,
+			// so a reclaimable classification can never be clobbered by the
+			// funding_canceled fallback and closing cannot race or double-fire.
+			setBidFundingLifecycleState((current) => resolveAuctionBidFundingModalClose(current, reason).nextState)
+			setIsDepositOpen(false)
+			setPendingBidSubmission((current) =>
+				resolveAuctionBidFundingModalClose(bidFundingLifecycleState, reason).preservePendingSubmission ? current : null,
+			)
+		},
+		[bidFundingLifecycleState],
+	)
 
 	return {
 		bidFundingLifecycleState,

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -127,6 +127,19 @@ interface UseAuctionBidFundingOptions {
 	onBidSuccess?: () => void
 	onPendingRulesAck?: () => void
 	hasAcknowledgedRules: boolean
+	/**
+	 * #12 (Blocker 1): Rebroadcast an already-signed kind-1023 bid event by id.
+	 *
+	 * When a bid was successfully signed and published once (so
+	 * `publishedBidEventId` is set) but a subsequent relay broadcast
+	 * failed (e.g. transient relay outage on retry), retrying the publish
+	 * must NOT re-run `publishAuctionBid` — that would re-lock funds and
+	 * re-sign a new event, double-charging the bidder. Instead, this
+	 * callback fetches the original signed event by id and rebroadcasts it
+	 * verbatim. Falls back to `publishBid` (full re-submit) when unset or
+	 * when no event id was captured.
+	 */
+	republishBid?: (bidEventId: string) => Promise<void>
 }
 
 const TERMINAL_FUNDING_STATES: AuctionBidFundingLifecycleState[] = [
@@ -152,6 +165,8 @@ const CLOSE_NO_CANCEL_FUNDING_STATES = new Set<AuctionBidFundingLifecycleState>(
 const CLOSE_PRESERVE_PENDING_SUBMISSION_STATES = new Set<AuctionBidFundingLifecycleState>([
 	...FUNDED_IN_FLIGHT_FUNDING_STATES,
 	'mint_succeeded_bid_publish_failed_reclaimable',
+	'invoice_paid_mint_failed_reclaimable',
+	'invoice_unpaid_or_expired_reclaimable',
 ])
 
 const AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS: Record<AuctionBidFundingLifecycleState, ReadonlySet<AuctionBidFundingLifecycleState>> = {
@@ -167,7 +182,7 @@ const AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS: Record<AuctionBidFundingLifecycle
 	invoice_unpaid_or_expired_reclaimable: new Set(['funding_session_created']),
 	invoice_paid_mint_failed_reclaimable: new Set(['funding_session_created']),
 	mint_succeeded_bid_publish_failed_reclaimable: new Set(['bid_publish_attempted', 'funding_session_created']),
-	funding_canceled: new Set(['funding_session_created']),
+	funding_canceled: new Set(['funding_session_created', 'invoice_unpaid_or_expired_reclaimable', 'invoice_paid_mint_failed_reclaimable']),
 }
 
 export const canTransitionAuctionBidFundingState = (from: AuctionBidFundingLifecycleState, to: AuctionBidFundingLifecycleState): boolean =>
@@ -190,6 +205,7 @@ export function useAuctionBidFunding({
 	onBidSuccess,
 	onPendingRulesAck,
 	hasAcknowledgedRules,
+	republishBid,
 }: UseAuctionBidFundingOptions) {
 	const [isDepositOpen, setIsDepositOpen] = useState(false)
 	const [depositAmount, setDepositAmount] = useState(0)
@@ -197,12 +213,26 @@ export function useAuctionBidFunding({
 	const [pendingBidSubmission, setPendingBidSubmission] = useState<AuctionBidFormData | null>(null)
 	const [pendingRulesAckBidData, setPendingRulesAckBidData] = useState<AuctionBidFormData | null>(null)
 	const [bidFundingLifecycleState, setBidFundingLifecycleState] = useState<AuctionBidFundingLifecycleState>('idle')
+	// #12 (Blocker 1): id of the kind-1023 bid event that was already signed
+	// and published for the current `pendingBidSubmission`. Set only AFTER the
+	// publish succeeds, so `retryBidPublish` can rebroadcast the exact same
+	// signed event instead of re-running `publishAuctionBid` (which would
+	// re-lock funds and re-sign a new event — double-charging the bidder).
+	const [publishedBidEventId, setPublishedBidEventId] = useState<string | null>(null)
 
 	const submitPreparedBid = useCallback(
 		async (bidData: AuctionBidFormData) => {
 			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_publish_attempted'))
 			try {
-				await publishBid(bidData)
+				const publishResult = await publishBid(bidData)
+				// Capture the published event id (if the publish path returned one)
+				// so a later retry can rebroadcast this exact signed event instead
+				// of re-running the full lock+sign pipeline. `publishBid` is wired
+				// to `bidMutation.mutateAsync` in AuctionBidder, whose mutationFn
+				// resolves to `publishAuctionBid`'s return value — the bid event id.
+				if (typeof publishResult === 'string' && publishResult) {
+					setPublishedBidEventId(publishResult)
+				}
 				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_published'))
 				toast.success('Bid placed successfully')
 				setPendingBidSubmission(null)
@@ -223,6 +253,11 @@ export function useAuctionBidFunding({
 
 	const startFundingForBid = useCallback(
 		({ bidData, hasInsufficientBidFunds, depositMint, deltaAmount, mintError, selectedMint, canFund }: StartFundingForBidInput) => {
+			// New funding session — clear any captured publish id from a previous
+			// leg. Without this, a later retry in a NEW bid session could try to
+			// rebroadcast the PREVIOUS leg's event (stale cross-leg leak), which
+			// would silently announce an old bid instead of the new one.
+			setPublishedBidEventId(null)
 			if (hasInsufficientBidFunds) {
 				if (!depositMint) {
 					toast.error(mintError || 'No suitable mint available for bidding.')
@@ -310,14 +345,52 @@ export function useAuctionBidFunding({
 	}, [pendingRulesAckBidData, submitPreparedBid])
 
 	/**
-	 * Retry bid publish from the mint_succeeded_bid_publish_failed_reclaimable
-	 * state. Uses the preserved pendingBidSubmission so the user doesn't need
-	 * to re-enter the bid amount or reselect mints.
+	 * #12 (Blocker 1): Retry bid publish from the
+	 * mint_succeeded_bid_publish_failed_reclaimable state.
+	 *
+	 * Two retry paths:
+	 *
+	 * - **Idempotent rebroadcast (preferred):** if the bid was already
+	 *   signed and published once (captured in `publishedBidEventId`) and a
+	 *   `republishBid` callback is wired, rebroadcast the exact signed
+	 *   kind-1023 event by id. This is a relay-only rebroadcast — no
+	 *   re-lock, no re-sign, no new event id. This is the correct path
+	 *   when the original publish broadcast threw after the event was
+	 *   signed (e.g. relay timeout) OR when a prior successful publish
+	 *   needs to be re-announced to relays that missed it.
+	 *
+	 * - **Full re-submit (fallback):** when no event id was captured (the
+	 *   publish threw before signing completed, so there's nothing to
+	 *   rebroadcast) or no `republishBid` callback is wired, fall back to
+	 *   `submitPreparedBid`, which re-runs `publishAuctionBid` (re-lock +
+	 *   re-sign). This only happens when there's genuinely no signed event
+	 *   to rebroadcast.
+	 *
+	 * The rebroadcast path is what makes this idempotent: retrying a
+	 * completed-but-not-broadcast publish never double-charges the bidder.
 	 */
 	const retryBidPublish = useCallback(async () => {
 		if (!pendingBidSubmission) return
+		if (publishedBidEventId && republishBid) {
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_publish_attempted'))
+			try {
+				await republishBid(publishedBidEventId)
+				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_published'))
+				setPendingBidSubmission(null)
+				setIsDepositOpen(false)
+				setPublishedBidEventId(null)
+				onBidSuccess?.()
+			} catch (error) {
+				setBidFundingLifecycleState((currentState) =>
+					resolveAuctionBidFundingTransition(currentState, 'mint_succeeded_bid_publish_failed_reclaimable'),
+				)
+				const errorMessage = error instanceof Error ? error.message : String(error)
+				toast.error(`Bid rebroadcast failed: ${errorMessage}`)
+			}
+			return
+		}
 		await submitPreparedBid(pendingBidSubmission)
-	}, [pendingBidSubmission, submitPreparedBid])
+	}, [pendingBidSubmission, publishedBidEventId, republishBid, submitPreparedBid, onBidSuccess])
 
 	const handleInvoiceCreated = useCallback(() => {
 		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'invoice_created'))

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -210,6 +210,46 @@ export const shouldPreservePendingBidSubmissionOnModalClose = (state: AuctionBid
 	CLOSE_PRESERVE_PENDING_SUBMISSION_STATES.has(state)
 
 /**
+ * Lifecycle states in which the staged bid progress dialog is (or becomes)
+ * open.
+ *
+ * Ported from the lost full-UX lineage (AuctionBidder's `POST_FUNDING_STATES`):
+ * the dialog opens only AFTER funding is complete — i.e. once e-cash has been
+ * minted and the flow is in the publish/validation phase. During the funding
+ * stage (invoice_created, payment_acknowledged, …) the DepositLightningModal
+ * is the sole UI — showing both simultaneously causes interference and
+ * duplicate dialogs.
+ *
+ * The set deliberately includes:
+ *
+ * - `ecash_minted` / `ecash_minted_pending_rules_ack`: the deposit modal is
+ *   closed as funding completes (see `handleFundingSuccess`), so the progress
+ *   dialog must take over immediately — otherwise no modal is visible during
+ *   the lock+sign+publish leg. The rules-ack variant stacks the rules dialog
+ *   on top until the user acknowledges.
+ * - `mint_succeeded_bid_publish_failed_reclaimable`: a failed publish keeps a
+ *   retry surface — even if the user dismissed the dialog during the publish
+ *   attempt, it reopens with the "Retry publish" affordance (fixes M7's
+ *   close-then-fail dead end).
+ *
+ * The dialog never auto-closes: the user dismisses it explicitly via the
+ * Done/Cancel button after a terminal outcome (confirmed, rejected, or
+ * failed). Closing the dialog does NOT touch the funding lifecycle.
+ */
+export const AUCTION_BID_PROGRESS_DIALOG_OPEN_STATES: readonly AuctionBidFundingLifecycleState[] = [
+	'ecash_minted',
+	'ecash_minted_pending_rules_ack',
+	'bid_publish_attempted',
+	'bid_published',
+	'mint_succeeded_bid_publish_failed_reclaimable',
+]
+
+const AUCTION_BID_PROGRESS_DIALOG_OPEN_STATE_SET = new Set<AuctionBidFundingLifecycleState>(AUCTION_BID_PROGRESS_DIALOG_OPEN_STATES)
+
+export const shouldOpenBidProgressDialog = (state: AuctionBidFundingLifecycleState): boolean =>
+	AUCTION_BID_PROGRESS_DIALOG_OPEN_STATE_SET.has(state)
+
+/**
  * Paid-or-unknown failure classification (S2/S4).
  *
  * Used by BOTH deposit-failure paths (the modal's error effect and the modal's
@@ -300,7 +340,9 @@ export function useAuctionBidFunding({
 					setPublishedBidEventId(publishResult)
 				}
 				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_published'))
-				toast.success('Bid placed successfully')
+				// No success toast here: the staged bid progress dialog ("Bid
+				// successfully placed!") is the success surface — a duplicate toast
+				// was never part of the staged UX.
 				setPendingBidSubmission(null)
 				setIsDepositOpen(false)
 				onBidSuccess?.()
@@ -358,6 +400,13 @@ export function useAuctionBidFunding({
 
 	const handleFundingSuccess = useCallback(() => {
 		if (!pendingBidSubmission) return
+
+		// Close the deposit modal immediately so the bid progress dialog
+		// (which opens on the ecash_minted state transition below) is
+		// visible without being obscured by the "Deposit Successful!"
+		// screen. The progress dialog's stepper shows the funding stage
+		// as completed, so the success screen in the modal is redundant.
+		setIsDepositOpen(false)
 
 		void (async () => {
 			// Advance through the intermediate funding states to ecash_minted.

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -309,6 +309,16 @@ export function useAuctionBidFunding({
 		await submitPreparedBid(bidData)
 	}, [pendingRulesAckBidData, submitPreparedBid])
 
+	/**
+	 * Retry bid publish from the mint_succeeded_bid_publish_failed_reclaimable
+	 * state. Uses the preserved pendingBidSubmission so the user doesn't need
+	 * to re-enter the bid amount or reselect mints.
+	 */
+	const retryBidPublish = useCallback(async () => {
+		if (!pendingBidSubmission) return
+		await submitPreparedBid(pendingBidSubmission)
+	}, [pendingBidSubmission, submitPreparedBid])
+
 	const handleInvoiceCreated = useCallback(() => {
 		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'invoice_created'))
 	}, [])
@@ -349,5 +359,6 @@ export function useAuctionBidFunding({
 		handleFundingFailed,
 		handleDepositModalClose,
 		resumeBidAfterRulesAck,
+		retryBidPublish,
 	}
 }

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -66,6 +66,46 @@ export const AUCTION_BID_FUNDING_RECLAIMABLE_STATES: readonly AuctionBidFundingL
 	'mint_succeeded_bid_publish_failed_reclaimable',
 ]
 
+/**
+ * Reclaim / refund flow for reclaimable states:
+ *
+ * When a bid funding session ends in one of the reclaimable terminal states,
+ * the user's sats are not lost — they remain as Cashu proofs at the mint,
+ * locked under a P2PK timelock with a refund path. Recovery works as follows:
+ *
+ * 1. `invoice_unpaid_or_expired_reclaimable`: The Lightning invoice expired
+ *    or was never paid. No funds were minted — nothing to reclaim. The user
+ *    can simply start a new funding session.
+ *
+ * 2. `invoice_paid_mint_failed_reclaimable`: The invoice was paid but minting
+ *    failed. Funds may be at the mint in a partially-minted state. The user
+ *    can retry the funding session (transition back to funding_session_created
+ *    is allowed), which re-attempts minting. If minting keeps failing, the
+ *    pending token entry in nip60Store will eventually become eligible for
+ *    reclaimToken() once the timelock expires.
+ *
+ * 3. `mint_succeeded_bid_publish_failed_reclaimable`: E-cash was minted but
+ *    the bid event could not be published to relays. The proofs are in the
+ *    user's wallet as a pending token. The user can retry publishing (transition
+ *    back to bid_publish_attempted is allowed). If they abandon the bid, the
+ *    funds are reclaimable via nip60Actions.reclaimToken() after the timelock.
+ *
+ * 4. `ecash_minted_pending_rules_ack`: E-cash was minted but the user hasn't
+ *    acknowledged the auction rules yet. The funds are in the wallet as a
+ *    pending token. If the user closes the modal, the pending bid is preserved
+ *    (shouldPreservePendingBidSubmissionOnModalClose returns true). Once rules
+ *    are acknowledged, publishing resumes. If abandoned, reclaimToken() recovers
+ *    funds after the timelock.
+ *
+ * The actual reclaim implementation lives in nip60Actions.reclaimToken() in
+ * src/lib/stores/nip60.ts. It:
+ *   - Checks the timelock from the proof secret (not cached context)
+ *   - Looks up the refund private key from BidderBidRecord or wallet.privkeys
+ *   - Calls receiveTokenWithPrivkey() to sweep the locked proofs back
+ *   - Marks the token as 'reclaimed' in pendingTokens
+ * An auto-reclaim sweep runs periodically with exponential backoff; the user
+ * can also manually trigger reclaim from the UI.
+ */
 const AUCTION_BID_FUNDING_RECLAIMABLE_STATE_SET = new Set<AuctionBidFundingLifecycleState>(AUCTION_BID_FUNDING_RECLAIMABLE_STATES)
 
 export const isAuctionBidFundingReclaimableState = (state: AuctionBidFundingLifecycleState): boolean =>

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -433,5 +433,6 @@ export function useAuctionBidFunding({
 		handleDepositModalClose,
 		resumeBidAfterRulesAck,
 		retryBidPublish,
+		publishedBidEventId,
 	}
 }

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -10,6 +10,7 @@ export type AuctionBidFundingLifecycleState =
 	| 'payment_acknowledged'
 	| 'minting_started'
 	| 'ecash_minted'
+	| 'ecash_minted_pending_rules_ack'
 	| 'bid_publish_attempted'
 	| 'bid_published'
 	| 'invoice_unpaid_or_expired_reclaimable'
@@ -40,6 +41,7 @@ export const AUCTION_BID_FUNDING_ADR_STATE_MAPPING = {
 export const AUCTION_BID_FUNDING_RECLAIMABLE_STATES: readonly AuctionBidFundingLifecycleState[] = [
 	'invoice_unpaid_or_expired_reclaimable',
 	'invoice_paid_mint_failed_reclaimable',
+	'ecash_minted_pending_rules_ack',
 	'mint_succeeded_bid_publish_failed_reclaimable',
 ]
 
@@ -62,6 +64,8 @@ interface UseAuctionBidFundingOptions {
 	previousBidAmount: number
 	publishBid: (bidData: AuctionBidFormData) => Promise<unknown>
 	onBidSuccess?: () => void
+	onPendingRulesAck?: () => void
+	hasAcknowledgedRules: boolean
 }
 
 const TERMINAL_FUNDING_STATES: AuctionBidFundingLifecycleState[] = [
@@ -75,6 +79,7 @@ const FUNDED_IN_FLIGHT_FUNDING_STATES: AuctionBidFundingLifecycleState[] = [
 	'payment_acknowledged',
 	'minting_started',
 	'ecash_minted',
+	'ecash_minted_pending_rules_ack',
 	'bid_publish_attempted',
 ]
 
@@ -94,7 +99,8 @@ const AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS: Record<AuctionBidFundingLifecycle
 	invoice_created: new Set(['payment_acknowledged', 'invoice_unpaid_or_expired_reclaimable', 'funding_canceled']),
 	payment_acknowledged: new Set(['minting_started', 'invoice_paid_mint_failed_reclaimable']),
 	minting_started: new Set(['ecash_minted', 'invoice_paid_mint_failed_reclaimable']),
-	ecash_minted: new Set(['bid_publish_attempted', 'invoice_paid_mint_failed_reclaimable']),
+	ecash_minted: new Set(['ecash_minted_pending_rules_ack', 'bid_publish_attempted', 'invoice_paid_mint_failed_reclaimable']),
+	ecash_minted_pending_rules_ack: new Set(['bid_publish_attempted', 'funding_session_created']),
 	bid_publish_attempted: new Set(['bid_published', 'mint_succeeded_bid_publish_failed_reclaimable']),
 	bid_published: new Set(['funding_session_created']),
 	invoice_unpaid_or_expired_reclaimable: new Set(['funding_session_created']),
@@ -117,11 +123,18 @@ export const shouldCancelFundingOnModalClose = (state: AuctionBidFundingLifecycl
 export const shouldPreservePendingBidSubmissionOnModalClose = (state: AuctionBidFundingLifecycleState): boolean =>
 	CLOSE_PRESERVE_PENDING_SUBMISSION_STATES.has(state)
 
-export function useAuctionBidFunding({ previousBidAmount, publishBid, onBidSuccess }: UseAuctionBidFundingOptions) {
+export function useAuctionBidFunding({
+	previousBidAmount,
+	publishBid,
+	onBidSuccess,
+	onPendingRulesAck,
+	hasAcknowledgedRules,
+}: UseAuctionBidFundingOptions) {
 	const [isDepositOpen, setIsDepositOpen] = useState(false)
 	const [depositAmount, setDepositAmount] = useState(0)
 	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
 	const [pendingBidSubmission, setPendingBidSubmission] = useState<AuctionBidFormData | null>(null)
+	const [pendingRulesAckBidData, setPendingRulesAckBidData] = useState<AuctionBidFormData | null>(null)
 	const [bidFundingLifecycleState, setBidFundingLifecycleState] = useState<AuctionBidFundingLifecycleState>('idle')
 
 	const submitPreparedBid = useCallback(
@@ -215,9 +228,25 @@ export function useAuctionBidFunding({ previousBidAmount, publishBid, onBidSucce
 			}
 
 			const orderedMintCandidates = [fundableMint, ...fundingMintCandidates.filter((mintUrl) => mintUrl !== fundableMint)]
-			await submitPreparedBid({ ...pendingBidSubmission, mintCandidates: orderedMintCandidates })
+			const preparedBid = { ...pendingBidSubmission, mintCandidates: orderedMintCandidates }
+
+			if (!hasAcknowledgedRules) {
+				setPendingRulesAckBidData(preparedBid)
+				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'ecash_minted_pending_rules_ack'))
+				onPendingRulesAck?.()
+				return
+			}
+
+			await submitPreparedBid(preparedBid)
 		})()
-	}, [pendingBidSubmission, previousBidAmount, submitPreparedBid])
+	}, [pendingBidSubmission, previousBidAmount, submitPreparedBid, hasAcknowledgedRules, onPendingRulesAck])
+
+	const resumeBidAfterRulesAck = useCallback(async () => {
+		if (!pendingRulesAckBidData) return
+		const bidData = pendingRulesAckBidData
+		setPendingRulesAckBidData(null)
+		await submitPreparedBid(bidData)
+	}, [pendingRulesAckBidData, submitPreparedBid])
 
 	const handleInvoiceCreated = useCallback(() => {
 		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'invoice_created'))
@@ -258,5 +287,6 @@ export function useAuctionBidFunding({ previousBidAmount, publishBid, onBidSucce
 		handleMintingStarted,
 		handleFundingFailed,
 		handleDepositModalClose,
+		resumeBidAfterRulesAck,
 	}
 }

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -1,0 +1,262 @@
+import { nip60Actions, nip60Store } from '@/lib/stores/nip60'
+import type { AuctionBidFormData } from '@/publish/auctions'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+
+export type AuctionBidFundingLifecycleState =
+	| 'idle'
+	| 'funding_session_created'
+	| 'invoice_created'
+	| 'payment_acknowledged'
+	| 'minting_started'
+	| 'ecash_minted'
+	| 'bid_publish_attempted'
+	| 'bid_published'
+	| 'invoice_unpaid_or_expired_reclaimable'
+	| 'invoice_paid_mint_failed_reclaimable'
+	| 'mint_succeeded_bid_publish_failed_reclaimable'
+	| 'funding_canceled'
+
+export type AuctionBidFundingFailureReason = 'invoice_unpaid_or_expired_reclaimable' | 'invoice_paid_mint_failed_reclaimable'
+
+/**
+ * ADR lifecycle mapping note:
+ * - ADR `bid_lock_conversion_attempted` maps to `bid_publish_attempted`.
+ * - ADR `bid_lock_conversion_complete` is represented by terminal outcomes after
+ *   the publish attempt finishes:
+ *   - `bid_published` when lock conversion and bid publish both succeed.
+ *   - `mint_succeeded_bid_publish_failed_reclaimable` when lock conversion
+ *     succeeded but bid publish failed and funds remain reclaimable.
+ *
+ * We intentionally keep lock conversion under the publish-attempt phase instead
+ * of adding separate conversion-only states to avoid splitting one atomic UX
+ * step into multiple user-visible transitions.
+ */
+export const AUCTION_BID_FUNDING_ADR_STATE_MAPPING = {
+	bid_lock_conversion_attempted: 'bid_publish_attempted',
+	bid_lock_conversion_complete: ['bid_published', 'mint_succeeded_bid_publish_failed_reclaimable'],
+} as const
+
+export const AUCTION_BID_FUNDING_RECLAIMABLE_STATES: readonly AuctionBidFundingLifecycleState[] = [
+	'invoice_unpaid_or_expired_reclaimable',
+	'invoice_paid_mint_failed_reclaimable',
+	'mint_succeeded_bid_publish_failed_reclaimable',
+]
+
+const AUCTION_BID_FUNDING_RECLAIMABLE_STATE_SET = new Set<AuctionBidFundingLifecycleState>(AUCTION_BID_FUNDING_RECLAIMABLE_STATES)
+
+export const isAuctionBidFundingReclaimableState = (state: AuctionBidFundingLifecycleState): boolean =>
+	AUCTION_BID_FUNDING_RECLAIMABLE_STATE_SET.has(state)
+
+interface StartFundingForBidInput {
+	bidData: AuctionBidFormData
+	hasInsufficientBidFunds: boolean
+	depositMint: string | null
+	deltaAmount: number
+	mintError: string | null
+	selectedMint: string | null
+	canFund: boolean
+}
+
+interface UseAuctionBidFundingOptions {
+	previousBidAmount: number
+	publishBid: (bidData: AuctionBidFormData) => Promise<unknown>
+	onBidSuccess?: () => void
+}
+
+const TERMINAL_FUNDING_STATES: AuctionBidFundingLifecycleState[] = [
+	'bid_published',
+	'invoice_unpaid_or_expired_reclaimable',
+	'invoice_paid_mint_failed_reclaimable',
+	'mint_succeeded_bid_publish_failed_reclaimable',
+]
+
+const FUNDED_IN_FLIGHT_FUNDING_STATES: AuctionBidFundingLifecycleState[] = [
+	'payment_acknowledged',
+	'minting_started',
+	'ecash_minted',
+	'bid_publish_attempted',
+]
+
+const CLOSE_NO_CANCEL_FUNDING_STATES = new Set<AuctionBidFundingLifecycleState>([
+	...TERMINAL_FUNDING_STATES,
+	...FUNDED_IN_FLIGHT_FUNDING_STATES,
+])
+
+const CLOSE_PRESERVE_PENDING_SUBMISSION_STATES = new Set<AuctionBidFundingLifecycleState>([
+	...FUNDED_IN_FLIGHT_FUNDING_STATES,
+	'mint_succeeded_bid_publish_failed_reclaimable',
+])
+
+const AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS: Record<AuctionBidFundingLifecycleState, ReadonlySet<AuctionBidFundingLifecycleState>> = {
+	idle: new Set(['funding_session_created', 'invoice_unpaid_or_expired_reclaimable', 'bid_publish_attempted', 'funding_canceled']),
+	funding_session_created: new Set(['invoice_created', 'invoice_unpaid_or_expired_reclaimable', 'funding_canceled']),
+	invoice_created: new Set(['payment_acknowledged', 'invoice_unpaid_or_expired_reclaimable', 'funding_canceled']),
+	payment_acknowledged: new Set(['minting_started', 'invoice_paid_mint_failed_reclaimable']),
+	minting_started: new Set(['ecash_minted', 'invoice_paid_mint_failed_reclaimable']),
+	ecash_minted: new Set(['bid_publish_attempted', 'invoice_paid_mint_failed_reclaimable']),
+	bid_publish_attempted: new Set(['bid_published', 'mint_succeeded_bid_publish_failed_reclaimable']),
+	bid_published: new Set(['funding_session_created']),
+	invoice_unpaid_or_expired_reclaimable: new Set(['funding_session_created']),
+	invoice_paid_mint_failed_reclaimable: new Set(['funding_session_created']),
+	mint_succeeded_bid_publish_failed_reclaimable: new Set(['bid_publish_attempted', 'funding_session_created']),
+	funding_canceled: new Set(['funding_session_created']),
+}
+
+export const canTransitionAuctionBidFundingState = (from: AuctionBidFundingLifecycleState, to: AuctionBidFundingLifecycleState): boolean =>
+	from === to || AUCTION_BID_FUNDING_ALLOWED_TRANSITIONS[from].has(to)
+
+const resolveAuctionBidFundingTransition = (
+	currentState: AuctionBidFundingLifecycleState,
+	nextState: AuctionBidFundingLifecycleState,
+): AuctionBidFundingLifecycleState => (canTransitionAuctionBidFundingState(currentState, nextState) ? nextState : currentState)
+
+export const shouldCancelFundingOnModalClose = (state: AuctionBidFundingLifecycleState): boolean =>
+	!CLOSE_NO_CANCEL_FUNDING_STATES.has(state)
+
+export const shouldPreservePendingBidSubmissionOnModalClose = (state: AuctionBidFundingLifecycleState): boolean =>
+	CLOSE_PRESERVE_PENDING_SUBMISSION_STATES.has(state)
+
+export function useAuctionBidFunding({ previousBidAmount, publishBid, onBidSuccess }: UseAuctionBidFundingOptions) {
+	const [isDepositOpen, setIsDepositOpen] = useState(false)
+	const [depositAmount, setDepositAmount] = useState(0)
+	const [preferredDepositMint, setPreferredDepositMint] = useState<string | undefined>(undefined)
+	const [pendingBidSubmission, setPendingBidSubmission] = useState<AuctionBidFormData | null>(null)
+	const [bidFundingLifecycleState, setBidFundingLifecycleState] = useState<AuctionBidFundingLifecycleState>('idle')
+
+	const submitPreparedBid = useCallback(
+		async (bidData: AuctionBidFormData) => {
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_publish_attempted'))
+			try {
+				await publishBid(bidData)
+				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'bid_published'))
+				toast.success('Bid placed successfully')
+				setPendingBidSubmission(null)
+				setIsDepositOpen(false)
+				onBidSuccess?.()
+				return true
+			} catch (error) {
+				setBidFundingLifecycleState((currentState) =>
+					resolveAuctionBidFundingTransition(currentState, 'mint_succeeded_bid_publish_failed_reclaimable'),
+				)
+				const errorMessage = error instanceof Error ? error.message : String(error)
+				toast.error(`Funding completed, but bid publishing failed: ${errorMessage}`)
+				return false
+			}
+		},
+		[onBidSuccess, publishBid],
+	)
+
+	const startFundingForBid = useCallback(
+		({ bidData, hasInsufficientBidFunds, depositMint, deltaAmount, mintError, selectedMint, canFund }: StartFundingForBidInput) => {
+			if (hasInsufficientBidFunds) {
+				if (!depositMint) {
+					toast.error(mintError || 'No suitable mint available for bidding.')
+					setBidFundingLifecycleState((currentState) =>
+						resolveAuctionBidFundingTransition(currentState, 'invoice_unpaid_or_expired_reclaimable'),
+					)
+					return null
+				}
+
+				setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'funding_session_created'))
+				setPendingBidSubmission(bidData)
+				setDepositAmount(Math.ceil(deltaAmount))
+				setPreferredDepositMint(depositMint)
+				setIsDepositOpen(true)
+				return null
+			}
+
+			if (!selectedMint) {
+				toast.error(mintError || 'No suitable mint available for bidding.')
+				return null
+			}
+
+			if (!canFund) {
+				toast.error('Insufficient balance on selected mint to cover the required delta.')
+				return null
+			}
+
+			return bidData
+		},
+		[],
+	)
+
+	const handleFundingSuccess = useCallback(() => {
+		if (!pendingBidSubmission) return
+
+		void (async () => {
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'ecash_minted'))
+
+			try {
+				await nip60Actions.refresh()
+			} catch {
+				// Best-effort refresh; we still evaluate from current wallet state below.
+			}
+
+			const fundingMintCandidates = pendingBidSubmission.mintCandidates
+			if (!fundingMintCandidates.length) {
+				setBidFundingLifecycleState((currentState) =>
+					resolveAuctionBidFundingTransition(currentState, 'invoice_paid_mint_failed_reclaimable'),
+				)
+				toast.error('Invoice was paid, but no funding mint was selected for bid locking. Please retry the bid submission.')
+				return
+			}
+
+			const latestNip60State = nip60Store.state
+			const requiredDelta = Math.max(0, pendingBidSubmission.amount - previousBidAmount)
+			const fundableMint = fundingMintCandidates.find((mintUrl) => (latestNip60State.mintBalances[mintUrl] ?? 0) >= requiredDelta)
+
+			if (!fundableMint) {
+				setBidFundingLifecycleState((currentState) =>
+					resolveAuctionBidFundingTransition(currentState, 'invoice_paid_mint_failed_reclaimable'),
+				)
+				toast.error('Invoice was paid, but minted funds are not yet spendable on any accepted mint. Please retry once minting completes.')
+				return
+			}
+
+			const orderedMintCandidates = [fundableMint, ...fundingMintCandidates.filter((mintUrl) => mintUrl !== fundableMint)]
+			await submitPreparedBid({ ...pendingBidSubmission, mintCandidates: orderedMintCandidates })
+		})()
+	}, [pendingBidSubmission, previousBidAmount, submitPreparedBid])
+
+	const handleInvoiceCreated = useCallback(() => {
+		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'invoice_created'))
+	}, [])
+
+	const handlePaymentAcknowledged = useCallback(() => {
+		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'payment_acknowledged'))
+	}, [])
+
+	const handleMintingStarted = useCallback(() => {
+		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'minting_started'))
+	}, [])
+
+	const handleFundingFailed = useCallback((reason: AuctionBidFundingFailureReason) => {
+		setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, reason))
+	}, [])
+
+	const handleDepositModalClose = useCallback(() => {
+		if (shouldCancelFundingOnModalClose(bidFundingLifecycleState)) {
+			setBidFundingLifecycleState((currentState) => resolveAuctionBidFundingTransition(currentState, 'funding_canceled'))
+		}
+		setIsDepositOpen(false)
+		if (!shouldPreservePendingBidSubmissionOnModalClose(bidFundingLifecycleState)) {
+			setPendingBidSubmission(null)
+		}
+	}, [bidFundingLifecycleState])
+
+	return {
+		bidFundingLifecycleState,
+		isDepositOpen,
+		depositAmount,
+		preferredDepositMint,
+		startFundingForBid,
+		submitPreparedBid,
+		handleFundingSuccess,
+		handleInvoiceCreated,
+		handlePaymentAcknowledged,
+		handleMintingStarted,
+		handleFundingFailed,
+		handleDepositModalClose,
+	}
+}

--- a/src/hooks/useAuctionBidFunding.ts
+++ b/src/hooks/useAuctionBidFunding.ts
@@ -21,17 +21,38 @@ export type AuctionBidFundingLifecycleState =
 export type AuctionBidFundingFailureReason = 'invoice_unpaid_or_expired_reclaimable' | 'invoice_paid_mint_failed_reclaimable'
 
 /**
- * ADR lifecycle mapping note:
- * - ADR `bid_lock_conversion_attempted` maps to `bid_publish_attempted`.
- * - ADR `bid_lock_conversion_complete` is represented by terminal outcomes after
- *   the publish attempt finishes:
- *   - `bid_published` when lock conversion and bid publish both succeed.
- *   - `mint_succeeded_bid_publish_failed_reclaimable` when lock conversion
- *     succeeded but bid publish failed and funds remain reclaimable.
+ * #12: ADR-0004 state mapping. The ADR lists a full payment/bid state model
+ * (see ADR-0004 §"Payment and Bid State Model"). Most ADR states map 1:1 to
+ * lifecycle states with identical names; only the two non-obvious mappings
+ * below need explicit documentation.
  *
- * We intentionally keep lock conversion under the publish-attempt phase instead
- * of adding separate conversion-only states to avoid splitting one atomic UX
- * step into multiple user-visible transitions.
+ * Direct 1:1 mappings (not listed in the object):
+ *   ADR "Funding session created"      → funding_session_created
+ *   ADR "Invoice created"              → invoice_created
+ *   ADR "Invoice paid" / "Wallet ack"  → payment_acknowledged
+ *   ADR "E-cash minting attempted"     → minting_started
+ *   ADR "E-cash minted"                → ecash_minted
+ *   ADR "Invoice expired or unpaid"    → invoice_unpaid_or_expired_reclaimable
+ *   ADR "Bid published"                → bid_published
+ *   ADR "Bid publish attempted"        → bid_publish_attempted
+ *   ADR "Funding failed, reclaimable"  → invoice_paid_mint_failed_reclaimable
+ *                                         / mint_succeeded_bid_publish_failed_reclaimable
+ *
+ * Non-obvious mappings (listed in the object below):
+ *   ADR "Bid lock conversion attempted" → bid_publish_attempted
+ *     Lock conversion is folded into the publish attempt — we don't split it
+ *     into a separate user-visible state because it's an atomic UX step.
+ *   ADR "Bid lock conversion complete"  → ['bid_published', 'mint_succeeded_bid_publish_failed_reclaimable']
+ *     Two terminal outcomes: success (bid_published) or publish failure with
+ *     reclaimable funds (mint_succeeded_bid_publish_failed_reclaimable).
+ *
+ * ADR states without a dedicated lifecycle state:
+ *   "Bid requested"        — represented by the initial `idle` state
+ *   "Mint target resolved" — handled inside startFundingForBid() before
+ *                            transitioning to funding_session_created
+ *   "Invoice payment attempted" — external Lightning payment; no client state
+ *                            between invoice_created and payment_acknowledged
+ *   "Bid funding failed"   — generic; covered by the specific reclaimable states
  */
 export const AUCTION_BID_FUNDING_ADR_STATE_MAPPING = {
 	bid_lock_conversion_attempted: 'bid_publish_attempted',

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	canTransitionAuctionBidFundingState,
+	isAuctionBidFundingReclaimableState,
+	shouldCancelFundingOnModalClose,
+	shouldPreservePendingBidSubmissionOnModalClose,
+	type AuctionBidFundingLifecycleState,
+} from '@/hooks/useAuctionBidFunding'
+
+describe('auction bid funding modal close lifecycle', () => {
+	test.each<AuctionBidFundingLifecycleState>(['payment_acknowledged', 'minting_started', 'ecash_minted', 'bid_publish_attempted'])(
+		'does not mark %s as canceled on close',
+		(state) => {
+			expect(shouldCancelFundingOnModalClose(state)).toBe(false)
+		},
+	)
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'payment_acknowledged',
+		'minting_started',
+		'ecash_minted',
+		'bid_publish_attempted',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+	])('preserves pending bid submission for %s on close', (state) => {
+		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(true)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>(['idle', 'funding_session_created', 'invoice_created'])(
+		'marks %s as canceled on close',
+		(state) => {
+			expect(shouldCancelFundingOnModalClose(state)).toBe(true)
+		},
+	)
+})
+
+describe('auction bid funding state machine integrity', () => {
+	test('models invoice timeout/unpaid as reclaimable terminal state', () => {
+		expect(canTransitionAuctionBidFundingState('idle', 'funding_session_created')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('funding_session_created', 'invoice_created')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'invoice_unpaid_or_expired_reclaimable')).toBe(true)
+		expect(isAuctionBidFundingReclaimableState('invoice_unpaid_or_expired_reclaimable')).toBe(true)
+	})
+
+	test('models invoice-paid-but-mint-failed as reclaimable terminal state', () => {
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'payment_acknowledged')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('payment_acknowledged', 'minting_started')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('minting_started', 'invoice_paid_mint_failed_reclaimable')).toBe(true)
+		expect(isAuctionBidFundingReclaimableState('invoice_paid_mint_failed_reclaimable')).toBe(true)
+	})
+
+	test('models mint-success-but-publish-failed, then user-confirmed retry', () => {
+		expect(canTransitionAuctionBidFundingState('minting_started', 'ecash_minted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'bid_publish_attempted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+		expect(isAuctionBidFundingReclaimableState('mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+
+		// User confirms retry from the reclaimable publish-failed state.
+		expect(canTransitionAuctionBidFundingState('mint_succeeded_bid_publish_failed_reclaimable', 'bid_publish_attempted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_published')).toBe(true)
+	})
+
+	test('publish-failed reclaimable state preserves pending bid on modal close', () => {
+		expect(shouldCancelFundingOnModalClose('mint_succeeded_bid_publish_failed_reclaimable')).toBe(false)
+		expect(shouldPreservePendingBidSubmissionOnModalClose('mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+	})
+
+	test('rejects invalid transition that skips payment acknowledgment', () => {
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'ecash_minted')).toBe(false)
+	})
+
+	test('rejects invalid transition from idle directly to settled state', () => {
+		expect(canTransitionAuctionBidFundingState('idle', 'bid_published')).toBe(false)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+	])('%s is reclaimable', (state) => {
+		expect(isAuctionBidFundingReclaimableState(state)).toBe(true)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'idle',
+		'funding_session_created',
+		'invoice_created',
+		'payment_acknowledged',
+		'bid_published',
+	])('%s is not reclaimable', (state) => {
+		expect(isAuctionBidFundingReclaimableState(state)).toBe(false)
+	})
+})

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -262,3 +262,17 @@ describe('modal close behavior: comprehensive state coverage', () => {
 		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(false)
 	})
 })
+
+describe('retryBidPublish state transitions', () => {
+	test('can retry publish from mint_succeeded_bid_publish_failed_reclaimable to bid_publish_attempted', () => {
+		expect(canTransitionAuctionBidFundingState('mint_succeeded_bid_publish_failed_reclaimable', 'bid_publish_attempted')).toBe(true)
+	})
+
+	test('retry path completes: bid_publish_attempted → bid_published on success', () => {
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_published')).toBe(true)
+	})
+
+	test('retry path can fail again: bid_publish_attempted → mint_succeeded_bid_publish_failed_reclaimable', () => {
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+	})
+})

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -4,6 +4,7 @@ import {
 	isAuctionBidFundingReclaimableState,
 	shouldCancelFundingOnModalClose,
 	shouldPreservePendingBidSubmissionOnModalClose,
+	AUCTION_BID_FUNDING_RECLAIMABLE_STATES,
 	type AuctionBidFundingLifecycleState,
 } from '@/hooks/useAuctionBidFunding'
 
@@ -88,5 +89,44 @@ describe('auction bid funding state machine integrity', () => {
 		'bid_published',
 	])('%s is not reclaimable', (state) => {
 		expect(isAuctionBidFundingReclaimableState(state)).toBe(false)
+	})
+})
+
+describe('rules-ack gating on funded bid path', () => {
+	test('ecash_minted_pending_rules_ack is a valid lifecycle state', () => {
+		expect(AUCTION_BID_FUNDING_RECLAIMABLE_STATES).toContain('ecash_minted_pending_rules_ack')
+	})
+
+	test('can transition from ecash_minted to ecash_minted_pending_rules_ack', () => {
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'ecash_minted_pending_rules_ack')).toBe(true)
+	})
+
+	test('can transition from ecash_minted_pending_rules_ack to bid_publish_attempted (resume after ack)', () => {
+		expect(canTransitionAuctionBidFundingState('ecash_minted_pending_rules_ack', 'bid_publish_attempted')).toBe(true)
+	})
+
+	test('ecash_minted_pending_rules_ack is reclaimable (funds are minted, bid not yet published)', () => {
+		expect(isAuctionBidFundingReclaimableState('ecash_minted_pending_rules_ack')).toBe(true)
+	})
+
+	test('ecash_minted_pending_rules_ack preserves pending bid submission on modal close', () => {
+		expect(shouldPreservePendingBidSubmissionOnModalClose('ecash_minted_pending_rules_ack')).toBe(true)
+	})
+
+	test('ecash_minted_pending_rules_ack does not cancel funding on modal close', () => {
+		expect(shouldCancelFundingOnModalClose('ecash_minted_pending_rules_ack')).toBe(false)
+	})
+
+	test('funding success with unacknowledged rules does not publish bid — stays in pending rules-ack state', () => {
+		// The state machine must not allow skipping from ecash_minted_pending_rules_ack
+		// directly to bid_published — it must go through bid_publish_attempted.
+		expect(canTransitionAuctionBidFundingState('ecash_minted_pending_rules_ack', 'bid_published')).toBe(false)
+	})
+
+	test('funding success with acknowledged rules publishes bid — transitions through bid_publish_attempted', () => {
+		// After rules ack, the pending state transitions to bid_publish_attempted,
+		// which then transitions to bid_published on success.
+		expect(canTransitionAuctionBidFundingState('ecash_minted_pending_rules_ack', 'bid_publish_attempted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_published')).toBe(true)
 	})
 })

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 import {
 	canTransitionAuctionBidFundingState,
 	isAuctionBidFundingReclaimableState,
+	resolveAuctionBidFundingFailureReason,
+	resolveAuctionBidFundingModalClose,
 	shouldCancelFundingOnModalClose,
 	shouldPreservePendingBidSubmissionOnModalClose,
 	AUCTION_BID_FUNDING_RECLAIMABLE_STATES,
@@ -294,5 +296,101 @@ describe('retryBidPublish rebroadcast path (Blocker 1)', () => {
 		// Runtime behavior is verified in the component/integration layer.
 		const republishBid: ((bidEventId: string) => Promise<void>) | undefined = undefined
 		expect(republishBid).toBeUndefined()
+	})
+})
+
+describe('QR-path funding success walk-forward (M1: flagship flow lifecycle advancement)', () => {
+	test('QR deposit success walks invoice_created forward to ecash_minted and on to bid_published', () => {
+		// The QR path never separately observes payment_acknowledged or
+		// minting_started — handleFundingSuccess walks the lifecycle forward
+		// through them, so every step of the chain must be a valid transition.
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'payment_acknowledged')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('payment_acknowledged', 'minting_started')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('minting_started', 'ecash_minted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'bid_publish_attempted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_published')).toBe(true)
+	})
+
+	test('walk-forward steps are idempotent when the NWC path already advanced the lifecycle', () => {
+		// Already past a step: re-resolving it is an invalid transition, so the
+		// resolver keeps the current state (silent no-op).
+		expect(canTransitionAuctionBidFundingState('minting_started', 'payment_acknowledged')).toBe(false)
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'payment_acknowledged')).toBe(false)
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'minting_started')).toBe(false)
+		// Already at the target state: self-transition is an allowed no-op.
+		expect(canTransitionAuctionBidFundingState('ecash_minted', 'ecash_minted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_publish_attempted')).toBe(true)
+	})
+
+	test('walk-forward cannot skip states from pre-funded states', () => {
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'ecash_minted')).toBe(false)
+		expect(canTransitionAuctionBidFundingState('invoice_created', 'bid_publish_attempted')).toBe(false)
+		expect(canTransitionAuctionBidFundingState('funding_session_created', 'ecash_minted')).toBe(false)
+	})
+})
+
+describe('close classification: paid-or-unknown safety (S2/S4)', () => {
+	test('QR user close (nwcPaymentAttempted=false) during invoice_created classifies paid-or-unknown, preserves pending submission, and cannot be overwritten by funding_canceled', () => {
+		// QR flow: the app cannot observe the external wallet's payment.
+		const reason = resolveAuctionBidFundingFailureReason({ paymentAcknowledged: false, nwcPaymentAttempted: false })
+		expect(reason).toBe('invoice_paid_mint_failed_reclaimable')
+
+		// User close hands the reason to the funding hook BEFORE the modal-open
+		// state flips; the hook resolves it against the CURRENT state.
+		const close = resolveAuctionBidFundingModalClose('invoice_created', reason)
+		expect(close.nextState).toBe('invoice_paid_mint_failed_reclaimable')
+		// pendingBidSubmission is preserved for the reclaimable classification.
+		expect(close.preservePendingSubmission).toBe(true)
+		expect(shouldPreservePendingBidSubmissionOnModalClose(close.nextState)).toBe(true)
+
+		// Ordering guarantee: a subsequent close/cancel pass cannot clobber the
+		// reclaimable classification with funding_canceled.
+		expect(resolveAuctionBidFundingModalClose(close.nextState, null).nextState).toBe('invoice_paid_mint_failed_reclaimable')
+		expect(resolveAuctionBidFundingModalClose(close.nextState, undefined).nextState).toBe('invoice_paid_mint_failed_reclaimable')
+		expect(canTransitionAuctionBidFundingState(close.nextState, 'funding_canceled')).toBe(false)
+	})
+
+	test('NWC close with no payment sent classifies as unpaid/expired (observable non-payment)', () => {
+		const reason = resolveAuctionBidFundingFailureReason({ paymentAcknowledged: false, nwcPaymentAttempted: true })
+		expect(reason).toBe('invoice_unpaid_or_expired_reclaimable')
+
+		const close = resolveAuctionBidFundingModalClose('invoice_created', reason)
+		expect(close.nextState).toBe('invoice_unpaid_or_expired_reclaimable')
+		expect(close.preservePendingSubmission).toBe(true)
+		expect(resolveAuctionBidFundingModalClose(close.nextState, null).nextState).toBe('invoice_unpaid_or_expired_reclaimable')
+	})
+
+	test('NWC-sent close from payment_acknowledged classifies as paid/mint-failed and is not canceled', () => {
+		const reason = resolveAuctionBidFundingFailureReason({ paymentAcknowledged: true, nwcPaymentAttempted: true })
+		expect(reason).toBe('invoice_paid_mint_failed_reclaimable')
+
+		const close = resolveAuctionBidFundingModalClose('payment_acknowledged', reason)
+		expect(close.nextState).toBe('invoice_paid_mint_failed_reclaimable')
+		expect(close.preservePendingSubmission).toBe(true)
+	})
+
+	test('QR close from a pre-invoice state (no reason) still cancels funding', () => {
+		const close = resolveAuctionBidFundingModalClose('funding_session_created', null)
+		expect(close.nextState).toBe('funding_canceled')
+		expect(close.preservePendingSubmission).toBe(false)
+	})
+
+	test('plain close from invoice_created cancels funding and clears the pending submission', () => {
+		const close = resolveAuctionBidFundingModalClose('invoice_created', null)
+		expect(close.nextState).toBe('funding_canceled')
+		expect(close.preservePendingSubmission).toBe(false)
+	})
+
+	test('plain close never downgrades an already-terminal state', () => {
+		expect(resolveAuctionBidFundingModalClose('mint_succeeded_bid_publish_failed_reclaimable', null).nextState).toBe(
+			'mint_succeeded_bid_publish_failed_reclaimable',
+		)
+		expect(resolveAuctionBidFundingModalClose('bid_published', null).nextState).toBe('bid_published')
+	})
+
+	test('funding_canceled can be re-classified to a reclaimable state (batch 1 retry path)', () => {
+		expect(resolveAuctionBidFundingModalClose('funding_canceled', 'invoice_paid_mint_failed_reclaimable').nextState).toBe(
+			'invoice_paid_mint_failed_reclaimable',
+		)
 	})
 })

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -246,21 +246,18 @@ describe('modal close behavior: comprehensive state coverage', () => {
 		'ecash_minted_pending_rules_ack',
 		'bid_publish_attempted',
 		'mint_succeeded_bid_publish_failed_reclaimable',
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
 	])('preserves pending bid submission for %s on close', (state) => {
 		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(true)
 	})
 
-	test.each<AuctionBidFundingLifecycleState>([
-		'idle',
-		'funding_session_created',
-		'invoice_created',
-		'bid_published',
-		'invoice_unpaid_or_expired_reclaimable',
-		'invoice_paid_mint_failed_reclaimable',
-		'funding_canceled',
-	])('does not preserve pending bid submission for %s on close', (state) => {
-		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(false)
-	})
+	test.each<AuctionBidFundingLifecycleState>(['idle', 'funding_session_created', 'invoice_created', 'bid_published', 'funding_canceled'])(
+		'does not preserve pending bid submission for %s on close',
+		(state) => {
+			expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(false)
+		},
+	)
 })
 
 describe('retryBidPublish state transitions', () => {
@@ -274,5 +271,28 @@ describe('retryBidPublish state transitions', () => {
 
 	test('retry path can fail again: bid_publish_attempted → mint_succeeded_bid_publish_failed_reclaimable', () => {
 		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+	})
+})
+
+describe('funding_canceled transitions to reclaimable states', () => {
+	test('funding_canceled can transition to invoice_unpaid_or_expired_reclaimable', () => {
+		expect(canTransitionAuctionBidFundingState('funding_canceled', 'invoice_unpaid_or_expired_reclaimable')).toBe(true)
+	})
+
+	test('funding_canceled can transition to invoice_paid_mint_failed_reclaimable', () => {
+		expect(canTransitionAuctionBidFundingState('funding_canceled', 'invoice_paid_mint_failed_reclaimable')).toBe(true)
+	})
+
+	test('funding_canceled cannot transition to mint_succeeded_bid_publish_failed_reclaimable (publish failure must originate from bid_publish_attempted)', () => {
+		expect(canTransitionAuctionBidFundingState('funding_canceled', 'mint_succeeded_bid_publish_failed_reclaimable')).toBe(false)
+	})
+})
+
+describe('retryBidPublish rebroadcast path (Blocker 1)', () => {
+	test('republishBid is exposed as an optional hook option for rebroadcasting a signed event', () => {
+		// Type-level contract: republishBid accepts a bidEventId string.
+		// Runtime behavior is verified in the component/integration layer.
+		const republishBid: ((bidEventId: string) => Promise<void>) | undefined = undefined
+		expect(republishBid).toBeUndefined()
 	})
 })

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -130,3 +130,135 @@ describe('rules-ack gating on funded bid path', () => {
 		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'bid_published')).toBe(true)
 	})
 })
+
+describe('state-transition integrity: retry and direct paths', () => {
+	test('funding_canceled can retry to funding_session_created (retry after cancel)', () => {
+		expect(canTransitionAuctionBidFundingState('funding_canceled', 'funding_session_created')).toBe(true)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+		'ecash_minted_pending_rules_ack',
+	])('reclaimable state %s can retry to funding_session_created (retry from any failure)', (state) => {
+		expect(canTransitionAuctionBidFundingState(state, 'funding_session_created')).toBe(true)
+	})
+
+	test('idle can directly transition to bid_publish_attempted (sufficient balance, no deposit needed)', () => {
+		expect(canTransitionAuctionBidFundingState('idle', 'bid_publish_attempted')).toBe(true)
+	})
+
+	test('bid_published can start a new funding session (new bid after success)', () => {
+		expect(canTransitionAuctionBidFundingState('bid_published', 'funding_session_created')).toBe(true)
+	})
+
+	test('funding_canceled is NOT reclaimable (canceled is distinct from failure)', () => {
+		expect(isAuctionBidFundingReclaimableState('funding_canceled')).toBe(false)
+	})
+
+	test('mint_succeeded_bid_publish_failed_reclaimable can retry publish directly (skip funding_session_created)', () => {
+		// Funds are already minted — retry should go straight back to bid_publish_attempted,
+		// not all the way back to funding_session_created.
+		expect(canTransitionAuctionBidFundingState('mint_succeeded_bid_publish_failed_reclaimable', 'bid_publish_attempted')).toBe(true)
+	})
+})
+
+describe('state-transition integrity: cannot skip states', () => {
+	test.each<[AuctionBidFundingLifecycleState, AuctionBidFundingLifecycleState]>([
+		// idle cannot jump to funded or settled states
+		['idle', 'bid_published'],
+		['idle', 'ecash_minted'],
+		['idle', 'payment_acknowledged'],
+		['idle', 'minting_started'],
+		['idle', 'invoice_created'],
+		// funding_session_created cannot skip to funded/publish/settled states
+		['funding_session_created', 'bid_published'],
+		['funding_session_created', 'ecash_minted'],
+		['funding_session_created', 'payment_acknowledged'],
+		['funding_session_created', 'minting_started'],
+		['funding_session_created', 'bid_publish_attempted'],
+		// invoice_created cannot skip minting or publish
+		['invoice_created', 'bid_published'],
+		['invoice_created', 'ecash_minted'],
+		['invoice_created', 'minting_started'],
+		['invoice_created', 'bid_publish_attempted'],
+		// payment_acknowledged cannot skip minting
+		['payment_acknowledged', 'bid_published'],
+		['payment_acknowledged', 'ecash_minted'],
+		['payment_acknowledged', 'bid_publish_attempted'],
+		// minting_started cannot skip to publish
+		['minting_started', 'bid_published'],
+		['minting_started', 'bid_publish_attempted'],
+		// ecash_minted cannot skip to bid_published (must go through bid_publish_attempted)
+		['ecash_minted', 'bid_published'],
+	])('rejects invalid transition %s → %s (skips intermediate state)', (from, to) => {
+		expect(canTransitionAuctionBidFundingState(from, to)).toBe(false)
+	})
+})
+
+describe('canTransitionAuctionBidFundingState: self-transitions', () => {
+	test.each<AuctionBidFundingLifecycleState>([
+		'idle',
+		'funding_session_created',
+		'invoice_created',
+		'payment_acknowledged',
+		'minting_started',
+		'ecash_minted',
+		'ecash_minted_pending_rules_ack',
+		'bid_publish_attempted',
+		'bid_published',
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+		'funding_canceled',
+	])('allows self-transition %s → %s (no-op is safe)', (state) => {
+		expect(canTransitionAuctionBidFundingState(state, state)).toBe(true)
+	})
+})
+
+describe('modal close behavior: comprehensive state coverage', () => {
+	test.each<AuctionBidFundingLifecycleState>([
+		'payment_acknowledged',
+		'minting_started',
+		'ecash_minted',
+		'ecash_minted_pending_rules_ack',
+		'bid_publish_attempted',
+		'bid_published',
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+	])('does not cancel funding on modal close for %s', (state) => {
+		expect(shouldCancelFundingOnModalClose(state)).toBe(false)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>(['idle', 'funding_session_created', 'invoice_created', 'funding_canceled'])(
+		'cancels funding on modal close for %s',
+		(state) => {
+			expect(shouldCancelFundingOnModalClose(state)).toBe(true)
+		},
+	)
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'payment_acknowledged',
+		'minting_started',
+		'ecash_minted',
+		'ecash_minted_pending_rules_ack',
+		'bid_publish_attempted',
+		'mint_succeeded_bid_publish_failed_reclaimable',
+	])('preserves pending bid submission for %s on close', (state) => {
+		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(true)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'idle',
+		'funding_session_created',
+		'invoice_created',
+		'bid_published',
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'funding_canceled',
+	])('does not preserve pending bid submission for %s on close', (state) => {
+		expect(shouldPreservePendingBidSubmissionOnModalClose(state)).toBe(false)
+	})
+})

--- a/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
+++ b/src/lib/__tests__/auctionBidFundingLifecycle.test.ts
@@ -6,7 +6,9 @@ import {
 	resolveAuctionBidFundingModalClose,
 	shouldCancelFundingOnModalClose,
 	shouldPreservePendingBidSubmissionOnModalClose,
+	shouldOpenBidProgressDialog,
 	AUCTION_BID_FUNDING_RECLAIMABLE_STATES,
+	AUCTION_BID_PROGRESS_DIALOG_OPEN_STATES,
 	type AuctionBidFundingLifecycleState,
 } from '@/hooks/useAuctionBidFunding'
 
@@ -326,6 +328,52 @@ describe('QR-path funding success walk-forward (M1: flagship flow lifecycle adva
 		expect(canTransitionAuctionBidFundingState('invoice_created', 'ecash_minted')).toBe(false)
 		expect(canTransitionAuctionBidFundingState('invoice_created', 'bid_publish_attempted')).toBe(false)
 		expect(canTransitionAuctionBidFundingState('funding_session_created', 'ecash_minted')).toBe(false)
+	})
+})
+
+describe('staged bid progress dialog open-set (lost-UX port)', () => {
+	test.each<AuctionBidFundingLifecycleState>(['ecash_minted', 'ecash_minted_pending_rules_ack', 'bid_publish_attempted', 'bid_published'])(
+		'opens the progress dialog for post-funding state %s',
+		(state) => {
+			expect(shouldOpenBidProgressDialog(state)).toBe(true)
+		},
+	)
+
+	test('opens the progress dialog for the publish-failure state so a failed publish keeps a retry surface (M7)', () => {
+		expect(shouldOpenBidProgressDialog('mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+	})
+
+	test.each<AuctionBidFundingLifecycleState>([
+		'idle',
+		'funding_session_created',
+		'invoice_created',
+		'payment_acknowledged',
+		'minting_started',
+		'invoice_unpaid_or_expired_reclaimable',
+		'invoice_paid_mint_failed_reclaimable',
+		'funding_canceled',
+	])('keeps the progress dialog closed for funding-phase/cancel state %s (deposit modal is the sole UI)', (state) => {
+		expect(shouldOpenBidProgressDialog(state)).toBe(false)
+	})
+
+	test('the open-set is exactly the post-funding + publish-failure states', () => {
+		const expected: AuctionBidFundingLifecycleState[] = [
+			'ecash_minted',
+			'ecash_minted_pending_rules_ack',
+			'bid_publish_attempted',
+			'bid_published',
+			'mint_succeeded_bid_publish_failed_reclaimable',
+		]
+		expect([...AUCTION_BID_PROGRESS_DIALOG_OPEN_STATES].sort()).toEqual([...expected].sort())
+	})
+
+	test('dialog reopens when a dismissed publish attempt later fails (close cannot hide the retry affordance)', () => {
+		// Walk the publish attempt: dialog opens on attempt, user dismisses it
+		// (dialog state only — lifecycle untouched), then the publish fails —
+		// the open-set must still fire for the failure state.
+		expect(shouldOpenBidProgressDialog('bid_publish_attempted')).toBe(true)
+		expect(canTransitionAuctionBidFundingState('bid_publish_attempted', 'mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
+		expect(shouldOpenBidProgressDialog('mint_succeeded_bid_publish_failed_reclaimable')).toBe(true)
 	})
 })
 

--- a/src/lib/__tests__/auctionMintSelection.test.ts
+++ b/src/lib/__tests__/auctionMintSelection.test.ts
@@ -237,4 +237,33 @@ describe('resolveAuctionMintSelection', () => {
 		expect(result.availableMints[0].balance).toBe(75)
 		expect(result.availableMints[1].balance).toBe(25)
 	})
+
+	test('allowlist order determines auto-selected mint when multiple are eligible', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_B, MINT_A],
+				walletMints: [MINT_A, MINT_B],
+				mintBalances: { [MINT_A]: 5_000, [MINT_B]: 2_000 },
+				bidAmount: 1_000,
+			}),
+		)
+
+		expect(result.selectedMint).toBe(MINT_B)
+		expect(result.eligibleMints.map((mint) => mint.mintUrl)).toEqual([MINT_B, MINT_A])
+	})
+
+	test('allowlist excludes funded but untrusted mints from eligibility and selection', () => {
+		const result = resolveAuctionMintSelection(
+			makeInput({
+				trustedMints: [MINT_A],
+				walletMints: [MINT_A, MINT_B],
+				mintBalances: { [MINT_A]: 25, [MINT_B]: 20_000 },
+				bidAmount: 50,
+			}),
+		)
+
+		expect(result.selectedMint).toBeNull()
+		expect(result.availableMints.map((mint) => mint.mintUrl)).toEqual([MINT_A])
+		expect(result.error).toContain('Insufficient balance')
+	})
 })

--- a/src/lib/__tests__/verdictQuorum.test.ts
+++ b/src/lib/__tests__/verdictQuorum.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'bun:test'
+import { computeVerdictQuorum } from '@/lib/auction/verdictQuorum'
+import type { ParsedValidatorVerdictEvent } from '@/lib/auction/events'
+
+const AUDITORS = ['auditor-1', 'auditor-2', 'auditor-3']
+
+function verdict(overrides: {
+	bidEventId: string
+	validatorPubkey: string
+	claim: ParsedValidatorVerdictEvent['claim']
+}): ParsedValidatorVerdictEvent {
+	return {
+		rawEvent: { id: '', pubkey: '', created_at: 0, kind: 30440, tags: [], content: '' },
+		id: '',
+		validatorPubkey: overrides.validatorPubkey,
+		createdAt: 0,
+		dTag: '',
+		bidderPubkey: 'bidder',
+		auctionRootEventId: 'auction-root',
+		auctionCoordinate: '',
+		bidEventId: overrides.bidEventId,
+		claim: overrides.claim,
+		observedAt: 0,
+	} as ParsedValidatorVerdictEvent
+}
+
+describe('computeVerdictQuorum', () => {
+	test('no verdicts → not positive/negative/neutral (awaiting)', () => {
+		const r = computeVerdictQuorum([], 'bid-1', AUDITORS, 2)
+		expect(r.hasPositiveVerdict).toBe(false)
+		expect(r.hasNegativeVerdict).toBe(false)
+		expect(r.hasNeutralVerdict).toBe(false)
+		expect(r.representativeVerdict).toBeNull()
+	})
+
+	test('quorum of confirms → positive', () => {
+		const verdicts = [
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-2', claim: 'valid_bid_placed' }),
+		]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.confirmCount).toBe(2)
+		expect(r.hasPositiveVerdict).toBe(true)
+		expect(r.hasNegativeVerdict).toBe(false)
+	})
+
+	test('below quorum → still awaiting (not positive)', () => {
+		const verdicts = [verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' })]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.confirmCount).toBe(1)
+		expect(r.hasPositiveVerdict).toBe(false)
+		expect(r.hasNegativeVerdict).toBe(false)
+		expect(r.hasNeutralVerdict).toBe(true)
+	})
+
+	test('quorum of condemns → negative', () => {
+		const verdicts = [
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'bid_invalid' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-2', claim: 'bid_invalid' }),
+		]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.condemnCount).toBe(2)
+		expect(r.hasNegativeVerdict).toBe(true)
+		expect(r.hasPositiveVerdict).toBe(false)
+	})
+
+	test('defaults auditorQuorum to 1', () => {
+		const verdicts = [verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' })]
+		expect(computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, undefined).hasPositiveVerdict).toBe(true)
+		expect(computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 0).hasPositiveVerdict).toBe(true)
+	})
+
+	test('binds to the exact bid event id — earlier leg verdict does not leak', () => {
+		const verdicts = [verdict({ bidEventId: 'bid-old', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' })]
+		const r = computeVerdictQuorum(verdicts, 'bid-new', AUDITORS, 1)
+		expect(r.confirmCount).toBe(0)
+		expect(r.hasPositiveVerdict).toBe(false)
+		expect(r.hasNeutralVerdict).toBe(false)
+	})
+
+	test('without bidEventId, does not filter by bid (legacy/back-compat)', () => {
+		const verdicts = [verdict({ bidEventId: 'bid-old', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' })]
+		expect(computeVerdictQuorum(verdicts, undefined, AUDITORS, 1).hasPositiveVerdict).toBe(true)
+	})
+
+	test('ignores verdicts from non-configured auditors', () => {
+		const verdicts = [
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'rogue', claim: 'valid_bid_placed' }),
+		]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.confirmCount).toBe(1)
+		expect(r.hasPositiveVerdict).toBe(false)
+	})
+
+	test('dedupes by validator pubkey (one latest verdict per validator)', () => {
+		// Newest-first list: the same auditor published two verdicts for the bid;
+		// only the first (latest) should be counted once.
+		const verdicts = [
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'valid_bid_placed' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'bid_invalid' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-2', claim: 'valid_bid_placed' }),
+		]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.confirmCount).toBe(2)
+		expect(r.condemnCount).toBe(0)
+		expect(r.hasPositiveVerdict).toBe(true)
+	})
+
+	test('neutral claim (bid_pending_review) is not confirm nor condemn', () => {
+		const verdicts = [verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'bid_pending_review' })]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 1)
+		expect(r.confirmCount).toBe(0)
+		expect(r.condemnCount).toBe(0)
+		expect(r.hasPositiveVerdict).toBe(false)
+		expect(r.hasNegativeVerdict).toBe(false)
+		expect(r.hasNeutralVerdict).toBe(true)
+	})
+
+	test('won_pending_settlement counts as a confirm (stronger than valid_bid_placed)', () => {
+		const verdicts = [
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-1', claim: 'won_pending_settlement' }),
+			verdict({ bidEventId: 'bid-1', validatorPubkey: 'auditor-2', claim: 'valid_bid_placed' }),
+		]
+		const r = computeVerdictQuorum(verdicts, 'bid-1', AUDITORS, 2)
+		expect(r.hasPositiveVerdict).toBe(true)
+	})
+})

--- a/src/lib/auction/constants.ts
+++ b/src/lib/auction/constants.ts
@@ -169,6 +169,17 @@ export const VALIDATOR_CLAIMS = [
 export type ValidatorClaim = (typeof VALIDATOR_CLAIMS)[number]
 
 /**
+ * Verdict claims that confirm a bid as valid (per AUCTIONS.md §4.4.3).
+ * Shared by the validator publisher (Fix 3: suppress late_arrival
+ * downgrades of a prior confirm) and the client quorum screen
+ * (`computeVerdictQuorum`). Kept here so both sides agree on the set.
+ */
+export const VALIDATOR_CONFIRM_CLAIMS: ReadonlySet<ValidatorClaim> = new Set<ValidatorClaim>(['valid_bid_placed', 'won_pending_settlement'])
+
+/** Verdict claims that condemn a bid as invalid. */
+export const VALIDATOR_CONDEMN_CLAIMS: ReadonlySet<ValidatorClaim> = new Set<ValidatorClaim>(['bid_invalid', 'fraudulent_bid'])
+
+/**
  * Standardised machine codes for `bid_invalid` / negative verdicts — §4.4.3.
  * Validators MAY emit additional implementation-specific reasons; compliant
  * clients SHOULD show unknown reasons verbatim rather than ignoring them.

--- a/src/lib/auction/verdictQuorum.ts
+++ b/src/lib/auction/verdictQuorum.ts
@@ -1,0 +1,72 @@
+import { VALIDATOR_CONFIRM_CLAIMS, VALIDATOR_CONDEMN_CLAIMS } from './constants'
+import type { ParsedValidatorVerdictEvent } from './events'
+
+/**
+ * Result of tallying validator verdicts for a single published bid.
+ *
+ * `hasPositiveVerdict` / `hasNegativeVerdict` are quorum-gated: they only
+ * flip true once the number of distinct configured auditors that confirmed
+ * (or condemned) the bid reaches `auditorQuorum`. This mirrors the validator
+ * publisher's own quorum semantics (AUCTIONS.md §4.4.3) so the client's
+ * "confirmed"/"rejected" UI agrees with the validator's valid/invalid decision.
+ */
+export interface VerdictQuorumResult {
+	/** The newest verdict from a configured auditor for this bid (for display). */
+	representativeVerdict: ParsedValidatorVerdictEvent | null
+	confirmCount: number
+	condemnCount: number
+	hasPositiveVerdict: boolean
+	hasNegativeVerdict: boolean
+	/** A verdict exists, but neither a confirm nor a condemn quorum has formed. */
+	hasNeutralVerdict: boolean
+}
+
+/**
+ * Tally configured-auditor verdicts for one bid into a quorum decision.
+ *
+ * @param verdicts     Parsed kind-30440 verdicts, newest-first (as returned by
+ *                     `fetchAuctionVerdicts`).
+ * @param bidEventId   The published kind-1023 bid event id. When provided,
+ *                     verdicts are bound to exactly this bid (a rebid's verdict
+ *                     cannot leak into an earlier leg and vice-versa).
+ * @param validatorPubkeys The auction's configured `auditors` (trusted only).
+ * @param auditorQuorum    The auction's `auditor_quorum` (default 1).
+ */
+export function computeVerdictQuorum(
+	verdicts: ParsedValidatorVerdictEvent[],
+	bidEventId: string | undefined,
+	validatorPubkeys: string[],
+	auditorQuorum: number | undefined,
+): VerdictQuorumResult {
+	const seenValidators = new Set<string>()
+	let representative: ParsedValidatorVerdictEvent | null = null
+	let confirm = 0
+	let condemn = 0
+
+	for (const v of verdicts) {
+		// Bind to the exact published bid event, not just the bidder.
+		if (bidEventId && v.bidEventId !== bidEventId) continue
+		// Only accept verdicts from the auction's configured auditors.
+		if (!validatorPubkeys.includes(v.validatorPubkey)) continue
+		// Dedupe: one latest verdict per validator (input is newest-first).
+		if (seenValidators.has(v.validatorPubkey)) continue
+		seenValidators.add(v.validatorPubkey)
+
+		if (!representative) representative = v
+		if (VALIDATOR_CONFIRM_CLAIMS.has(v.claim)) confirm++
+		else if (VALIDATOR_CONDEMN_CLAIMS.has(v.claim)) condemn++
+	}
+
+	const quorum = auditorQuorum && auditorQuorum > 0 ? auditorQuorum : 1
+	const hasPositiveVerdict = confirm >= quorum
+	const hasNegativeVerdict = condemn >= quorum
+
+	return {
+		representativeVerdict: representative,
+		confirmCount: confirm,
+		condemnCount: condemn,
+		hasPositiveVerdict,
+		hasNegativeVerdict,
+		hasNeutralVerdict: !!representative && !hasPositiveVerdict && !hasNegativeVerdict,
+	}
+}

--- a/src/lib/stores/cart.test.ts
+++ b/src/lib/stores/cart.test.ts
@@ -150,7 +150,7 @@ describe('cart store persistence orchestration', () => {
 			},
 		})
 
-		await cartActions.addProduct('buyer', {
+		await cartActions.addProduct({
 			id: 'product-1',
 			amount: 1,
 			shippingMethodId: null,

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -966,7 +966,7 @@ function getAllMints(wallet: NDKCashuWallet): string[] {
  * wallet.state.dump() provides the source of truth for proofs and balances.
  */
 function getBalancesFromState(wallet: NDKCashuWallet): { totalBalance: number; mintBalances: Record<string, number> } {
-		const mintBalances: Record<string, number> = {}
+	const mintBalances: Record<string, number> = {}
 	let totalBalance = 0
 
 	for (const mint of getAllMints(wallet)) {

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -190,10 +190,12 @@ const initialState: Nip60State = {
 	pendingTokens: [],
 }
 
-const DEV_TEST_MINT_URL = process.env.APP_DEV_TEST_MINT_URL || 'http://localhost:3338'
+// Default to the public testnet mint. Set APP_DEV_TEST_MINT_URL to override
+// (e.g. http://localhost:3338 for local e2e tests with a local nutshell mint).
+const DEV_TEST_MINT_URL = process.env.APP_DEV_TEST_MINT_URL || 'https://testnut.cashu.space'
 export const NIP60_DEV_TEST_MINTS = Array.from(
 	new Set(
-		[DEV_TEST_MINT_URL, 'http://localhost:3338', 'http://127.0.0.1:3338'].map((mint) => mint.trim().replace(/\/$/, '')).filter(Boolean),
+		[DEV_TEST_MINT_URL, 'https://testnut.cashu.space', 'https://nofees.testnut.cashu.space'].map((mint) => mint.trim().replace(/\/$/, '')).filter(Boolean),
 	),
 )
 const NIP60_WALLET_KIND = 17375 as unknown as NonNullable<NDKFilter['kinds']>[number]

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1141,6 +1141,24 @@ export const nip60Actions = {
 						mints: nip60Store.state.mints,
 						mintBalances: nip60Store.state.mintBalances,
 					}),
+					getDepositStatus: () => ({
+						depositStatus: nip60Store.state.depositStatus,
+						depositInvoice: nip60Store.state.depositInvoice,
+						error: nip60Store.state.error,
+					}),
+					/**
+					 * Dev-only: simulate a Lightning invoice payment by emitting
+					 * the 'success' event on the active NDKCashuDeposit. This
+					 * triggers the same store transition as a real mint
+					 * confirmation, making it possible to e2e-test the funding
+					 * → mint → bid-publish flow without a Lightning node.
+					 */
+					simulateDepositSuccess: () => {
+						const deposit = nip60Store.state.activeDeposit
+						if (deposit) {
+							deposit.emit('success', null)
+						}
+					},
 				}
 			}
 		} catch (err) {

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -190,12 +190,10 @@ const initialState: Nip60State = {
 	pendingTokens: [],
 }
 
-const DEV_TEST_MINT_URL = process.env.APP_DEV_TEST_MINT_URL || 'https://testnut.cashu.space'
+const DEV_TEST_MINT_URL = process.env.APP_DEV_TEST_MINT_URL || 'http://localhost:3338'
 export const NIP60_DEV_TEST_MINTS = Array.from(
 	new Set(
-		[DEV_TEST_MINT_URL, 'https://testnut.cashu.space', 'https://nofees.testnut.cashu.space']
-			.map((mint) => mint.trim().replace(/\/$/, ''))
-			.filter(Boolean),
+		[DEV_TEST_MINT_URL, 'http://localhost:3338', 'http://127.0.0.1:3338'].map((mint) => mint.trim().replace(/\/$/, '')).filter(Boolean),
 	),
 )
 const NIP60_WALLET_KIND = 17375 as unknown as NonNullable<NDKFilter['kinds']>[number]

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -54,12 +54,22 @@ export interface Nip60DepositOptions {
 
 export type Nip60DepositStatus = 'idle' | 'pending' | 'awaiting_confirmation_retry' | 'success' | 'error'
 
+/**
+ * #10: Deposit quote estimate. `usedFallbackEstimate` and `feeSource` are
+ * derived from the per-component `mintFeeSource`/`lightningFeeSource` fields
+ * (see buildDepositQuoteEstimate). They are kept as convenience accessors so
+ * callers can check "did we fall back?" without OR-ing two fields, and so
+ * tests can assert on a single `feeSource` value. The per-component fields
+ * remain the source of truth for which specific fee used a fallback.
+ */
 export interface Nip60DepositQuoteEstimate {
 	requiredBidFundingAmount: number
 	totalDepositAmount: number
 	mintFeePaddingAmount: number
 	lightningFeePaddingAmount: number
+	/** Convenience: true when either mintFeeSource or lightningFeeSource is 'fallback'. */
 	usedFallbackEstimate: boolean
+	/** Convenience: 'fallback' if usedFallbackEstimate, else 'quote'. */
 	feeSource: 'quote' | 'fallback'
 	mintFeeSource: 'quote' | 'fallback'
 	lightningFeeSource: 'quote' | 'fallback'
@@ -1561,13 +1571,25 @@ export const nip60Actions = {
 
 			let depositAmount = requestedAmount
 			if (options?.includeFeePadding) {
-				// Keep deposit sizing deterministic to avoid minting an abandoned quote
-				// before creating the real payable invoice.
+				// #4: Fallback-only fee design — we do NOT call the mint quote API
+				// here to estimate fees. Instead, we add a conservative static padding
+				// (0.5%, min 5 sats, max 100 sats) via getAuctionDepositFeePadding().
+				// This avoids creating an abandoned mint quote (and consuming mint
+				// rate-limit budget) just for estimation. The actual Lightning fee
+				// is whatever the mint embeds in the invoice returned by
+				// deposit.start(); validateAuctionDepositInvoiceQuote() then checks
+				// that the invoice fee is within acceptable caps before we show it.
+				// estimateDepositQuote() exposes the same fallback logic for callers
+				// that need a pre-flight estimate without side effects.
 				depositAmount = requestedAmount + getAuctionDepositFeePadding(requestedAmount)
 			}
 
 			const deposit = wallet.deposit(depositAmount, targetMint)
-			const invoice = await deposit.start()
+			// #3: Wrap deposit.start() in a 15s timeout so a hung mint quote
+			// request doesn't leave the user staring at a spinner indefinitely.
+			// The ADR §3b timeout also covers the post-payment confirmation phase
+			// via monitorDepositConfirmation() below.
+			const invoice = await withTimeout(deposit.start(), NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS, 'deposit invoice creation')
 
 			if (invoice) {
 				const invoiceAmountSats = extractInvoiceAmountSats(invoice)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1157,7 +1157,14 @@ export const nip60Actions = {
 							deposit.emit('success', null)
 						}
 					},
-				}
+					/**
+					 * Dev-only: explicitly register a mint URL in the wallet.
+					 * Exposed via the __nip60 bridge so e2e tests can call
+					 * nip60Actions.addMint() after fundWallet to ensure the
+					 * mint appears in the store before the deposit modal opens.
+					 */
+					addMint: nip60Actions.addMint,
+					}
 			}
 		} catch (err) {
 			console.error('[nip60] Failed to initialize wallet:', err)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1639,6 +1639,11 @@ export const nip60Actions = {
 
 			// Listen for deposit completion
 			deposit.on('success', (token) => {
+				// Identity guard, mirroring monitorDepositConfirmation's timeout guard:
+				// a stale deposit object (canceled or replaced by a newer deposit) can
+				// still emit a late 'success' — only the currently-active deposit may
+				// flip the global deposit status.
+				if (nip60Store.state.activeDeposit !== deposit) return
 				nip60Store.setState((s) => ({
 					...s,
 					depositStatus: 'success',

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1,6 +1,7 @@
 import {
 	getMintHostname,
 	getProofsForMint,
+	getSpendableProofsForMint,
 	loadUserData,
 	saveUserData,
 	type AuctionBidPendingTokenContext,
@@ -32,6 +33,7 @@ import { NDKEvent, NDKNutzap, NDKRelaySet, NDKUser, NDKZapper, type NDKFilter, t
 import { NDKCashuDeposit, NDKCashuWallet, NDKWalletStatus, type NDKWalletTransaction } from '@nostr-dev-kit/wallet'
 import { HDKey } from '@scure/bip32'
 import { Store } from '@tanstack/store'
+import { decode as decodeBolt11 } from 'light-bolt11-decoder'
 import { ndkActions, ndkStore } from './ndk'
 import { configStore } from './config'
 import { findBidderRecordByRefundPubkey } from '@/lib/auction/bidderRecords'
@@ -44,6 +46,23 @@ export type PendingNip60Token = PendingToken
 
 export interface Nip60LightningPaymentResult {
 	preimage?: string
+}
+
+export interface Nip60DepositOptions {
+	includeFeePadding?: boolean
+}
+
+export type Nip60DepositStatus = 'idle' | 'pending' | 'awaiting_confirmation_retry' | 'success' | 'error'
+
+export interface Nip60DepositQuoteEstimate {
+	requiredBidFundingAmount: number
+	totalDepositAmount: number
+	mintFeePaddingAmount: number
+	lightningFeePaddingAmount: number
+	usedFallbackEstimate: boolean
+	feeSource: 'quote' | 'fallback'
+	mintFeeSource: 'quote' | 'fallback'
+	lightningFeeSource: 'quote' | 'fallback'
 }
 
 export interface Nip60NutzapResult {
@@ -141,7 +160,7 @@ export interface Nip60State {
 	// Active deposit tracking
 	activeDeposit: NDKCashuDeposit | null
 	depositInvoice: string | null
-	depositStatus: 'idle' | 'pending' | 'success' | 'error'
+	depositStatus: Nip60DepositStatus
 	// Pending tokens tracking (tokens generated but not yet claimed by recipient)
 	pendingTokens: PendingNip60Token[]
 }
@@ -173,6 +192,13 @@ const NIP60_WALLET_KIND = 17375 as unknown as NonNullable<NDKFilter['kinds']>[nu
 const NIP60_WALLET_FETCH_TIMEOUT_MS = 5000
 const NIP60_WALLET_LOAD_TIMEOUT_MS = 5000
 const NIP60_WALLET_START_TIMEOUT_MS = 7000
+export const NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS = 15_000
+const AUCTION_DEPOSIT_PADDING_RATE = 0.005
+const AUCTION_DEPOSIT_MIN_PADDING_SATS = 5
+const AUCTION_DEPOSIT_MAX_PADDING_SATS = 100
+const AUCTION_MINT_QUOTE_FEE_MIN_CAP_SATS = 25
+const AUCTION_MINT_QUOTE_FEE_RELATIVE_CAP_RATE = 0.1
+const AUCTION_MINT_QUOTE_FEE_ABSOLUTE_CAP_SATS = 2000
 const AUCTION_KIND = 30408 as unknown as NonNullable<NDKFilter['kinds']>[number]
 const AUCTION_BID_KIND = 1023 as unknown as NonNullable<NDKFilter['kinds']>[number]
 /**
@@ -211,6 +237,72 @@ const AUCTION_RECLAIM_BACKOFF_SECONDS = [30, 120, 600, 1800, 7200]
  */
 const AUCTION_RECLAIM_PERMANENT_ERROR_KEYWORDS = ['witness is missing', 'signature is not valid', 'spending conditions not met']
 let auctionAutoReclaimLastSweepMs = 0
+
+/**
+ * Returns the bounded safety buffer for an auction funding deposit.
+ *
+ * The buffer is 0.5% of the requested deposit, rounded up, with a 5 sat
+ * minimum and 100 sat maximum. It is used only when the mint quote does not
+ * provide a fee component; it is not a fee reported by the mint.
+ */
+export const getAuctionDepositFeePadding = (depositAmount: number): number =>
+	Math.min(
+		Math.max(Math.ceil(depositAmount * AUCTION_DEPOSIT_PADDING_RATE), AUCTION_DEPOSIT_MIN_PADDING_SATS),
+		AUCTION_DEPOSIT_MAX_PADDING_SATS,
+	)
+
+export const getAuctionDepositMaxMintQuoteFeeSats = (requestedAmount: number): number => {
+	const relativeCap = Math.ceil(requestedAmount * AUCTION_MINT_QUOTE_FEE_RELATIVE_CAP_RATE)
+	return Math.min(AUCTION_MINT_QUOTE_FEE_ABSOLUTE_CAP_SATS, Math.max(AUCTION_MINT_QUOTE_FEE_MIN_CAP_SATS, relativeCap))
+}
+
+const extractInvoiceAmountSats = (invoice: string): number | null => {
+	const normalizedInvoice = invoice.trim().replace(/^lightning:/i, '')
+	if (!normalizedInvoice) return null
+
+	try {
+		const decoded = decodeBolt11(normalizedInvoice)
+		const amountMillisatsRaw = decoded.sections.find((section) => section.name === 'amount')?.value
+		if (amountMillisatsRaw == null) return null
+
+		const amountMillisats =
+			typeof amountMillisatsRaw === 'number'
+				? amountMillisatsRaw
+				: Number.parseInt(typeof amountMillisatsRaw === 'string' ? amountMillisatsRaw : String(amountMillisatsRaw), 10)
+
+		if (!Number.isFinite(amountMillisats) || amountMillisats <= 0) return null
+		return Math.ceil(amountMillisats / 1000)
+	} catch {
+		return null
+	}
+}
+
+export const validateAuctionDepositInvoiceQuote = (params: {
+	requestedAmount: number
+	depositAmount: number
+	invoiceAmountSats: number
+	mintUrl: string
+}): void => {
+	const { requestedAmount, depositAmount, invoiceAmountSats, mintUrl } = params
+	if (!Number.isFinite(invoiceAmountSats) || invoiceAmountSats <= 0) {
+		throw new Error('Mint returned an invalid Lightning invoice amount. Please retry with a different mint.')
+	}
+
+	if (invoiceAmountSats < depositAmount) {
+		throw new Error(
+			`Mint ${getMintHostname(mintUrl)} returned an invoice below the requested deposit amount. Please retry with a different mint.`,
+		)
+	}
+
+	const quoteFeeSats = invoiceAmountSats - depositAmount
+	const maxAllowedQuoteFeeSats = getAuctionDepositMaxMintQuoteFeeSats(requestedAmount)
+	if (quoteFeeSats > maxAllowedQuoteFeeSats) {
+		throw new Error(
+			`Mint ${getMintHostname(mintUrl)} returned an unusually high Lightning fee quote (${quoteFeeSats} sats on a ${requestedAmount} sat deposit). ` +
+				`Maximum allowed is ${maxAllowedQuoteFeeSats} sats. Please choose another mint.`,
+		)
+	}
+}
 
 /**
  * Resolve the earliest-reclaim timestamp for a bid token. We prefer the
@@ -294,6 +386,33 @@ const getDevTestMintCandidates = (preferredMintUrl?: string): string[] => {
 const isKeysetVerificationError = (err: unknown): err is Error => err instanceof Error && err.message.includes("Couldn't verify keyset ID")
 
 const getErrorMessage = (err: unknown): string => (err instanceof Error ? err.message : String(err))
+
+const computePaddedDepositAmount = (
+	requiredBidFundingAmount: number,
+	mintFeePaddingAmount: number,
+	lightningFeePaddingAmount: number,
+): number => requiredBidFundingAmount + mintFeePaddingAmount + lightningFeePaddingAmount
+
+const buildDepositQuoteEstimate = (params: {
+	requiredBidFundingAmount: number
+	mintFeePaddingAmount: number
+	lightningFeePaddingAmount: number
+	mintFeeSource: 'quote' | 'fallback'
+	lightningFeeSource: 'quote' | 'fallback'
+}): Nip60DepositQuoteEstimate => {
+	const { requiredBidFundingAmount, mintFeePaddingAmount, lightningFeePaddingAmount, mintFeeSource, lightningFeeSource } = params
+	const usedFallbackEstimate = mintFeeSource === 'fallback' || lightningFeeSource === 'fallback'
+	return {
+		requiredBidFundingAmount,
+		totalDepositAmount: computePaddedDepositAmount(requiredBidFundingAmount, mintFeePaddingAmount, lightningFeePaddingAmount),
+		mintFeePaddingAmount,
+		lightningFeePaddingAmount,
+		usedFallbackEstimate,
+		feeSource: usedFallbackEstimate ? 'fallback' : 'quote',
+		mintFeeSource,
+		lightningFeeSource,
+	}
+}
 
 const ensureWalletRuntimeDefaults = (wallet: NDKCashuWallet, ndk: NDKEvent['ndk']): void => {
 	if (!ndk) return
@@ -561,6 +680,41 @@ const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, label: str
 	}
 }
 
+const DEPOSIT_CONFIRMATION_TIMEOUT_LABEL = 'wallet acknowledgment and mint confirmation'
+
+const getDepositConfirmationTimeoutMessage = (timeoutMs: number): string =>
+	`${DEPOSIT_CONFIRMATION_TIMEOUT_LABEL} timeout after ${timeoutMs}ms`
+
+export const waitForDepositConfirmation = async (
+	deposit: Pick<NDKCashuDeposit, 'on'>,
+	timeoutMs = NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS,
+): Promise<void> =>
+	withTimeout(
+		new Promise<void>((resolve, reject) => {
+			deposit.on('success', () => resolve())
+			deposit.on('error', (error) => reject(new Error(typeof error === 'string' ? error : String(error))))
+		}),
+		timeoutMs,
+		DEPOSIT_CONFIRMATION_TIMEOUT_LABEL,
+	)
+
+const isDepositConfirmationTimeoutError = (error: unknown, timeoutMs = NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS): boolean =>
+	error instanceof Error && error.message === getDepositConfirmationTimeoutMessage(timeoutMs)
+
+const monitorDepositConfirmation = (deposit: NDKCashuDeposit, timeoutMs = NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS): void => {
+	void waitForDepositConfirmation(deposit, timeoutMs).catch((error) => {
+		const state = nip60Store.state
+		if (state.activeDeposit !== deposit || state.depositStatus !== 'pending') return
+		if (!isDepositConfirmationTimeoutError(error, timeoutMs)) return
+
+		nip60Store.setState((current) => ({
+			...current,
+			depositStatus: 'awaiting_confirmation_retry',
+			error: 'Payment confirmation timed out. Retry confirmation to check the mint again.',
+		}))
+	})
+}
+
 function extractPreimageCandidate(result: unknown): string | undefined {
 	if (!result || typeof result !== 'object') return undefined
 	const r = result as Record<string, unknown>
@@ -812,18 +966,18 @@ function getAllMints(wallet: NDKCashuWallet): string[] {
  * wallet.state.dump() provides the source of truth for proofs and balances.
  */
 function getBalancesFromState(wallet: NDKCashuWallet): { totalBalance: number; mintBalances: Record<string, number> } {
-	const dump = wallet.state.dump()
-	const mintBalances = { ...dump.balances }
+		const mintBalances: Record<string, number> = {}
+	let totalBalance = 0
 
-	// Ensure all configured mints are present (even with 0 balance)
-	for (const mint of wallet.mints ?? []) {
-		if (!(mint in mintBalances)) {
-			mintBalances[mint] = 0
-		}
+	for (const mint of getAllMints(wallet)) {
+		const spendableProofs = getSpendableProofsForMint(wallet, mint)
+		const balance = spendableProofs.reduce((sum, proof) => sum + proof.amount, 0)
+		mintBalances[mint] = balance
+		totalBalance += balance
 	}
 
 	return {
-		totalBalance: dump.totalBalance,
+		totalBalance,
 		mintBalances,
 	}
 }
@@ -1362,11 +1516,21 @@ export const nip60Actions = {
 	 * @param amount Amount in sats to deposit
 	 * @param mint Optional mint URL (uses default if not specified)
 	 */
-	startDeposit: async (amount: number, mint?: string): Promise<string | null> => {
+	startDeposit: async (amount: number, mint?: string, options?: Nip60DepositOptions): Promise<string | null> => {
 		const wallet = nip60Store.state.wallet
 		const state = nip60Store.state
 		if (!wallet) {
 			console.warn('[nip60] Cannot deposit without wallet')
+			return null
+		}
+
+		const requestedAmount = Math.ceil(amount)
+		if (!Number.isFinite(requestedAmount) || requestedAmount <= 0) {
+			nip60Store.setState((s) => ({
+				...s,
+				depositStatus: 'error',
+				error: 'Deposit amount must be a positive integer.',
+			}))
 			return null
 		}
 
@@ -1395,8 +1559,28 @@ export const nip60Actions = {
 
 			await primeDevTestMintDepositWalletCache(wallet, targetMint)
 
-			const deposit = wallet.deposit(amount, targetMint)
+			let depositAmount = requestedAmount
+			if (options?.includeFeePadding) {
+				// Keep deposit sizing deterministic to avoid minting an abandoned quote
+				// before creating the real payable invoice.
+				depositAmount = requestedAmount + getAuctionDepositFeePadding(requestedAmount)
+			}
+
+			const deposit = wallet.deposit(depositAmount, targetMint)
 			const invoice = await deposit.start()
+
+			if (invoice) {
+				const invoiceAmountSats = extractInvoiceAmountSats(invoice)
+				if (invoiceAmountSats == null) {
+					throw new Error('Mint returned an invoice without a parseable amount. Please retry with a different mint.')
+				}
+				validateAuctionDepositInvoiceQuote({
+					requestedAmount,
+					depositAmount,
+					invoiceAmountSats,
+					mintUrl: targetMint,
+				})
+			}
 
 			nip60Store.setState((s) => ({
 				...s,
@@ -1427,6 +1611,8 @@ export const nip60Actions = {
 				}))
 			})
 
+			monitorDepositConfirmation(deposit)
+
 			return invoice ?? null
 		} catch (err) {
 			console.error('[nip60] Failed to start deposit:', err)
@@ -1439,6 +1625,68 @@ export const nip60Actions = {
 			}))
 			return null
 		}
+	},
+
+	retryDepositConfirmation: (): void => {
+		const { activeDeposit, depositStatus } = nip60Store.state
+		if (!activeDeposit || depositStatus !== 'awaiting_confirmation_retry') return
+
+		nip60Store.setState((state) => ({
+			...state,
+			depositStatus: 'pending',
+			error: null,
+		}))
+
+		monitorDepositConfirmation(activeDeposit)
+		void activeDeposit.check(NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS).catch((error) => {
+			console.error('[nip60] Deposit confirmation retry failed:', error)
+		})
+	},
+
+	/**
+	 * Manual "check now" for a "Confirm" button — unlike `retryDepositConfirmation`,
+	 * this isn't gated behind the `awaiting_confirmation_retry` timeout state, so it
+	 * works while a deposit is still `pending`. Reuses the success/error listeners
+	 * `startDeposit` already attached to `activeDeposit`, so a payment found here
+	 * still transitions `depositStatus` normally.
+	 */
+	checkDepositNow: async (): Promise<void> => {
+		const { activeDeposit, depositStatus } = nip60Store.state
+		if (!activeDeposit || (depositStatus !== 'pending' && depositStatus !== 'awaiting_confirmation_retry')) return
+
+		if (depositStatus === 'awaiting_confirmation_retry') {
+			nip60Actions.retryDepositConfirmation()
+			return
+		}
+
+		try {
+			await activeDeposit.check(NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS)
+		} catch (error) {
+			console.error('[nip60] Manual deposit check failed:', error)
+		}
+	},
+
+	estimateDepositQuote: async (amount: number, mintUrl: string): Promise<Nip60DepositQuoteEstimate> => {
+		const requiredBidFundingAmount = Math.ceil(amount)
+		const targetMint = normalizeMintUrl(mintUrl)
+		if (!Number.isFinite(requiredBidFundingAmount) || requiredBidFundingAmount <= 0) {
+			throw new Error('Deposit quote amount must be a positive integer')
+		}
+		if (!targetMint) {
+			throw new Error('Mint URL is required for deposit quote estimation')
+		}
+
+		const fallbackPaddingAmount = getAuctionDepositFeePadding(requiredBidFundingAmount)
+
+		// Do not call mint quote APIs from estimation. The only quote should be the
+		// one generated by wallet.deposit(...).start() that the user actually pays.
+		return buildDepositQuoteEstimate({
+			requiredBidFundingAmount,
+			mintFeePaddingAmount: 0,
+			lightningFeePaddingAmount: fallbackPaddingAmount,
+			mintFeeSource: 'fallback',
+			lightningFeeSource: 'fallback',
+		})
 	},
 
 	/**
@@ -1646,7 +1894,7 @@ export const nip60Actions = {
 			throw new Error(`Insufficient balance at ${getMintHostname(targetMint)}. Available: ${mintBalance} sats`)
 		}
 
-		const mintProofs = getProofsForMint(wallet, targetMint)
+		const mintProofs = getSpendableProofsForMint(wallet, targetMint)
 		if (mintProofs.length === 0) {
 			throw new Error(`No proofs available at ${getMintHostname(targetMint)}. Try refreshing your wallet.`)
 		}
@@ -1703,7 +1951,7 @@ export const nip60Actions = {
 						console.error('[nip60] Consolidation during bid send retry failed:', consolidateErr)
 					}
 
-					const refreshedProofs = getProofsForMint(wallet, targetMint)
+					const refreshedProofs = getSpendableProofsForMint(wallet, targetMint)
 					const retryAfterConsolidate = await lockAuctionBidProofs(cashuWallet, amount, refreshedProofs, buildLockOptions(false))
 					lockedProofs = retryAfterConsolidate.send
 					changeProofs = retryAfterConsolidate.keep
@@ -1846,7 +2094,7 @@ export const nip60Actions = {
 		}
 
 		// Get proofs for this mint using shared utility
-		const mintProofs = getProofsForMint(wallet, targetMint)
+		const mintProofs = getSpendableProofsForMint(wallet, targetMint)
 
 		if (mintProofs.length === 0) {
 			throw new Error(`No proofs available at ${getMintHostname(targetMint)}. Try refreshing your wallet.`)
@@ -2117,9 +2365,6 @@ export const nip60Actions = {
 			auctionLocktimeAt: maxEndAt,
 			settlementGraceSeconds,
 			sellerPubkey: selected.pubkey,
-			// Legacy field kept for back-compat with the publish form.
-			// publishAuctionBid no longer uses it for path issuance.
-			pathIssuerPubkey: '',
 			p2pkXpub,
 			mintCandidates: trustedMints.length ? trustedMints : [mintForLock],
 		}

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -1164,7 +1164,7 @@ export const nip60Actions = {
 					 * mint appears in the store before the deposit modal opens.
 					 */
 					addMint: nip60Actions.addMint,
-					}
+				}
 			}
 		} catch (err) {
 			console.error('[nip60] Failed to initialize wallet:', err)

--- a/src/lib/stores/nip60.ts
+++ b/src/lib/stores/nip60.ts
@@ -195,7 +195,9 @@ const initialState: Nip60State = {
 const DEV_TEST_MINT_URL = process.env.APP_DEV_TEST_MINT_URL || 'https://testnut.cashu.space'
 export const NIP60_DEV_TEST_MINTS = Array.from(
 	new Set(
-		[DEV_TEST_MINT_URL, 'https://testnut.cashu.space', 'https://nofees.testnut.cashu.space'].map((mint) => mint.trim().replace(/\/$/, '')).filter(Boolean),
+		[DEV_TEST_MINT_URL, 'https://testnut.cashu.space', 'https://nofees.testnut.cashu.space']
+			.map((mint) => mint.trim().replace(/\/$/, ''))
+			.filter(Boolean),
 	),
 )
 const NIP60_WALLET_KIND = 17375 as unknown as NonNullable<NDKFilter['kinds']>[number]

--- a/src/lib/wallet/index.ts
+++ b/src/lib/wallet/index.ts
@@ -2,7 +2,7 @@
 export type { ProofInfo, PendingToken, PendingTokenContext, AuctionBidPendingTokenContext, ProofEntry } from './types'
 
 // Proof utilities
-export { extractProofsByMint, getProofsForMint } from './proofs'
+export { extractProofsByMint, getProofsForMint, getSpendableProofsForMint } from './proofs'
 
 // Storage utilities
 export { loadUserData, saveUserData, removeUserData } from './storage'

--- a/src/lib/wallet/nip60.test.ts
+++ b/src/lib/wallet/nip60.test.ts
@@ -151,3 +151,127 @@ describe('mint quote fee bounds', () => {
 		).toThrow('invoice below the requested deposit amount')
 	})
 })
+
+describe('checkDepositNow', () => {
+	test('while pending resolves on success via deposit check', async () => {
+		const deposit = createMockDeposit()
+
+		// Simulate the success handler that startDeposit attaches to the deposit
+		deposit.on('success', () => {
+			nip60Store.setState((s) => ({
+				...s,
+				depositStatus: 'success',
+				activeDeposit: null,
+				depositInvoice: null,
+			}))
+		})
+
+		nip60Store.setState((state) => ({
+			...state,
+			activeDeposit: deposit as never,
+			depositInvoice: 'lnbc1test',
+			depositStatus: 'pending',
+			error: null,
+		}))
+
+		await nip60Actions.checkDepositNow()
+
+		expect(nip60Store.state.depositStatus).toBe('success')
+		expect(deposit.getCheckCalls()).toBe(1)
+	})
+
+	test('while pending with check error stays pending (error is caught, not fatal)', async () => {
+		const handlers: Partial<Record<DepositEventName, (value?: unknown) => void>> = {}
+		const failingDeposit = {
+			on: (event: DepositEventName, handler: (value?: unknown) => void) => {
+				handlers[event] = handler
+				return undefined
+			},
+			check: async () => {
+				throw new Error('mint unreachable')
+			},
+			emitSuccess: () => handlers.success?.(),
+			emitError: (error: string) => handlers.error?.(error),
+		}
+
+		nip60Store.setState((state) => ({
+			...state,
+			activeDeposit: failingDeposit as never,
+			depositInvoice: 'lnbc1test',
+			depositStatus: 'pending',
+			error: null,
+		}))
+
+		await nip60Actions.checkDepositNow()
+
+		// checkDepositNow catches the check error; depositStatus stays pending
+		expect(nip60Store.state.depositStatus).toBe('pending')
+	})
+
+	test('while awaiting_confirmation_retry delegates to retryDepositConfirmation', async () => {
+		const deposit = createMockDeposit()
+
+		nip60Store.setState((state) => ({
+			...state,
+			activeDeposit: deposit as never,
+			depositInvoice: 'lnbc1test',
+			depositStatus: 'awaiting_confirmation_retry',
+			error: 'Payment confirmation timed out. Retry confirmation to check the mint again.',
+		}))
+
+		await nip60Actions.checkDepositNow()
+
+		// retryDepositConfirmation sets status to pending and triggers a re-check
+		expect(nip60Store.state.depositStatus).toBe('pending')
+		expect(nip60Store.state.error).toBeNull()
+		expect(deposit.getCheckCalls()).toBe(1)
+	})
+
+	test('while idle is a no-op (no active deposit)', async () => {
+		await nip60Actions.checkDepositNow()
+		expect(nip60Store.state.depositStatus).toBe('idle')
+	})
+
+	test('while success is a no-op (does not re-check a completed deposit)', async () => {
+		const deposit = createMockDeposit()
+
+		nip60Store.setState((state) => ({
+			...state,
+			activeDeposit: deposit as never,
+			depositStatus: 'success',
+		}))
+
+		await nip60Actions.checkDepositNow()
+
+		expect(deposit.getCheckCalls()).toBe(0)
+		expect(nip60Store.state.depositStatus).toBe('success')
+	})
+})
+
+describe('deposit timeout error detection', () => {
+	test('waitForDepositConfirmation timeout error message includes timeout duration', async () => {
+		const deposit = createMockDeposit()
+
+		// The error message format is what monitorDepositConfirmation uses to
+		// distinguish a timeout from other errors (isDepositConfirmationTimeoutError).
+		await expect(waitForDepositConfirmation(deposit as never, 50)).rejects.toThrow(/timeout after 50ms/)
+	})
+
+	test('waitForDepositConfirmation error event is distinct from timeout (not mistaken for timeout)', async () => {
+		const deposit = createMockDeposit()
+
+		const promise = waitForDepositConfirmation(deposit as never, 5000)
+		deposit.emitError('mint connection refused')
+
+		await expect(promise).rejects.toThrow('mint connection refused')
+	})
+
+	test('waitForDepositConfirmation resolves before timeout when success arrives first', async () => {
+		const deposit = createMockDeposit()
+
+		const promise = waitForDepositConfirmation(deposit as never, 5000)
+		deposit.emitSuccess()
+
+		await expect(promise).resolves.toBeUndefined()
+	})
+})

--- a/src/lib/wallet/nip60.test.ts
+++ b/src/lib/wallet/nip60.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+	getAuctionDepositFeePadding,
+	getAuctionDepositMaxMintQuoteFeeSats,
+	NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS,
+	nip60Actions,
+	nip60Store,
+	validateAuctionDepositInvoiceQuote,
+	waitForDepositConfirmation,
+} from '@/lib/stores/nip60'
+
+type DepositEventName = 'success' | 'error'
+
+const createMockDeposit = () => {
+	const handlers: Partial<Record<DepositEventName, (value?: unknown) => void>> = {}
+	let checkCalls = 0
+
+	return {
+		on: (event: DepositEventName, handler: (value?: unknown) => void) => {
+			handlers[event] = handler
+			return undefined
+		},
+		check: async () => {
+			checkCalls += 1
+			handlers.success?.()
+		},
+		emitSuccess: () => handlers.success?.(),
+		emitError: (error: string) => handlers.error?.(error),
+		getCheckCalls: () => checkCalls,
+	}
+}
+
+afterEach(() => {
+	nip60Store.setState((state) => ({
+		...state,
+		activeDeposit: null,
+		depositInvoice: null,
+		depositStatus: 'idle',
+		error: null,
+	}))
+})
+
+describe('getAuctionDepositFeePadding', () => {
+	test.each([
+		[100, 5],
+		[1_000, 5],
+		[10_000, 50],
+		[20_000, 100],
+		[100_000, 100],
+	])('%d sat deposit receives %d sats of padding', (depositAmount, expectedPadding) =>
+		expect(getAuctionDepositFeePadding(depositAmount)).toBe(expectedPadding),
+	)
+})
+
+describe('waitForDepositConfirmation', () => {
+	test('uses a 15s default confirmation timeout', () => {
+		expect(NIP60_DEPOSIT_CONFIRMATION_TIMEOUT_MS).toBe(15_000)
+	})
+
+	test('rejects when confirmation times out', async () => {
+		const deposit = createMockDeposit()
+
+		await expect(waitForDepositConfirmation(deposit as never, 1)).rejects.toThrow(
+			'wallet acknowledgment and mint confirmation timeout after 1ms',
+		)
+	})
+
+	test('resolves when deposit succeeds before timeout', async () => {
+		const deposit = createMockDeposit()
+		const confirmationPromise = waitForDepositConfirmation(deposit as never, 50)
+
+		deposit.emitSuccess()
+
+		await expect(confirmationPromise).resolves.toBeUndefined()
+	})
+})
+
+describe('retryDepositConfirmation', () => {
+	test('re-enters pending state and triggers a deposit re-check', async () => {
+		const deposit = createMockDeposit()
+
+		nip60Store.setState((state) => ({
+			...state,
+			activeDeposit: deposit as never,
+			depositInvoice: 'lnbc1test',
+			depositStatus: 'awaiting_confirmation_retry',
+			error: 'Payment confirmation timed out. Retry confirmation to check the mint again.',
+		}))
+
+		nip60Actions.retryDepositConfirmation()
+		await Promise.resolve()
+
+		expect(nip60Store.state.depositStatus).toBe('pending')
+		expect(nip60Store.state.error).toBeNull()
+		expect(deposit.getCheckCalls()).toBe(1)
+	})
+})
+
+describe('estimateDepositQuote', () => {
+	test('returns deterministic fallback padding without depending on mint quote side effects', async () => {
+		const estimate = await nip60Actions.estimateDepositQuote(10_000, 'https://mint.minibits.cash/Bitcoin')
+
+		expect(estimate.requiredBidFundingAmount).toBe(10_000)
+		expect(estimate.totalDepositAmount).toBe(10_050)
+		expect(estimate.mintFeePaddingAmount).toBe(0)
+		expect(estimate.lightningFeePaddingAmount).toBe(50)
+		expect(estimate.feeSource).toBe('fallback')
+		expect(estimate.usedFallbackEstimate).toBe(true)
+	})
+})
+
+describe('mint quote fee bounds', () => {
+	test.each([
+		[100, 25],
+		[10_000, 1_000],
+		[50_000, 2_000],
+	])('caps mint quote fees for %d sats at %d sats', (requestedAmount, expectedMax) => {
+		expect(getAuctionDepositMaxMintQuoteFeeSats(requestedAmount)).toBe(expectedMax)
+	})
+
+	test('accepts invoice quote fee within cap', () => {
+		expect(() =>
+			validateAuctionDepositInvoiceQuote({
+				requestedAmount: 10_000,
+				depositAmount: 10_050,
+				invoiceAmountSats: 10_500,
+				mintUrl: 'https://mint.minibits.cash',
+			}),
+		).not.toThrow()
+	})
+
+	test('rejects invoice quote fee that exceeds cap', () => {
+		expect(() =>
+			validateAuctionDepositInvoiceQuote({
+				requestedAmount: 10_000,
+				depositAmount: 10_050,
+				invoiceAmountSats: 30_000,
+				mintUrl: 'https://mint.minibits.cash',
+			}),
+		).toThrow('unusually high Lightning fee quote')
+	})
+
+	test('rejects invoice amount below requested deposit', () => {
+		expect(() =>
+			validateAuctionDepositInvoiceQuote({
+				requestedAmount: 10_000,
+				depositAmount: 10_050,
+				invoiceAmountSats: 9_000,
+				mintUrl: 'https://mint.minibits.cash',
+			}),
+		).toThrow('invoice below the requested deposit amount')
+	})
+})

--- a/src/lib/wallet/proofs.test.ts
+++ b/src/lib/wallet/proofs.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test'
+import { getSpendableProofsForMint } from './proofs'
+
+describe('getSpendableProofsForMint', () => {
+	test('requests only spendable proofs from wallet state and returns them', () => {
+		const availableProof = { amount: 100, secret: 'available' } as never
+		const spentProof = { amount: 200, secret: 'spent' } as never
+		const calls: Array<{ mint?: string; includeDeleted?: boolean; onlyAvailable?: boolean }> = []
+
+		const wallet = {
+			state: {
+				getProofs: (options: { mint?: string; includeDeleted?: boolean; onlyAvailable?: boolean }) => {
+					calls.push(options)
+					if (options.onlyAvailable) return [availableProof]
+					return [availableProof, spentProof]
+				},
+			},
+		} as never
+
+		const result = getSpendableProofsForMint(wallet, 'https://mint.example')
+
+		expect(calls).toEqual([
+			{
+				mint: 'https://mint.example',
+				includeDeleted: false,
+				onlyAvailable: true,
+			},
+		])
+		expect(result).toEqual([availableProof])
+	})
+})

--- a/src/lib/wallet/proofs.ts
+++ b/src/lib/wallet/proofs.ts
@@ -90,6 +90,15 @@ export function getSpendableProofsForMint(wallet: NDKCashuWallet, mintUrl: strin
 		}
 	}
 
+	// Fallback: dump-based extraction with proof.state filtering.
+	// This path is hit when wallet.state.getProofs() is unavailable or throws.
+	// proof.state may be undefined for proofs that haven't been through NDK's
+	// state tracking, so the filter only excludes proofs explicitly marked as
+	// 'spent' or 'deleted' — undefined state is treated as spendable.
+	console.warn(
+		`[wallet/proofs] getSpendableProofsForMint: falling back to dump-based extraction for mint ${mintUrl}` +
+			` (wallet.state.getProofs unavailable or returned non-array)`,
+	)
 	const proofs = getProofsForMint(wallet, mintUrl)
 	return proofs.filter((proof) => {
 		const state = (proof as unknown as { state?: string }).state

--- a/src/lib/wallet/proofs.ts
+++ b/src/lib/wallet/proofs.ts
@@ -68,3 +68,31 @@ export function getProofsForMint(wallet: NDKCashuWallet, mintUrl: string): Proof
 	const proofsByMint = extractProofsByMint(wallet, [mintUrl])
 	return proofsByMint.get(mintUrl) || []
 }
+
+/**
+ * Get proofs that are currently spendable from wallet state.
+ * This intentionally avoids proofs already marked as spent/deleted so they
+ * cannot be reused for a new bid or ecash send.
+ */
+export function getSpendableProofsForMint(wallet: NDKCashuWallet, mintUrl: string): Proof[] {
+	if (typeof wallet.state?.getProofs === 'function') {
+		try {
+			const proofs = wallet.state.getProofs({
+				mint: mintUrl,
+				includeDeleted: false,
+				onlyAvailable: true,
+			})
+			if (Array.isArray(proofs)) {
+				return proofs as Proof[]
+			}
+		} catch {
+			// Fall back to the dump-based extraction below.
+		}
+	}
+
+	const proofs = getProofsForMint(wallet, mintUrl)
+	return proofs.filter((proof) => {
+		const state = (proof as unknown as { state?: string }).state
+		return state !== 'spent' && state !== 'deleted'
+	})
+}

--- a/src/publish/auctions.tsx
+++ b/src/publish/auctions.tsx
@@ -640,6 +640,46 @@ export const publishAuctionBid = async (formData: AuctionBidFormData, signer: ND
 	return bidEvent.id
 }
 
+/**
+ * #12 (Blocker 1): Rebroadcast an already-signed kind-1023 auction bid event
+ * by id, without re-locking funds or re-signing.
+ *
+ * Used by the `retryBidPublish` idempotent-retry path in `useAuctionBidFunding`:
+ * when a bid was successfully signed and published once (so `publishedBidEventId`
+ * is known) but a subsequent relay broadcast failed (transient relay outage on
+ * retry, or relays that missed the original announcement), retrying must NOT
+ * re-run `publishAuctionBid` — that would re-lock funds and re-sign a new event,
+ * double-charging the bidder. Instead we fetch the original signed event by id
+ * from the relay pool and republish it verbatim.
+ *
+ * This is a relay rebroadcast only: the event's id, signature, and tags are
+ * preserved exactly, so relays that already have it deduplicate and relays
+ * that missed it ingest it. No mint interaction, no signer interaction.
+ *
+ * @param bidEventId  id of the previously-signed kind-1023 bid event
+ * @param ndk         NDK instance to fetch/publish through
+ * @throws if NDK is unavailable, the event can't be found by id, or the found
+ *         event is not a kind-1023 bid event (defends against rebroadcasting
+ *         an unrelated/attacker-supplied id)
+ */
+export const republishAuctionBid = async (bidEventId: string, ndk: NDK): Promise<void> => {
+	if (!bidEventId) throw new Error('Cannot rebroadcast auction bid: bidEventId is empty')
+	if (!ndk) throw new Error('Cannot rebroadcast auction bid: NDK is not initialized')
+
+	const fetched = await ndk.fetchEvent({ ids: [bidEventId], kinds: [AUCTION_BID_KIND] })
+	if (!fetched) {
+		throw new Error(`Could not find signed bid event ${bidEventId} on any relay to rebroadcast`)
+	}
+	if (fetched.kind !== AUCTION_BID_KIND) {
+		throw new Error(`Refusing to rebroadcast event ${bidEventId}: expected kind ${AUCTION_BID_KIND}, got kind ${fetched.kind}`)
+	}
+	if (!fetched.sig) {
+		throw new Error(`Refusing to rebroadcast event ${bidEventId}: it is not signed`)
+	}
+
+	await ndkActions.publishEvent(fetched)
+}
+
 const bytesToLowerHex = (bytes: Uint8Array): string => {
 	let out = ''
 	for (let i = 0; i < bytes.length; i++) out += bytes[i].toString(16).padStart(2, '0')

--- a/src/queries/auctions.tsx
+++ b/src/queries/auctions.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { ORDER_MESSAGE_TYPE, ORDER_PROCESS_KIND } from '@/lib/schemas/order'
 import { ndkActions } from '@/lib/stores/ndk'
-import { AUCTION_PATH_RELEASE_KIND, VALIDATOR_VERDICT_KIND } from '@/lib/auction/constants'
+import { AUCTION_PATH_RELEASE_KIND, DEFAULT_AUDITOR_QUORUM, VALIDATOR_VERDICT_KIND } from '@/lib/auction/constants'
 import {
 	decryptPrivateAuctionClaimMessageWithSigner,
 	getAuctionClaimPublicMarkerFields,
@@ -503,11 +503,17 @@ export function isAuctionPathReleaseForCoordinate(event: NDKEvent, auctionCoordi
  * Fetch kind-30440 validator verdicts for an auction. These are
  * parameterised-replaceable per (validator, bidder, auction), so the
  * relay returns at most one per such tuple.
+ *
+ * When `validatorPubkeys` is a non-empty list, verdicts are fetched only
+ * from the auction's configured auditors (`authors` filter) — without
+ * this, a forged kind-30440 from any pubkey would reach the client's
+ * quorum tally (NDK runs without signature verification configured).
  */
 export const fetchAuctionVerdicts = async (
 	auctionEventId: string,
 	limit: number = 500,
 	auctionCoordinates?: string,
+	validatorPubkeys?: string[],
 ): Promise<NDKEvent[]> => {
 	if (!auctionEventId && !auctionCoordinates) return []
 	const ndk = ndkActions.getNDK()
@@ -519,6 +525,7 @@ export const fetchAuctionVerdicts = async (
 	}
 	if (auctionEventId) (filter as { '#e'?: string[] })['#e'] = [auctionEventId]
 	if (auctionCoordinates) (filter as { '#a'?: string[] })['#a'] = [auctionCoordinates]
+	if (validatorPubkeys && validatorPubkeys.length > 0) filter.authors = toStableUniqueStrings(validatorPubkeys)
 
 	const events = await ndkActions.fetchEventsWithTimeout(filter, { timeoutMs: 8000 })
 	return filterBlacklistedEvents(Array.from(events)).sort((a, b) => (b.created_at || 0) - (a.created_at || 0))
@@ -650,10 +657,19 @@ export const auctionPathReleasesQueryOptions = (auctionEventId: string, limit: n
 		refetchInterval: 5000,
 	})
 
-export const auctionVerdictsQueryOptions = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) =>
+export const auctionVerdictsQueryOptions = (
+	auctionEventId: string,
+	limit: number = 500,
+	auctionCoordinates?: string,
+	validatorPubkeys?: string[],
+) =>
 	queryOptions({
-		queryKey: [...auctionKeys.verdicts(auctionEventId || auctionCoordinates || ''), auctionCoordinates || ''],
-		queryFn: () => fetchAuctionVerdicts(auctionEventId, limit, auctionCoordinates),
+		queryKey: [
+			...auctionKeys.verdicts(auctionEventId || auctionCoordinates || ''),
+			auctionCoordinates || '',
+			validatorPubkeys ? toStableUniqueStrings(validatorPubkeys) : [],
+		],
+		queryFn: () => fetchAuctionVerdicts(auctionEventId, limit, auctionCoordinates, validatorPubkeys),
 		enabled: !!(auctionEventId || auctionCoordinates),
 		staleTime: 5000,
 		refetchInterval: 5000,
@@ -765,6 +781,13 @@ export const getAuctionP2pkXpub = (event: NDKEvent | null): string => event?.tag
  */
 export const getAuctionAuditors = (event: NDKEvent | null): string[] =>
 	(event?.tags ?? []).filter((tag) => tag[0] === 'auditors' && !!tag[1]).map((tag) => tag[1])
+
+/** Number of distinct auditor verdicts required for a bid to be confirmed (§4.1). */
+export const getAuctionAuditorQuorum = (event: NDKEvent | null): number => {
+	const raw = event?.tags.find((tag) => tag[0] === 'auditor_quorum' && !!tag[1])?.[1]
+	const parsed = raw ? parseInt(raw, 10) : NaN
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_AUDITOR_QUORUM
+}
 
 /**
  * Legacy single-pubkey accessor preserved for callers still phrased
@@ -990,9 +1013,9 @@ export const useAuctionPathReleases = (auctionEventId: string, limit: number = 2
 		...auctionPathReleasesQueryOptions(auctionEventId, limit, auctionCoordinates),
 	})
 
-export const useAuctionVerdicts = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string) =>
+export const useAuctionVerdicts = (auctionEventId: string, limit: number = 500, auctionCoordinates?: string, validatorPubkeys?: string[]) =>
 	useQuery({
-		...auctionVerdictsQueryOptions(auctionEventId, limit, auctionCoordinates),
+		...auctionVerdictsQueryOptions(auctionEventId, limit, auctionCoordinates, validatorPubkeys),
 	})
 
 // ---------------------------------------------------------------------------

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -57,994 +57,1063 @@ import { Route as DashboardLayoutDashboardProductsCollectionsCollectionIdRouteIm
 import { Route as DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport } from './routes/_dashboard-layout/dashboard/products/auctions.$auctionId'
 
 const SetupRoute = SetupRouteImport.update({
-	id: '/setup',
-	path: '/setup',
-	getParentRoute: () => rootRouteImport,
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CheckoutRoute = CheckoutRouteImport.update({
-	id: '/checkout',
-	path: '/checkout',
-	getParentRoute: () => rootRouteImport,
+  id: '/checkout',
+  path: '/checkout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const DashboardLayoutRoute = DashboardLayoutRouteImport.update({
-	id: '/_dashboard-layout',
-	getParentRoute: () => rootRouteImport,
+  id: '/_dashboard-layout',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const VanityNameRoute = VanityNameRouteImport.update({
-	id: '/$vanityName',
-	path: '/$vanityName',
-	getParentRoute: () => rootRouteImport,
+  id: '/$vanityName',
+  path: '/$vanityName',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
-	id: '/',
-	path: '/',
-	getParentRoute: () => rootRouteImport,
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsIndexRoute = ProductsIndexRouteImport.update({
-	id: '/products/',
-	path: '/products/',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/',
+  path: '/products/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsIndexRoute = PostsIndexRouteImport.update({
-	id: '/posts/',
-	path: '/posts/',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/',
+  path: '/posts/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const NostrIndexRoute = NostrIndexRouteImport.update({
-	id: '/nostr/',
-	path: '/nostr/',
-	getParentRoute: () => rootRouteImport,
+  id: '/nostr/',
+  path: '/nostr/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CommunityIndexRoute = CommunityIndexRouteImport.update({
-	id: '/community/',
-	path: '/community/',
-	getParentRoute: () => rootRouteImport,
+  id: '/community/',
+  path: '/community/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsIndexRoute = AuctionsIndexRouteImport.update({
-	id: '/auctions/',
-	path: '/auctions/',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/',
+  path: '/auctions/',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const SearchProductsRoute = SearchProductsRouteImport.update({
-	id: '/search/products',
-	path: '/search/products',
-	getParentRoute: () => rootRouteImport,
+  id: '/search/products',
+  path: '/search/products',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProfileProfileIdRoute = ProfileProfileIdRouteImport.update({
-	id: '/profile/$profileId',
-	path: '/profile/$profileId',
-	getParentRoute: () => rootRouteImport,
+  id: '/profile/$profileId',
+  path: '/profile/$profileId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ProductsProductIdRoute = ProductsProductIdRouteImport.update({
-	id: '/products/$productId',
-	path: '/products/$productId',
-	getParentRoute: () => rootRouteImport,
+  id: '/products/$productId',
+  path: '/products/$productId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const PostsPostIdRoute = PostsPostIdRouteImport.update({
-	id: '/posts/$postId',
-	path: '/posts/$postId',
-	getParentRoute: () => rootRouteImport,
+  id: '/posts/$postId',
+  path: '/posts/$postId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const CollectionCollectionIdRoute = CollectionCollectionIdRouteImport.update({
-	id: '/collection/$collectionId',
-	path: '/collection/$collectionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/collection/$collectionId',
+  path: '/collection/$collectionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuctionsAuctionIdRoute = AuctionsAuctionIdRouteImport.update({
-	id: '/auctions/$auctionId',
-	path: '/auctions/$auctionId',
-	getParentRoute: () => rootRouteImport,
+  id: '/auctions/$auctionId',
+  path: '/auctions/$auctionId',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const DashboardLayoutDashboardIndexRoute = DashboardLayoutDashboardIndexRouteImport.update({
-	id: '/dashboard/',
-	path: '/dashboard/',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAboutRoute = DashboardLayoutDashboardAboutRouteImport.update({
-	id: '/dashboard/about',
-	path: '/dashboard/about',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesSalesRoute = DashboardLayoutDashboardSalesSalesRouteImport.update({
-	id: '/dashboard/sales/sales',
-	path: '/dashboard/sales/sales',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesRoute = DashboardLayoutDashboardSalesMessagesRouteImport.update({
-	id: '/dashboard/sales/messages',
-	path: '/dashboard/sales/messages',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesCircularEconomyRoute = DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
-	id: '/dashboard/sales/circular-economy',
-	path: '/dashboard/sales/circular-economy',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsShippingOptionsRoute = DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
-	id: '/dashboard/products/shipping-options',
-	path: '/dashboard/products/shipping-options',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsRoute = DashboardLayoutDashboardProductsProductsRouteImport.update({
-	id: '/dashboard/products/products',
-	path: '/dashboard/products/products',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsMigrationToolRoute = DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
-	id: '/dashboard/products/migration-tool',
-	path: '/dashboard/products/migration-tool',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsRoute = DashboardLayoutDashboardProductsCollectionsRouteImport.update({
-	id: '/dashboard/products/collections',
-	path: '/dashboard/products/collections',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsBidsRoute = DashboardLayoutDashboardProductsBidsRouteImport.update({
-	id: '/dashboard/products/bids',
-	path: '/dashboard/products/bids',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardProductsAuctionsRoute = DashboardLayoutDashboardProductsAuctionsRouteImport.update({
-	id: '/dashboard/products/auctions',
-	path: '/dashboard/products/auctions',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardOrdersOrderIdRoute = DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
-	id: '/dashboard/orders/$orderId',
-	path: '/dashboard/orders/$orderId',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsTeamRoute = DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
-	id: '/dashboard/app-settings/team',
-	path: '/dashboard/app-settings/team',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute = DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
-	id: '/dashboard/app-settings/featured-items',
-	path: '/dashboard/app-settings/featured-items',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsBlacklistsRoute = DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
-	id: '/dashboard/app-settings/blacklists',
-	path: '/dashboard/app-settings/blacklists',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute = DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
-	id: '/dashboard/app-settings/app-miscelleneous',
-	path: '/dashboard/app-settings/app-miscelleneous',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountYourPurchasesRoute = DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
-	id: '/dashboard/account/your-purchases',
-	path: '/dashboard/account/your-purchases',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountVanityUrlRoute = DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
-	id: '/dashboard/account/vanity-url',
-	path: '/dashboard/account/vanity-url',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountReceivingPaymentsRoute = DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
-	id: '/dashboard/account/receiving-payments',
-	path: '/dashboard/account/receiving-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountProfileRoute = DashboardLayoutDashboardAccountProfileRouteImport.update({
-	id: '/dashboard/account/profile',
-	path: '/dashboard/account/profile',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountPreferencesRoute = DashboardLayoutDashboardAccountPreferencesRouteImport.update({
-	id: '/dashboard/account/preferences',
-	path: '/dashboard/account/preferences',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNostrAddressRoute = DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
-	id: '/dashboard/account/nostr-address',
-	path: '/dashboard/account/nostr-address',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountNetworkRoute = DashboardLayoutDashboardAccountNetworkRouteImport.update({
-	id: '/dashboard/account/network',
-	path: '/dashboard/account/network',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardAccountMakingPaymentsRoute = DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
-	id: '/dashboard/account/making-payments',
-	path: '/dashboard/account/making-payments',
-	getParentRoute: () => DashboardLayoutRoute,
-} as any)
-const DashboardLayoutDashboardSalesMessagesPubkeyRoute = DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
-	id: '/$pubkey',
-	path: '/$pubkey',
-	getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsNewRoute = DashboardLayoutDashboardProductsProductsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsProductsProductIdRoute = DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
-	id: '/$productId',
-	path: '/$productId',
-	getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
-} as any)
-const DashboardLayoutDashboardProductsCollectionsNewRoute = DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
-	id: '/new',
-	path: '/new',
-	getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-} as any)
+const DashboardLayoutDashboardIndexRoute =
+  DashboardLayoutDashboardIndexRouteImport.update({
+    id: '/dashboard/',
+    path: '/dashboard/',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAboutRoute =
+  DashboardLayoutDashboardAboutRouteImport.update({
+    id: '/dashboard/about',
+    path: '/dashboard/about',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesSalesRoute =
+  DashboardLayoutDashboardSalesSalesRouteImport.update({
+    id: '/dashboard/sales/sales',
+    path: '/dashboard/sales/sales',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesRoute =
+  DashboardLayoutDashboardSalesMessagesRouteImport.update({
+    id: '/dashboard/sales/messages',
+    path: '/dashboard/sales/messages',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesCircularEconomyRoute =
+  DashboardLayoutDashboardSalesCircularEconomyRouteImport.update({
+    id: '/dashboard/sales/circular-economy',
+    path: '/dashboard/sales/circular-economy',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsShippingOptionsRoute =
+  DashboardLayoutDashboardProductsShippingOptionsRouteImport.update({
+    id: '/dashboard/products/shipping-options',
+    path: '/dashboard/products/shipping-options',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsRoute =
+  DashboardLayoutDashboardProductsProductsRouteImport.update({
+    id: '/dashboard/products/products',
+    path: '/dashboard/products/products',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsMigrationToolRoute =
+  DashboardLayoutDashboardProductsMigrationToolRouteImport.update({
+    id: '/dashboard/products/migration-tool',
+    path: '/dashboard/products/migration-tool',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsRoute =
+  DashboardLayoutDashboardProductsCollectionsRouteImport.update({
+    id: '/dashboard/products/collections',
+    path: '/dashboard/products/collections',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsBidsRoute =
+  DashboardLayoutDashboardProductsBidsRouteImport.update({
+    id: '/dashboard/products/bids',
+    path: '/dashboard/products/bids',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsRoute =
+  DashboardLayoutDashboardProductsAuctionsRouteImport.update({
+    id: '/dashboard/products/auctions',
+    path: '/dashboard/products/auctions',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardOrdersOrderIdRoute =
+  DashboardLayoutDashboardOrdersOrderIdRouteImport.update({
+    id: '/dashboard/orders/$orderId',
+    path: '/dashboard/orders/$orderId',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsTeamRoute =
+  DashboardLayoutDashboardAppSettingsTeamRouteImport.update({
+    id: '/dashboard/app-settings/team',
+    path: '/dashboard/app-settings/team',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsFeaturedItemsRoute =
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport.update({
+    id: '/dashboard/app-settings/featured-items',
+    path: '/dashboard/app-settings/featured-items',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsBlacklistsRoute =
+  DashboardLayoutDashboardAppSettingsBlacklistsRouteImport.update({
+    id: '/dashboard/app-settings/blacklists',
+    path: '/dashboard/app-settings/blacklists',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute =
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport.update({
+    id: '/dashboard/app-settings/app-miscelleneous',
+    path: '/dashboard/app-settings/app-miscelleneous',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountYourPurchasesRoute =
+  DashboardLayoutDashboardAccountYourPurchasesRouteImport.update({
+    id: '/dashboard/account/your-purchases',
+    path: '/dashboard/account/your-purchases',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountVanityUrlRoute =
+  DashboardLayoutDashboardAccountVanityUrlRouteImport.update({
+    id: '/dashboard/account/vanity-url',
+    path: '/dashboard/account/vanity-url',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountReceivingPaymentsRoute =
+  DashboardLayoutDashboardAccountReceivingPaymentsRouteImport.update({
+    id: '/dashboard/account/receiving-payments',
+    path: '/dashboard/account/receiving-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountProfileRoute =
+  DashboardLayoutDashboardAccountProfileRouteImport.update({
+    id: '/dashboard/account/profile',
+    path: '/dashboard/account/profile',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountPreferencesRoute =
+  DashboardLayoutDashboardAccountPreferencesRouteImport.update({
+    id: '/dashboard/account/preferences',
+    path: '/dashboard/account/preferences',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNostrAddressRoute =
+  DashboardLayoutDashboardAccountNostrAddressRouteImport.update({
+    id: '/dashboard/account/nostr-address',
+    path: '/dashboard/account/nostr-address',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountNetworkRoute =
+  DashboardLayoutDashboardAccountNetworkRouteImport.update({
+    id: '/dashboard/account/network',
+    path: '/dashboard/account/network',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardAccountMakingPaymentsRoute =
+  DashboardLayoutDashboardAccountMakingPaymentsRouteImport.update({
+    id: '/dashboard/account/making-payments',
+    path: '/dashboard/account/making-payments',
+    getParentRoute: () => DashboardLayoutRoute,
+  } as any)
+const DashboardLayoutDashboardSalesMessagesPubkeyRoute =
+  DashboardLayoutDashboardSalesMessagesPubkeyRouteImport.update({
+    id: '/$pubkey',
+    path: '/$pubkey',
+    getParentRoute: () => DashboardLayoutDashboardSalesMessagesRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsNewRoute =
+  DashboardLayoutDashboardProductsProductsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsProductsProductIdRoute =
+  DashboardLayoutDashboardProductsProductsProductIdRouteImport.update({
+    id: '/$productId',
+    path: '/$productId',
+    getParentRoute: () => DashboardLayoutDashboardProductsProductsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsCollectionsNewRoute =
+  DashboardLayoutDashboardProductsCollectionsNewRouteImport.update({
+    id: '/new',
+    path: '/new',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
 const DashboardLayoutDashboardProductsCollectionsCollectionIdRoute =
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
-		id: '/$collectionId',
-		path: '/$collectionId',
-		getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
-	} as any)
-const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute = DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
-	id: '/$auctionId',
-	path: '/$auctionId',
-	getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
-} as any)
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport.update({
+    id: '/$collectionId',
+    path: '/$collectionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsCollectionsRoute,
+  } as any)
+const DashboardLayoutDashboardProductsAuctionsAuctionIdRoute =
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport.update({
+    id: '/$auctionId',
+    path: '/$auctionId',
+    getParentRoute: () => DashboardLayoutDashboardProductsAuctionsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesByTo {
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions': typeof AuctionsIndexRoute
-	'/community': typeof CommunityIndexRoute
-	'/nostr': typeof NostrIndexRoute
-	'/posts': typeof PostsIndexRoute
-	'/products': typeof ProductsIndexRoute
-	'/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/dashboard': typeof DashboardLayoutDashboardIndexRoute
-	'/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions': typeof AuctionsIndexRoute
+  '/community': typeof CommunityIndexRoute
+  '/nostr': typeof NostrIndexRoute
+  '/posts': typeof PostsIndexRoute
+  '/products': typeof ProductsIndexRoute
+  '/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/dashboard': typeof DashboardLayoutDashboardIndexRoute
+  '/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport
-	'/': typeof IndexRoute
-	'/$vanityName': typeof VanityNameRoute
-	'/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
-	'/checkout': typeof CheckoutRoute
-	'/setup': typeof SetupRoute
-	'/auctions/$auctionId': typeof AuctionsAuctionIdRoute
-	'/collection/$collectionId': typeof CollectionCollectionIdRoute
-	'/posts/$postId': typeof PostsPostIdRoute
-	'/products/$productId': typeof ProductsProductIdRoute
-	'/profile/$profileId': typeof ProfileProfileIdRoute
-	'/search/products': typeof SearchProductsRoute
-	'/auctions/': typeof AuctionsIndexRoute
-	'/community/': typeof CommunityIndexRoute
-	'/nostr/': typeof NostrIndexRoute
-	'/posts/': typeof PostsIndexRoute
-	'/products/': typeof ProductsIndexRoute
-	'/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
-	'/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
-	'/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
-	'/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	'/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
-	'/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
-	'/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	'/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	'/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	'/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	'/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	'/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	'/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	'/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
-	'/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	'/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	'/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	'/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	'/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	'/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
-	'/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	'/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
-	'/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	'/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
-	'/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/$vanityName': typeof VanityNameRoute
+  '/_dashboard-layout': typeof DashboardLayoutRouteWithChildren
+  '/checkout': typeof CheckoutRoute
+  '/setup': typeof SetupRoute
+  '/auctions/$auctionId': typeof AuctionsAuctionIdRoute
+  '/collection/$collectionId': typeof CollectionCollectionIdRoute
+  '/posts/$postId': typeof PostsPostIdRoute
+  '/products/$productId': typeof ProductsProductIdRoute
+  '/profile/$profileId': typeof ProfileProfileIdRoute
+  '/search/products': typeof SearchProductsRoute
+  '/auctions/': typeof AuctionsIndexRoute
+  '/community/': typeof CommunityIndexRoute
+  '/nostr/': typeof NostrIndexRoute
+  '/posts/': typeof PostsIndexRoute
+  '/products/': typeof ProductsIndexRoute
+  '/_dashboard-layout/dashboard/about': typeof DashboardLayoutDashboardAboutRoute
+  '/_dashboard-layout/dashboard/': typeof DashboardLayoutDashboardIndexRoute
+  '/_dashboard-layout/dashboard/account/making-payments': typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/network': typeof DashboardLayoutDashboardAccountNetworkRoute
+  '/_dashboard-layout/dashboard/account/nostr-address': typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  '/_dashboard-layout/dashboard/account/preferences': typeof DashboardLayoutDashboardAccountPreferencesRoute
+  '/_dashboard-layout/dashboard/account/profile': typeof DashboardLayoutDashboardAccountProfileRoute
+  '/_dashboard-layout/dashboard/account/receiving-payments': typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  '/_dashboard-layout/dashboard/account/vanity-url': typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  '/_dashboard-layout/dashboard/account/your-purchases': typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  '/_dashboard-layout/dashboard/app-settings/blacklists': typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  '/_dashboard-layout/dashboard/app-settings/featured-items': typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  '/_dashboard-layout/dashboard/app-settings/team': typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  '/_dashboard-layout/dashboard/orders/$orderId': typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  '/_dashboard-layout/dashboard/products/auctions': typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/bids': typeof DashboardLayoutDashboardProductsBidsRoute
+  '/_dashboard-layout/dashboard/products/collections': typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/migration-tool': typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  '/_dashboard-layout/dashboard/products/products': typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  '/_dashboard-layout/dashboard/products/shipping-options': typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  '/_dashboard-layout/dashboard/sales/circular-economy': typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  '/_dashboard-layout/dashboard/sales/messages': typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  '/_dashboard-layout/dashboard/sales/sales': typeof DashboardLayoutDashboardSalesSalesRoute
+  '/_dashboard-layout/dashboard/products/auctions/$auctionId': typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/$collectionId': typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  '/_dashboard-layout/dashboard/products/collections/new': typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  '/_dashboard-layout/dashboard/products/products/$productId': typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  '/_dashboard-layout/dashboard/products/products/new': typeof DashboardLayoutDashboardProductsProductsNewRoute
+  '/_dashboard-layout/dashboard/sales/messages/$pubkey': typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath
-	fullPaths:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/dashboard/about'
-		| '/dashboard/'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	fileRoutesByTo: FileRoutesByTo
-	to:
-		| '/'
-		| '/$vanityName'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions'
-		| '/community'
-		| '/nostr'
-		| '/posts'
-		| '/products'
-		| '/dashboard/about'
-		| '/dashboard'
-		| '/dashboard/account/making-payments'
-		| '/dashboard/account/network'
-		| '/dashboard/account/nostr-address'
-		| '/dashboard/account/preferences'
-		| '/dashboard/account/profile'
-		| '/dashboard/account/receiving-payments'
-		| '/dashboard/account/vanity-url'
-		| '/dashboard/account/your-purchases'
-		| '/dashboard/app-settings/app-miscelleneous'
-		| '/dashboard/app-settings/blacklists'
-		| '/dashboard/app-settings/featured-items'
-		| '/dashboard/app-settings/team'
-		| '/dashboard/orders/$orderId'
-		| '/dashboard/products/auctions'
-		| '/dashboard/products/bids'
-		| '/dashboard/products/collections'
-		| '/dashboard/products/migration-tool'
-		| '/dashboard/products/products'
-		| '/dashboard/products/shipping-options'
-		| '/dashboard/sales/circular-economy'
-		| '/dashboard/sales/messages'
-		| '/dashboard/sales/sales'
-		| '/dashboard/products/auctions/$auctionId'
-		| '/dashboard/products/collections/$collectionId'
-		| '/dashboard/products/collections/new'
-		| '/dashboard/products/products/$productId'
-		| '/dashboard/products/products/new'
-		| '/dashboard/sales/messages/$pubkey'
-	id:
-		| '__root__'
-		| '/'
-		| '/$vanityName'
-		| '/_dashboard-layout'
-		| '/checkout'
-		| '/setup'
-		| '/auctions/$auctionId'
-		| '/collection/$collectionId'
-		| '/posts/$postId'
-		| '/products/$productId'
-		| '/profile/$profileId'
-		| '/search/products'
-		| '/auctions/'
-		| '/community/'
-		| '/nostr/'
-		| '/posts/'
-		| '/products/'
-		| '/_dashboard-layout/dashboard/about'
-		| '/_dashboard-layout/dashboard/'
-		| '/_dashboard-layout/dashboard/account/making-payments'
-		| '/_dashboard-layout/dashboard/account/network'
-		| '/_dashboard-layout/dashboard/account/nostr-address'
-		| '/_dashboard-layout/dashboard/account/preferences'
-		| '/_dashboard-layout/dashboard/account/profile'
-		| '/_dashboard-layout/dashboard/account/receiving-payments'
-		| '/_dashboard-layout/dashboard/account/vanity-url'
-		| '/_dashboard-layout/dashboard/account/your-purchases'
-		| '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-		| '/_dashboard-layout/dashboard/app-settings/blacklists'
-		| '/_dashboard-layout/dashboard/app-settings/featured-items'
-		| '/_dashboard-layout/dashboard/app-settings/team'
-		| '/_dashboard-layout/dashboard/orders/$orderId'
-		| '/_dashboard-layout/dashboard/products/auctions'
-		| '/_dashboard-layout/dashboard/products/bids'
-		| '/_dashboard-layout/dashboard/products/collections'
-		| '/_dashboard-layout/dashboard/products/migration-tool'
-		| '/_dashboard-layout/dashboard/products/products'
-		| '/_dashboard-layout/dashboard/products/shipping-options'
-		| '/_dashboard-layout/dashboard/sales/circular-economy'
-		| '/_dashboard-layout/dashboard/sales/messages'
-		| '/_dashboard-layout/dashboard/sales/sales'
-		| '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-		| '/_dashboard-layout/dashboard/products/collections/$collectionId'
-		| '/_dashboard-layout/dashboard/products/collections/new'
-		| '/_dashboard-layout/dashboard/products/products/$productId'
-		| '/_dashboard-layout/dashboard/products/products/new'
-		| '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-	fileRoutesById: FileRoutesById
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/dashboard/about'
+    | '/dashboard/'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/$vanityName'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions'
+    | '/community'
+    | '/nostr'
+    | '/posts'
+    | '/products'
+    | '/dashboard/about'
+    | '/dashboard'
+    | '/dashboard/account/making-payments'
+    | '/dashboard/account/network'
+    | '/dashboard/account/nostr-address'
+    | '/dashboard/account/preferences'
+    | '/dashboard/account/profile'
+    | '/dashboard/account/receiving-payments'
+    | '/dashboard/account/vanity-url'
+    | '/dashboard/account/your-purchases'
+    | '/dashboard/app-settings/app-miscelleneous'
+    | '/dashboard/app-settings/blacklists'
+    | '/dashboard/app-settings/featured-items'
+    | '/dashboard/app-settings/team'
+    | '/dashboard/orders/$orderId'
+    | '/dashboard/products/auctions'
+    | '/dashboard/products/bids'
+    | '/dashboard/products/collections'
+    | '/dashboard/products/migration-tool'
+    | '/dashboard/products/products'
+    | '/dashboard/products/shipping-options'
+    | '/dashboard/sales/circular-economy'
+    | '/dashboard/sales/messages'
+    | '/dashboard/sales/sales'
+    | '/dashboard/products/auctions/$auctionId'
+    | '/dashboard/products/collections/$collectionId'
+    | '/dashboard/products/collections/new'
+    | '/dashboard/products/products/$productId'
+    | '/dashboard/products/products/new'
+    | '/dashboard/sales/messages/$pubkey'
+  id:
+    | '__root__'
+    | '/'
+    | '/$vanityName'
+    | '/_dashboard-layout'
+    | '/checkout'
+    | '/setup'
+    | '/auctions/$auctionId'
+    | '/collection/$collectionId'
+    | '/posts/$postId'
+    | '/products/$productId'
+    | '/profile/$profileId'
+    | '/search/products'
+    | '/auctions/'
+    | '/community/'
+    | '/nostr/'
+    | '/posts/'
+    | '/products/'
+    | '/_dashboard-layout/dashboard/about'
+    | '/_dashboard-layout/dashboard/'
+    | '/_dashboard-layout/dashboard/account/making-payments'
+    | '/_dashboard-layout/dashboard/account/network'
+    | '/_dashboard-layout/dashboard/account/nostr-address'
+    | '/_dashboard-layout/dashboard/account/preferences'
+    | '/_dashboard-layout/dashboard/account/profile'
+    | '/_dashboard-layout/dashboard/account/receiving-payments'
+    | '/_dashboard-layout/dashboard/account/vanity-url'
+    | '/_dashboard-layout/dashboard/account/your-purchases'
+    | '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+    | '/_dashboard-layout/dashboard/app-settings/blacklists'
+    | '/_dashboard-layout/dashboard/app-settings/featured-items'
+    | '/_dashboard-layout/dashboard/app-settings/team'
+    | '/_dashboard-layout/dashboard/orders/$orderId'
+    | '/_dashboard-layout/dashboard/products/auctions'
+    | '/_dashboard-layout/dashboard/products/bids'
+    | '/_dashboard-layout/dashboard/products/collections'
+    | '/_dashboard-layout/dashboard/products/migration-tool'
+    | '/_dashboard-layout/dashboard/products/products'
+    | '/_dashboard-layout/dashboard/products/shipping-options'
+    | '/_dashboard-layout/dashboard/sales/circular-economy'
+    | '/_dashboard-layout/dashboard/sales/messages'
+    | '/_dashboard-layout/dashboard/sales/sales'
+    | '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+    | '/_dashboard-layout/dashboard/products/collections/$collectionId'
+    | '/_dashboard-layout/dashboard/products/collections/new'
+    | '/_dashboard-layout/dashboard/products/products/$productId'
+    | '/_dashboard-layout/dashboard/products/products/new'
+    | '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	IndexRoute: typeof IndexRoute
-	VanityNameRoute: typeof VanityNameRoute
-	DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
-	CheckoutRoute: typeof CheckoutRoute
-	SetupRoute: typeof SetupRoute
-	AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
-	CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
-	PostsPostIdRoute: typeof PostsPostIdRoute
-	ProductsProductIdRoute: typeof ProductsProductIdRoute
-	ProfileProfileIdRoute: typeof ProfileProfileIdRoute
-	SearchProductsRoute: typeof SearchProductsRoute
-	AuctionsIndexRoute: typeof AuctionsIndexRoute
-	CommunityIndexRoute: typeof CommunityIndexRoute
-	NostrIndexRoute: typeof NostrIndexRoute
-	PostsIndexRoute: typeof PostsIndexRoute
-	ProductsIndexRoute: typeof ProductsIndexRoute
+  IndexRoute: typeof IndexRoute
+  VanityNameRoute: typeof VanityNameRoute
+  DashboardLayoutRoute: typeof DashboardLayoutRouteWithChildren
+  CheckoutRoute: typeof CheckoutRoute
+  SetupRoute: typeof SetupRoute
+  AuctionsAuctionIdRoute: typeof AuctionsAuctionIdRoute
+  CollectionCollectionIdRoute: typeof CollectionCollectionIdRoute
+  PostsPostIdRoute: typeof PostsPostIdRoute
+  ProductsProductIdRoute: typeof ProductsProductIdRoute
+  ProfileProfileIdRoute: typeof ProfileProfileIdRoute
+  SearchProductsRoute: typeof SearchProductsRoute
+  AuctionsIndexRoute: typeof AuctionsIndexRoute
+  CommunityIndexRoute: typeof CommunityIndexRoute
+  NostrIndexRoute: typeof NostrIndexRoute
+  PostsIndexRoute: typeof PostsIndexRoute
+  ProductsIndexRoute: typeof ProductsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
-	interface FileRoutesByPath {
-		'/setup': {
-			id: '/setup'
-			path: '/setup'
-			fullPath: '/setup'
-			preLoaderRoute: typeof SetupRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/checkout': {
-			id: '/checkout'
-			path: '/checkout'
-			fullPath: '/checkout'
-			preLoaderRoute: typeof CheckoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout': {
-			id: '/_dashboard-layout'
-			path: ''
-			fullPath: '/'
-			preLoaderRoute: typeof DashboardLayoutRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/$vanityName': {
-			id: '/$vanityName'
-			path: '/$vanityName'
-			fullPath: '/$vanityName'
-			preLoaderRoute: typeof VanityNameRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/': {
-			id: '/'
-			path: '/'
-			fullPath: '/'
-			preLoaderRoute: typeof IndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/': {
-			id: '/products/'
-			path: '/products'
-			fullPath: '/products/'
-			preLoaderRoute: typeof ProductsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/': {
-			id: '/posts/'
-			path: '/posts'
-			fullPath: '/posts/'
-			preLoaderRoute: typeof PostsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/nostr/': {
-			id: '/nostr/'
-			path: '/nostr'
-			fullPath: '/nostr/'
-			preLoaderRoute: typeof NostrIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/community/': {
-			id: '/community/'
-			path: '/community'
-			fullPath: '/community/'
-			preLoaderRoute: typeof CommunityIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/': {
-			id: '/auctions/'
-			path: '/auctions'
-			fullPath: '/auctions/'
-			preLoaderRoute: typeof AuctionsIndexRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/search/products': {
-			id: '/search/products'
-			path: '/search/products'
-			fullPath: '/search/products'
-			preLoaderRoute: typeof SearchProductsRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/profile/$profileId': {
-			id: '/profile/$profileId'
-			path: '/profile/$profileId'
-			fullPath: '/profile/$profileId'
-			preLoaderRoute: typeof ProfileProfileIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/products/$productId': {
-			id: '/products/$productId'
-			path: '/products/$productId'
-			fullPath: '/products/$productId'
-			preLoaderRoute: typeof ProductsProductIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/posts/$postId': {
-			id: '/posts/$postId'
-			path: '/posts/$postId'
-			fullPath: '/posts/$postId'
-			preLoaderRoute: typeof PostsPostIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/collection/$collectionId': {
-			id: '/collection/$collectionId'
-			path: '/collection/$collectionId'
-			fullPath: '/collection/$collectionId'
-			preLoaderRoute: typeof CollectionCollectionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/auctions/$auctionId': {
-			id: '/auctions/$auctionId'
-			path: '/auctions/$auctionId'
-			fullPath: '/auctions/$auctionId'
-			preLoaderRoute: typeof AuctionsAuctionIdRouteImport
-			parentRoute: typeof rootRouteImport
-		}
-		'/_dashboard-layout/dashboard/': {
-			id: '/_dashboard-layout/dashboard/'
-			path: '/dashboard'
-			fullPath: '/dashboard/'
-			preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/about': {
-			id: '/_dashboard-layout/dashboard/about'
-			path: '/dashboard/about'
-			fullPath: '/dashboard/about'
-			preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/sales': {
-			id: '/_dashboard-layout/dashboard/sales/sales'
-			path: '/dashboard/sales/sales'
-			fullPath: '/dashboard/sales/sales'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages': {
-			id: '/_dashboard-layout/dashboard/sales/messages'
-			path: '/dashboard/sales/messages'
-			fullPath: '/dashboard/sales/messages'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/circular-economy': {
-			id: '/_dashboard-layout/dashboard/sales/circular-economy'
-			path: '/dashboard/sales/circular-economy'
-			fullPath: '/dashboard/sales/circular-economy'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/shipping-options': {
-			id: '/_dashboard-layout/dashboard/products/shipping-options'
-			path: '/dashboard/products/shipping-options'
-			fullPath: '/dashboard/products/shipping-options'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/products': {
-			id: '/_dashboard-layout/dashboard/products/products'
-			path: '/dashboard/products/products'
-			fullPath: '/dashboard/products/products'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/migration-tool': {
-			id: '/_dashboard-layout/dashboard/products/migration-tool'
-			path: '/dashboard/products/migration-tool'
-			fullPath: '/dashboard/products/migration-tool'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections': {
-			id: '/_dashboard-layout/dashboard/products/collections'
-			path: '/dashboard/products/collections'
-			fullPath: '/dashboard/products/collections'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/bids': {
-			id: '/_dashboard-layout/dashboard/products/bids'
-			path: '/dashboard/products/bids'
-			fullPath: '/dashboard/products/bids'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions': {
-			id: '/_dashboard-layout/dashboard/products/auctions'
-			path: '/dashboard/products/auctions'
-			fullPath: '/dashboard/products/auctions'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/orders/$orderId': {
-			id: '/_dashboard-layout/dashboard/orders/$orderId'
-			path: '/dashboard/orders/$orderId'
-			fullPath: '/dashboard/orders/$orderId'
-			preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/team': {
-			id: '/_dashboard-layout/dashboard/app-settings/team'
-			path: '/dashboard/app-settings/team'
-			fullPath: '/dashboard/app-settings/team'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/featured-items': {
-			id: '/_dashboard-layout/dashboard/app-settings/featured-items'
-			path: '/dashboard/app-settings/featured-items'
-			fullPath: '/dashboard/app-settings/featured-items'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/blacklists': {
-			id: '/_dashboard-layout/dashboard/app-settings/blacklists'
-			path: '/dashboard/app-settings/blacklists'
-			fullPath: '/dashboard/app-settings/blacklists'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
-			id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
-			path: '/dashboard/app-settings/app-miscelleneous'
-			fullPath: '/dashboard/app-settings/app-miscelleneous'
-			preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/your-purchases': {
-			id: '/_dashboard-layout/dashboard/account/your-purchases'
-			path: '/dashboard/account/your-purchases'
-			fullPath: '/dashboard/account/your-purchases'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/vanity-url': {
-			id: '/_dashboard-layout/dashboard/account/vanity-url'
-			path: '/dashboard/account/vanity-url'
-			fullPath: '/dashboard/account/vanity-url'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/receiving-payments': {
-			id: '/_dashboard-layout/dashboard/account/receiving-payments'
-			path: '/dashboard/account/receiving-payments'
-			fullPath: '/dashboard/account/receiving-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/profile': {
-			id: '/_dashboard-layout/dashboard/account/profile'
-			path: '/dashboard/account/profile'
-			fullPath: '/dashboard/account/profile'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/preferences': {
-			id: '/_dashboard-layout/dashboard/account/preferences'
-			path: '/dashboard/account/preferences'
-			fullPath: '/dashboard/account/preferences'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/nostr-address': {
-			id: '/_dashboard-layout/dashboard/account/nostr-address'
-			path: '/dashboard/account/nostr-address'
-			fullPath: '/dashboard/account/nostr-address'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/network': {
-			id: '/_dashboard-layout/dashboard/account/network'
-			path: '/dashboard/account/network'
-			fullPath: '/dashboard/account/network'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/account/making-payments': {
-			id: '/_dashboard-layout/dashboard/account/making-payments'
-			path: '/dashboard/account/making-payments'
-			fullPath: '/dashboard/account/making-payments'
-			preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
-			parentRoute: typeof DashboardLayoutRoute
-		}
-		'/_dashboard-layout/dashboard/sales/messages/$pubkey': {
-			id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
-			path: '/$pubkey'
-			fullPath: '/dashboard/sales/messages/$pubkey'
-			preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
-			parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/new': {
-			id: '/_dashboard-layout/dashboard/products/products/new'
-			path: '/new'
-			fullPath: '/dashboard/products/products/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/products/$productId': {
-			id: '/_dashboard-layout/dashboard/products/products/$productId'
-			path: '/$productId'
-			fullPath: '/dashboard/products/products/$productId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/new': {
-			id: '/_dashboard-layout/dashboard/products/collections/new'
-			path: '/new'
-			fullPath: '/dashboard/products/collections/new'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/collections/$collectionId': {
-			id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
-			path: '/$collectionId'
-			fullPath: '/dashboard/products/collections/$collectionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
-		}
-		'/_dashboard-layout/dashboard/products/auctions/$auctionId': {
-			id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
-			path: '/$auctionId'
-			fullPath: '/dashboard/products/auctions/$auctionId'
-			preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
-			parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
-		}
-	}
+  interface FileRoutesByPath {
+    '/setup': {
+      id: '/setup'
+      path: '/setup'
+      fullPath: '/setup'
+      preLoaderRoute: typeof SetupRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/checkout': {
+      id: '/checkout'
+      path: '/checkout'
+      fullPath: '/checkout'
+      preLoaderRoute: typeof CheckoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout': {
+      id: '/_dashboard-layout'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof DashboardLayoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$vanityName': {
+      id: '/$vanityName'
+      path: '/$vanityName'
+      fullPath: '/$vanityName'
+      preLoaderRoute: typeof VanityNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/': {
+      id: '/products/'
+      path: '/products'
+      fullPath: '/products/'
+      preLoaderRoute: typeof ProductsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/': {
+      id: '/posts/'
+      path: '/posts'
+      fullPath: '/posts/'
+      preLoaderRoute: typeof PostsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/nostr/': {
+      id: '/nostr/'
+      path: '/nostr'
+      fullPath: '/nostr/'
+      preLoaderRoute: typeof NostrIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/community/': {
+      id: '/community/'
+      path: '/community'
+      fullPath: '/community/'
+      preLoaderRoute: typeof CommunityIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/': {
+      id: '/auctions/'
+      path: '/auctions'
+      fullPath: '/auctions/'
+      preLoaderRoute: typeof AuctionsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search/products': {
+      id: '/search/products'
+      path: '/search/products'
+      fullPath: '/search/products'
+      preLoaderRoute: typeof SearchProductsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/profile/$profileId': {
+      id: '/profile/$profileId'
+      path: '/profile/$profileId'
+      fullPath: '/profile/$profileId'
+      preLoaderRoute: typeof ProfileProfileIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/products/$productId': {
+      id: '/products/$productId'
+      path: '/products/$productId'
+      fullPath: '/products/$productId'
+      preLoaderRoute: typeof ProductsProductIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/posts/$postId': {
+      id: '/posts/$postId'
+      path: '/posts/$postId'
+      fullPath: '/posts/$postId'
+      preLoaderRoute: typeof PostsPostIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/collection/$collectionId': {
+      id: '/collection/$collectionId'
+      path: '/collection/$collectionId'
+      fullPath: '/collection/$collectionId'
+      preLoaderRoute: typeof CollectionCollectionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auctions/$auctionId': {
+      id: '/auctions/$auctionId'
+      path: '/auctions/$auctionId'
+      fullPath: '/auctions/$auctionId'
+      preLoaderRoute: typeof AuctionsAuctionIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_dashboard-layout/dashboard/': {
+      id: '/_dashboard-layout/dashboard/'
+      path: '/dashboard'
+      fullPath: '/dashboard/'
+      preLoaderRoute: typeof DashboardLayoutDashboardIndexRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/about': {
+      id: '/_dashboard-layout/dashboard/about'
+      path: '/dashboard/about'
+      fullPath: '/dashboard/about'
+      preLoaderRoute: typeof DashboardLayoutDashboardAboutRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/sales': {
+      id: '/_dashboard-layout/dashboard/sales/sales'
+      path: '/dashboard/sales/sales'
+      fullPath: '/dashboard/sales/sales'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesSalesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages': {
+      id: '/_dashboard-layout/dashboard/sales/messages'
+      path: '/dashboard/sales/messages'
+      fullPath: '/dashboard/sales/messages'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/circular-economy': {
+      id: '/_dashboard-layout/dashboard/sales/circular-economy'
+      path: '/dashboard/sales/circular-economy'
+      fullPath: '/dashboard/sales/circular-economy'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/shipping-options': {
+      id: '/_dashboard-layout/dashboard/products/shipping-options'
+      path: '/dashboard/products/shipping-options'
+      fullPath: '/dashboard/products/shipping-options'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/products': {
+      id: '/_dashboard-layout/dashboard/products/products'
+      path: '/dashboard/products/products'
+      fullPath: '/dashboard/products/products'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/migration-tool': {
+      id: '/_dashboard-layout/dashboard/products/migration-tool'
+      path: '/dashboard/products/migration-tool'
+      fullPath: '/dashboard/products/migration-tool'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsMigrationToolRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections': {
+      id: '/_dashboard-layout/dashboard/products/collections'
+      path: '/dashboard/products/collections'
+      fullPath: '/dashboard/products/collections'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/bids': {
+      id: '/_dashboard-layout/dashboard/products/bids'
+      path: '/dashboard/products/bids'
+      fullPath: '/dashboard/products/bids'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsBidsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions': {
+      id: '/_dashboard-layout/dashboard/products/auctions'
+      path: '/dashboard/products/auctions'
+      fullPath: '/dashboard/products/auctions'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/orders/$orderId': {
+      id: '/_dashboard-layout/dashboard/orders/$orderId'
+      path: '/dashboard/orders/$orderId'
+      fullPath: '/dashboard/orders/$orderId'
+      preLoaderRoute: typeof DashboardLayoutDashboardOrdersOrderIdRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/team': {
+      id: '/_dashboard-layout/dashboard/app-settings/team'
+      path: '/dashboard/app-settings/team'
+      fullPath: '/dashboard/app-settings/team'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsTeamRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/featured-items': {
+      id: '/_dashboard-layout/dashboard/app-settings/featured-items'
+      path: '/dashboard/app-settings/featured-items'
+      fullPath: '/dashboard/app-settings/featured-items'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/blacklists': {
+      id: '/_dashboard-layout/dashboard/app-settings/blacklists'
+      path: '/dashboard/app-settings/blacklists'
+      fullPath: '/dashboard/app-settings/blacklists'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/app-settings/app-miscelleneous': {
+      id: '/_dashboard-layout/dashboard/app-settings/app-miscelleneous'
+      path: '/dashboard/app-settings/app-miscelleneous'
+      fullPath: '/dashboard/app-settings/app-miscelleneous'
+      preLoaderRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/your-purchases': {
+      id: '/_dashboard-layout/dashboard/account/your-purchases'
+      path: '/dashboard/account/your-purchases'
+      fullPath: '/dashboard/account/your-purchases'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/vanity-url': {
+      id: '/_dashboard-layout/dashboard/account/vanity-url'
+      path: '/dashboard/account/vanity-url'
+      fullPath: '/dashboard/account/vanity-url'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountVanityUrlRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/receiving-payments': {
+      id: '/_dashboard-layout/dashboard/account/receiving-payments'
+      path: '/dashboard/account/receiving-payments'
+      fullPath: '/dashboard/account/receiving-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/profile': {
+      id: '/_dashboard-layout/dashboard/account/profile'
+      path: '/dashboard/account/profile'
+      fullPath: '/dashboard/account/profile'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountProfileRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/preferences': {
+      id: '/_dashboard-layout/dashboard/account/preferences'
+      path: '/dashboard/account/preferences'
+      fullPath: '/dashboard/account/preferences'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountPreferencesRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/nostr-address': {
+      id: '/_dashboard-layout/dashboard/account/nostr-address'
+      path: '/dashboard/account/nostr-address'
+      fullPath: '/dashboard/account/nostr-address'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNostrAddressRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/network': {
+      id: '/_dashboard-layout/dashboard/account/network'
+      path: '/dashboard/account/network'
+      fullPath: '/dashboard/account/network'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountNetworkRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/account/making-payments': {
+      id: '/_dashboard-layout/dashboard/account/making-payments'
+      path: '/dashboard/account/making-payments'
+      fullPath: '/dashboard/account/making-payments'
+      preLoaderRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRouteImport
+      parentRoute: typeof DashboardLayoutRoute
+    }
+    '/_dashboard-layout/dashboard/sales/messages/$pubkey': {
+      id: '/_dashboard-layout/dashboard/sales/messages/$pubkey'
+      path: '/$pubkey'
+      fullPath: '/dashboard/sales/messages/$pubkey'
+      preLoaderRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRouteImport
+      parentRoute: typeof DashboardLayoutDashboardSalesMessagesRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/new': {
+      id: '/_dashboard-layout/dashboard/products/products/new'
+      path: '/new'
+      fullPath: '/dashboard/products/products/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/products/$productId': {
+      id: '/_dashboard-layout/dashboard/products/products/$productId'
+      path: '/$productId'
+      fullPath: '/dashboard/products/products/$productId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsProductsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/new': {
+      id: '/_dashboard-layout/dashboard/products/collections/new'
+      path: '/new'
+      fullPath: '/dashboard/products/collections/new'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/collections/$collectionId': {
+      id: '/_dashboard-layout/dashboard/products/collections/$collectionId'
+      path: '/$collectionId'
+      fullPath: '/dashboard/products/collections/$collectionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsCollectionsRoute
+    }
+    '/_dashboard-layout/dashboard/products/auctions/$auctionId': {
+      id: '/_dashboard-layout/dashboard/products/auctions/$auctionId'
+      path: '/$auctionId'
+      fullPath: '/dashboard/products/auctions/$auctionId'
+      preLoaderRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRouteImport
+      parentRoute: typeof DashboardLayoutDashboardProductsAuctionsRoute
+    }
+  }
 }
 
 interface DashboardLayoutDashboardProductsAuctionsRouteChildren {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
+  DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: typeof DashboardLayoutDashboardProductsAuctionsAuctionIdRoute
 }
 
-const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren = {
-	DashboardLayoutDashboardProductsAuctionsAuctionIdRoute: DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
-}
+const DashboardLayoutDashboardProductsAuctionsRouteChildren: DashboardLayoutDashboardProductsAuctionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsAuctionsAuctionIdRoute:
+      DashboardLayoutDashboardProductsAuctionsAuctionIdRoute,
+  }
 
-const DashboardLayoutDashboardProductsAuctionsRouteWithChildren = DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsAuctionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsAuctionsRouteWithChildren =
+  DashboardLayoutDashboardProductsAuctionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsAuctionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsCollectionsRouteChildren {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
-	DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
+  DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: typeof DashboardLayoutDashboardProductsCollectionsCollectionIdRoute
+  DashboardLayoutDashboardProductsCollectionsNewRoute: typeof DashboardLayoutDashboardProductsCollectionsNewRoute
 }
 
-const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren = {
-	DashboardLayoutDashboardProductsCollectionsCollectionIdRoute: DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
-	DashboardLayoutDashboardProductsCollectionsNewRoute: DashboardLayoutDashboardProductsCollectionsNewRoute,
-}
+const DashboardLayoutDashboardProductsCollectionsRouteChildren: DashboardLayoutDashboardProductsCollectionsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsCollectionsCollectionIdRoute:
+      DashboardLayoutDashboardProductsCollectionsCollectionIdRoute,
+    DashboardLayoutDashboardProductsCollectionsNewRoute:
+      DashboardLayoutDashboardProductsCollectionsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsCollectionsRouteWithChildren = DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsCollectionsRouteChildren,
-)
+const DashboardLayoutDashboardProductsCollectionsRouteWithChildren =
+  DashboardLayoutDashboardProductsCollectionsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsCollectionsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardProductsProductsRouteChildren {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
-	DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
+  DashboardLayoutDashboardProductsProductsProductIdRoute: typeof DashboardLayoutDashboardProductsProductsProductIdRoute
+  DashboardLayoutDashboardProductsProductsNewRoute: typeof DashboardLayoutDashboardProductsProductsNewRoute
 }
 
-const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren = {
-	DashboardLayoutDashboardProductsProductsProductIdRoute: DashboardLayoutDashboardProductsProductsProductIdRoute,
-	DashboardLayoutDashboardProductsProductsNewRoute: DashboardLayoutDashboardProductsProductsNewRoute,
-}
+const DashboardLayoutDashboardProductsProductsRouteChildren: DashboardLayoutDashboardProductsProductsRouteChildren =
+  {
+    DashboardLayoutDashboardProductsProductsProductIdRoute:
+      DashboardLayoutDashboardProductsProductsProductIdRoute,
+    DashboardLayoutDashboardProductsProductsNewRoute:
+      DashboardLayoutDashboardProductsProductsNewRoute,
+  }
 
-const DashboardLayoutDashboardProductsProductsRouteWithChildren = DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
-	DashboardLayoutDashboardProductsProductsRouteChildren,
-)
+const DashboardLayoutDashboardProductsProductsRouteWithChildren =
+  DashboardLayoutDashboardProductsProductsRoute._addFileChildren(
+    DashboardLayoutDashboardProductsProductsRouteChildren,
+  )
 
 interface DashboardLayoutDashboardSalesMessagesRouteChildren {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
+  DashboardLayoutDashboardSalesMessagesPubkeyRoute: typeof DashboardLayoutDashboardSalesMessagesPubkeyRoute
 }
 
-const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren = {
-	DashboardLayoutDashboardSalesMessagesPubkeyRoute: DashboardLayoutDashboardSalesMessagesPubkeyRoute,
-}
+const DashboardLayoutDashboardSalesMessagesRouteChildren: DashboardLayoutDashboardSalesMessagesRouteChildren =
+  {
+    DashboardLayoutDashboardSalesMessagesPubkeyRoute:
+      DashboardLayoutDashboardSalesMessagesPubkeyRoute,
+  }
 
-const DashboardLayoutDashboardSalesMessagesRouteWithChildren = DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
-	DashboardLayoutDashboardSalesMessagesRouteChildren,
-)
+const DashboardLayoutDashboardSalesMessagesRouteWithChildren =
+  DashboardLayoutDashboardSalesMessagesRoute._addFileChildren(
+    DashboardLayoutDashboardSalesMessagesRouteChildren,
+  )
 
 interface DashboardLayoutRouteChildren {
-	DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
-	DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
-	DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
-	DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
-	DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
-	DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
-	DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
-	DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
-	DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
-	DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
-	DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
-	DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
-	DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
-	DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
-	DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
-	DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
-	DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
-	DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
-	DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
+  DashboardLayoutDashboardAboutRoute: typeof DashboardLayoutDashboardAboutRoute
+  DashboardLayoutDashboardIndexRoute: typeof DashboardLayoutDashboardIndexRoute
+  DashboardLayoutDashboardAccountMakingPaymentsRoute: typeof DashboardLayoutDashboardAccountMakingPaymentsRoute
+  DashboardLayoutDashboardAccountNetworkRoute: typeof DashboardLayoutDashboardAccountNetworkRoute
+  DashboardLayoutDashboardAccountNostrAddressRoute: typeof DashboardLayoutDashboardAccountNostrAddressRoute
+  DashboardLayoutDashboardAccountPreferencesRoute: typeof DashboardLayoutDashboardAccountPreferencesRoute
+  DashboardLayoutDashboardAccountProfileRoute: typeof DashboardLayoutDashboardAccountProfileRoute
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute: typeof DashboardLayoutDashboardAccountReceivingPaymentsRoute
+  DashboardLayoutDashboardAccountVanityUrlRoute: typeof DashboardLayoutDashboardAccountVanityUrlRoute
+  DashboardLayoutDashboardAccountYourPurchasesRoute: typeof DashboardLayoutDashboardAccountYourPurchasesRoute
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: typeof DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute: typeof DashboardLayoutDashboardAppSettingsBlacklistsRoute
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: typeof DashboardLayoutDashboardAppSettingsFeaturedItemsRoute
+  DashboardLayoutDashboardAppSettingsTeamRoute: typeof DashboardLayoutDashboardAppSettingsTeamRoute
+  DashboardLayoutDashboardOrdersOrderIdRoute: typeof DashboardLayoutDashboardOrdersOrderIdRoute
+  DashboardLayoutDashboardProductsAuctionsRoute: typeof DashboardLayoutDashboardProductsAuctionsRouteWithChildren
+  DashboardLayoutDashboardProductsBidsRoute: typeof DashboardLayoutDashboardProductsBidsRoute
+  DashboardLayoutDashboardProductsCollectionsRoute: typeof DashboardLayoutDashboardProductsCollectionsRouteWithChildren
+  DashboardLayoutDashboardProductsMigrationToolRoute: typeof DashboardLayoutDashboardProductsMigrationToolRoute
+  DashboardLayoutDashboardProductsProductsRoute: typeof DashboardLayoutDashboardProductsProductsRouteWithChildren
+  DashboardLayoutDashboardProductsShippingOptionsRoute: typeof DashboardLayoutDashboardProductsShippingOptionsRoute
+  DashboardLayoutDashboardSalesCircularEconomyRoute: typeof DashboardLayoutDashboardSalesCircularEconomyRoute
+  DashboardLayoutDashboardSalesMessagesRoute: typeof DashboardLayoutDashboardSalesMessagesRouteWithChildren
+  DashboardLayoutDashboardSalesSalesRoute: typeof DashboardLayoutDashboardSalesSalesRoute
 }
 
 const DashboardLayoutRouteChildren: DashboardLayoutRouteChildren = {
-	DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
-	DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
-	DashboardLayoutDashboardAccountMakingPaymentsRoute: DashboardLayoutDashboardAccountMakingPaymentsRoute,
-	DashboardLayoutDashboardAccountNetworkRoute: DashboardLayoutDashboardAccountNetworkRoute,
-	DashboardLayoutDashboardAccountNostrAddressRoute: DashboardLayoutDashboardAccountNostrAddressRoute,
-	DashboardLayoutDashboardAccountPreferencesRoute: DashboardLayoutDashboardAccountPreferencesRoute,
-	DashboardLayoutDashboardAccountProfileRoute: DashboardLayoutDashboardAccountProfileRoute,
-	DashboardLayoutDashboardAccountReceivingPaymentsRoute: DashboardLayoutDashboardAccountReceivingPaymentsRoute,
-	DashboardLayoutDashboardAccountVanityUrlRoute: DashboardLayoutDashboardAccountVanityUrlRoute,
-	DashboardLayoutDashboardAccountYourPurchasesRoute: DashboardLayoutDashboardAccountYourPurchasesRoute,
-	DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute: DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
-	DashboardLayoutDashboardAppSettingsBlacklistsRoute: DashboardLayoutDashboardAppSettingsBlacklistsRoute,
-	DashboardLayoutDashboardAppSettingsFeaturedItemsRoute: DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
-	DashboardLayoutDashboardAppSettingsTeamRoute: DashboardLayoutDashboardAppSettingsTeamRoute,
-	DashboardLayoutDashboardOrdersOrderIdRoute: DashboardLayoutDashboardOrdersOrderIdRoute,
-	DashboardLayoutDashboardProductsAuctionsRoute: DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
-	DashboardLayoutDashboardProductsBidsRoute: DashboardLayoutDashboardProductsBidsRoute,
-	DashboardLayoutDashboardProductsCollectionsRoute: DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
-	DashboardLayoutDashboardProductsMigrationToolRoute: DashboardLayoutDashboardProductsMigrationToolRoute,
-	DashboardLayoutDashboardProductsProductsRoute: DashboardLayoutDashboardProductsProductsRouteWithChildren,
-	DashboardLayoutDashboardProductsShippingOptionsRoute: DashboardLayoutDashboardProductsShippingOptionsRoute,
-	DashboardLayoutDashboardSalesCircularEconomyRoute: DashboardLayoutDashboardSalesCircularEconomyRoute,
-	DashboardLayoutDashboardSalesMessagesRoute: DashboardLayoutDashboardSalesMessagesRouteWithChildren,
-	DashboardLayoutDashboardSalesSalesRoute: DashboardLayoutDashboardSalesSalesRoute,
+  DashboardLayoutDashboardAboutRoute: DashboardLayoutDashboardAboutRoute,
+  DashboardLayoutDashboardIndexRoute: DashboardLayoutDashboardIndexRoute,
+  DashboardLayoutDashboardAccountMakingPaymentsRoute:
+    DashboardLayoutDashboardAccountMakingPaymentsRoute,
+  DashboardLayoutDashboardAccountNetworkRoute:
+    DashboardLayoutDashboardAccountNetworkRoute,
+  DashboardLayoutDashboardAccountNostrAddressRoute:
+    DashboardLayoutDashboardAccountNostrAddressRoute,
+  DashboardLayoutDashboardAccountPreferencesRoute:
+    DashboardLayoutDashboardAccountPreferencesRoute,
+  DashboardLayoutDashboardAccountProfileRoute:
+    DashboardLayoutDashboardAccountProfileRoute,
+  DashboardLayoutDashboardAccountReceivingPaymentsRoute:
+    DashboardLayoutDashboardAccountReceivingPaymentsRoute,
+  DashboardLayoutDashboardAccountVanityUrlRoute:
+    DashboardLayoutDashboardAccountVanityUrlRoute,
+  DashboardLayoutDashboardAccountYourPurchasesRoute:
+    DashboardLayoutDashboardAccountYourPurchasesRoute,
+  DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute:
+    DashboardLayoutDashboardAppSettingsAppMiscelleneousRoute,
+  DashboardLayoutDashboardAppSettingsBlacklistsRoute:
+    DashboardLayoutDashboardAppSettingsBlacklistsRoute,
+  DashboardLayoutDashboardAppSettingsFeaturedItemsRoute:
+    DashboardLayoutDashboardAppSettingsFeaturedItemsRoute,
+  DashboardLayoutDashboardAppSettingsTeamRoute:
+    DashboardLayoutDashboardAppSettingsTeamRoute,
+  DashboardLayoutDashboardOrdersOrderIdRoute:
+    DashboardLayoutDashboardOrdersOrderIdRoute,
+  DashboardLayoutDashboardProductsAuctionsRoute:
+    DashboardLayoutDashboardProductsAuctionsRouteWithChildren,
+  DashboardLayoutDashboardProductsBidsRoute:
+    DashboardLayoutDashboardProductsBidsRoute,
+  DashboardLayoutDashboardProductsCollectionsRoute:
+    DashboardLayoutDashboardProductsCollectionsRouteWithChildren,
+  DashboardLayoutDashboardProductsMigrationToolRoute:
+    DashboardLayoutDashboardProductsMigrationToolRoute,
+  DashboardLayoutDashboardProductsProductsRoute:
+    DashboardLayoutDashboardProductsProductsRouteWithChildren,
+  DashboardLayoutDashboardProductsShippingOptionsRoute:
+    DashboardLayoutDashboardProductsShippingOptionsRoute,
+  DashboardLayoutDashboardSalesCircularEconomyRoute:
+    DashboardLayoutDashboardSalesCircularEconomyRoute,
+  DashboardLayoutDashboardSalesMessagesRoute:
+    DashboardLayoutDashboardSalesMessagesRouteWithChildren,
+  DashboardLayoutDashboardSalesSalesRoute:
+    DashboardLayoutDashboardSalesSalesRoute,
 }
 
-const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(DashboardLayoutRouteChildren)
+const DashboardLayoutRouteWithChildren = DashboardLayoutRoute._addFileChildren(
+  DashboardLayoutRouteChildren,
+)
 
 const rootRouteChildren: RootRouteChildren = {
-	IndexRoute: IndexRoute,
-	VanityNameRoute: VanityNameRoute,
-	DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
-	CheckoutRoute: CheckoutRoute,
-	SetupRoute: SetupRoute,
-	AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
-	CollectionCollectionIdRoute: CollectionCollectionIdRoute,
-	PostsPostIdRoute: PostsPostIdRoute,
-	ProductsProductIdRoute: ProductsProductIdRoute,
-	ProfileProfileIdRoute: ProfileProfileIdRoute,
-	SearchProductsRoute: SearchProductsRoute,
-	AuctionsIndexRoute: AuctionsIndexRoute,
-	CommunityIndexRoute: CommunityIndexRoute,
-	NostrIndexRoute: NostrIndexRoute,
-	PostsIndexRoute: PostsIndexRoute,
-	ProductsIndexRoute: ProductsIndexRoute,
+  IndexRoute: IndexRoute,
+  VanityNameRoute: VanityNameRoute,
+  DashboardLayoutRoute: DashboardLayoutRouteWithChildren,
+  CheckoutRoute: CheckoutRoute,
+  SetupRoute: SetupRoute,
+  AuctionsAuctionIdRoute: AuctionsAuctionIdRoute,
+  CollectionCollectionIdRoute: CollectionCollectionIdRoute,
+  PostsPostIdRoute: PostsPostIdRoute,
+  ProductsProductIdRoute: ProductsProductIdRoute,
+  ProfileProfileIdRoute: ProfileProfileIdRoute,
+  SearchProductsRoute: SearchProductsRoute,
+  AuctionsIndexRoute: AuctionsIndexRoute,
+  CommunityIndexRoute: CommunityIndexRoute,
+  NostrIndexRoute: NostrIndexRoute,
+  PostsIndexRoute: PostsIndexRoute,
+  ProductsIndexRoute: ProductsIndexRoute,
 }
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>()
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()


### PR DESCRIPTION
## Port: restore lost review fixes + staged bid-progress UX — stacked on #1235

**Base:** `feat/1202-direct-lightning-bid-funding` @ `415c2d61` (current #1235 head)
**Why:** the branch was force-pushed to a reworked line that re-implemented much of the review feedback, but several landed fixes and the staged bid-confirmation UX were lost in the process (they survived only in local reflog/stash). This PR re-applies them **on top of** the current rework — nothing from `14a05ebd`/`592f3ddf` is reverted.

An independent multi-agent audit of the current head confirmed both of maximotodev's outstanding blockers are still open at `415c2d61`; this port closes both, plus the flagship-path defect the audit found.

### What each commit restores

| Commit | Restores | Closes |
|---|---|---|
| `03d9d586` | **Idempotent retry publish** — `republishAuctionBid()` fetches the already-signed kind-1023 by id (kind+sig validated) and rebroadcasts verbatim; `retryBidPublish` uses it when `publishedBidEventId` is captured; id is reset per funding session (also fixes the rebid cross-leg leak). E2E note: Scenario 3's double-lock expectation should be updated — retry no longer re-locks. | **Blocker 1** |
| `d2f5f28f` | **Verdict authenticity + quorum** — `verdictQuorum.ts` (+11 tests) ported byte-identical from the lost lineage: verdicts bound to exact `bidEventId`, filtered to configured auditors, deduped per validator, quorum-gated terminal states; `authors` filter on `fetchAuctionVerdicts` so forged kind-30440s aren't fetched; canonical claim constants; `bid_pending_review`/`lost_pending_refund`/`settled_late` no longer render as eternal pending | **Blocker 5** |
| `e2610118` | **QR-path lifecycle** — the flagship QR flow now advances `invoice_created → payment_acknowledged → minting_started → ecash_minted` (idempotent walk-forward), so the progress dialog/retry/validator UI actually activate; close/cancel classification is paid-or-unknown-safe and exactly-once (pure resolvers, regression-tested); nip60 deposit `success` identity guard added | Audit M1, S4/S5/S6 |
| `18710355` | **Staged bid-progress modal UX** — 4-stage stepper (`Funding e-cash → P2PK lock → Publishing bid to relays → Awaiting validator check`), `"Bid successfully placed!"` success card with refund-locktime row, publish-failure retry surface, deposit-modal hand-off, simple toast removed (modal is the success surface) | Restores the lost UX |

### Verification
- Unit suite: **847 → 851 → 862 → 872 → 887, 0 failures at every step** (each commit independently re-verified).
- Prettier clean on all touched files; `tsc --noEmit` error set identical to baseline (no new errors).
- Every commit was reviewed against the pre-force-push lineage (`pr1235-old-full-ux`); `verdictQuorum.ts` is byte-identical to the original.
- Lineage backups pushed: `pr1235-old-full-ux` (the lost full-UX line), plus audit artifacts (`PR_REVIEW_REPORT.md`, `FINAL_VERDICT.md`) from the review that drove this.

### ⚠️ Known remaining gaps (not addressed here, follow-ups recommended)
1. **Refund-key persistence order (triage action #1):** `upsertBidderRecord({ refundPrivateKey })` still runs at `publish/auctions.tsx:617`, *after* `publishEvent` (`:594`) — a publish failure can permanently strand the locked leg. The port did not change that ordering; it should be a separate small fix (persist the refund key immediately after `lockAuctionBidFunds`).
2. **E2E Scenario 3** (`auction-bidding-mints.spec.ts`) still enshrines the double-lock retry path; it should be reworked to click "Retry publish" and assert the *same* event id now that retry is idempotent.
3. hkarani's orphaned commits `3a4b1fe`/`677b7cf` ("prevent bidding with already spent proofs") are not ancestors of `415c2d61` and are not included here — the ported publish path does handle NUT-07 spent-proof errors (`getSpendableProofsForMint` filtering + spent-message detection), but please confirm coverage is equivalent.

### Review notes
- The `computeVerdictQuorum` + 11 tests were claimed implemented in review Round 7 but are absent from the current head — restored here verbatim from commit `38625ac7` of the old lineage.
- Batch reports, diff-vs-reference checks, and the full audit trail: `FINAL_VERDICT.md` in the branch root.
- Unit tests: `bun run test:unit`. No behavior changes to NWC paths beyond idempotency; `nip60.ts` touched only for the success identity guard.