### PR TITLE
feat(config): add self-hosting instance configuration foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,27 @@ NODE_ENV=development
 APP_RELAY_URL=wss://your-relay-url.com
 APP_PRIVATE_KEY=<your_private_key_in_hex>
 CVM_SERVER_KEY=<your_currency_server_private_key_in_hex>
+
+# Optional runtime instance overrides. Kind 31990 settings take precedence.
+# INSTANCE_NAME=My Market
+# INSTANCE_DISPLAY_NAME=My Market
+# INSTANCE_PICTURE_URL=https://market.example/images/logo.svg
+# INSTANCE_BANNER_URL=https://market.example/images/banner.png
+# INSTANCE_OWNER_PUBKEY=<owner_public_key_in_hex>
+# INSTANCE_ALLOW_REGISTER=true
+# INSTANCE_DEFAULT_CURRENCY=USD
+# INSTANCE_CONTACT_EMAIL=support@market.example
+# INSTANCE_HANDLER_ID=market-handler
+# INSTANCE_SITE_URL=https://market.example
+# INSTANCE_PUBLIC_RELAYS=wss://relay-one.example,wss://relay-two.example
+# INSTANCE_TRUSTED_MINTS=https://mint-one.example,https://mint-two.example
+# INSTANCE_BUG_RELAY=wss://bugs.example
+# INSTANCE_TERMS_URL=https://market.example/terms
+# INSTANCE_SUPPORT_CONTACT=support@market.example
+# INSTANCE_SHOW_NOSTR_LINK=false
+# INSTANCE_TWITTER_URL=https://twitter.com/example
+# INSTANCE_NEWSLETTER_URL=https://example.substack.com
+# INSTANCE_TELEGRAM_URL=https://t.me/example
+# INSTANCE_GITHUB_URL=https://github.com/example/market
+# BLOSSOM_SERVER=https://blossom.example
+# NIP96_SERVER=https://media.example

