### PR TITLE
fix(nostr): dedupe event sets by coordinate + track main relay in live subs

### DIFF
--- a/src/lib/__tests__/ndk-events.test.ts
+++ b/src/lib/__tests__/ndk-events.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Set-level regression tests for `fetchNdkEventSet`.
+ *
+ * Relays routinely serve conflicting `created_at` versions of the same
+ * addressable event: replaceable (kind 0/3/1e4-2e4, coordinate `kind:pubkey`)
+ * and parameterized replaceable (kind 3e4-4e4, coordinate `kind:pubkey:d`).
+ * Before this fix the seam deduped raw events by `event.id`, so every
+ * conflicting version survived and consumers that index the set (`[0]`) or
+ * iterate it saw stale copies in relay-arrival order. These tests pin the
+ * coordinate-level `deduplicationKey()` + created_at latest-wins contract.
+ *
+ * Each event is a real `finalizeEvent`-signed event; the seam fetch is stubbed
+ * (no network). No NDK package import here — NDKEvent rehydration only stores
+ * the ndk reference, so a minimal stub context is enough and the NDK footprint
+ * guard is not perturbed.
+ */
+import { describe, expect, test } from 'bun:test'
+import { finalizeEvent } from 'nostr-tools'
+import type { NostrEvent } from 'nostr-tools/pure'
+
+import type { NostrIo } from '@/lib/nostr/io'
+import { fetchNdkEventSet } from '@/lib/nostr/ndk-events'
+
+const TEST_SECRET_KEY = new Uint8Array(32).fill(7)
+const OTHER_SECRET_KEY = new Uint8Array(32).fill(8)
+
+interface EventTemplate {
+	kind: number
+	created_at: number
+	tags: string[][]
+	content: string
+}
+
+/** A validly-signed event; `secretKey` selects the author pubkey. */
+function signedEvent(template: EventTemplate, secretKey: Uint8Array = TEST_SECRET_KEY): NostrEvent {
+	return finalizeEvent(template, secretKey)
+}
+
+/** Stub seam port returning a fixed relay result, in the given arrival order. */
+function ioReturning(events: NostrEvent[]): Pick<NostrIo, 'fetchEvents'> {
+	return { fetchEvents: async () => events } as unknown as Pick<NostrIo, 'fetchEvents'>
+}
+
+// NDKEvent rehydration only stores the reference (see NDKEvent's constructor);
+// a minimal object is enough and keeps the package import out of this file.
+const stubNdk = {
+	fetchEvent: async () => null,
+	queuesNip05: { add: async (item: { func: () => Promise<unknown> }) => item.func() },
+} as unknown as Parameters<typeof fetchNdkEventSet>[1]
+
+async function winnerIds(events: NostrEvent[]): Promise<string[]> {
+	const set = await fetchNdkEventSet(ioReturning(events), stubNdk, { kinds: [events[0]!.kind] })
+	return Array.from(set).map((event) => event.id)
+}
+
+describe('fetchNdkEventSet dedupes on coordinate + created_at latest-wins', () => {
+	test('parameterized replaceable (30405 collection) collapses same d-tag to latest, either arrival order', async () => {
+		const stale = signedEvent({ kind: 30405, created_at: 1_700_000_000, tags: [['d', 'summer']], content: '{"n":1}' })
+		const fresh = signedEvent({ kind: 30405, created_at: 1_700_000_100, tags: [['d', 'summer']], content: '{"n":2}' })
+
+		const staleFirst = await winnerIds([stale, fresh])
+		expect(staleFirst).toEqual([fresh.id])
+
+		const freshFirst = await winnerIds([fresh, stale])
+		expect(freshFirst).toEqual([fresh.id])
+	})
+
+	test('parameterized replaceable (30402 product) latest-wins and keeps distinct d-tags separate', async () => {
+		const productOld = signedEvent({ kind: 30402, created_at: 1_700_000_000, tags: [['d', 'sku-1']], content: '{"title":"old"}' })
+		const productNew = signedEvent({ kind: 30402, created_at: 1_700_000_100, tags: [['d', 'sku-1']], content: '{"title":"new"}' })
+		const otherProduct = signedEvent({ kind: 30402, created_at: 1_700_000_050, tags: [['d', 'sku-2']], content: '{"title":"other"}' })
+
+		const winners = await winnerIds([productOld, productNew, otherProduct])
+		expect(winners).toHaveLength(2)
+		expect(winners).toContain(productNew.id)
+		expect(winners).toContain(otherProduct.id)
+		expect(winners).not.toContain(productOld.id)
+	})
+
+	test('replaceable kind 0 collapses same pubkey to latest created_at', async () => {
+		const stale = signedEvent({ kind: 0, created_at: 1_700_000_000, tags: [], content: '{"name":"old"}' })
+		const fresh = signedEvent({ kind: 0, created_at: 1_700_000_100, tags: [], content: '{"name":"new"}' })
+
+		expect(await winnerIds([stale, fresh])).toEqual([fresh.id])
+		expect(await winnerIds([fresh, stale])).toEqual([fresh.id])
+	})
+
+	test('replaceable kind 10000 collapses same pubkey to latest created_at', async () => {
+		const stale = signedEvent({ kind: 10000, created_at: 1_700_000_000, tags: [['p', 'a']], content: '' })
+		const fresh = signedEvent({
+			kind: 10000,
+			created_at: 1_700_000_100,
+			tags: [
+				['p', 'a'],
+				['p', 'b'],
+			],
+			content: '',
+		})
+
+		expect(await winnerIds([stale, fresh])).toEqual([fresh.id])
+	})
+
+	test('same replaceable kind from different authors stays separate', async () => {
+		const mine = signedEvent({ kind: 0, created_at: 1_700_000_000, tags: [], content: '{"name":"mine"}' })
+		const theirs = signedEvent({ kind: 0, created_at: 1_700_000_100, tags: [], content: '{"name":"theirs"}' }, OTHER_SECRET_KEY)
+
+		expect(await winnerIds([mine, theirs])).toHaveLength(2)
+	})
+
+	test('immutable non-replaceable events with distinct ids stay separate', async () => {
+		const first = signedEvent({ kind: 1, created_at: 1_700_000_000, tags: [], content: 'one' })
+		const second = signedEvent({ kind: 1, created_at: 1_700_000_001, tags: [], content: 'two' })
+
+		expect(await winnerIds([first, second])).toHaveLength(2)
+	})
+
+	test('equal created_at keeps the lexicographically lowest id, arrival-order independent', async () => {
+		const a = signedEvent({ kind: 30402, created_at: 1_700_000_000, tags: [['d', 'sku-1']], content: '{"v":"a"}' })
+		const b = signedEvent({ kind: 30402, created_at: 1_700_000_000, tags: [['d', 'sku-1']], content: '{"v":"b"}' })
+		const [lowerId, higherId] = [a.id, b.id].sort()
+		const lower = a.id === lowerId ? a : b
+		const higher = a.id === lowerId ? b : a
+
+		expect(lowerId).not.toBe(higherId)
+		expect(await winnerIds([higher, lower])).toEqual([lowerId])
+		expect(await winnerIds([lower, higher])).toEqual([lowerId])
+	})
+})

