### PR TITLE
docs(spec): app mute lists MUST NOT affect bids or auction outcomes (AUCTIONS.md §7.2 + ADR-0003)

### DIFF
--- a/AUCTIONS.md
+++ b/AUCTIONS.md
@@ -1421,6 +1421,37 @@ Operational notes:
   `valid_bid_placed` verdicts before treating the bid as a real
   bid for tie-breaking and floor computation.
 
+## 7.2 App mute lists and auctions (normative)
+
+The marketplace app maintains an app-level mute list — a NIP-51
+kind 10000 event published by the app pubkey — as its client-side
+content-moderation and ToS-enforcement mechanism. It governs the
+app's own content surfaces: hiding listings, products, and
+collections from muted sellers. It is app-internal; this spec does
+not standardize the mute list itself and names it only to bound its
+effect.
+
+Its boundary with the auction mechanism is strict:
+
+- The mute list MUST NOT affect bids or any outcome-relevant auction
+  event. A compliant client MUST NOT drop a kind 1023 bid, kind 30440
+  verdict, kind 1024 settlement, or kind 1025 path release because
+  its author is muted, and bid validity MUST NOT consider mute lists
+  in any component — client or validator.
+- Muting a participant never removes them from the auction mechanism:
+  a muted bidder's bids remain surfaced and rankable; validators,
+  auditors, and mints are not subject to mute-list hiding.
+- The only ban list that MAY affect a bid's validity is a validator's
+  own published kind 30441 policy (§4.4.2), applied per §5.6 step 3 /
+  §7.5 step 3 and gated by `auditor_quorum` (`on_blacklist`, §4.4.3).
+  "Blacklist" in this spec always means that mechanism.
+- The client surfaces faithfully the bid data it obtains: ranking,
+  current-price, minimum-bid, and winner-display computations MUST
+  run on the bids the client actually discovers, with no further
+  reduction by mute lists. What a client has discovered is always
+  subject to relay availability; this rule requires only that the
+  mute list not reduce it further.
+
 ## 7.5 Validator audit protocol (normative)
 
 There is no oracle protocol in this scheme. Validators are passive

--- a/docs/adr/ADR-0003-auctions-comprehensive-validation-protocol.md
+++ b/docs/adr/ADR-0003-auctions-comprehensive-validation-protocol.md
@@ -39,7 +39,7 @@ This protocol mandates that no bid is considered valid unless it passes all stru
 ## Consequences
 
 - Modular Validation Architecture: The codebase will implement granular helper functions (e.g., validateBidStructure, verifyDerivationPath) rather than monolithic validators, allowing independent testing and reuse.
-- Deterministic Outcome: All participants (bidders, sellers, validators, observers) will reach the same conclusion regarding the validity of a bid or settlement, reducing disputes.
+- Deterministic Outcome: All participants (bidders, sellers, validators, observers) will reach the same conclusion regarding the validity of a bid or settlement, reducing disputes. App-level client moderation (the NIP-51 mute list, bounded by AUCTIONS.md §7.2) is not an input to bid validity or outcome determination, and compliant clients MUST NOT let it remove bids or outcome-relevant events from the data they surface and rank.
 - Enhanced Security: Cryptographic fraud (e.g., fake paths, spent-behind-lock) will be detected immediately upon event ingestion, preventing wasted redemption attempts.
 - Clear Failure Modes: Every validation failure will map to a specific error code (e.g., proof_spent, derivation_mismatch), enabling precise UI feedback and automated retry logic.
 - Documentation Obligation: Any future modification to the auction protocol (e.g., new settlement policies, curve shapes) must update this validation specification and the corresponding atomic checklists before implementation.


### PR DESCRIPTION
### Summary

Bounds the app-level mute list away from the auction mechanism, in the spec. **This PR changes documentation only** (`AUCTIONS.md`, ADR-0003) — the client behavior fix follows in a separate implementation PR.

The app-level mute list (NIP-51 kind 10000 published by the app pubkey, admin-controlled) is the client's content-moderation and ToS-enforcement mechanism over its content surfaces — products, sellers, collections, and by consequence auction listings. That job is legitimate and stays. The problem is that this moderation mechanism currently **also filters auction bids**: every client bid pipeline drops kind-1023 events whose author is muted, while validators (by policy, "no blacklist") count them.