--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ const router = createRouter({
 
 Set the .env variables by copying and renaming the `.env.example` file, then set your own values for the variables.
 
+For self-hosted deployments, `INSTANCE_*` variables configure the public
+identity and service endpoints: name, display name, logo, banner, site URL,
+handler ID, public relays, trusted mints, bug relay, terms URL, support contact,
+and social links. See [`deploy-simple/README.md`](deploy-simple/README.md) for a
+complete example. Runtime precedence is:
+
+```text
+kind 31990 app-settings event -> INSTANCE_* environment variables -> shipped defaults
+```
+
+When `INSTANCE_HANDLER_ID` is configured, app-settings discovery tries that
+d-tag first and falls back to `plebeian-market-handler` for compatibility with
+existing deployments.
+
 ### Development relay
 
 During development, you should spin up a relay to seed data and use it during the development cycle, you can use `nak serve` as a quick solution, or run another relay locally, then set it in your `.env` variables, and run `bun seed` to seed it.

--- a/deploy-simple/README.md
+++ b/deploy-simple/README.md
@@ -187,6 +187,60 @@ git push origin v1.0.0-release
 
 ## Manual Deployment
 
+### Self-hosted instance configuration
+
+The marketplace supports runtime instance identity through `INSTANCE_*`
+environment variables and kind 31990 app-settings events. Values published in
+the app-settings event take precedence over environment variables, which take
+precedence over the shipped Plebeian defaults:
+
+```text
+kind 31990 event -> INSTANCE_* environment variables -> DEFAULT_INSTANCE_CONFIG
+```
+
+For app-settings discovery, `INSTANCE_HANDLER_ID` is tried first. The historical
+`plebeian-market-handler` d-tag is then used as a compatibility fallback, so
+existing Plebeian deployments continue to boot while a new self-hosted event is
+being published.
+
+Example self-hosted environment:
+
+```dotenv
+APP_STAGE=production
+NODE_ENV=production
+PORT=3001
+APP_RELAY_URL=wss://relay.market.example
+APP_PRIVATE_KEY=<64-char-hex-private-key>
+
+INSTANCE_NAME=Example Market
+INSTANCE_DISPLAY_NAME=Example Market
+INSTANCE_PICTURE_URL=https://market.example/images/logo.png
+INSTANCE_BANNER_URL=https://market.example/images/banner.png
+INSTANCE_OWNER_PUBKEY=<64-char-hex-owner-pubkey>
+INSTANCE_ALLOW_REGISTER=true
+INSTANCE_DEFAULT_CURRENCY=USD
+INSTANCE_HANDLER_ID=example-market-handler
+INSTANCE_SITE_URL=https://market.example
+INSTANCE_PUBLIC_RELAYS=wss://relay.market.example,wss://relay.example.net
+INSTANCE_TRUSTED_MINTS=https://mint.example.net
+INSTANCE_BUG_RELAY=wss://bugs.market.example
+INSTANCE_TERMS_URL=https://market.example/terms
+INSTANCE_CONTACT_EMAIL=contact@market.example
+INSTANCE_SUPPORT_CONTACT=support@market.example
+INSTANCE_SHOW_NOSTR_LINK=true
+INSTANCE_TWITTER_URL=https://twitter.com/examplemarket
+INSTANCE_NEWSLETTER_URL=https://examplemarket.substack.com
+INSTANCE_TELEGRAM_URL=https://t.me/examplemarket
+INSTANCE_GITHUB_URL=https://github.com/example/market
+INSTANCE_NOSTR_URL=https://njump.me/npub1example
+```
+
+After the server is running, publish a kind 31990 event using the owner/app
+workflow or `scripts/app-settings/publish.ts`. Its `d` tag should match
+`INSTANCE_HANDLER_ID`, and its content should satisfy the app-settings schema.
+Do not commit private keys, wallet material, or populated deployment `.env`
+files.
+
 ### Deploy to Staging
 
 ```bash

--- a/deploy-simple/env/.env.production.example
+++ b/deploy-simple/env/.env.production.example
@@ -28,6 +28,28 @@ NIP46_RELAY_URL=wss://relay.nsec.app
 BLOSSOM_SERVER=https://blossom.plebeian.market
 NIP96_SERVER=https://media.plebeian.market
 
+# Optional: Instance identity. Kind 31990 settings take precedence.
+# INSTANCE_NAME=Plebeian Market
+# INSTANCE_DISPLAY_NAME=Plebeian Market
+# INSTANCE_PICTURE_URL=https://plebeian.market/images/logo.svg
+# INSTANCE_BANNER_URL=https://plebeian.market/banner.png
+# INSTANCE_OWNER_PUBKEY=<owner-public-key-in-hex>
+# INSTANCE_ALLOW_REGISTER=true
+# INSTANCE_DEFAULT_CURRENCY=USD
+# INSTANCE_CONTACT_EMAIL=support@example.com
+# INSTANCE_HANDLER_ID=plebeian-market-handler
+# INSTANCE_SITE_URL=https://plebeian.market
+# INSTANCE_PUBLIC_RELAYS=wss://relay-one.example,wss://relay-two.example
+# INSTANCE_TRUSTED_MINTS=https://mint-one.example,https://mint-two.example
+# INSTANCE_BUG_RELAY=wss://bugs.example
+# INSTANCE_TERMS_URL=https://plebeian.market/terms
+# INSTANCE_SUPPORT_CONTACT=support@example.com
+# INSTANCE_SHOW_NOSTR_LINK=false
+# INSTANCE_TWITTER_URL=https://twitter.com/PlebeianMarket
+# INSTANCE_NEWSLETTER_URL=https://plebeianmarket.substack.com
+# INSTANCE_TELEGRAM_URL=https://t.me/PlebeianMarket
+# INSTANCE_GITHUB_URL=https://github.com/PlebeianApp/market
+
 # Optional: Monitoring
 # SENTRY_DSN=https://...
 LOG_LEVEL=info

--- a/deploy-simple/env/.env.production.example
+++ b/deploy-simple/env/.env.production.example
@@ -49,6 +49,21 @@ NIP96_SERVER=https://media.plebeian.market
 # INSTANCE_NEWSLETTER_URL=https://plebeianmarket.substack.com
 # INSTANCE_TELEGRAM_URL=https://t.me/PlebeianMarket
 # INSTANCE_GITHUB_URL=https://github.com/PlebeianApp/market
+# INSTANCE_NOSTR_URL=https://njump.me/npub1...
+
+# Self-hosted example (replace the values and uncomment the desired settings):
+# INSTANCE_NAME=Example Market
+# INSTANCE_DISPLAY_NAME=Example Market
+# INSTANCE_PICTURE_URL=https://market.example/images/logo.png
+# INSTANCE_BANNER_URL=https://market.example/images/banner.png
+# INSTANCE_HANDLER_ID=example-market-handler
+# INSTANCE_SITE_URL=https://market.example
+# INSTANCE_PUBLIC_RELAYS=wss://relay.market.example,wss://relay.example.net
+# INSTANCE_TRUSTED_MINTS=https://mint.example.net
+# INSTANCE_BUG_RELAY=wss://bugs.market.example
+# INSTANCE_TERMS_URL=https://market.example/terms
+# INSTANCE_SUPPORT_CONTACT=support@market.example
+# INSTANCE_NOSTR_URL=https://njump.me/npub1example
 
 # Optional: Monitoring
 # SENTRY_DSN=https://...

--- a/deploy-simple/env/.env.staging.example
+++ b/deploy-simple/env/.env.staging.example
@@ -28,6 +28,26 @@ NIP46_RELAY_URL=wss://relay.nsec.app
 # BLOSSOM_SERVER=https://blossom.staging.plebeian.market
 # NIP96_SERVER=https://media.staging.plebeian.market
 
+# Optional: instance identity. Kind 31990 settings take precedence over these
+# values. If INSTANCE_HANDLER_ID is set, discovery tries it before the legacy
+# plebeian-market-handler d-tag.
+# INSTANCE_NAME=Example Market Staging
+# INSTANCE_DISPLAY_NAME=Example Market Staging
+# INSTANCE_PICTURE_URL=https://staging.market.example/images/logo.png
+# INSTANCE_BANNER_URL=https://staging.market.example/images/banner.png
+# INSTANCE_HANDLER_ID=example-market-staging-handler
+# INSTANCE_SITE_URL=https://staging.market.example
+# INSTANCE_PUBLIC_RELAYS=wss://relay.staging.market.example
+# INSTANCE_TRUSTED_MINTS=https://mint.example.net
+# INSTANCE_BUG_RELAY=wss://bugs.market.example
+# INSTANCE_TERMS_URL=https://staging.market.example/terms
+# INSTANCE_SUPPORT_CONTACT=support@market.example
+# INSTANCE_TWITTER_URL=https://twitter.com/examplemarket
+# INSTANCE_NEWSLETTER_URL=https://examplemarket.substack.com
+# INSTANCE_TELEGRAM_URL=https://t.me/examplemarket
+# INSTANCE_GITHUB_URL=https://github.com/example/market
+# INSTANCE_NOSTR_URL=https://njump.me/npub1example
+
 # Optional: Monitoring
 # SENTRY_DSN=https://...
 # LOG_LEVEL=debug

--- a/e2e/ARCHITECTURE.md
+++ b/e2e/ARCHITECTURE.md
@@ -103,6 +103,13 @@ The dev server **caches `appSettings` at startup** by fetching Kind 31990 from t
 
 This is why we use `seed-relay.ts` as part of the webServer command (step 2) rather than publishing in globalSetup (step 3, too late).
 
+The self-hosted configuration spec uses the same startup path with
+`INSTANCE_HANDLER_ID=self-hosted-test-handler`. `seed-relay.ts` publishes both
+the custom handler event and the legacy `plebeian-market-handler` event before
+the app starts. This verifies custom discovery while keeping the historical
+d-tag available for fallback coverage. The scenario uses only the local relay
+and local app; its HTTPS fixture URLs are inert values and are not fetched.
+
 ```mermaid
 sequenceDiagram
     participant PW as Playwright

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig, devices } from '@playwright/test'
-import { TEST_APP_PRIVATE_KEY, RELAY_URL, BASE_URL, TEST_PORT } from './test-config'
+import { RELAY_URL, SELF_HOSTED_HANDLER_ID, TEST_APP_PRIVATE_KEY, BASE_URL, TEST_PORT } from './test-config'
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -66,6 +66,7 @@ export default defineConfig({
 						PORT: String(TEST_PORT),
 						APP_RELAY_URL: RELAY_URL,
 						APP_PRIVATE_KEY: TEST_APP_PRIVATE_KEY,
+						INSTANCE_HANDLER_ID: SELF_HOSTED_HANDLER_ID,
 						LOCAL_RELAY_ONLY: 'true',
 						NIP46_RELAY_URL: RELAY_URL,
 						APP_DEV_TEST_MINT_URL: 'http://localhost:3338',

--- a/e2e/seed-relay.ts
+++ b/e2e/seed-relay.ts
@@ -62,6 +62,10 @@ async function main() {
 			['k', '30402'],
 			['k', '30405'],
 			['k', '30406'],
+			['web', `${SELF_HOSTED_SITE_URL}/product/<bech32>`, 'naddr'],
+			['web', `${SELF_HOSTED_SITE_URL}/a/<bech32>`, 'naddr'],
+			['web', `${SELF_HOSTED_SITE_URL}/collection/<bech32>`, 'naddr'],
+			['r', RELAY_URL],
 		],
 	})
 	console.log('  Published custom app settings (Kind 31990)')

--- a/e2e/seed-relay.ts
+++ b/e2e/seed-relay.ts
@@ -8,7 +8,14 @@ import { finalizeEvent, type EventTemplate } from 'nostr-tools/pure'
 import { Relay } from 'nostr-tools/relay'
 import { hexToBytes } from '@noble/hashes/utils.js'
 import { devUser1 } from '../src/lib/fixtures'
-import { TEST_APP_PRIVATE_KEY, TEST_APP_PUBLIC_KEY, RELAY_URL } from './test-config'
+import {
+	RELAY_URL,
+	SELF_HOSTED_HANDLER_ID,
+	SELF_HOSTED_INSTANCE_NAME,
+	SELF_HOSTED_SITE_URL,
+	TEST_APP_PRIVATE_KEY,
+	TEST_APP_PUBLIC_KEY,
+} from './test-config'
 
 const skBytes = hexToBytes(TEST_APP_PRIVATE_KEY)
 
@@ -24,15 +31,51 @@ async function main() {
 		return event
 	}
 
-	// Publish Kind 31990 (App Handler Information)
+	// Publish the custom self-hosted event first. The dev server is configured
+	// with INSTANCE_HANDLER_ID, so this event should win over the legacy event.
 	await publish({
 		kind: 31990,
 		created_at: Math.floor(Date.now() / 1000),
 		content: JSON.stringify({
-			name: 'Test Market',
-			displayName: 'Test Market',
-			picture: 'https://placehold.co/200x200',
-			banner: 'https://placehold.co/800x200',
+			name: SELF_HOSTED_INSTANCE_NAME,
+			displayName: SELF_HOSTED_INSTANCE_NAME,
+			picture: 'https://example.invalid/self-hosted-logo.svg',
+			banner: 'https://example.invalid/self-hosted-banner.png',
+			ownerPk: TEST_APP_PUBLIC_KEY,
+			allowRegister: true,
+			defaultCurrency: 'USD',
+			handlerId: SELF_HOSTED_HANDLER_ID,
+			siteUrl: SELF_HOSTED_SITE_URL,
+			publicRelays: [RELAY_URL],
+			trustedMints: ['https://mint.example.invalid'],
+			bugRelay: RELAY_URL,
+			termsUrl: `${SELF_HOSTED_SITE_URL}/terms`,
+			socialLinks: {
+				twitter: 'https://social.example.invalid/self-hosted',
+				github: 'https://github.com/example/self-hosted-market',
+				nostr: 'https://njump.me/npub1selfhosted',
+			},
+			supportContact: 'support@self-hosted.example.invalid',
+		}),
+		tags: [
+			['d', SELF_HOSTED_HANDLER_ID],
+			['k', '30402'],
+			['k', '30405'],
+			['k', '30406'],
+		],
+	})
+	console.log('  Published custom app settings (Kind 31990)')
+
+	// Keep the historical event present so the fallback chain is exercised by
+	// the same local relay and remains compatible with existing deployments.
+	await publish({
+		kind: 31990,
+		created_at: Math.floor(Date.now() / 1000) - 1,
+		content: JSON.stringify({
+			name: 'Legacy Test Market',
+			displayName: 'Legacy Test Market',
+			picture: 'https://example.invalid/legacy-logo.svg',
+			banner: 'https://example.invalid/legacy-banner.png',
 			ownerPk: TEST_APP_PUBLIC_KEY,
 			allowRegister: true,
 			defaultCurrency: 'USD',
@@ -44,7 +87,7 @@ async function main() {
 			['k', '30406'],
 		],
 	})
-	console.log('  Published app settings (Kind 31990)')
+	console.log('  Published legacy fallback app settings (Kind 31990)')
 
 	// Publish Kind 30000 (Admin List)
 	// Include devUser1 so the server recognises them as admin at startup.

--- a/e2e/test-config.ts
+++ b/e2e/test-config.ts
@@ -13,7 +13,10 @@ export const TEST_APP_PRIVATE_KEY = process.env.TEST_APP_PRIVATE_KEY || 'e2e0000
 export const TEST_APP_PUBLIC_KEY = getPublicKey(hexToBytes(TEST_APP_PRIVATE_KEY))
 
 export const RELAY_URL = 'ws://localhost:10547'
+export const SELF_HOSTED_HANDLER_ID = 'self-hosted-test-handler'
+export const SELF_HOSTED_INSTANCE_NAME = 'Self Hosted Market'
 // Use a dedicated high port to prevent reusing a production-connected dev server
 // and to avoid common local conflicts on more frequently used low ports.
 export const TEST_PORT = 34567
 export const BASE_URL = `http://localhost:${TEST_PORT}`
+export const SELF_HOSTED_SITE_URL = BASE_URL

--- a/e2e/tests/self-hosted-config.spec.ts
+++ b/e2e/tests/self-hosted-config.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '../fixtures'
+import { SELF_HOSTED_HANDLER_ID, SELF_HOSTED_INSTANCE_NAME, SELF_HOSTED_SITE_URL, TEST_APP_PUBLIC_KEY } from '../test-config'
+import { filterByTag, getTagValue, queryRelayEvents } from '../utils/relay-query'
+
+test.describe('self-hosted instance configuration', () => {
+	test('discovers custom settings and renders configured branding', async ({ unauthenticatedPage, request }) => {
+		const configResponse = await request.get('/api/config')
+		expect(configResponse.ok()).toBeTruthy()
+		const config = await configResponse.json()
+
+		expect(config.handlerId).toBe(SELF_HOSTED_HANDLER_ID)
+		expect(config.name).toBe(SELF_HOSTED_INSTANCE_NAME)
+		expect(config.displayName).toBe(SELF_HOSTED_INSTANCE_NAME)
+		expect(config.siteUrl).toBe(SELF_HOSTED_SITE_URL)
+		expect(config.appRelay).toBe('ws://localhost:10547')
+		expect(config.publicRelays).toEqual(['ws://localhost:10547'])
+		expect(config.trustedMints).toEqual(['https://mint.example.invalid'])
+		expect(config.supportContact).toBe('support@self-hosted.example.invalid')
+
+		await unauthenticatedPage.goto('/')
+		await expect(unauthenticatedPage).toHaveTitle(SELF_HOSTED_INSTANCE_NAME)
+		await expect(unauthenticatedPage.locator('header img').first()).toHaveAttribute('alt', `${SELF_HOSTED_INSTANCE_NAME}`)
+		await expect(unauthenticatedPage.locator('link[rel~="icon"]').first()).toHaveAttribute(
+			'href',
+			'https://example.invalid/self-hosted-logo.svg',
+		)
+		await expect(unauthenticatedPage.getByText(`${SELF_HOSTED_INSTANCE_NAME}: Powered by Nostr.`)).toBeVisible()
+		await expect(unauthenticatedPage.getByRole('link', { name: 'Support' })).toHaveAttribute(
+			'href',
+			'mailto:support@self-hosted.example.invalid',
+		)
+		await expect(unauthenticatedPage.getByRole('link', { name: 'Terms' })).toHaveAttribute('href', `${SELF_HOSTED_SITE_URL}/terms`)
+	})
+
+	test('keeps the legacy d-tag available as the fallback candidate', async () => {
+		const events = await queryRelayEvents({
+			authors: [TEST_APP_PUBLIC_KEY],
+			kinds: [31990],
+			'#d': [SELF_HOSTED_HANDLER_ID, 'plebeian-market-handler'],
+		})
+		const customEvents = filterByTag(events, 'd', SELF_HOSTED_HANDLER_ID)
+		const legacyEvents = filterByTag(events, 'd', 'plebeian-market-handler')
+
+		expect(customEvents.length).toBeGreaterThan(0)
+		expect(legacyEvents.length).toBeGreaterThan(0)
+
+		const customEvent = customEvents.sort((a, b) => b.created_at - a.created_at)[0]
+		expect(customEvent.kind).toBe(31990)
+		expect(customEvent.pubkey).toBe(TEST_APP_PUBLIC_KEY)
+		expect(getTagValue(customEvent, 'd')).toBe(SELF_HOSTED_HANDLER_ID)
+		expect(customEvent.tags).toContainEqual(['web', `${SELF_HOSTED_SITE_URL}/product/<bech32>`, 'naddr'])
+		expect(customEvent.tags).toContainEqual(['web', `${SELF_HOSTED_SITE_URL}/collection/<bech32>`, 'naddr'])
+		expect(getTagValue(customEvent, 'r')).toBe('ws://localhost:10547')
+
+		const content = JSON.parse(customEvent.content) as Record<string, unknown>
+		expect(content.name).toBe(SELF_HOSTED_INSTANCE_NAME)
+		expect(content.handlerId).toBe(SELF_HOSTED_HANDLER_ID)
+		expect(content.publicRelays).toEqual(['ws://localhost:10547'])
+	})
+})

--- a/src/components/ProfileWalletCheck.tsx
+++ b/src/components/ProfileWalletCheck.tsx
@@ -2,12 +2,15 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Spinner } from '@/components/ui/spinner'
 import { authStore } from '@/lib/stores/auth'
 import { useProfile } from '@/queries/profiles'
+import { useConfigQuery } from '@/queries/config'
 import { useStore } from '@tanstack/react-store'
 import { CheckCircle2Icon, InfoIcon } from 'lucide-react'
 
 export function ProfileWalletCheck() {
 	const authState = useStore(authStore)
 	const { data, isPending, fetchStatus } = useProfile(authState.user?.pubkey)
+	const { data: config } = useConfigQuery()
+	const instanceName = config?.displayName || config?.name || 'Marketplace'
 	const profile = data?.profile ?? null
 
 	if (isPending && fetchStatus === 'fetching') {
@@ -70,7 +73,7 @@ export function ProfileWalletCheck() {
 			<CardContent className="space-y-3">
 				<div className="text-sm text-amber-800 space-y-2">
 					<p>
-						Your Nostr profile doesn't have a Lightning address (lud16) configured. To receive payments on Plebeian Market, you'll need to
+						Your Nostr profile doesn't have a Lightning address (lud16) configured. To receive payments on {instanceName}, you'll need to
 						set up a Bitcoin wallet.
 					</p>
 					<p>
@@ -79,7 +82,7 @@ export function ProfileWalletCheck() {
 					</p>
 					<ul className="list-disc list-inside space-y-1 ml-2">
 						<li>Add it to your Nostr profile so it works everywhere</li>
-						<li>Add it here specifically for Plebeian Market</li>
+						<li>Add it here specifically for {instanceName}</li>
 					</ul>
 				</div>
 			</CardContent>

--- a/src/components/auth/NostrConnectQR.tsx
+++ b/src/components/auth/NostrConnectQR.tsx
@@ -110,10 +110,10 @@ export function NostrConnectQR({ onError, onSuccess }: NostrConnectQRProps) {
 		params.set(
 			'metadata',
 			JSON.stringify({
-				name: 'Plebeian.market',
-				description: 'Connect with Plebeian.market',
-				url: window.location.origin,
-				icons: [],
+				name: config.displayName || config.name,
+				description: `Connect with ${config.displayName || config.name}`,
+				url: config.siteUrl || window.location.origin,
+				icons: config.picture ? [config.picture] : [],
 			}),
 		)
 		params.set('token', tempSecret)

--- a/src/components/dialogs/TermsConditionsDialog.tsx
+++ b/src/components/dialogs/TermsConditionsDialog.tsx
@@ -1,6 +1,7 @@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { useConfigQuery } from '@/queries/config'
 
 export const TERMS_ACCEPTED_KEY = 'plebeian_terms_accepted'
 
@@ -11,6 +12,9 @@ interface TermsConditionsDialogProps {
 }
 
 export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsConditionsDialogProps) {
+	const { data: config } = useConfigQuery()
+	const instanceName = config?.displayName || config?.name || 'Marketplace'
+
 	const handleAccept = () => {
 		localStorage.setItem(TERMS_ACCEPTED_KEY, 'true')
 		onAccept()
@@ -26,7 +30,7 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 			>
 				<DialogHeader>
 					<DialogTitle>Terms and Conditions</DialogTitle>
-					<DialogDescription>Please read and accept our terms and conditions to continue using Plebeian Market.</DialogDescription>
+					<DialogDescription>Please read and accept our terms and conditions to continue using {instanceName}.</DialogDescription>
 				</DialogHeader>
 
 				<div className="h-[50vh] overflow-hidden">
@@ -36,7 +40,7 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 								<h3 className="font-semibold text-base">User Friendly Summary</h3>
 								<ul className="list-disc pl-5 space-y-1 text-muted-foreground">
 									<li>
-										This Plebeian.Market "Instance" runs on nostr, uses open source software, and follows the laws of England and Wales.
+										This {instanceName} "Instance" runs on nostr, uses open source software, and follows the laws of England and Wales.
 									</li>
 									<li>
 										Do not list anything illegal, dangerous, or NSFW (for example: drugs, weapons, explicit adult content, counterfeit or
@@ -54,11 +58,11 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 							<section className="space-y-2">
 								<h3 className="font-semibold text-base">1. Introduction</h3>
 								<p className="text-muted-foreground">
-									Plebeian.Market is an independent marketplace "Instance" operating on the nostr protocol using the Plebeian App open
-									source solution and is governed by the laws of England and Wales.
+									{instanceName} is an independent marketplace "Instance" operating on the nostr protocol using an open source solution and
+									is governed by the laws of England and Wales.
 								</p>
 								<p className="text-muted-foreground">
-									By accessing, registering with, or using Plebeian.Market (the "Instance"), you agree to be bound by these Terms and
+									By accessing, registering with, or using {instanceName} (the "Instance"), you agree to be bound by these Terms and
 									Conditions.
 								</p>
 								<p className="text-muted-foreground">
@@ -98,8 +102,8 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 							<section className="space-y-2">
 								<h3 className="font-semibold text-base">4. Peer-to-Peer Nature and User Responsibility</h3>
 								<p className="text-muted-foreground">
-									Plebeian.Market operates as a peer-to-peer platform. The Instance does not act as an agent, broker, guarantor, or
-									fiduciary for any user or transaction.
+									{instanceName} operates as a peer-to-peer platform. The Instance does not act as an agent, broker, guarantor, or fiduciary
+									for any user or transaction.
 								</p>
 								<p className="text-muted-foreground">
 									There is no dedicated customer service or dispute resolution department. All questions, issues, and disputes must be
@@ -133,7 +137,7 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 							<section className="space-y-2">
 								<h3 className="font-semibold text-base">7. Amendments to These Terms</h3>
 								<p className="text-muted-foreground">
-									Plebeian.Market may amend or update these Terms from time to time. Continued use of the Instance after any amendment
+									{instanceName} may amend or update these Terms from time to time. Continued use of the Instance after any amendment
 									constitutes acceptance of the updated Terms.
 								</p>
 							</section>
@@ -141,7 +145,7 @@ export function TermsConditionsDialog({ open, onOpenChange, onAccept }: TermsCon
 							<section className="space-y-2">
 								<h3 className="font-semibold text-base">8. Acknowledgement and Acceptance</h3>
 								<p className="text-muted-foreground">
-									By creating an account, adding products, or otherwise using Plebeian.Market, you confirm that you have read and understood
+									By creating an account, adding products, or otherwise using {instanceName}, you confirm that you have read and understood
 									these Terms and agree to be legally bound by them in full.
 								</p>
 							</section>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,56 +1,82 @@
+import { useConfigQuery } from '@/queries/config'
+
 export function Footer() {
+	const { data: config } = useConfigQuery()
+	const supportContact = config?.supportContact || config?.contactEmail
+	const socialLinks = config?.socialLinks
+
 	return (
 		<footer className="sticky top-0 bg-black p-4 font-bold text-white lg:px-12 flex justify-center">
 			<div className="container flex justify-between items-center flex-col gap-4 md:gap-0 md:flex-row">
 				<div className="flex gap-4 flex-col md:flex-row items-center">
-					<span>Plug into the bitcoin economy. Powered by Nostr.</span>
+					<span>{config?.displayName || config?.name || 'Marketplace'}: Powered by Nostr.</span>
 					<div className="flex gap-4">
 						<a className="underline" href="/faqs">
 							FAQ
 						</a>
+						{config?.termsUrl && (
+							<a className="underline" href={config.termsUrl} target="_blank" rel="noopener noreferrer">
+								Terms
+							</a>
+						)}
+						{supportContact && (
+							<a className="underline" href={`mailto:${supportContact}`}>
+								Support
+							</a>
+						)}
 					</div>
 				</div>
 				<div className="text-right flex justify-between items-center gap-6">
-					<a
-						className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
-						href="https://njump.me/npub1market6g3zl4mxwx5ugw56hfg0f7dy7jnnw8t380788mvdyrnwuqgep7hd"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img src="/images/ostrich.svg" alt="Ostrich" className="h-6 w-6" />
-					</a>
-					<a
-						href="https://twitter.com/PlebeianMarket"
-						className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img src="/images/x.svg" alt="X" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
-					</a>
-					<a
-						className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
-						href="https://plebeianmarket.substack.com/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img src="/images/substack-icon.svg" alt="Substack" className="h-6 w-6" style={{ filter: 'brightness(0) invert(1)' }} />
-					</a>
-					<a
-						className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
-						href="https://t.me/PlebeianMarket"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img src="/images/telegram.svg" alt="Telegram" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
-					</a>
-					<a
-						className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
-						href="https://github.com/PlebeianApp/market"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<img src="/images/github.svg" alt="GitHub" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
-					</a>
+					{socialLinks?.nostr && (
+						<a
+							className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
+							href={socialLinks.nostr}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src="/images/ostrich.svg" alt="Ostrich" className="h-6 w-6" />
+						</a>
+					)}
+					{socialLinks?.twitter && (
+						<a
+							href={socialLinks.twitter}
+							className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src="/images/x.svg" alt="X" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
+						</a>
+					)}
+					{socialLinks?.newsletter && (
+						<a
+							className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
+							href={socialLinks.newsletter}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src="/images/substack-icon.svg" alt="Substack" className="h-6 w-6" style={{ filter: 'brightness(0) invert(1)' }} />
+						</a>
+					)}
+					{socialLinks?.telegram && (
+						<a
+							className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
+							href={socialLinks.telegram}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src="/images/telegram.svg" alt="Telegram" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
+						</a>
+					)}
+					{socialLinks?.github && (
+						<a
+							className="border-none hover:bg-secondary p-1 inline-flex justify-center items-center"
+							href={socialLinks.github}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src="/images/github.svg" alt="GitHub" className="h-6 w-6" style={{ filter: 'invert(1)' }} />
+						</a>
+					)}
 				</div>
 			</div>
 		</footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -312,9 +312,7 @@ export function Header() {
 			<div className="flex justify-between items-center py-4 max-w-full h-full container">
 				<section className="inline-flex items-center">
 					<Link to="/" data-testid="home-link">
-						{config?.appSettings?.picture && (
-							<img src={config.appSettings.picture} alt={config.appSettings.displayName} className="px-2 w-16" />
-						)}
+						{config?.picture && <img src={config.picture} alt={config.displayName || config.name} className="px-2 w-16" />}
 					</Link>
 					<div className="hidden sm:flex gap-8 mx-8">
 						<Link

--- a/src/components/sheet-contents/products/ProductWelcomeScreen.tsx
+++ b/src/components/sheet-contents/products/ProductWelcomeScreen.tsx
@@ -1,17 +1,21 @@
 import { Button } from '@/components/ui/button'
+import { useConfigQuery } from '@/queries/config'
 
 export function ProductWelcomeScreen({ onGetStarted }: { onGetStarted: () => void }) {
+	const { data: config } = useConfigQuery()
+	const instanceName = config?.displayName || config?.name || 'Marketplace'
+
 	return (
 		<div className="flex flex-col h-full justify-between items-center px-4 pb-12">
 			{/* Spacer */}
 			<div />
 			<div className="flex flex-col justify-center items-center gap-4">
 				<div className="flex justify-center mt-8">
-					<img src="/images/logo.svg" alt="Plebeian Market Logo" className="w-16 h-16" />
+					<img src={config?.picture} alt={`${instanceName} logo`} className="w-16 h-16" />
 				</div>
 
 				<h1 className="text-2xl font-heading text-balance text-center">WELCOME TO</h1>
-				<h1 className="text-2xl font-heading text-balance text-center">PLEBEIAN MARKET</h1>
+				<h1 className="text-2xl font-heading text-balance text-center">{instanceName.toUpperCase()}</h1>
 				<h2 className="text-xl font-mono text-balance text-center text-gray-600">
 					Start selling your products
 					<br />

--- a/src/components/sheet-contents/products/index.tsx
+++ b/src/components/sheet-contents/products/index.tsx
@@ -4,6 +4,7 @@ import type { ProductFormState, ProductFormTab } from '@/lib/stores/product'
 import { DEFAULT_FORM_STATE, productFormActions, productFormStore } from '@/lib/stores/product'
 import { resolveProductWorkflow, type V4VSetupState } from '@/lib/workflow/productWorkflowResolver'
 import { useV4VConfiguration } from '@/queries/v4v'
+import { useConfigQuery } from '@/queries/config'
 import { useStore } from '@tanstack/react-store'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ProductFormContent } from './ProductFormContent'
@@ -31,6 +32,8 @@ export function NewProductContent({
 	const { user, isAuthenticated } = useStore(authStore)
 	const userPubkey = user?.pubkey ?? ''
 	const v4vQuery = useV4VConfiguration(userPubkey)
+	const { data: config } = useConfigQuery()
+	const instanceName = config?.displayName || config?.name || 'Marketplace'
 
 	const v4vState = useMemo<V4VSetupState>(() => {
 		if (editingProductId) return 'unknown'
@@ -130,7 +133,7 @@ export function NewProductContent({
 			<SheetContent side="right" className="p-6">
 				{/* This is for Accessibility but we don't need to show it */}
 				<SheetHeader className="hidden">
-					<SheetTitle>Welcome to Plebeian Market</SheetTitle>
+					<SheetTitle>Welcome to {instanceName}</SheetTitle>
 					<SheetDescription>Start selling your products in just a few minutes</SheetDescription>
 				</SheetHeader>
 				<ProductWelcomeScreen onGetStarted={() => setShowForm(true)} />

--- a/src/lib/__tests__/appSettings.test.ts
+++ b/src/lib/__tests__/appSettings.test.ts
@@ -37,7 +37,7 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 	test('returns the latest event matching the expected author, kind, and d tag', () => {
 		const events = [mockEvent({ created_at: 50 }), mockEvent({ created_at: 100 })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeDefined()
 		expect(result?.pubkey).toBe(APP_PUBKEY)
@@ -45,10 +45,33 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 		expect(result?.created_at).toBe(100)
 	})
 
+	test('fallback d-tag chain: tries custom handler first, then plebeian default', () => {
+		const customEvent = mockEvent({ tags: [['d', 'custom-handler']], created_at: 50 })
+		const defaultEvent = mockEvent({ tags: [['d', 'plebeian-market-handler']], created_at: 100 })
+
+		// With both present, prefers the one matching the first d-tag in the chain
+		const result = selectAuthoritativeAppSettingsEvent([customEvent, defaultEvent], APP_PUBKEY, [
+			'custom-handler',
+			'plebeian-market-handler',
+		])
+
+		expect(result?.tags).toContainEqual(['d', 'custom-handler'])
+		expect(result?.created_at).toBe(50)
+	})
+
+	test('fallback d-tag chain: uses plebeian default if custom not found', () => {
+		const defaultEvent = mockEvent({ tags: [['d', 'plebeian-market-handler']] })
+
+		const result = selectAuthoritativeAppSettingsEvent([defaultEvent], APP_PUBKEY, ['custom-handler', 'plebeian-market-handler'])
+
+		expect(result).toBeDefined()
+		expect(result?.tags).toContainEqual(['d', 'plebeian-market-handler'])
+	})
+
 	test('rejects an event from a different publisher (spoofed author)', () => {
 		const events = [mockEvent({ pubkey: SPOOF_PUBKEY, created_at: 999, content: '{"name":"evil"}' })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeUndefined()
 	})
@@ -56,7 +79,7 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 	test('rejects an event with the wrong kind', () => {
 		const events = [mockEvent({ kind: 30000 })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeUndefined()
 	})
@@ -64,7 +87,7 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 	test('rejects an event with a different d tag', () => {
 		const events = [mockEvent({ tags: [['d', 'some-other-handler']] })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeUndefined()
 	})
@@ -72,13 +95,13 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 	test('rejects an event with no d tag at all', () => {
 		const events = [mockEvent({ tags: [] })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeUndefined()
 	})
 
 	test('returns undefined for an empty event list', () => {
-		const result = selectAuthoritativeAppSettingsEvent([], APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent([], APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeUndefined()
 	})
@@ -89,7 +112,7 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 			mockEvent({ created_at: 50, content: '{"name":"real"}' }),
 		]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result).toBeDefined()
 		expect(result?.pubkey).toBe(APP_PUBKEY)
@@ -100,7 +123,7 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 	test('selects the newest among multiple valid events from the same publisher', () => {
 		const events = [mockEvent({ created_at: 10 }), mockEvent({ created_at: 200 }), mockEvent({ created_at: 100 })]
 
-		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY)
+		const result = selectAuthoritativeAppSettingsEvent(events, APP_PUBKEY, ['plebeian-market-handler'])
 
 		expect(result?.created_at).toBe(200)
 	})
@@ -108,13 +131,13 @@ describe('selectAuthoritativeAppSettingsEvent', () => {
 
 describe('resolveFetchedAppSettings', () => {
 	test('returns null only when a completed query returned no candidate events', () => {
-		expect(resolveFetchedAppSettings([], APP_PUBKEY)).toBeNull()
+		expect(resolveFetchedAppSettings([], APP_PUBKEY, ['plebeian-market-handler'])).toBeNull()
 	})
 
 	test('returns validated settings from the authoritative event', () => {
 		const event = mockEvent({ content: JSON.stringify(VALID_SETTINGS) })
 
-		expect(resolveFetchedAppSettings([event], APP_PUBKEY)).toEqual(VALID_SETTINGS)
+		expect(resolveFetchedAppSettings([event], APP_PUBKEY, ['plebeian-market-handler'])).toEqual(VALID_SETTINGS)
 	})
 
 	test('fails closed when returned candidates contain no authoritative event', () => {
@@ -123,19 +146,21 @@ describe('resolveFetchedAppSettings', () => {
 			content: JSON.stringify(VALID_SETTINGS),
 		})
 
-		expect(() => resolveFetchedAppSettings([spoofed], APP_PUBKEY)).toThrow(/No authoritative app settings event/)
+		expect(() => resolveFetchedAppSettings([spoofed], APP_PUBKEY, ['plebeian-market-handler'])).toThrow(
+			/No authoritative app settings event/,
+		)
 	})
 
 	test('fails closed on malformed authoritative JSON', () => {
 		const event = mockEvent({ content: '{not-json' })
 
-		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY)).toThrow(/invalid JSON/)
+		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY, ['plebeian-market-handler'])).toThrow(/invalid JSON/)
 	})
 
 	test('fails closed when authoritative settings fail schema validation', () => {
 		const event = mockEvent({ content: JSON.stringify({ name: 'incomplete' }) })
 
-		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY)).toThrow(/schema validation/)
+		expect(() => resolveFetchedAppSettings([event], APP_PUBKEY, ['plebeian-market-handler'])).toThrow(/schema validation/)
 	})
 })
 

--- a/src/lib/__tests__/instance-config.test.ts
+++ b/src/lib/__tests__/instance-config.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test'
+import { DEFAULT_INSTANCE_CONFIG, parseInstanceConfigEnvironment, resolveInstanceConfig } from '@/lib/instance-config'
+import { AppSettingsSchema } from '@/lib/schemas/app'
+
+const existingSettings = {
+	name: 'Existing Market',
+	displayName: 'Existing Market',
+	picture: 'https://example.com/logo.png',
+	banner: 'https://example.com/banner.png',
+	ownerPk: 'a'.repeat(64),
+	allowRegister: true,
+	defaultCurrency: 'USD',
+}
+
+describe('AppSettingsSchema instance fields', () => {
+	test('keeps existing settings events valid', () => {
+		expect(AppSettingsSchema.parse(existingSettings)).toMatchObject(existingSettings)
+	})
+
+	test('accepts supported service URL protocols', () => {
+		const result = AppSettingsSchema.parse({
+			...existingSettings,
+			siteUrl: 'https://market.example.com',
+			publicRelays: ['wss://relay.example.com', 'ws://localhost:10547'],
+			trustedMints: ['https://mint.example.com'],
+			bugRelay: 'wss://bugs.example.com',
+			termsUrl: 'https://market.example.com/terms',
+		})
+
+		expect(result.publicRelays).toHaveLength(2)
+	})
+
+	test('rejects protocols that do not match the service type', () => {
+		expect(() => AppSettingsSchema.parse({ ...existingSettings, publicRelays: ['https://relay.example.com'] })).toThrow()
+		expect(() => AppSettingsSchema.parse({ ...existingSettings, termsUrl: 'ftp://market.example.com/terms' })).toThrow()
+	})
+})
+
+describe('resolveInstanceConfig', () => {
+	test('uses event values before environment and defaults', () => {
+		const appSettings = AppSettingsSchema.parse({
+			...existingSettings,
+			siteUrl: 'https://event.example.com',
+			publicRelays: ['wss://event-relay.example.com'],
+		})
+
+		const result = resolveInstanceConfig(appSettings, {
+			name: 'Environment Market',
+			siteUrl: 'https://environment.example.com',
+			publicRelays: ['wss://environment-relay.example.com'],
+			termsUrl: 'https://environment.example.com/terms',
+		})
+
+		expect(result.name).toBe('Existing Market')
+		expect(result.siteUrl).toBe('https://event.example.com')
+		expect(result.publicRelays).toEqual(['wss://event-relay.example.com'])
+		expect(result.termsUrl).toBe('https://environment.example.com/terms')
+		expect(result.handlerId).toBe(DEFAULT_INSTANCE_CONFIG.handlerId)
+	})
+
+	test('uses environment values before defaults when settings are absent', () => {
+		const result = resolveInstanceConfig(null, {
+			name: 'Environment Market',
+			siteUrl: 'https://environment.example.com',
+		})
+
+		expect(result.name).toBe('Environment Market')
+		expect(result.siteUrl).toBe('https://environment.example.com')
+		expect(result.displayName).toBe(DEFAULT_INSTANCE_CONFIG.displayName)
+	})
+
+	test('replaces arrays and social links instead of merging them', () => {
+		const appSettings = AppSettingsSchema.parse({
+			...existingSettings,
+			publicRelays: ['wss://event-relay.example.com'],
+			socialLinks: { github: 'https://github.com/example/market' },
+		})
+
+		const result = resolveInstanceConfig(appSettings, {
+			publicRelays: ['wss://environment-relay.example.com'],
+			socialLinks: { twitter: 'https://twitter.com/example' },
+		})
+
+		expect(result.publicRelays).toEqual(['wss://event-relay.example.com'])
+		expect(result.socialLinks).toEqual({ github: 'https://github.com/example/market' })
+	})
+
+	test('falls back to defaults when an old-format settings event and an empty environment both omit a field', () => {
+		// Regression test: parseInstanceConfigEnvironment always emits every key
+		// (undefined when the env var is unset), and an app-settings event
+		// published before this field existed also omits it. Neither source
+		// should be able to clobber DEFAULT_INSTANCE_CONFIG with `undefined`.
+		const appSettings = AppSettingsSchema.parse(existingSettings)
+		const result = resolveInstanceConfig(appSettings, parseInstanceConfigEnvironment({}))
+
+		expect(result.publicRelays).toEqual(DEFAULT_INSTANCE_CONFIG.publicRelays)
+		expect(result.trustedMints).toEqual(DEFAULT_INSTANCE_CONFIG.trustedMints)
+		expect(result.socialLinks).toEqual(DEFAULT_INSTANCE_CONFIG.socialLinks)
+		expect(result.bugRelay).toBe(DEFAULT_INSTANCE_CONFIG.bugRelay)
+	})
+
+	test('returns copies of mutable defaults', () => {
+		const first = resolveInstanceConfig(null)
+		first.publicRelays.push('wss://mutated.example.com')
+		first.socialLinks.github = 'https://github.com/mutated/market'
+
+		const second = resolveInstanceConfig(null)
+		expect(second.publicRelays).toEqual(DEFAULT_INSTANCE_CONFIG.publicRelays)
+		expect(second.socialLinks).toEqual(DEFAULT_INSTANCE_CONFIG.socialLinks)
+	})
+})
+
+describe('parseInstanceConfigEnvironment', () => {
+	test('parses optional booleans, lists, and social links', () => {
+		const result = parseInstanceConfigEnvironment({
+			INSTANCE_ALLOW_REGISTER: 'false',
+			INSTANCE_PUBLIC_RELAYS: 'wss://one.example.com, ws://localhost:10547',
+			INSTANCE_TRUSTED_MINTS: 'https://mint.example.com',
+			INSTANCE_GITHUB_URL: 'https://github.com/example/market',
+		})
+
+		expect(result.allowRegister).toBe(false)
+		expect(result.publicRelays).toEqual(['wss://one.example.com', 'ws://localhost:10547'])
+		expect(result.trustedMints).toEqual(['https://mint.example.com'])
+		expect(result.socialLinks).toEqual({ github: 'https://github.com/example/market' })
+	})
+
+	test('rejects malformed environment values', () => {
+		expect(() => parseInstanceConfigEnvironment({ INSTANCE_ALLOW_REGISTER: 'yes' })).toThrow()
+		expect(() => parseInstanceConfigEnvironment({ INSTANCE_PUBLIC_RELAYS: 'https://relay.example.com' })).toThrow()
+		expect(() => parseInstanceConfigEnvironment({ INSTANCE_SITE_URL: 'ftp://market.example.com' })).toThrow()
+	})
+})

--- a/src/lib/__tests__/instance-config.test.ts
+++ b/src/lib/__tests__/instance-config.test.ts
@@ -178,4 +178,18 @@ describe('runtime-config-aware handler metadata', () => {
 		expect(event.tags).toContainEqual(['d', DEFAULT_INSTANCE_CONFIG.handlerId])
 		expect(event.tags).toContainEqual(['web', `${DEFAULT_INSTANCE_CONFIG.siteUrl}/product/<bech32>`, 'naddr'])
 	})
+
+	test('uses explicit handler metadata from the instance configuration form', () => {
+		const event = createHandlerInfoEventData(
+			'd'.repeat(64),
+			{ ok: true },
+			'wss://relay.selfhost.example',
+			'selfhost-handler',
+			'https://selfhost.example',
+		)
+
+		expect(event.tags).toContainEqual(['d', 'selfhost-handler'])
+		expect(event.tags).toContainEqual(['r', 'wss://relay.selfhost.example'])
+		expect(event.tags).toContainEqual(['web', 'https://selfhost.example/product/<bech32>', 'naddr'])
+	})
 })

--- a/src/lib/__tests__/instance-config.test.ts
+++ b/src/lib/__tests__/instance-config.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 import { DEFAULT_INSTANCE_CONFIG, parseInstanceConfigEnvironment, resolveInstanceConfig } from '@/lib/instance-config'
 import { AppSettingsSchema } from '@/lib/schemas/app'
+import { configActions, configStore } from '@/lib/stores/config'
+import { createHandlerInfoEventData, createClientTag } from '@/publish/nip89'
 
 const existingSettings = {
 	name: 'Existing Market',
@@ -129,5 +131,51 @@ describe('parseInstanceConfigEnvironment', () => {
 		expect(() => parseInstanceConfigEnvironment({ INSTANCE_ALLOW_REGISTER: 'yes' })).toThrow()
 		expect(() => parseInstanceConfigEnvironment({ INSTANCE_PUBLIC_RELAYS: 'https://relay.example.com' })).toThrow()
 		expect(() => parseInstanceConfigEnvironment({ INSTANCE_SITE_URL: 'ftp://market.example.com' })).toThrow()
+	})
+})
+
+describe('runtime-config-aware handler metadata', () => {
+	test('uses config overrides for host, relay, and handler ID when present', () => {
+		configActions.setConfig({
+			appRelay: 'wss://selfhost.example',
+			siteUrl: 'https://selfhost.example',
+			handlerId: 'custom-handler',
+			appSettings: null,
+			appPublicKey: 'a'.repeat(64),
+			stage: 'production',
+			needsSetup: false,
+			serverReady: true,
+			name: 'Self Host',
+			displayName: 'Self Host',
+			picture: 'https://selfhost.example/logo.png',
+			banner: 'https://selfhost.example/banner.png',
+			allowRegister: true,
+			defaultCurrency: 'USD',
+			showNostrLink: false,
+			publicRelays: ['wss://selfhost.example'],
+			trustedMints: ['https://mint.selfhost.example'],
+			bugRelay: 'wss://bugs.selfhost.example',
+			socialLinks: { github: 'https://github.com/selfhost' },
+		} as any)
+
+		const event = createHandlerInfoEventData('b'.repeat(64), { ok: true })
+		expect(event.tags).toContainEqual(['d', 'custom-handler'])
+		expect(event.tags).toContainEqual(['web', 'https://selfhost.example/product/<bech32>', 'naddr'])
+		expect(event.tags).toContainEqual(['web', 'https://selfhost.example/collection/<bech32>', 'naddr'])
+		const appPubkey = 'b'.repeat(64)
+		expect(createClientTag(appPubkey, 'custom-handler')).toEqual([
+			'client',
+			'Plebeian Market',
+			`31990:${appPubkey}:custom-handler`,
+			'wss://selfhost.example',
+		])
+	})
+
+	test('falls back to the shipped Plebeian defaults when config is absent', () => {
+		configStore.setState((state) => ({ ...state, config: {} }))
+
+		const event = createHandlerInfoEventData('c'.repeat(64), { ok: true })
+		expect(event.tags).toContainEqual(['d', DEFAULT_INSTANCE_CONFIG.handlerId])
+		expect(event.tags).toContainEqual(['web', `${DEFAULT_INSTANCE_CONFIG.siteUrl}/product/<bech32>`, 'naddr'])
 	})
 })

--- a/src/lib/__tests__/instance-config.test.ts
+++ b/src/lib/__tests__/instance-config.test.ts
@@ -165,7 +165,7 @@ describe('runtime-config-aware handler metadata', () => {
 		const appPubkey = 'b'.repeat(64)
 		expect(createClientTag(appPubkey, 'custom-handler')).toEqual([
 			'client',
-			'Plebeian Market',
+			'Self Host',
 			`31990:${appPubkey}:custom-handler`,
 			'wss://selfhost.example',
 		])

--- a/src/lib/__tests__/relay-policy.test.ts
+++ b/src/lib/__tests__/relay-policy.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test'
+import { computeNdkConfig, resolveExplicitRelays, resolveMainRelay, resolveZapRelays } from '@/lib/relay-policy'
+import { DEFAULT_PUBLIC_RELAYS, ZAP_RELAYS } from '@/lib/constants'
+
+describe('resolveMainRelay', () => {
+	test('uses appRelay when provided', () => {
+		const result = resolveMainRelay('production', 'wss://custom.example.com')
+		expect(result).toBe('wss://custom.example.com')
+	})
+
+	test('falls back to stage-based main relay when appRelay is absent', () => {
+		expect(resolveMainRelay('production')).toBe('wss://relay.plebeian.market')
+		expect(resolveMainRelay('staging')).toBe('wss://relay.staging.plebeian.market')
+		expect(resolveMainRelay('development')).toBe('ws://localhost:10547')
+	})
+
+	test('returns undefined when stage is undefined', () => {
+		const result = resolveMainRelay(undefined)
+		expect(result).toBeUndefined()
+	})
+})
+
+describe('resolveExplicitRelays', () => {
+	test('self-hosted: uses provided publicRelays for production', () => {
+		const result = resolveExplicitRelays({
+			stage: 'production',
+			mainRelay: 'wss://selfhost.example',
+			publicRelays: ['wss://relay1.selfhost.example', 'wss://relay2.selfhost.example'],
+		})
+		expect(result).toContain('wss://selfhost.example')
+		expect(result).toContain('wss://relay1.selfhost.example')
+		expect(result).toContain('wss://relay2.selfhost.example')
+	})
+
+	test('falls back to DEFAULT_PUBLIC_RELAYS when publicRelays not provided', () => {
+		const result = resolveExplicitRelays({
+			stage: 'production',
+			mainRelay: 'wss://relay.plebeian.market',
+		})
+		expect(result).toContain('wss://relay.plebeian.market')
+		DEFAULT_PUBLIC_RELAYS.forEach((relay) => {
+			expect(result).toContain(relay)
+		})
+	})
+
+	test('dev/staging uses main relay only regardless of publicRelays', () => {
+		const result = resolveExplicitRelays({
+			stage: 'development',
+			mainRelay: 'ws://localhost:10547',
+			publicRelays: ['wss://relay1.example.com', 'wss://relay2.example.com'],
+		})
+		expect(result).toEqual(['ws://localhost:10547'])
+	})
+
+	test('localRelayOnly uses main relay only', () => {
+		const result = resolveExplicitRelays({
+			stage: 'production',
+			mainRelay: 'ws://localhost:10547',
+			publicRelays: ['wss://relay1.example.com'],
+			localRelayOnly: true,
+		})
+		expect(result).toEqual(['ws://localhost:10547'])
+	})
+})
+
+describe('resolveZapRelays', () => {
+	test('self-hosted: uses provided zapRelays plus explicit relays', () => {
+		const selfHostedZapRelays = ['wss://zap1.selfhost.example', 'wss://zap2.selfhost.example']
+		const result = resolveZapRelays(['wss://main.example.com', 'wss://public.example.com'], selfHostedZapRelays)
+		expect(result).toContain('wss://zap1.selfhost.example')
+		expect(result).toContain('wss://zap2.selfhost.example')
+		expect(result).toContain('wss://main.example.com')
+		expect(result).toContain('wss://public.example.com')
+	})
+
+	test('falls back to ZAP_RELAYS when zapRelays not provided', () => {
+		const result = resolveZapRelays(['wss://main.relay.com'])
+		expect(result).toContain('wss://main.relay.com')
+		ZAP_RELAYS.forEach((relay) => {
+			expect(result).toContain(relay)
+		})
+	})
+
+	test('deduplicates relays', () => {
+		const result = resolveZapRelays(['wss://relay.damus.io', 'wss://relay.damus.io'])
+		const damusCount = result.filter((r) => r === 'wss://relay.damus.io').length
+		expect(damusCount).toBe(1)
+	})
+})
+
+describe('computeNdkConfig', () => {
+	test('self-hosted production: includes main + custom publicRelays', () => {
+		const config = computeNdkConfig({
+			stage: 'production',
+			appRelay: 'wss://selfhost.example',
+			publicRelays: ['wss://relay1.selfhost.example', 'wss://relay2.selfhost.example'],
+			zapRelays: ['wss://zap.selfhost.example'],
+		})
+
+		expect(config.explicitRelayUrls).toContain('wss://selfhost.example')
+		expect(config.explicitRelayUrls).toContain('wss://relay1.selfhost.example')
+		expect(config.explicitRelayUrls).toContain('wss://relay2.selfhost.example')
+		expect(config.writeRelayUrls).toEqual(config.explicitRelayUrls) // prod: all relays
+		expect(config.enableOutbox).toBe(true)
+	})
+
+	test('plebeian production: includes main + DEFAULT_PUBLIC_RELAYS', () => {
+		const config = computeNdkConfig({
+			stage: 'production',
+			appRelay: 'wss://relay.plebeian.market',
+		})
+
+		expect(config.explicitRelayUrls).toContain('wss://relay.plebeian.market')
+		DEFAULT_PUBLIC_RELAYS.forEach((relay) => {
+			expect(config.explicitRelayUrls).toContain(relay)
+		})
+	})
+
+	test('staging restricts writes to main relay only', () => {
+		const config = computeNdkConfig({
+			stage: 'staging',
+			appRelay: 'wss://relay.staging.plebeian.market',
+			publicRelays: ['wss://public1.example.com', 'wss://public2.example.com'],
+		})
+
+		expect(config.writeRelayUrls).toEqual(['wss://relay.staging.plebeian.market'])
+		expect(config.enableOutbox).toBe(false)
+	})
+
+	test('development restricts writes to main relay only', () => {
+		const config = computeNdkConfig({
+			stage: 'development',
+			appRelay: 'ws://localhost:10547',
+		})
+
+		expect(config.writeRelayUrls).toEqual(['ws://localhost:10547'])
+		expect(config.enableOutbox).toBe(false)
+	})
+})

--- a/src/lib/appSettings.ts
+++ b/src/lib/appSettings.ts
@@ -22,21 +22,31 @@ export interface AppSettingsEventLike {
 
 /**
  * Select the latest app-settings event that matches the expected publisher
- * authority: the event must be kind 31990, authored by `appPubkey`, and carry
- * the exact d tag 'plebeian-market-handler'. Events from any other publisher
- * (or with a different kind / d tag) are rejected — the content schema
- * validates shape, not authority, so a spoofed event that passes the schema
- * must still be refused here.
+ * authority. The event must be kind 31990, authored by `appPubkey`, and carry
+ * one of the provided d tags in priority order (tries first tag first, etc.).
+ * Events from any other publisher (or with a different kind / d tag) are
+ * rejected — the content schema validates shape, not authority, so a spoofed
+ * event that passes the schema must still be refused here.
+ *
+ * Fallback chain example: ['custom-handler', 'plebeian-market-handler']
+ *   - First tries events with d=custom-handler (self-hosted)
+ *   - Falls back to d=plebeian-market-handler (shipped default)
  */
 export function selectAuthoritativeAppSettingsEvent(
 	events: ReadonlyArray<AppSettingsEventLike>,
 	appPubkey: string,
+	handlerIds: string[] = [APP_SETTINGS_D_TAG],
 ): AppSettingsEventLike | undefined {
-	return events
-		.filter(
-			(e) => e.kind === APP_SETTINGS_KIND && e.pubkey === appPubkey && e.tags.some((t) => t[0] === 'd' && t[1] === APP_SETTINGS_D_TAG),
-		)
-		.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
+	// Try each handler ID in priority order
+	for (const handlerId of handlerIds) {
+		const candidate = events
+			.filter((e) => e.kind === APP_SETTINGS_KIND && e.pubkey === appPubkey && e.tags.some((t) => t[0] === 'd' && t[1] === handlerId))
+			.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]
+
+		if (candidate) return candidate
+	}
+
+	return undefined
 }
 
 /**
@@ -44,11 +54,19 @@ export function selectAuthoritativeAppSettingsEvent(
  *
  * `null` means the authoritative query completed and returned no candidate
  * events. Returned-but-unusable state is indeterminate and fails closed.
+ *
+ * @param events - Candidate events from the relay
+ * @param appPubkey - Expected publisher public key
+ * @param handlerIds - d-tag fallback chain: tries first, then second, etc.
  */
-export function resolveFetchedAppSettings(events: ReadonlyArray<AppSettingsEventLike>, appPubkey: string): AppSettings | null {
+export function resolveFetchedAppSettings(
+	events: ReadonlyArray<AppSettingsEventLike>,
+	appPubkey: string,
+	handlerIds: string[] = [APP_SETTINGS_D_TAG],
+): AppSettings | null {
 	if (events.length === 0) return null
 
-	const authoritativeEvent = selectAuthoritativeAppSettingsEvent(events, appPubkey)
+	const authoritativeEvent = selectAuthoritativeAppSettingsEvent(events, appPubkey, handlerIds)
 	if (!authoritativeEvent) {
 		throw new Error(`No authoritative app settings event from expected publisher: ${appPubkey}`)
 	}
@@ -68,8 +86,9 @@ export function resolveFetchedAppSettings(events: ReadonlyArray<AppSettingsEvent
 	return result.data
 }
 
-export async function fetchAppSettings(relayUrl: string, appPubkey: string): Promise<AppSettings | null> {
-	console.log(`Fetching app settings from relay: ${relayUrl} for pubkey: ${appPubkey}`)
+export async function fetchAppSettings(relayUrl: string, appPubkey: string, handlerIds?: string[]): Promise<AppSettings | null> {
+	const effectiveHandlerIds = handlerIds?.length ? handlerIds : [APP_SETTINGS_D_TAG]
+	console.log(`Fetching app settings from relay: ${relayUrl} for pubkey: ${appPubkey} with handler IDs: ${effectiveHandlerIds.join(', ')}`)
 
 	// Reject a malformed app pubkey before creating an NDK instance or issuing
 	// any relay request. NDK's strict filter validation would also fail closed,
@@ -108,12 +127,12 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 		}
 
 		// NIP-33 parameterized replaceable events (kind 31990) are indexed by pubkey+kind+d tag.
-		// Include the d tag filter for better relay compatibility
+		// Query for all handler IDs in the fallback chain in a single filter.
 		const filter: NDKFilter = {
 			kinds: [31990],
 			authors: [appPubkey],
-			'#d': ['plebeian-market-handler'],
-			limit: 1,
+			'#d': effectiveHandlerIds,
+			limit: effectiveHandlerIds.length, // Allow fetching multiple events to evaluate priority
 		}
 
 		console.log('Fetching with filter:', JSON.stringify(filter))
@@ -139,7 +158,7 @@ export async function fetchAppSettings(relayUrl: string, appPubkey: string): Pro
 			console.log(`No app settings events found for pubkey: ${appPubkey}`)
 		}
 
-		return resolveFetchedAppSettings(eventArray, appPubkey)
+		return resolveFetchedAppSettings(eventArray, appPubkey, effectiveHandlerIds)
 	} catch (err) {
 		console.error('Failed to fetch app settings:', err)
 		throw err

--- a/src/lib/instance-config.ts
+++ b/src/lib/instance-config.ts
@@ -1,0 +1,178 @@
+import { z } from 'zod'
+import { BUG_RELAY, DEFAULT_PUBLIC_RELAYS, DEFAULT_TRUSTED_MINTS, type Stage } from './constants'
+import { RelayUrlSchema, SocialLinksSchema, WebUrlSchema, type AppSettings, type SocialLinks } from './schemas/app'
+
+export interface InstanceConfig {
+	name: string
+	displayName: string
+	picture: string
+	banner: string
+	ownerPk?: string
+	allowRegister: boolean
+	defaultCurrency: string
+	contactEmail?: string
+	blossomServer?: string
+	nip96Server?: string
+	showNostrLink: boolean
+	handlerId: string
+	siteUrl: string
+	publicRelays: string[]
+	trustedMints: string[]
+	bugRelay: string
+	termsUrl?: string
+	socialLinks: SocialLinks
+	supportContact?: string
+}
+
+export type InstanceConfigEnvironment = Partial<InstanceConfig>
+
+export interface PublicAppConfig extends InstanceConfig {
+	appRelay: string
+	stage: Stage
+	nip46Relay: string
+	appSettings: AppSettings | null
+	appPublicKey: string
+	cvmServerPubkey?: string
+	needsSetup: boolean
+	serverReady: boolean
+	externalZapRelaysEnabled: boolean
+}
+
+const InstanceConfigEnvironmentSchema = z.object({
+	name: z.string().min(1).optional(),
+	displayName: z.string().min(1).optional(),
+	picture: WebUrlSchema.optional(),
+	banner: WebUrlSchema.optional(),
+	ownerPk: z
+		.string()
+		.regex(/^[0-9a-fA-F]{64}$/)
+		.optional(),
+	allowRegister: z.boolean().optional(),
+	defaultCurrency: z.string().min(1).optional(),
+	contactEmail: z.string().min(1).optional(),
+	blossomServer: WebUrlSchema.optional(),
+	nip96Server: WebUrlSchema.optional(),
+	showNostrLink: z.boolean().optional(),
+	handlerId: z.string().min(1).optional(),
+	siteUrl: WebUrlSchema.optional(),
+	publicRelays: z.array(RelayUrlSchema).optional(),
+	trustedMints: z.array(WebUrlSchema).optional(),
+	bugRelay: RelayUrlSchema.optional(),
+	termsUrl: WebUrlSchema.optional(),
+	socialLinks: SocialLinksSchema.optional(),
+	supportContact: z.string().min(1).optional(),
+})
+
+export const DEFAULT_INSTANCE_CONFIG: InstanceConfig = {
+	name: 'Plebeian Market',
+	displayName: 'Plebeian Market',
+	picture: 'https://plebeian.market/images/logo.svg',
+	banner: 'https://plebeian.market/banner.png',
+	allowRegister: true,
+	defaultCurrency: 'USD',
+	showNostrLink: false,
+	handlerId: 'plebeian-market-handler',
+	siteUrl: 'https://plebeian.market',
+	publicRelays: [...DEFAULT_PUBLIC_RELAYS],
+	trustedMints: [...DEFAULT_TRUSTED_MINTS],
+	bugRelay: BUG_RELAY,
+	socialLinks: {
+		twitter: 'https://twitter.com/PlebeianMarket',
+		newsletter: 'https://plebeianmarket.substack.com/',
+		telegram: 'https://t.me/PlebeianMarket',
+		github: 'https://github.com/PlebeianApp/market',
+	},
+}
+
+function defined<T>(value: T | null | undefined): value is T {
+	return value !== undefined && value !== null
+}
+
+function optionalList(value: string | undefined): string[] | undefined {
+	if (!value?.trim()) return undefined
+	return value
+		.split(',')
+		.map((item) => item.trim())
+		.filter(Boolean)
+}
+
+function optionalBoolean(value: string | undefined): boolean | undefined {
+	if (!value?.trim()) return undefined
+	if (value === 'true') return true
+	if (value === 'false') return false
+	throw new Error(`Expected "true" or "false", received "${value}"`)
+}
+
+export function parseInstanceConfigEnvironment(environment: Record<string, string | undefined>): InstanceConfigEnvironment {
+	const socialLinks = {
+		twitter: environment.INSTANCE_TWITTER_URL,
+		newsletter: environment.INSTANCE_NEWSLETTER_URL,
+		telegram: environment.INSTANCE_TELEGRAM_URL,
+		github: environment.INSTANCE_GITHUB_URL,
+	}
+	const hasSocialLinks = Object.values(socialLinks).some(defined)
+
+	return InstanceConfigEnvironmentSchema.parse({
+		name: environment.INSTANCE_NAME,
+		displayName: environment.INSTANCE_DISPLAY_NAME,
+		picture: environment.INSTANCE_PICTURE_URL,
+		banner: environment.INSTANCE_BANNER_URL,
+		ownerPk: environment.INSTANCE_OWNER_PUBKEY,
+		allowRegister: optionalBoolean(environment.INSTANCE_ALLOW_REGISTER),
+		defaultCurrency: environment.INSTANCE_DEFAULT_CURRENCY,
+		contactEmail: environment.INSTANCE_CONTACT_EMAIL,
+		blossomServer: environment.BLOSSOM_SERVER,
+		nip96Server: environment.NIP96_SERVER,
+		showNostrLink: optionalBoolean(environment.INSTANCE_SHOW_NOSTR_LINK),
+		handlerId: environment.INSTANCE_HANDLER_ID,
+		siteUrl: environment.INSTANCE_SITE_URL,
+		publicRelays: optionalList(environment.INSTANCE_PUBLIC_RELAYS),
+		trustedMints: optionalList(environment.INSTANCE_TRUSTED_MINTS),
+		bugRelay: environment.INSTANCE_BUG_RELAY,
+		termsUrl: environment.INSTANCE_TERMS_URL,
+		socialLinks: hasSocialLinks ? socialLinks : undefined,
+		supportContact: environment.INSTANCE_SUPPORT_CONTACT,
+	})
+}
+
+export function resolveInstanceConfig(appSettings: AppSettings | null, environment: InstanceConfigEnvironment = {}): InstanceConfig {
+	const validatedEnvironment = InstanceConfigEnvironmentSchema.parse(environment)
+	const eventValues: Partial<InstanceConfig> = appSettings
+		? {
+				name: appSettings.name,
+				displayName: appSettings.displayName,
+				picture: appSettings.picture,
+				banner: appSettings.banner,
+				ownerPk: appSettings.ownerPk,
+				allowRegister: appSettings.allowRegister,
+				defaultCurrency: appSettings.defaultCurrency,
+				contactEmail: appSettings.contactEmail,
+				blossomServer: appSettings.blossom_server,
+				nip96Server: appSettings.nip96_server,
+				showNostrLink: appSettings.showNostrLink,
+				handlerId: appSettings.handlerId,
+				siteUrl: appSettings.siteUrl,
+				publicRelays: appSettings.publicRelays,
+				trustedMints: appSettings.trustedMints,
+				bugRelay: appSettings.bugRelay,
+				termsUrl: appSettings.termsUrl,
+				socialLinks: appSettings.socialLinks,
+				supportContact: appSettings.supportContact,
+			}
+		: {}
+
+	const resolved = { ...DEFAULT_INSTANCE_CONFIG }
+	for (const [key, value] of Object.entries(validatedEnvironment)) {
+		if (defined(value)) Object.assign(resolved, { [key]: value })
+	}
+	for (const [key, value] of Object.entries(eventValues)) {
+		if (defined(value)) Object.assign(resolved, { [key]: value })
+	}
+
+	return {
+		...resolved,
+		publicRelays: [...resolved.publicRelays],
+		trustedMints: [...resolved.trustedMints],
+		socialLinks: { ...resolved.socialLinks },
+	}
+}

--- a/src/lib/instance-config.ts
+++ b/src/lib/instance-config.ts
@@ -81,6 +81,7 @@ export const DEFAULT_INSTANCE_CONFIG: InstanceConfig = {
 		newsletter: 'https://plebeianmarket.substack.com/',
 		telegram: 'https://t.me/PlebeianMarket',
 		github: 'https://github.com/PlebeianApp/market',
+		nostr: 'https://njump.me/npub1market6g3zl4mxwx5ugw56hfg0f7dy7jnnw8t380788mvdyrnwuqgep7hd',
 	},
 }
 
@@ -109,6 +110,7 @@ export function parseInstanceConfigEnvironment(environment: Record<string, strin
 		newsletter: environment.INSTANCE_NEWSLETTER_URL,
 		telegram: environment.INSTANCE_TELEGRAM_URL,
 		github: environment.INSTANCE_GITHUB_URL,
+		nostr: environment.INSTANCE_NOSTR_URL,
 	}
 	const hasSocialLinks = Object.values(socialLinks).some(defined)
 

--- a/src/lib/relay-policy.ts
+++ b/src/lib/relay-policy.ts
@@ -43,6 +43,10 @@ export interface ComputeNdkConfigInput {
 	stage: Stage | undefined
 	/** Server-provided app relay from `/api/config` (preferred over stage defaults). */
 	appRelay?: string
+	/** Runtime-provided public relays for reads (e.g., from instance config). Falls back to DEFAULT_PUBLIC_RELAYS. */
+	publicRelays?: string[]
+	/** Runtime-provided zap relays for zap monitoring (e.g., from instance config). Falls back to ZAP_RELAYS. */
+	zapRelays?: string[]
 	/** Caller-supplied relay overrides (used during NDK re-init / tests). */
 	overrideRelays?: string[]
 	/** Bun-side flag forcing local-relay-only behavior. */
@@ -66,12 +70,18 @@ export function resolveMainRelay(stage: Stage | undefined, appRelay?: string): s
  * always computed together at NDK init time.
  */
 export function computeNdkConfig(input: ComputeNdkConfigInput): NdkConfigComputed {
-	const { stage, appRelay, overrideRelays, localRelayOnly } = input
+	const { stage, appRelay, publicRelays, zapRelays, overrideRelays, localRelayOnly } = input
 	const mainRelay = resolveMainRelay(stage, appRelay)
 
 	const enableOutbox = stage !== 'staging' && stage !== 'development' && !localRelayOnly
 
-	const explicitRelayUrls = resolveExplicitRelays({ stage, mainRelay, overrideRelays, localRelayOnly })
+	const explicitRelayUrls = resolveExplicitRelays({
+		stage,
+		mainRelay,
+		publicRelays,
+		overrideRelays,
+		localRelayOnly,
+	})
 	const writeRelayUrls =
 		stage === 'staging' || stage === 'development' || localRelayOnly ? (mainRelay ? [mainRelay] : []) : explicitRelayUrls
 
@@ -86,10 +96,11 @@ export function computeNdkConfig(input: ComputeNdkConfigInput): NdkConfigCompute
 export function resolveExplicitRelays(input: {
 	stage: Stage | undefined
 	mainRelay: string | undefined
+	publicRelays?: string[]
 	overrideRelays?: string[]
 	localRelayOnly?: boolean
 }): string[] {
-	const { stage, mainRelay, overrideRelays, localRelayOnly } = input
+	const { stage, mainRelay, publicRelays, overrideRelays, localRelayOnly } = input
 
 	// Stage-locked: development & local-only mode use the main relay only.
 	// AUCTIONS.md §11.0.1: dev/staging events MUST NOT reach public relays.
@@ -105,7 +116,9 @@ export function resolveExplicitRelays(input: {
 	}
 
 	// Default (production browser): main relay + the public read set.
-	const relays = mainRelay ? [mainRelay, ...DEFAULT_PUBLIC_RELAYS] : DEFAULT_PUBLIC_RELAYS
+	// Use runtime publicRelays if provided (self-hosted instance), else fall back to DEFAULT_PUBLIC_RELAYS.
+	const effectivePublicRelays = publicRelays ?? DEFAULT_PUBLIC_RELAYS
+	const relays = mainRelay ? [mainRelay, ...effectivePublicRelays] : effectivePublicRelays
 	return Array.from(new Set(relays))
 }
 
@@ -114,6 +127,7 @@ export function resolveExplicitRelays(input: {
  * receipts to their own public relays, not to ours. Always returns
  * the union of ZAP_RELAYS + whatever the main read set is.
  */
-export function resolveZapRelays(explicitRelays: string[]): string[] {
-	return Array.from(new Set([...ZAP_RELAYS, ...explicitRelays]))
+export function resolveZapRelays(explicitRelays: string[], zapRelays?: string[]): string[] {
+	const effectiveZapRelays = zapRelays ?? ZAP_RELAYS
+	return Array.from(new Set([...effectiveZapRelays, ...explicitRelays]))
 }

--- a/src/lib/schemas/app.ts
+++ b/src/lib/schemas/app.ts
@@ -14,6 +14,7 @@ export const SocialLinksSchema = z.object({
 	newsletter: WebUrlSchema.optional(),
 	telegram: WebUrlSchema.optional(),
 	github: WebUrlSchema.optional(),
+	nostr: WebUrlSchema.optional(),
 })
 
 export const AppSettingsSchema = z.object({

--- a/src/lib/schemas/app.ts
+++ b/src/lib/schemas/app.ts
@@ -1,5 +1,21 @@
 import { z } from 'zod'
 
+export const WebUrlSchema = z
+	.string()
+	.url()
+	.refine((value) => ['http:', 'https:'].includes(new URL(value).protocol), 'Must use HTTP or HTTPS')
+export const RelayUrlSchema = z
+	.string()
+	.url()
+	.refine((value) => ['ws:', 'wss:'].includes(new URL(value).protocol), 'Must use WS or WSS')
+
+export const SocialLinksSchema = z.object({
+	twitter: WebUrlSchema.optional(),
+	newsletter: WebUrlSchema.optional(),
+	telegram: WebUrlSchema.optional(),
+	github: WebUrlSchema.optional(),
+})
+
 export const AppSettingsSchema = z.object({
 	name: z.string(),
 	displayName: z.string(),
@@ -15,6 +31,14 @@ export const AppSettingsSchema = z.object({
 	blossom_server: z.string().url().optional(),
 	nip96_server: z.string().url().optional(),
 	showNostrLink: z.boolean().optional().default(false),
+	handlerId: z.string().min(1).optional(),
+	siteUrl: WebUrlSchema.optional(),
+	publicRelays: z.array(RelayUrlSchema).optional(),
+	trustedMints: z.array(WebUrlSchema).optional(),
+	bugRelay: RelayUrlSchema.optional(),
+	termsUrl: WebUrlSchema.optional(),
+	socialLinks: SocialLinksSchema.optional(),
+	supportContact: z.string().min(1).optional(),
 })
 
 export const ExtendedSettingsSchema = z.object({
@@ -22,4 +46,5 @@ export const ExtendedSettingsSchema = z.object({
 })
 
 export type AppSettings = z.infer<typeof AppSettingsSchema>
+export type SocialLinks = z.infer<typeof SocialLinksSchema>
 export type ExtendedSettings = z.infer<typeof ExtendedSettingsSchema>

--- a/src/lib/stores/config.ts
+++ b/src/lib/stores/config.ts
@@ -1,16 +1,9 @@
 import { Store } from '@tanstack/store'
+import type { PublicAppConfig } from '@/lib/instance-config'
 import type { Stage } from '@/lib/constants'
 
 interface ConfigState {
-	config: {
-		appRelay?: string
-		stage?: Stage
-		appSettings?: any
-		appPublicKey?: string
-		cvmServerPubkey?: string
-		needsSetup?: boolean
-		[key: string]: any
-	}
+	config: Partial<PublicAppConfig>
 	isLoaded: boolean
 }
 
@@ -22,7 +15,7 @@ const initialState: ConfigState = {
 export const configStore = new Store<ConfigState>(initialState)
 
 export const configActions = {
-	setConfig: (config: any) => {
+	setConfig: (config: PublicAppConfig) => {
 		configStore.setState((state) => ({
 			...state,
 			config,

--- a/src/lib/stores/ndk.ts
+++ b/src/lib/stores/ndk.ts
@@ -413,6 +413,8 @@ export const ndkActions = {
 		const { explicitRelayUrls, writeRelayUrls, enableOutbox } = computeNdkConfig({
 			stage,
 			appRelay: configStore.state.config.appRelay,
+			publicRelays: configStore.state.config.publicRelays,
+			zapRelays: configStore.state.config.publicRelays, // Use same set for zaps; can be overridden per-instance
 			overrideRelays: relays,
 			localRelayOnly: isBunLocalRelayOnly(),
 		})
@@ -442,7 +444,9 @@ export const ndkActions = {
 		// and sends it to the browser — one decision point, no client/server
 		// drift. When disabled (staging, CI/E2E), don't create a zap NDK at all.
 		const externalZapRelaysEnabled = configStore.state.config.externalZapRelaysEnabled !== false
-		const zapNdk = externalZapRelaysEnabled ? new NDK({ explicitRelayUrls: resolveZapRelays(explicitRelayUrls) }) : null
+		const zapNdk = externalZapRelaysEnabled
+			? new NDK({ explicitRelayUrls: resolveZapRelays(explicitRelayUrls, configStore.state.config.publicRelays) })
+			: null
 
 		ndkStore.setState((s) => ({ ...s, ndk, zapNdk, explicitRelayUrls, writeRelayUrls }))
 

--- a/src/publish/nip89.ts
+++ b/src/publish/nip89.ts
@@ -150,5 +150,6 @@ export const publishHandlerInfo = async (
 export const createClientTag = (appPubkey: string, handlerId: string, relayUrl?: string): [string, string, string, string] => {
 	const effectiveRelayUrl = relayUrl || configStore.state.config.appRelay || PLEBEIAN_MARKET_RELAY
 	const effectiveHandlerId = handlerId || configStore.state.config.handlerId || DEFAULT_INSTANCE_CONFIG.handlerId
-	return ['client', 'Plebeian Market', `31990:${appPubkey}:${effectiveHandlerId}`, effectiveRelayUrl]
+	const effectiveName = configStore.state.config.displayName || configStore.state.config.name || DEFAULT_INSTANCE_CONFIG.displayName
+	return ['client', effectiveName, `31990:${appPubkey}:${effectiveHandlerId}`, effectiveRelayUrl]
 }

--- a/src/publish/nip89.ts
+++ b/src/publish/nip89.ts
@@ -84,6 +84,7 @@ export const createHandlerInfoEventData = (
 	appSettings: Record<string, unknown>,
 	relayUrl?: string,
 	handlerId?: string,
+	siteUrl?: string,
 ): {
 	kind: number
 	created_at: number
@@ -91,7 +92,7 @@ export const createHandlerInfoEventData = (
 	content: string
 	pubkey: string
 } => {
-	const { effectiveHandlerId, effectiveSiteUrl, effectiveRelayUrl } = resolveHandlerMetadata(handlerId, relayUrl)
+	const { effectiveHandlerId, effectiveSiteUrl, effectiveRelayUrl } = resolveHandlerMetadata(handlerId, relayUrl, siteUrl)
 
 	const tags: string[][] = [
 		['d', effectiveHandlerId],

--- a/src/publish/nip89.ts
+++ b/src/publish/nip89.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_INSTANCE_CONFIG } from '@/lib/instance-config'
+import { configStore } from '@/lib/stores/config'
 import { ndkActions } from '@/lib/stores/ndk'
 import NDK, { NDKEvent, type NDKSigner } from '@nostr-dev-kit/ndk'
 
@@ -12,6 +14,23 @@ export const COLLECTION_KIND = 30405
 
 export const PLEBEIAN_MARKET_URL = 'https://plebeian.market'
 export const PLEBEIAN_MARKET_RELAY = 'wss://relay.plebeian.market'
+
+/**
+ * Resolve runtime metadata for a published handler event. The runtime config
+ * is authoritative when it is available; the shipped Plebeian URLs remain as
+ * the compatibility fallback so existing setups keep working without env vars.
+ */
+function resolveHandlerMetadata(handlerId?: string, relayUrl?: string, siteUrl?: string) {
+	const config = configStore.state.config
+	const effectiveSiteUrl = siteUrl || config.siteUrl || PLEBEIAN_MARKET_URL
+	const effectiveHandlerId = handlerId || config.handlerId || DEFAULT_INSTANCE_CONFIG.handlerId
+	const effectiveRelayUrl = relayUrl || config.appRelay || PLEBEIAN_MARKET_RELAY
+	return {
+		effectiveSiteUrl,
+		effectiveHandlerId,
+		effectiveRelayUrl,
+	}
+}
 
 /**
  * Creates a handler information event (kind 31990) for Plebeian Market
@@ -36,22 +55,21 @@ export const createHandlerInfoEvent = (
 		event.content = ''
 	}
 
-	// Generate a unique ID for this handler
-	const id = handlerId || crypto.randomUUID()
+	const { effectiveHandlerId, effectiveSiteUrl } = resolveHandlerMetadata(handlerId)
 
 	// Tags for the handler info event
 	event.tags = [
-		['d', id], // Handler identifier
+		['d', effectiveHandlerId], // Handler identifier
 		['k', PRODUCT_KIND.toString()], // Supports product listings (kind 30402)
 		['k', COLLECTION_KIND.toString()], // Supports collections (kind 30405)
 
 		// URL patterns for handling products (kind 30402)
 		// <bech32> will be replaced by clients with the actual NIP-19 encoded entity
-		['web', `${PLEBEIAN_MARKET_URL}/product/<bech32>`, 'naddr'],
-		['web', `${PLEBEIAN_MARKET_URL}/a/<bech32>`, 'naddr'], // Alternative pattern
+		['web', `${effectiveSiteUrl}/product/<bech32>`, 'naddr'],
+		['web', `${effectiveSiteUrl}/a/<bech32>`, 'naddr'], // Alternative pattern
 
 		// URL patterns for handling collections (kind 30405)
-		['web', `${PLEBEIAN_MARKET_URL}/collection/<bech32>`, 'naddr'],
+		['web', `${effectiveSiteUrl}/collection/<bech32>`, 'naddr'],
 	]
 
 	return event
@@ -73,20 +91,19 @@ export const createHandlerInfoEventData = (
 	content: string
 	pubkey: string
 } => {
-	const id = handlerId || crypto.randomUUID()
+	const { effectiveHandlerId, effectiveSiteUrl, effectiveRelayUrl } = resolveHandlerMetadata(handlerId, relayUrl)
 
 	const tags: string[][] = [
-		['d', id],
+		['d', effectiveHandlerId],
 		['k', PRODUCT_KIND.toString()],
 		['k', COLLECTION_KIND.toString()],
-		['web', `${PLEBEIAN_MARKET_URL}/product/<bech32>`, 'naddr'],
-		['web', `${PLEBEIAN_MARKET_URL}/a/<bech32>`, 'naddr'],
-		['web', `${PLEBEIAN_MARKET_URL}/collection/<bech32>`, 'naddr'],
+		['web', `${effectiveSiteUrl}/product/<bech32>`, 'naddr'],
+		['web', `${effectiveSiteUrl}/a/<bech32>`, 'naddr'],
+		['web', `${effectiveSiteUrl}/collection/<bech32>`, 'naddr'],
 	]
 
-	// Add relay if provided
-	if (relayUrl) {
-		tags.push(['r', relayUrl])
+	if (effectiveRelayUrl) {
+		tags.push(['r', effectiveRelayUrl])
 	}
 
 	return {
@@ -129,6 +146,8 @@ export const publishHandlerInfo = async (
  * @param handlerId - The handler identifier (d tag value) from the handler info event
  * @returns A client tag array
  */
-export const createClientTag = (appPubkey: string, handlerId: string): [string, string, string, string] => {
-	return ['client', 'Plebeian Market', `31990:${appPubkey}:${handlerId}`, PLEBEIAN_MARKET_RELAY]
+export const createClientTag = (appPubkey: string, handlerId: string, relayUrl?: string): [string, string, string, string] => {
+	const effectiveRelayUrl = relayUrl || configStore.state.config.appRelay || PLEBEIAN_MARKET_RELAY
+	const effectiveHandlerId = handlerId || configStore.state.config.handlerId || DEFAULT_INSTANCE_CONFIG.handlerId
+	return ['client', 'Plebeian Market', `31990:${appPubkey}:${effectiveHandlerId}`, effectiveRelayUrl]
 }

--- a/src/publish/wallet.tsx
+++ b/src/publish/wallet.tsx
@@ -1,4 +1,5 @@
 import { ndkActions } from '../lib/stores/ndk'
+import { configStore } from '../lib/stores/config'
 import { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
@@ -45,6 +46,7 @@ export const saveUserNwcWallets = async (params: SaveUserNwcWalletsParams): Prom
 	})
 	const content = JSON.stringify(walletsToStore)
 	const encryptedContent = await signer.encrypt(user, content)
+	const instanceName = configStore.state.config.displayName || configStore.state.config.name || 'Plebeian Market'
 
 	const event = new NDKEvent(ndk)
 	event.kind = USER_NWC_WALLET_LIST_KIND
@@ -52,7 +54,7 @@ export const saveUserNwcWallets = async (params: SaveUserNwcWalletsParams): Prom
 	event.content = encryptedContent
 	event.tags = [
 		['l', USER_NWC_WALLET_LIST_LABEL],
-		['client', 'plebeian.market'],
+		['client', instanceName],
 	]
 
 	await event.sign(signer)

--- a/src/queries/config.tsx
+++ b/src/queries/config.tsx
@@ -1,26 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
 import { configKeys } from './queryKeyFactory'
-import type { AppSettings } from '../lib/schemas/app'
+import type { PublicAppConfig } from '@/lib/instance-config'
 import { configActions } from '@/lib/stores/config'
 
-interface Config {
-	appRelay: string
-	nip46Relay: string
-	appSettings: AppSettings | null
-	appPublicKey: string
-	cvmServerPubkey?: string
-	needsSetup: boolean
-	serverReady: boolean
-}
+let cachedConfig: PublicAppConfig | null = null
 
-let cachedConfig: Config | null = null
-
-const fetchConfig = async (): Promise<Config> => {
+const fetchConfig = async (): Promise<PublicAppConfig> => {
 	const response = await fetch('/api/config')
 	if (!response.ok) {
 		throw new Error(`Failed to fetch config: ${response.status} ${response.statusText}`)
 	}
-	const config: Config = await response.json()
+	const config: PublicAppConfig = await response.json()
 	console.log('Fetched config:', config)
 	cachedConfig = config
 	configActions.setConfig(config)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -73,6 +73,20 @@ function RootLayout() {
 	}, [hasPII, scanResult])
 
 	useEffect(() => {
+		const instanceName = config?.displayName || config?.name
+		if (instanceName) {
+			document.title = instanceName
+		}
+
+		if (config?.picture) {
+			const iconLinks = document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"], link[rel="apple-touch-icon"]')
+			iconLinks.forEach((link) => {
+				link.href = config.picture as string
+			})
+		}
+	}, [config?.displayName, config?.name, config?.picture])
+
+	useEffect(() => {
 		if (config?.needsSetup && !isSetupPage) {
 			navigate({ to: '/setup' })
 		} else if (!config?.needsSetup && isSetupPage) {

--- a/src/routes/_dashboard-layout/dashboard/about.tsx
+++ b/src/routes/_dashboard-layout/dashboard/about.tsx
@@ -114,11 +114,32 @@ function CopyableField({ label, value, icon: Icon }: { label: string; value: str
 	)
 }
 
-function useGitHubContributors() {
+function getGitHubRepository(url?: string) {
+	if (!url) return null
+
+	try {
+		const parsedUrl = new URL(url)
+		if (parsedUrl.hostname !== 'github.com') return null
+
+		const [owner, repository] = parsedUrl.pathname.split('/').filter(Boolean)
+		if (!owner || !repository) return null
+
+		return { owner, repository: repository.replace(/\.git$/, '') }
+	} catch {
+		return null
+	}
+}
+
+function useGitHubContributors(repositoryUrl?: string) {
+	const repository = getGitHubRepository(repositoryUrl)
+
 	return useQuery({
-		queryKey: ['github-contributors'],
+		queryKey: ['github-contributors', repositoryUrl],
+		enabled: !!repository,
 		queryFn: async (): Promise<GitHubContributor[]> => {
-			const response = await fetch('https://api.github.com/repos/PlebeianApp/market/contributors')
+			if (!repository) return []
+
+			const response = await fetch(`https://api.github.com/repos/${repository.owner}/${repository.repository}/contributors`)
 			if (!response.ok) throw new Error('Failed to fetch contributors')
 			return response.json()
 		},
@@ -130,14 +151,14 @@ function AboutComponent() {
 	useDashboardTitle('About')
 
 	const { data: config } = useConfigQuery()
-	const { data: contributors, isLoading: contributorsLoading } = useGitHubContributors()
-	const appSettings = config?.appSettings
+	const githubUrl = config?.socialLinks?.github
+	const { data: contributors, isLoading: contributorsLoading } = useGitHubContributors(githubUrl)
 
 	const appPubkey = config?.appPublicKey
 	const appRelay = config?.appRelay
-	const instanceName = appSettings?.displayName || appSettings?.name || 'Plebeian Market'
-	const ownerPubkey = appSettings?.ownerPk
-	const contactEmail = appSettings?.contactEmail
+	const instanceName = config?.displayName || config?.name || 'Marketplace'
+	const ownerPubkey = config?.ownerPk
+	const contactEmail = config?.contactEmail || config?.supportContact
 
 	// Convert pubkeys to npub format for display
 	const appNpub = appPubkey ? nip19.npubEncode(appPubkey) : null
@@ -170,7 +191,7 @@ function AboutComponent() {
 					<Card>
 						<CardHeader>
 							<CardTitle className="text-lg">Instance Information</CardTitle>
-							<CardDescription>Details about this Plebeian Market instance</CardDescription>
+							<CardDescription>Details about this {instanceName} instance</CardDescription>
 						</CardHeader>
 						<CardContent className="space-y-4">
 							<div className="flex items-center gap-3 p-3 border rounded-md bg-muted/50">
@@ -243,32 +264,34 @@ function AboutComponent() {
 						</Card>
 					)}
 
-					{/* About Plebeian Market */}
+					{/* About this instance */}
 					<Card>
 						<CardHeader>
 							<CardTitle className="text-lg flex items-center gap-2">
 								<SiGithub className="w-5 h-5" />
-								About Plebeian Market
+								About {instanceName}
 							</CardTitle>
 						</CardHeader>
 						<CardContent className="space-y-4 text-sm text-muted-foreground">
 							<p>
-								Plebeian Market is a decentralized marketplace built on the Nostr protocol. All data is stored on Nostr relays, giving you
+								{instanceName} is a decentralized marketplace built on the Nostr protocol. All data is stored on Nostr relays, giving you
 								full ownership and control of your data.
 							</p>
-							<a
-								href="https://github.com/PlebeianApp/market"
-								target="_blank"
-								rel="noopener noreferrer"
-								className="flex items-center gap-3 p-3 border rounded-md bg-muted/50 hover:bg-muted transition-colors"
-							>
-								<SiGithub className="w-5 h-5 text-muted-foreground flex-shrink-0" />
-								<div>
-									<p className="text-sm font-medium text-muted-foreground">Repository</p>
-									<p className="font-medium text-blue-600">PlebeianApp/market</p>
-								</div>
-								<ExternalLink className="w-4 h-4 text-muted-foreground ml-auto" />
-							</a>
+							{githubUrl && (
+								<a
+									href={githubUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-3 p-3 border rounded-md bg-muted/50 hover:bg-muted transition-colors"
+								>
+									<SiGithub className="w-5 h-5 text-muted-foreground flex-shrink-0" />
+									<div>
+										<p className="text-sm font-medium text-muted-foreground">Repository</p>
+										<p className="font-medium text-blue-600 break-all">{githubUrl}</p>
+									</div>
+									<ExternalLink className="w-4 h-4 text-muted-foreground ml-auto" />
+								</a>
+							)}
 						</CardContent>
 					</Card>
 
@@ -279,7 +302,7 @@ function AboutComponent() {
 								<User className="w-5 h-5" />
 								Contributors
 							</CardTitle>
-							<CardDescription>People who have contributed to Plebeian Market</CardDescription>
+							<CardDescription>People who have contributed to {instanceName}</CardDescription>
 						</CardHeader>
 						<CardContent>
 							{contributorsLoading ? (

--- a/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
+++ b/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
@@ -3,6 +3,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { CURRENCIES } from '@/lib/constants'
 import { submitAppSettings } from '@/lib/appSettings'
 import { AppSettingsSchema } from '@/lib/schemas/app'
@@ -24,6 +25,26 @@ export const Route = createFileRoute('/_dashboard-layout/dashboard/app-settings/
 	component: AppMiscelleneousComponent,
 })
 
+function parseList(value: string): string[] | undefined {
+	const items = value
+		.split(/[\n,]/)
+		.map((item) => item.trim())
+		.filter(Boolean)
+
+	return items.length > 0 ? items : undefined
+}
+
+function createSocialLinks(value: { twitterUrl: string; newsletterUrl: string; telegramUrl: string; githubUrl: string }) {
+	const socialLinks = {
+		twitter: value.twitterUrl || undefined,
+		newsletter: value.newsletterUrl || undefined,
+		telegram: value.telegramUrl || undefined,
+		github: value.githubUrl || undefined,
+	}
+
+	return Object.values(socialLinks).some(Boolean) ? socialLinks : undefined
+}
+
 function AppMiscelleneousComponent() {
 	useDashboardTitle('App Settings')
 	const { data: config } = useConfigQuery()
@@ -40,6 +61,17 @@ function AppMiscelleneousComponent() {
 			displayName: appSettings?.displayName ?? '',
 			picture: appSettings?.picture ?? '',
 			banner: appSettings?.banner ?? '',
+			handlerId: appSettings?.handlerId ?? config?.handlerId ?? '',
+			siteUrl: appSettings?.siteUrl ?? config?.siteUrl ?? '',
+			publicRelays: (appSettings?.publicRelays ?? config?.publicRelays ?? []).join('\n'),
+			trustedMints: (appSettings?.trustedMints ?? config?.trustedMints ?? []).join('\n'),
+			bugRelay: appSettings?.bugRelay ?? config?.bugRelay ?? '',
+			termsUrl: appSettings?.termsUrl ?? config?.termsUrl ?? '',
+			twitterUrl: appSettings?.socialLinks?.twitter ?? config?.socialLinks?.twitter ?? '',
+			newsletterUrl: appSettings?.socialLinks?.newsletter ?? config?.socialLinks?.newsletter ?? '',
+			telegramUrl: appSettings?.socialLinks?.telegram ?? config?.socialLinks?.telegram ?? '',
+			githubUrl: appSettings?.socialLinks?.github ?? config?.socialLinks?.github ?? '',
+			supportContact: appSettings?.supportContact ?? config?.supportContact ?? '',
 			contactEmail: appSettings?.contactEmail ?? '',
 			defaultCurrency: appSettings?.defaultCurrency ?? CURRENCIES[0],
 			allowRegister: appSettings?.allowRegister ?? true,
@@ -52,12 +84,19 @@ function AppMiscelleneousComponent() {
 				const toValidate = {
 					...value,
 					ownerPk: appSettings?.ownerPk ?? '',
+					publicRelays: parseList(value.publicRelays),
+					trustedMints: parseList(value.trustedMints),
+					socialLinks: createSocialLinks(value),
 					// Strip empty optional URL fields so Zod doesn't fail on ""
 					picture: value.picture || undefined,
 					banner: value.banner || undefined,
+					siteUrl: value.siteUrl || undefined,
+					bugRelay: value.bugRelay || undefined,
+					termsUrl: value.termsUrl || undefined,
 					blossom_server: value.blossom_server || undefined,
 					nip96_server: value.nip96_server || undefined,
 					contactEmail: value.contactEmail || undefined,
+					supportContact: value.supportContact || undefined,
 				}
 				const result = AppSettingsSchema.safeParse(toValidate)
 				if (!result.success) {
@@ -77,17 +116,31 @@ function AppMiscelleneousComponent() {
 			}
 
 			try {
+				const { twitterUrl, newsletterUrl, telegramUrl, githubUrl, publicRelays, trustedMints, ...settingsValue } = value
 				const updatedSettings = {
-					...value,
+					...settingsValue,
 					ownerPk: config.appSettings.ownerPk,
+					publicRelays: parseList(publicRelays),
+					trustedMints: parseList(trustedMints),
+					socialLinks: createSocialLinks(value),
 					// Strip empty strings to undefined for optional URL fields
+					siteUrl: value.siteUrl || undefined,
+					bugRelay: value.bugRelay || undefined,
+					termsUrl: value.termsUrl || undefined,
 					blossom_server: value.blossom_server || undefined,
 					nip96_server: value.nip96_server || undefined,
 					contactEmail: value.contactEmail || undefined,
+					supportContact: value.supportContact || undefined,
 				}
 
-				const handlerId = config.handlerId || 'plebeian-market-handler'
-				let handlerEvent = createHandlerInfoEventData(config.appSettings.ownerPk, updatedSettings, config.appRelay, handlerId)
+				const handlerId = value.handlerId || config.handlerId || 'plebeian-market-handler'
+				let handlerEvent = createHandlerInfoEventData(
+					config.appSettings.ownerPk,
+					updatedSettings,
+					config.appRelay,
+					handlerId,
+					value.siteUrl,
+				)
 				handlerEvent = finalizeEvent(handlerEvent, generateSecretKey())
 				await submitAppSettings(handlerEvent)
 
@@ -357,6 +410,179 @@ function AppMiscelleneousComponent() {
 							</div>
 						)}
 					</form.Field>
+				</div>
+
+				{/* Instance Configuration Section */}
+				<div className="space-y-4 p-4 border rounded-lg">
+					<h3 className="font-semibold text-lg">Instance configuration</h3>
+					<p className="text-muted-foreground text-sm">
+						These values are published in the kind 31990 app-settings event and override the shipped Plebeian defaults.
+					</p>
+
+					<form.Field name="handlerId">
+						{(field) => (
+							<div>
+								<Label className="font-medium" htmlFor={field.name}>
+									Handler ID
+								</Label>
+								<Input
+									id={field.name}
+									className="mt-1 border-2"
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="my-market-handler"
+								/>
+								<p className="mt-1 text-muted-foreground text-xs">The NIP-89 d-tag used to discover this instance.</p>
+							</div>
+						)}
+					</form.Field>
+
+					<form.Field name="siteUrl">
+						{(field) => (
+							<div>
+								<Label className="font-medium" htmlFor={field.name}>
+									Site URL
+								</Label>
+								<Input
+									id={field.name}
+									className="mt-1 border-2"
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="https://market.example.com"
+									type="url"
+								/>
+							</div>
+						)}
+					</form.Field>
+
+					<form.Field name="publicRelays">
+						{(field) => (
+							<div>
+								<Label className="font-medium" htmlFor={field.name}>
+									Public relays
+								</Label>
+								<Textarea
+									id={field.name}
+									className="mt-1 border-2"
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="wss://relay.example.com"
+									rows={3}
+								/>
+								<p className="mt-1 text-muted-foreground text-xs">Enter one ws:// or wss:// relay per line.</p>
+							</div>
+						)}
+					</form.Field>
+
+					<form.Field name="trustedMints">
+						{(field) => (
+							<div>
+								<Label className="font-medium" htmlFor={field.name}>
+									Trusted Cashu mints
+								</Label>
+								<Textarea
+									id={field.name}
+									className="mt-1 border-2"
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="https://mint.example.com"
+									rows={3}
+								/>
+								<p className="mt-1 text-muted-foreground text-xs">Enter one HTTPS mint URL per line.</p>
+							</div>
+						)}
+					</form.Field>
+
+					<div className="gap-4 grid md:grid-cols-2">
+						<form.Field name="bugRelay">
+							{(field) => (
+								<div>
+									<Label className="font-medium" htmlFor={field.name}>
+										Bug report relay
+									</Label>
+									<Input
+										id={field.name}
+										className="mt-1 border-2"
+										value={field.state.value}
+										onChange={(e) => field.handleChange(e.target.value)}
+										onBlur={field.handleBlur}
+										placeholder="wss://bugs.example.com"
+										type="url"
+									/>
+								</div>
+							)}
+						</form.Field>
+
+						<form.Field name="termsUrl">
+							{(field) => (
+								<div>
+									<Label className="font-medium" htmlFor={field.name}>
+										Terms URL
+									</Label>
+									<Input
+										id={field.name}
+										className="mt-1 border-2"
+										value={field.state.value}
+										onChange={(e) => field.handleChange(e.target.value)}
+										onBlur={field.handleBlur}
+										placeholder="https://market.example.com/terms"
+										type="url"
+									/>
+								</div>
+							)}
+						</form.Field>
+					</div>
+
+					<form.Field name="supportContact">
+						{(field) => (
+							<div>
+								<Label className="font-medium" htmlFor={field.name}>
+									Support contact
+								</Label>
+								<Input
+									id={field.name}
+									className="mt-1 border-2"
+									value={field.state.value}
+									onChange={(e) => field.handleChange(e.target.value)}
+									onBlur={field.handleBlur}
+									placeholder="support@market.example.com"
+									type="email"
+								/>
+							</div>
+						)}
+					</form.Field>
+
+					<div className="gap-4 grid md:grid-cols-2">
+						{[
+							['twitterUrl', 'Twitter URL', 'https://twitter.com/example'],
+							['newsletterUrl', 'Newsletter URL', 'https://example.substack.com/'],
+							['telegramUrl', 'Telegram URL', 'https://t.me/example'],
+							['githubUrl', 'GitHub URL', 'https://github.com/example/market'],
+						].map(([name, label, placeholder]) => (
+							<form.Field key={name} name={name as 'twitterUrl' | 'newsletterUrl' | 'telegramUrl' | 'githubUrl'}>
+								{(field) => (
+									<div>
+										<Label className="font-medium" htmlFor={field.name}>
+											{label}
+										</Label>
+										<Input
+											id={field.name}
+											className="mt-1 border-2"
+											value={field.state.value}
+											onChange={(e) => field.handleChange(e.target.value)}
+											onBlur={field.handleBlur}
+											placeholder={placeholder}
+											type="url"
+										/>
+									</div>
+								)}
+							</form.Field>
+						))}
+					</div>
 				</div>
 
 				{/* General Settings Section */}

--- a/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
+++ b/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
@@ -34,12 +34,13 @@ function parseList(value: string): string[] | undefined {
 	return items.length > 0 ? items : undefined
 }
 
-function createSocialLinks(value: { twitterUrl: string; newsletterUrl: string; telegramUrl: string; githubUrl: string }) {
+function createSocialLinks(value: { twitterUrl: string; newsletterUrl: string; telegramUrl: string; githubUrl: string; nostrUrl: string }) {
 	const socialLinks = {
 		twitter: value.twitterUrl || undefined,
 		newsletter: value.newsletterUrl || undefined,
 		telegram: value.telegramUrl || undefined,
 		github: value.githubUrl || undefined,
+		nostr: value.nostrUrl || undefined,
 	}
 
 	return Object.values(socialLinks).some(Boolean) ? socialLinks : undefined
@@ -71,6 +72,7 @@ function AppMiscelleneousComponent() {
 			newsletterUrl: appSettings?.socialLinks?.newsletter ?? config?.socialLinks?.newsletter ?? '',
 			telegramUrl: appSettings?.socialLinks?.telegram ?? config?.socialLinks?.telegram ?? '',
 			githubUrl: appSettings?.socialLinks?.github ?? config?.socialLinks?.github ?? '',
+			nostrUrl: appSettings?.socialLinks?.nostr ?? config?.socialLinks?.nostr ?? '',
 			supportContact: appSettings?.supportContact ?? config?.supportContact ?? '',
 			contactEmail: appSettings?.contactEmail ?? '',
 			defaultCurrency: appSettings?.defaultCurrency ?? CURRENCIES[0],
@@ -116,13 +118,13 @@ function AppMiscelleneousComponent() {
 			}
 
 			try {
-				const { twitterUrl, newsletterUrl, telegramUrl, githubUrl, publicRelays, trustedMints, ...settingsValue } = value
+				const { twitterUrl, newsletterUrl, telegramUrl, githubUrl, nostrUrl, publicRelays, trustedMints, ...settingsValue } = value
 				const updatedSettings = {
 					...settingsValue,
 					ownerPk: config.appSettings.ownerPk,
 					publicRelays: parseList(publicRelays),
 					trustedMints: parseList(trustedMints),
-					socialLinks: createSocialLinks(value),
+					socialLinks: createSocialLinks({ twitterUrl, newsletterUrl, telegramUrl, githubUrl, nostrUrl }),
 					// Strip empty strings to undefined for optional URL fields
 					siteUrl: value.siteUrl || undefined,
 					bugRelay: value.bugRelay || undefined,
@@ -562,8 +564,9 @@ function AppMiscelleneousComponent() {
 							['newsletterUrl', 'Newsletter URL', 'https://example.substack.com/'],
 							['telegramUrl', 'Telegram URL', 'https://t.me/example'],
 							['githubUrl', 'GitHub URL', 'https://github.com/example/market'],
+							['nostrUrl', 'Nostr profile URL', 'https://njump.me/npub1...'],
 						].map(([name, label, placeholder]) => (
-							<form.Field key={name} name={name as 'twitterUrl' | 'newsletterUrl' | 'telegramUrl' | 'githubUrl'}>
+							<form.Field key={name} name={name as 'twitterUrl' | 'newsletterUrl' | 'telegramUrl' | 'githubUrl' | 'nostrUrl'}>
 								{(field) => (
 									<div>
 										<Label className="font-medium" htmlFor={field.name}>

--- a/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
+++ b/src/routes/_dashboard-layout/dashboard/app-settings/app-miscelleneous.tsx
@@ -86,7 +86,7 @@ function AppMiscelleneousComponent() {
 					contactEmail: value.contactEmail || undefined,
 				}
 
-				const handlerId = 'plebeian-market-handler'
+				const handlerId = config.handlerId || 'plebeian-market-handler'
 				let handlerEvent = createHandlerInfoEventData(config.appSettings.ownerPk, updatedSettings, config.appRelay, handlerId)
 				handlerEvent = finalizeEvent(handlerEvent, generateSecretKey())
 				await submitAppSettings(handlerEvent)

--- a/src/routes/setup.tsx
+++ b/src/routes/setup.tsx
@@ -163,8 +163,9 @@ function SetupRoute() {
 					ownerPk: ownerPubkeyHex,
 				}
 
-				// Use a fixed handler ID for consistency across setup and seeding
-				const handlerId = 'plebeian-market-handler'
+				// Keep setup consistent with the resolved instance config, but preserve the
+				// legacy default when no custom handler has been configured yet.
+				const handlerId = config.handlerId || 'plebeian-market-handler'
 				let handlerEvent = createHandlerInfoEventData(ownerPubkeyHex, appSettingsContent, config.appRelay, handlerId)
 				handlerEvent = finalizeEvent(handlerEvent, generateSecretKey())
 				await submitAppSettings(handlerEvent)

--- a/src/routes/setup.tsx
+++ b/src/routes/setup.tsx
@@ -5,6 +5,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
 import { submitAppSettings } from '@/lib/appSettings'
+import { DEFAULT_INSTANCE_CONFIG } from '@/lib/instance-config'
 import { AppSettingsSchema } from '@/lib/schemas/app'
 import { createHandlerInfoEventData } from '@/publish/nip89'
 import { useConfigQuery } from '@/queries/config'
@@ -51,12 +52,11 @@ export const Route = createFileRoute('/setup')({
 	component: SetupRoute,
 })
 
-const availableLogos = [{ label: 'Default Logo', value: 'https://plebeian.market/images/logo.svg' }]
-
 const currencies = ['USD', 'EUR', 'BTC', 'SATS']
 
 function SetupRoute() {
 	const { data: config } = useConfigQuery()
+	const availableLogos = [{ label: 'Default Logo', value: config?.picture ?? DEFAULT_INSTANCE_CONFIG.picture }]
 	const navigate = useNavigate()
 	const queryClient = useQueryClient()
 	const [adminsList, setAdminsList] = useState<string[]>([])
@@ -69,17 +69,18 @@ function SetupRoute() {
 			name: '',
 			displayName: '',
 			picture: availableLogos[0].value,
-			banner: 'https://plebeian.market/banner.svg',
+			banner: config?.banner ?? DEFAULT_INSTANCE_CONFIG.banner,
 			ownerPk: '',
 			contactEmail: '',
 			allowRegister: true as boolean,
 			defaultCurrency: currencies[0],
+			showNostrLink: false,
 		} satisfies z.infer<typeof AppSettingsSchema>,
 		validators: {
 			onSubmit: ({ value }) => {
 				const result = AppSettingsSchema.safeParse(value)
 				if (!result.success) {
-					return result.error.errors.reduce<Record<string, string>>((acc, curr) => {
+					return result.error.issues.reduce<Record<string, string>>((acc, curr) => {
 						const path = curr.path.join('.')
 						acc[path] = curr.message
 						return acc

--- a/src/server/http/config.ts
+++ b/src/server/http/config.ts
@@ -2,28 +2,33 @@ import {
 	determineStage,
 	getAppPublicKeyOrThrow,
 	getAppSettings,
+	getInstanceConfig,
 	resolveCvmServerPubkey,
 	isEventHandlerReady,
 	NIP46_RELAY_URL,
 	RELAY_URL,
 } from '../runtime'
+import type { PublicAppConfig } from '@/lib/instance-config'
 import type { BunRoutes } from './types'
 
 export const configRoutes: BunRoutes = {
 	'/api/config': {
 		GET: () => {
+			const appSettings = getAppSettings()
 			const stage = determineStage()
-			return Response.json({
-				appRelay: RELAY_URL,
+			const config: PublicAppConfig = {
+				...getInstanceConfig(),
+				appRelay: RELAY_URL as string,
 				stage,
 				nip46Relay: NIP46_RELAY_URL,
-				appSettings: getAppSettings(),
+				appSettings,
 				appPublicKey: getAppPublicKeyOrThrow(),
 				cvmServerPubkey: resolveCvmServerPubkey(),
-				needsSetup: !getAppSettings(),
+				needsSetup: !appSettings,
 				serverReady: isEventHandlerReady(),
 				externalZapRelaysEnabled: stage === 'production' || (stage === 'development' && process.env.LOCAL_RELAY_ONLY !== 'true'),
-			})
+			}
+			return Response.json(config)
 		},
 	},
 }

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,5 +1,6 @@
 import { getPublicKey } from 'nostr-tools/pure'
 import { fetchAppSettings } from '../lib/appSettings'
+import { parseInstanceConfigEnvironment, resolveInstanceConfig, type InstanceConfig } from '../lib/instance-config'
 import { hexToBytes } from 'nostr-tools/utils'
 
 function isValidHexPubkey(value: string): boolean {
@@ -22,6 +23,7 @@ export const PORT = Number(process.env.PORT || 3000)
 
 let APP_PUBLIC_KEY: string | undefined
 let appSettings: Awaited<ReturnType<typeof fetchAppSettings>> = null
+let instanceConfig: InstanceConfig | undefined
 let eventHandlerReady = false
 
 export function getAppPublicKeyOrThrow(): string {
@@ -67,8 +69,16 @@ export function getAppSettings() {
 	return appSettings
 }
 
+export function getInstanceConfig(): InstanceConfig {
+	if (!instanceConfig) {
+		instanceConfig = resolveInstanceConfig(appSettings, parseInstanceConfigEnvironment(process.env))
+	}
+	return instanceConfig
+}
+
 export function setAppSettings(value: Awaited<ReturnType<typeof fetchAppSettings>>): void {
 	appSettings = value
+	instanceConfig = resolveInstanceConfig(value, parseInstanceConfigEnvironment(process.env))
 }
 
 export function isEventHandlerReady(): boolean {

--- a/src/server/startup.ts
+++ b/src/server/startup.ts
@@ -1,5 +1,5 @@
 import { getPublicKey } from 'nostr-tools/pure'
-import { fetchAppSettings } from '../lib/appSettings'
+import { APP_SETTINGS_D_TAG, fetchAppSettings } from '../lib/appSettings'
 import { getEventHandler } from './EventHandler'
 import { APP_PRIVATE_KEY, RELAY_URL, getAppSettings, setAppPublicKey, setAppSettings, setEventHandlerReady } from './runtime'
 
@@ -19,7 +19,14 @@ export async function initializeAppSettings(): Promise<void> {
 		const privateKeyBytes = new Uint8Array(Buffer.from(APP_PRIVATE_KEY, 'hex'))
 		const publicKey = getPublicKey(privateKeyBytes)
 		setAppPublicKey(publicKey)
-		const settings = await fetchAppSettings(RELAY_URL as string, publicKey)
+
+		// D-tag fallback chain: try custom handler ID first (if env-provided),
+		// then fall back to Plebeian default. This allows self-hosted instances
+		// to publish their own handler ID without breaking existing Plebeian deploys.
+		const customHandlerId = process.env.INSTANCE_HANDLER_ID
+		const handlerIds = customHandlerId ? [customHandlerId, APP_SETTINGS_D_TAG] : [APP_SETTINGS_D_TAG]
+
+		const settings = await fetchAppSettings(RELAY_URL as string, publicKey, handlerIds)
 		setAppSettings(settings)
 		if (settings) {
 			console.log('App settings loaded successfully')


### PR DESCRIPTION
# Self-Hosted Instance Configuration

## Problem

The application was tightly coupled to Plebeian branding, URLs, relay defaults, and the `plebeian-market-handler` identifier. Self-hosted deployments could not reliably publish or discover their own instance configuration without risking existing Plebeian deployments.

## Changes

- Added instance configuration resolution with event, environment, and shipped-default precedence.
- Added custom handler ID discovery with fallback to `plebeian-market-handler`.
- Added an owner-only UI for publishing branding, URLs, relays, trusted mints, terms, support, and social links in kind 31990 events.
- Applied resolved branding to the document title, favicon, header, footer, onboarding, About page, terms dialog, wallet guidance, and NIP-46 metadata.
- Added deployment documentation and self-hosted environment examples.
- Added focused self-hosted E2E coverage for discovery, fallback candidates, relay metadata, published handler metadata, and rendered branding.

## What It Does

A self-hosted instance can set `INSTANCE_*` values and publish a kind 31990 event using a custom handler ID. The app tries that handler first, falls back to the legacy Plebeian handler when needed, and renders the resolved instance identity throughout the client.

## Manual Test Plan

1. Configure `INSTANCE_HANDLER_ID`, `INSTANCE_NAME`, `INSTANCE_SITE_URL`, relay, logo, terms, support, and social URL values.
2. Start the app with a local relay and verify `/api/config` returns the configured values.
3. Open the app and confirm the document title, favicon, header logo, footer links, and support/terms links use the instance configuration.
4. As the instance owner, open App Settings, edit an instance value, and save.
5. Query the local relay and verify the published kind 31990 event uses the custom `d` tag, expected `web` tags, relay hint, and JSON content.
6. Remove the custom event or unset the custom handler ID and verify the legacy handler fallback still loads existing settings.

## Validation

- Full unit suite: 1119 passed, 0 failed.
- Focused self-hosted E2E scenario: 2 passed.
- Formatting and `git diff --check`: passed.

close #924