--- a/src/lib/nostr/ndk-events.ts
+++ b/src/lib/nostr/ndk-events.ts
@@ -17,18 +17,39 @@ export function rehydrateVerifiedNdkEvent(ndk: NdkEventContext, event: Event): N
 	}
 }
 
+/**
+ * Latest-wins ordering for two versions of the same deduplication-key event.
+ * Higher `created_at` wins; on an equal timestamp the lexicographically lower
+ * id wins (NIP-01 replaceable-event tie-break), so the winner never depends on
+ * relay-arrival order.
+ */
+function isNewerEvent(candidate: NDKEvent, existing: NDKEvent): boolean {
+	const candidateTime = candidate.created_at ?? 0
+	const existingTime = existing.created_at ?? 0
+	if (candidateTime !== existingTime) return candidateTime > existingTime
+	return candidate.id < existing.id
+}
+
 export async function fetchNdkEventSet(
 	nostrIo: Pick<NostrIo, 'fetchEvents'>,
 	ndk: NdkEventContext,
 	filter: NDKFilter | NDKFilter[],
 ): Promise<Set<NDKEvent>> {
 	const rawEvents = await nostrIo.fetchEvents(filter as NostrFilter | NostrFilter[])
-	const eventsById = new Map<string, NDKEvent>()
+	// Dedupe on NDK's coordinate-level identity, not the raw event id: replaceable
+	// (kind 0/3/1e4-2e4 -> `kind:pubkey`) and parameterized replaceable
+	// (kind 3e4-4e4 -> `kind:pubkey:d`) events are versions of one logical event,
+	// so conflicting copies collected from different relays must collapse to a
+	// single latest-wins winner instead of leaking in relay-arrival order.
+	const eventsByKey = new Map<string, NDKEvent>()
 	for (const event of rawEvents) {
 		const ndkEvent = rehydrateVerifiedNdkEvent(ndk, event)
-		if (ndkEvent && !eventsById.has(ndkEvent.id)) eventsById.set(ndkEvent.id, ndkEvent)
+		if (!ndkEvent) continue
+		const key = ndkEvent.deduplicationKey()
+		const existing = eventsByKey.get(key)
+		if (!existing || isNewerEvent(ndkEvent, existing)) eventsByKey.set(key, ndkEvent)
 	}
-	return new Set(eventsById.values())
+	return new Set(eventsByKey.values())
 }
 
 export function mergeNdkEventSetsById(...eventSets: Set<NDKEvent>[]): Set<NDKEvent> {

--- a/src/queries/app-settings.tsx
+++ b/src/queries/app-settings.tsx
@@ -1,4 +1,4 @@
-import { fetchLatestAppEvent, getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
+import { fetchLatestAppEvent, getMainRelay, ndkActions } from '@/lib/stores/ndk'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -62,10 +62,11 @@ export const fetchAdminSettings = async (appPubkey?: string): Promise<AdminSetti
 export const useAdminSettings = (appPubkey?: string) => {
 	const queryClient = useQueryClient()
 	const ndk = ndkActions.getNDK()
+	const mainRelay = getMainRelay()
 
 	// Set up a live subscription to monitor admin list changes
 	useEffect(() => {
-		if (!appPubkey || !ndk) return
+		if (!appPubkey || !ndk || !mainRelay) return
 
 		const adminListFilter = {
 			kinds: [30000],
@@ -79,7 +80,7 @@ export const useAdminSettings = (appPubkey?: string) => {
 
 		const subscription = ndk.subscribe(adminListFilter, {
 			closeOnEose: false, // Keep subscription open
-			relaySet: getAppRelaySet(),
+			relayUrls: [mainRelay],
 			exclusiveRelay: true, // Reject stale copies from other relays in the pool
 		})
 
@@ -103,7 +104,7 @@ export const useAdminSettings = (appPubkey?: string) => {
 		return () => {
 			subscription.stop()
 		}
-	}, [appPubkey, ndk, queryClient])
+	}, [appPubkey, ndk, mainRelay, queryClient])
 
 	return useQuery({
 		queryKey: configKeys.admins(appPubkey || ''),
@@ -211,10 +212,11 @@ export const fetchEditorSettings = async (appPubkey?: string): Promise<EditorSet
 export const useEditorSettings = (appPubkey?: string) => {
 	const queryClient = useQueryClient()
 	const ndk = ndkActions.getNDK()
+	const mainRelay = getMainRelay()
 
 	// Set up a live subscription to monitor editor list changes
 	useEffect(() => {
-		if (!appPubkey || !ndk) return
+		if (!appPubkey || !ndk || !mainRelay) return
 
 		const editorListFilter = {
 			kinds: [30000],
@@ -228,7 +230,7 @@ export const useEditorSettings = (appPubkey?: string) => {
 
 		const subscription = ndk.subscribe(editorListFilter, {
 			closeOnEose: false, // Keep subscription open
-			relaySet: getAppRelaySet(),
+			relayUrls: [mainRelay],
 			exclusiveRelay: true, // Reject stale copies from other relays in the pool
 		})
 
@@ -252,7 +254,7 @@ export const useEditorSettings = (appPubkey?: string) => {
 		return () => {
 			subscription.stop()
 		}
-	}, [appPubkey, ndk, queryClient])
+	}, [appPubkey, ndk, mainRelay, queryClient])
 
 	return useQuery({
 		queryKey: configKeys.editors(appPubkey || ''),

--- a/src/queries/blacklist.tsx
+++ b/src/queries/blacklist.tsx
@@ -1,4 +1,4 @@
-import { fetchLatestAppEvent, getAppRelaySet, ndkActions } from '@/lib/stores/ndk'
+import { fetchLatestAppEvent, getMainRelay, ndkActions } from '@/lib/stores/ndk'
 import type { NDKEvent } from '@nostr-dev-kit/ndk'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -66,10 +66,11 @@ export const fetchBlacklistSettings = async (appPubkey?: string): Promise<Blackl
 export const useBlacklistSettings = (appPubkey?: string) => {
 	const queryClient = useQueryClient()
 	const ndk = ndkActions.getNDK()
+	const mainRelay = getMainRelay()
 
 	// Set up a live subscription to monitor blacklist changes
 	useEffect(() => {
-		if (!appPubkey || !ndk) return
+		if (!appPubkey || !ndk || !mainRelay) return
 
 		const blacklistFilter = {
 			kinds: [10000], // NIP-51 mute list
@@ -81,7 +82,7 @@ export const useBlacklistSettings = (appPubkey?: string) => {
 
 		const subscription = ndk.subscribe(blacklistFilter, {
 			closeOnEose: false, // Keep subscription open
-			relaySet: getAppRelaySet(),
+			relayUrls: [mainRelay],
 			exclusiveRelay: true, // Reject stale copies from other relays in the pool
 		})
 
@@ -104,7 +105,7 @@ export const useBlacklistSettings = (appPubkey?: string) => {
 		return () => {
 			subscription.stop()
 		}
-	}, [appPubkey, ndk, queryClient])
+	}, [appPubkey, ndk, mainRelay, queryClient])
 
 	return useQuery({
 		queryKey: configKeys.blacklist(appPubkey || ''),


### PR DESCRIPTION
## What

Two fixes that surfaced while auditing the read paths around the wave-1 seam refactor (#1262, closed unmerged — but its `fetchNdkEventSet` helper lives on `master` via 50453810):

1. **`fetchNdkEventSet` deduplicates by event id, so duplicate/stale versions of the same event can leak through.** It now keys on `NDKEvent.deduplicationKey()` (kind:pubkey / kind:pubkey:d / id) with created_at latest-wins; equal timestamps fall back to the NIP-01 lowest-id tie-break, so the winner is relay-arrival-order independent. Affected: replaceable + addressable events fetched through the seam (profiles, mute lists, products, collections…).

2. **Live subscriptions in `app-settings.tsx` (×2) and `blacklist.tsx` didn't track `mainRelay`.** The relay set was resolved via `getAppRelaySet()` at effect run time with `mainRelay` absent from the deps, so a runtime app-relay change left existing live subscriptions pinned to the old relay — and an undefined relaySet before config load could fall back to all relays. Now `mainRelay` is hoisted, guarded, and in the deps; subscription tears down / re-creates on change.

## Tests

New `src/lib/__tests__/ndk-events.test.ts` (7 tests): 30405/30402 same-`d` collapse to latest in both arrival orders; distinct `d` preserved; kind 0 / kind 10000 collapse by coordinate; different authors separate; immutable kind-1 separate; equal-`created_at` lowest-id tie-break both orders. Real `finalizeEvent`-signed events, stubbed seam, no network.

- `bun test src/lib/__tests__/ndk-events.test.ts` — 7 pass
- `bun run test:unit` — 346 pass, 0 fail
- `bunx prettier --check` on changed files — clean
- `bash scripts/check-ndk-footprint.sh` — 127/127 (uses existing public `deduplicationKey()`, no new NDK imports)
- `bunx tsc --noEmit` — no new errors vs base (repo-wide 233 pre-existing are target-env noise; changed files clean under `--target es2022`)

## Notes for reviewers

- `mergeNdkEventSetsById` (used in `orders.tsx`) still merges by id — left alone here as its contract is explicitly id-based; flagging as possible follow-up if cross-set coordinate overlap is reachable there.
- `verifyEvent` still runs before rehydration/dedup; no trust-model change.