### The problem

Observed in a dev-stack incident (2026-09-08): the seed data mutes a user who holds the auction's real top bid (38,297 sats).

- The client never saw that bid: its visible top was 35,015, the form auto-filled a minimum of **36,656**, and the user published it.
- The mute-agnostic validator counted a top of 38,297 and required **39,938** — it condemned the funded 36,656 bid the same second (`under_increment`).
- The UI then showed **"You're winning"** for a bid that had already been rejected.

Relay forensics cleared the relay (the hidden bid was served on every query shape); the floor formula and increment source were correct and identical on both sides. The defect was purely the **bid set**: the client ranked a mute-filtered set while the validator ranked the unfiltered one. Hiding real, valid bids does the client's users a disfavour — they believe they are winning when they are not.

The root cause is structural: the spec never mentions the app mute list. Nothing sanctioned, permitted, or bounded its application to bids — so a client feature silently acquired authority over what participants see of a shared, decentralized mechanism.

### What changes

**1. `AUCTIONS.md` — new §7.2 "App mute lists and auctions (normative)"** (between §7.1 and §7.5). It:

- states the mute list's actual job: client-side content moderation / ToS enforcement over the app's content surfaces (listings, products, collections); app-internal, not standardized by this spec;
- forbids it from affecting bids or outcome-relevant auction events: a compliant client MUST NOT drop kind 1023 bids, kind 30440 verdicts, kind 1024 settlements, or kind 1025 path releases because their author is muted, and bid validity MUST NOT consider mute lists in any component (client or validator);
- states that muting never removes a participant from the auction mechanism: a muted bidder's bids remain surfaced and rankable; validators, auditors, and mints are not subject to mute-list hiding;
- re-states the existing boundary: the only ban list that MAY affect a bid's validity is a validator's own kind-30441 policy, quorum-gated (`on_blacklist`) — "blacklist" in this spec always means that;
- sets the client-side norm: the client surfaces faithfully the bid data it discovers — ranking, current-price, minimum-bid, and winner-display computations run on the bids the client actually obtains, with no further reduction by mute lists. (No completeness guarantee is implied; Nostr's non-global-state data model means what any client has discovered is always subject to relay availability. The rule only forbids the mute list from adding omissions.)

**2. `ADR-0003` — one sentence appended to the Deterministic Outcome bullet**, anchoring the same boundary to the protocol's determinism promise.

No other text in either document is modified. "Blacklist" continues to mean validator policy (kind 30441) exactly as before.

### What does NOT change

- **The mute list's job.** It continues to govern seller/content surfaces (hiding listings, products, collections from muted sellers) — that is its designed, legitimate use.
- **Winner selection** — amount-ranked per §8.0, untouched.
- **Validator policy autonomy** — kind-30441 `blacklist`/`blacklistRefs` and the `on_blacklist` reason remain the quorum-gated mechanism for condemning a bidder. Future validator-side features (web-of-trust, anti-spam, anti-grief blacklists) are validator discretion and out of scope here.
- **No wire-format change.** No new kind, tag, claim, or `reason`; the mute list stays app-internal, outside the event model. Relays untouched.

### Compatibility and rollout

Client-only rollout; no relay action, no re-derivation — bid events were always on the relay; their invisibility was client-applied and ends with the implementation fix. Existing mute lists keep governing seller/content surfaces as designed. Historical verdicts and settlements are not reinterpreted. Dev seed data that mutes a user holding seeded bids stays as-is: that diversified fixture is exactly what surfaced this defect, and the implementation PR's regression tests will assert muted-author bids **are** surfaced, ranked, and included in floor/price/winner computation.

### Follow-ups

- Implementation PR: remove author-mute filtering from the bid/verdict/settlement/path-release pipelines (`queries/auctions.tsx` call sites); keep it on listing kinds.
- #1287 — whole-app audit of mute-list scope (e.g. payments/orders from blacklisted users, comments), classifying each surface as legitimate content moderation vs. leakage.
